### PR TITLE
chore(profiling): use mock agent for profiling tests

### DIFF
--- a/.github/workflows/pytorch_gpu_tests.yml
+++ b/.github/workflows/pytorch_gpu_tests.yml
@@ -75,6 +75,8 @@ jobs:
           cp "$REPO_ROOT/tests/utils.py" "$TEST_ROOT/"
           cp "$REPO_ROOT/tests/subprocesstest.py" "$TEST_ROOT/"
           cp "$REPO_ROOT/tests/profiling/__init__.py" "$TEST_ROOT/profiling/"
+          cp "$REPO_ROOT/tests/profiling/conftest.py" "$TEST_ROOT/profiling/"
+          cp "$REPO_ROOT/tests/profiling/utils.py" "$TEST_ROOT/profiling/"
           cp "$REPO_ROOT/tests/profiling/test_pytorch.py" "$TEST_ROOT/profiling/"
           cp "$REPO_ROOT/tests/profiling/simple_program_pytorch_gpu.py" "$TEST_ROOT/profiling/"
           cp "$REPO_ROOT/tests/profiling/simple_program_pytorch_cpu.py" "$TEST_ROOT/profiling/"

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader_builder.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader_builder.cpp
@@ -101,9 +101,7 @@ Datadog::UploaderBuilder::set_process_tags(std::string_view p_tags)
 void
 Datadog::UploaderBuilder::set_output_filename(std::string_view _output_filename)
 {
-    if (!_output_filename.empty()) {
-        ProfilerState::get().output_filename = _output_filename;
-    }
+    ProfilerState::get().output_filename = _output_filename;
 }
 
 void

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader_builder.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader_builder.cpp
@@ -101,7 +101,9 @@ Datadog::UploaderBuilder::set_process_tags(std::string_view p_tags)
 void
 Datadog::UploaderBuilder::set_output_filename(std::string_view _output_filename)
 {
-    ProfilerState::get().output_filename = _output_filename;
+    if (!_output_filename.empty()) {
+        ProfilerState::get().output_filename = _output_filename;
+    }
 }
 
 void

--- a/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx
+++ b/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx
@@ -380,13 +380,8 @@ def config(
         call_func_with_str(ddup_config_env, env)
     if version:
         call_func_with_str(ddup_config_version, version)
-    # Always call ddup_config_output_filename even when output_filename is empty so that
-    # a previous file-output configuration is cleared.  call_func_with_str skips falsy
-    # strings, so call the C function directly with an empty string_view here.
     if output_filename:
         call_func_with_str(ddup_config_output_filename, output_filename)
-    else:
-        ddup_config_output_filename(string_view(<const char*>b"", 0))
     if process_tags:
         call_func_with_str(ddup_config_process_tags, process_tags)
 

--- a/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx
+++ b/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx
@@ -380,7 +380,13 @@ def config(
         call_func_with_str(ddup_config_env, env)
     if version:
         call_func_with_str(ddup_config_version, version)
-    call_func_with_str(ddup_config_output_filename, output_filename or "")
+    # Always call ddup_config_output_filename even when output_filename is empty so that
+    # a previous file-output configuration is cleared.  call_func_with_str skips falsy
+    # strings, so call the C function directly with an empty string_view here.
+    if output_filename:
+        call_func_with_str(ddup_config_output_filename, output_filename)
+    else:
+        ddup_config_output_filename(string_view(<const char*>b"", 0))
     if process_tags:
         call_func_with_str(ddup_config_process_tags, process_tags)
 

--- a/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx
+++ b/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx
@@ -25,11 +25,12 @@ from ddtrace.internal.runtime import get_process_role
 from ddtrace.internal.runtime import get_runtime_id
 from ddtrace.internal.settings._agent import config as agent_config
 
-# AIDEV-NOTE: Upload URL override for testing. Read from env once at import time so
-# exec-based child processes (gunicorn workers, uwsgi) pick it up automatically.
-# Updated at runtime via config_url() by with_profiling_test_agent() for in-process tests.
-# Never read from os.environ inside _get_endpoint() so production has zero env-var overhead.
-_upload_url_override = _os.environ.get("_DD_PROFILING_TEST_AGENT_URL")
+# Test session token for ddapm-test-agent per-test isolation. When set,
+# _get_endpoint() routes uploads through a local forwarding proxy that injects the
+# X-Datadog-Test-Session-Token header (libdatadog's exporter has no custom-header API).
+# Never set in production; only written by config_test_token() which is test-only.
+_test_token_override: Optional[str] = _os.environ.get("_DD_PROFILING_TEST_TOKEN")
+_test_proxy_base_url: Optional[str] = _os.environ.get("_DD_PROFILING_TEST_PROXY_URL")
 
 
 ctypedef void (*func_ptr_t)(string_view)
@@ -412,10 +413,20 @@ def set_profiler_settings_json(settings_json: StringType) -> None:
     call_func_with_str(ddup_set_profiler_settings_json, settings_json)
 
 
-def config_url(url: Optional[str]) -> None:
-    """Set or clear the upload URL override. Used by tests via with_profiling_test_agent()."""
-    global _upload_url_override
-    _upload_url_override = url
+def config_test_token(token: Optional[str], proxy_base_url: Optional[str] = None) -> None:
+    """Test-only: configure a session token for ddapm-test-agent per-test isolation.
+
+    When token is set, _get_endpoint() returns a proxy URL of the form
+    ``{proxy_base_url}/session/{token}`` so that libdatadog uploads to
+    ``{proxy_base_url}/session/{token}/profiling/v1/input``.  The local proxy
+    extracts the token from the path, injects X-Datadog-Test-Session-Token, and
+    forwards to the real ddapm-test-agent.
+
+    Never called in production code.
+    """
+    global _test_token_override, _test_proxy_base_url
+    _test_token_override = token
+    _test_proxy_base_url = proxy_base_url
 
 
 def _get_endpoint(tracer) -> str:
@@ -423,8 +434,10 @@ def _get_endpoint(tracer) -> str:
     # leads to a circular import, so re-implementing it here.
     # TODO(taegyunkim): support agentless mode by modifying uploader_builder to
     # build exporter for agentless mode too.
-    if _upload_url_override is not None:
-        return _upload_url_override
+    if _test_token_override is not None and _test_proxy_base_url is not None:
+        # Route through the local forwarding proxy so the upload carries the
+        # test session token.  libdatadog appends /profiling/v1/input to this.
+        return f"{_test_proxy_base_url}/session/{_test_token_override}"
     tracer_agent_url = tracer.agent_trace_url
     return tracer_agent_url if tracer_agent_url else agent_config.trace_agent_url
 

--- a/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx
+++ b/ddtrace/internal/datadog/profiling/ddup/_ddup.pyx
@@ -12,6 +12,8 @@ from cpython.unicode cimport PyUnicode_AsUTF8AndSize
 from libcpp.unordered_map cimport unordered_map
 from libcpp.utility cimport pair
 
+import os as _os
+
 import ddtrace
 from ddtrace._trace.span import Span
 from ddtrace._trace.tracer import Tracer
@@ -22,6 +24,12 @@ from ddtrace.internal.datadog.profiling.util import sanitize_string
 from ddtrace.internal.runtime import get_process_role
 from ddtrace.internal.runtime import get_runtime_id
 from ddtrace.internal.settings._agent import config as agent_config
+
+# AIDEV-NOTE: Upload URL override for testing. Read from env once at import time so
+# exec-based child processes (gunicorn workers, uwsgi) pick it up automatically.
+# Updated at runtime via config_url() by with_profiling_test_agent() for in-process tests.
+# Never read from os.environ inside _get_endpoint() so production has zero env-var overhead.
+_upload_url_override = _os.environ.get("_DD_PROFILING_TEST_AGENT_URL")
 
 
 ctypedef void (*func_ptr_t)(string_view)
@@ -371,8 +379,7 @@ def config(
         call_func_with_str(ddup_config_env, env)
     if version:
         call_func_with_str(ddup_config_version, version)
-    if output_filename:
-        call_func_with_str(ddup_config_output_filename, output_filename)
+    call_func_with_str(ddup_config_output_filename, output_filename or "")
     if process_tags:
         call_func_with_str(ddup_config_process_tags, process_tags)
 
@@ -405,14 +412,21 @@ def set_profiler_settings_json(settings_json: StringType) -> None:
     call_func_with_str(ddup_set_profiler_settings_json, settings_json)
 
 
-def _get_endpoint(tracer)-> str:
+def config_url(url: Optional[str]) -> None:
+    """Set or clear the upload URL override. Used by tests via with_profiling_test_agent()."""
+    global _upload_url_override
+    _upload_url_override = url
+
+
+def _get_endpoint(tracer) -> str:
     # DEV: ddtrace.profiling.utils has _get_endpoint but importing that function
     # leads to a circular import, so re-implementing it here.
     # TODO(taegyunkim): support agentless mode by modifying uploader_builder to
     # build exporter for agentless mode too.
+    if _upload_url_override is not None:
+        return _upload_url_override
     tracer_agent_url = tracer.agent_trace_url
-    endpoint = tracer_agent_url if tracer_agent_url else agent_config.trace_agent_url
-    return endpoint
+    return tracer_agent_url if tracer_agent_url else agent_config.trace_agent_url
 
 
 def upload(tracer: Optional[Tracer] = ddtrace.tracer, enable_code_provenance: Optional[bool] = None) -> None:

--- a/tests/profiling/collector/pprof_utils.py
+++ b/tests/profiling/collector/pprof_utils.py
@@ -341,7 +341,7 @@ class _ProfilingMiniAgentClient:
 
     def _request(self, method: str, path: str) -> "tuple[int, bytes]":
         parsed = urllib.parse.urlparse(self._base_url)
-        conn = _httplib.HTTPConnection(parsed.hostname, parsed.port, timeout=10)
+        conn = _httplib.HTTPConnection(parsed.hostname or "127.0.0.1", parsed.port, timeout=10)
         try:
             conn.request(method, path)
             resp = conn.getresponse()
@@ -349,15 +349,15 @@ class _ProfilingMiniAgentClient:
         finally:
             conn.close()
 
-    def profiling_requests(self) -> "list[dict]":
+    def profiling_requests(self) -> "list[dict[str, object]]":
         """Return all profiling uploads stored under this session token."""
         status, body = self._request("GET", f"/session/{self._token}/requests")
         if status != 200:
             return []
-        stored = json.loads(body)
+        stored: "list[dict[str, object]]" = json.loads(body)
         for req in stored:
             if isinstance(req.get("body"), str):
-                req["body"] = base64.b64decode(req["body"])
+                req["body"] = base64.b64decode(str(req["body"]))
         return stored
 
     def clear(self) -> None:

--- a/tests/profiling/collector/pprof_utils.py
+++ b/tests/profiling/collector/pprof_utils.py
@@ -1,14 +1,19 @@
+import base64
 import ctypes
 from enum import Enum
 import glob
+import http.client as _httplib
 import io
+import json
 import os
 import re
+import time
 from typing import TYPE_CHECKING
 from typing import Optional
 from typing import Sequence
 from typing import Union
 from typing import cast
+import urllib.parse
 
 import zstandard as zstd
 
@@ -304,14 +309,64 @@ def parse_internal_metadata_from_request(request: "dict[str, object]") -> "dict[
     return result
 
 
-def get_profile_from_agent(client, timeout: float = 30.0, poll_interval: float = 0.5, assert_samples: bool = True):
+class _ProfilingMiniAgentClient:
+    """HTTP client for _ProfilingMiniAgent.
+
+    Implements the profiling_requests() / clear() interface used by the
+    get_profile_from_agent helpers, so they work whether called in-process or
+    from inside a @pytest.mark.subprocess test body.
+    """
+
+    def __init__(self, base_url: str, token: str) -> None:
+        self._base_url = base_url
+        self._token = token
+
+    def _request(self, method: str, path: str) -> "tuple[int, bytes]":
+        parsed = urllib.parse.urlparse(self._base_url)
+        conn = _httplib.HTTPConnection(parsed.hostname, parsed.port, timeout=10)
+        try:
+            conn.request(method, path)
+            resp = conn.getresponse()
+            return resp.status, resp.read()
+        finally:
+            conn.close()
+
+    def profiling_requests(self) -> "list[dict]":
+        """Return all profiling uploads stored under this session token."""
+        status, body = self._request("GET", f"/session/{self._token}/requests")
+        if status != 200:
+            return []
+        stored = json.loads(body)
+        for req in stored:
+            if isinstance(req.get("body"), str):
+                req["body"] = base64.b64decode(req["body"])
+        return stored
+
+    def clear(self) -> None:
+        """Clear all stored uploads for this session token."""
+        self._request("GET", f"/session/{self._token}/clear")
+
+
+def _client_from_env() -> _ProfilingMiniAgentClient:
+    """Build a _ProfilingMiniAgentClient from env vars set by the parent profiling_test_agent fixture.
+
+    Used by get_profile_from_agent when called without an explicit client inside
+    @pytest.mark.subprocess test bodies.
+    """
+    token = os.environ.get("_DD_PROFILING_TEST_TOKEN", "")
+    base_url = os.environ.get("_DD_PROFILING_TEST_PROXY_URL", "http://127.0.0.1:0")
+    return _ProfilingMiniAgentClient(base_url=base_url, token=token)
+
+
+def get_profile_from_agent(client=None, timeout: float = 30.0, poll_interval: float = 0.5, assert_samples: bool = True):
     """Poll the test agent until a profiling upload appears, then return the parsed profile.
 
-    Convenience for use inside @pytest.mark.subprocess test functions alongside the
-    other pprof_utils helpers. The client must have a profiling_requests() method
-    (a TestAgentClient scoped to a with_profiling_test_agent() session).
+    When called without a client (the common case inside subprocess test bodies), builds a
+    client automatically from _DD_PROFILING_TEST_TOKEN / agent URL set by the
+    parent profiling_test_agent fixture.
     """
-    import time
+    if client is None:
+        client = _client_from_env()
 
     end_time = time.time() + timeout
     while time.time() < end_time:

--- a/tests/profiling/collector/pprof_utils.py
+++ b/tests/profiling/collector/pprof_utils.py
@@ -327,53 +327,33 @@ def parse_pid_from_request(request: "dict[str, object]") -> int:
     raise ValueError(f"No 'process_id' tag in tags_profiler: {tags_profiler!r}")
 
 
-class _ProfilingMiniAgentClient:
-    """HTTP client for _ProfilingMiniAgent.
+class _EnvClient:
+    """Minimal profiling mini-agent client built from env vars.
 
-    Implements the profiling_requests() / clear() interface used by the
-    get_profile_from_agent helpers, so they work whether called in-process or
-    from inside a @pytest.mark.subprocess test body.
+    Used by get_profile_from_agent() when no explicit client is supplied.
+    Kept in pprof_utils so the function has no runtime dependency on
+    tests.profiling.utils (which may not be importable in all test venvs).
     """
 
-    def __init__(self, base_url: str, token: str) -> None:
-        self._base_url = base_url
-        self._token = token
+    def __init__(self) -> None:
+        self._token = os.environ.get("_DD_PROFILING_TEST_TOKEN", "")
+        self._base_url = os.environ.get("_DD_PROFILING_TEST_PROXY_URL", "http://127.0.0.1:0")
 
-    def _request(self, method: str, path: str) -> "tuple[int, bytes]":
+    def profiling_requests(self) -> "list[dict[str, object]]":
         parsed = urllib.parse.urlparse(self._base_url)
         conn = _httplib.HTTPConnection(parsed.hostname or "127.0.0.1", parsed.port, timeout=10)
         try:
-            conn.request(method, path)
+            conn.request("GET", f"/session/{self._token}/requests")
             resp = conn.getresponse()
-            return resp.status, resp.read()
+            if resp.status != 200:
+                return []
+            stored: "list[dict[str, object]]" = json.loads(resp.read())
+            for req in stored:
+                if isinstance(req.get("body"), str):
+                    req["body"] = base64.b64decode(str(req["body"]))
+            return stored
         finally:
             conn.close()
-
-    def profiling_requests(self) -> "list[dict[str, object]]":
-        """Return all profiling uploads stored under this session token."""
-        status, body = self._request("GET", f"/session/{self._token}/requests")
-        if status != 200:
-            return []
-        stored: "list[dict[str, object]]" = json.loads(body)
-        for req in stored:
-            if isinstance(req.get("body"), str):
-                req["body"] = base64.b64decode(str(req["body"]))
-        return stored
-
-    def clear(self) -> None:
-        """Clear all stored uploads for this session token."""
-        self._request("GET", f"/session/{self._token}/clear")
-
-
-def _client_from_env() -> _ProfilingMiniAgentClient:
-    """Build a _ProfilingMiniAgentClient from env vars set by the parent profiling_test_agent fixture.
-
-    Used by get_profile_from_agent when called without an explicit client inside
-    @pytest.mark.subprocess test bodies.
-    """
-    token = os.environ.get("_DD_PROFILING_TEST_TOKEN", "")
-    base_url = os.environ.get("_DD_PROFILING_TEST_PROXY_URL", "http://127.0.0.1:0")
-    return _ProfilingMiniAgentClient(base_url=base_url, token=token)
 
 
 def get_profile_from_agent(client=None, timeout: float = 30.0, poll_interval: float = 0.5, assert_samples: bool = True):
@@ -384,7 +364,7 @@ def get_profile_from_agent(client=None, timeout: float = 30.0, poll_interval: fl
     parent profiling_test_agent fixture.
     """
     if client is None:
-        client = _client_from_env()
+        client = _EnvClient()
 
     end_time = time.time() + timeout
     while time.time() < end_time:

--- a/tests/profiling/collector/pprof_utils.py
+++ b/tests/profiling/collector/pprof_utils.py
@@ -309,6 +309,24 @@ def parse_internal_metadata_from_request(request: "dict[str, object]") -> "dict[
     return result
 
 
+def parse_pid_from_request(request: "dict[str, object]") -> int:
+    """Extract the process_id from the tags_profiler field of a profiling upload event.
+
+    libdatadog encodes process_id as a tag in the comma-separated tags_profiler string,
+    e.g. "runtime:CPython,process_id:1234,...".
+    """
+    parts = _parse_multipart_parts(request)
+    if "event" not in parts:
+        raise ValueError(f"No 'event' part found in profiling request. Available parts: {list(parts.keys())}")
+    event: "dict[str, object]" = json.loads(parts["event"])
+    tags_profiler = str(event.get("tags_profiler", ""))
+    for tag in tags_profiler.split(","):
+        tag = tag.strip()
+        if tag.startswith("process_id:"):
+            return int(tag.split(":", 1)[1])
+    raise ValueError(f"No 'process_id' tag in tags_profiler: {tags_profiler!r}")
+
+
 class _ProfilingMiniAgentClient:
     """HTTP client for _ProfilingMiniAgent.
 

--- a/tests/profiling/collector/pprof_utils.py
+++ b/tests/profiling/collector/pprof_utils.py
@@ -1,6 +1,7 @@
 import ctypes
 from enum import Enum
 import glob
+import io
 import os
 import re
 from typing import TYPE_CHECKING
@@ -239,6 +240,90 @@ def parse_profile(filename: str) -> pprof_pb2.Profile:
     profile = pprof_pb2.Profile()
     profile.ParseFromString(serialized_data)
     return profile
+
+
+def parse_profile_from_bytes(data: bytes) -> pprof_pb2.Profile:
+    """Parse a pprof profile from raw zstd-compressed bytes."""
+    dctx = zstd.ZstdDecompressor()
+    serialized_data = dctx.stream_reader(io.BytesIO(data)).read()
+    profile = pprof_pb2.Profile()
+    profile.ParseFromString(serialized_data)
+    return profile
+
+
+def _parse_multipart_parts(request: "dict[str, object]") -> "dict[str, bytes]":
+    """Parse all multipart form-data parts from a test agent profiling request.
+
+    Returns a dict mapping part name -> raw bytes payload.
+    """
+    import email
+
+    headers = cast("dict[str, str]", request["headers"])
+    body = cast(bytes, request["body"])
+    content_type = headers.get("content-type", "")
+    full_msg_bytes = ("Content-Type: " + content_type + "\r\n\r\n").encode() + body
+    msg = email.message_from_bytes(full_msg_bytes)
+    parts: "dict[str, bytes]" = {}
+    for part in msg.walk():
+        name = part.get_param("name", header="content-disposition")
+        if isinstance(name, str):
+            payload = part.get_payload(decode=True)
+            if isinstance(payload, bytes):
+                parts[name] = payload
+    return parts
+
+
+def parse_profile_from_request(request: "dict[str, object]") -> pprof_pb2.Profile:
+    """Extract and parse the pprof profile from a multipart/form-data profiling upload.
+
+    libdatadog sends the pprof as a multipart part named 'profile.pprof'.
+    """
+    parts = _parse_multipart_parts(request)
+    if "profile.pprof" not in parts:
+        raise ValueError(f"No 'profile.pprof' part found in profiling request. Available parts: {list(parts.keys())}")
+    return parse_profile_from_bytes(parts["profile.pprof"])
+
+
+def parse_internal_metadata_from_request(request: "dict[str, object]") -> "dict[str, object]":
+    """Extract the internal_metadata JSON from a profiling request.
+
+    libdatadog embeds internal_metadata as event["internal"] inside
+    the 'event' JSON field of the multipart upload.
+    """
+    import json
+
+    parts = _parse_multipart_parts(request)
+    if "event" not in parts:
+        raise ValueError(f"No 'event' part found in profiling request. Available parts: {list(parts.keys())}")
+    event: "dict[str, object]" = json.loads(parts["event"])
+    if "internal" not in event:
+        raise ValueError(f"No 'internal' key in event JSON. event keys: {list(event.keys())}")
+    result = event["internal"]
+    if not isinstance(result, dict):
+        raise ValueError(f"event['internal'] is not a dict: {type(result)}")
+    return result
+
+
+def get_profile_from_agent(client, timeout: float = 30.0, poll_interval: float = 0.5, assert_samples: bool = True):
+    """Poll the test agent until a profiling upload appears, then return the parsed profile.
+
+    Convenience for use inside @pytest.mark.subprocess test functions alongside the
+    other pprof_utils helpers. The client must have a profiling_requests() method
+    (a TestAgentClient scoped to a with_profiling_test_agent() session).
+    """
+    import time
+
+    end_time = time.time() + timeout
+    while time.time() < end_time:
+        reqs = client.profiling_requests()
+        if reqs:
+            profile = parse_profile_from_request(reqs[-1])
+            if assert_samples:
+                assert len(profile.sample) > 0, "No samples found in profile received from test agent"
+            return profile
+        time.sleep(poll_interval)
+
+    raise AssertionError(f"No profiling upload received from test agent within {timeout}s")
 
 
 def parse_newest_profile(

--- a/tests/profiling/collector/test_asyncio.py
+++ b/tests/profiling/collector/test_asyncio.py
@@ -194,7 +194,6 @@ def test_asyncio_lock_lock_events() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -205,15 +204,14 @@ def test_asyncio_lock_lock_events() -> None:
         lock.release()  # !RELEASE! asyncio_test_lock_events
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_asyncio_lock_lock_events", version="my_version")
-        ddup.start()
+    ddup.config(env="test", service="test_asyncio_lock_lock_events", version="my_version")
+    ddup.start()
 
-        with AsyncioLockCollector(capture_pct=100):
-            asyncio.run(test_lock_events())
+    with AsyncioLockCollector(capture_pct=100):
+        asyncio.run(test_lock_events())
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos = get_lock_linenos("asyncio_test_lock_events")
     expected_thread_id = _thread.get_ident()
@@ -251,7 +249,6 @@ def test_asyncio_semaphore_lock_events() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -262,15 +259,14 @@ def test_asyncio_semaphore_lock_events() -> None:
         lock.release()  # !RELEASE! asyncio_semaphore_lock_events
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_asyncio_semaphore_lock_events", version="my_version")
-        ddup.start()
+    ddup.config(env="test", service="test_asyncio_semaphore_lock_events", version="my_version")
+    ddup.start()
 
-        with AsyncioSemaphoreCollector(capture_pct=100):
-            asyncio.run(test_lock_events())
+    with AsyncioSemaphoreCollector(capture_pct=100):
+        asyncio.run(test_lock_events())
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos = get_lock_linenos("asyncio_semaphore_lock_events")
     expected_thread_id = _thread.get_ident()
@@ -308,7 +304,6 @@ def test_asyncio_bounded_semaphore_lock_events() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -319,15 +314,14 @@ def test_asyncio_bounded_semaphore_lock_events() -> None:
         lock.release()  # !RELEASE! asyncio_bounded_semaphore_lock_events
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_asyncio_bounded_semaphore_lock_events", version="my_version")
-        ddup.start()
+    ddup.config(env="test", service="test_asyncio_bounded_semaphore_lock_events", version="my_version")
+    ddup.start()
 
-        with AsyncioBoundedSemaphoreCollector(capture_pct=100):
-            asyncio.run(test_lock_events())
+    with AsyncioBoundedSemaphoreCollector(capture_pct=100):
+        asyncio.run(test_lock_events())
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos = get_lock_linenos("asyncio_bounded_semaphore_lock_events")
     expected_thread_id = _thread.get_ident()
@@ -365,7 +359,6 @@ def test_asyncio_condition_lock_events() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -376,15 +369,14 @@ def test_asyncio_condition_lock_events() -> None:
         lock.release()  # !RELEASE! asyncio_condition_lock_events
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_asyncio_condition_lock_events", version="my_version")
-        ddup.start()
+    ddup.config(env="test", service="test_asyncio_condition_lock_events", version="my_version")
+    ddup.start()
 
-        with AsyncioConditionCollector(capture_pct=100):
-            asyncio.run(test_lock_events())
+    with AsyncioConditionCollector(capture_pct=100):
+        asyncio.run(test_lock_events())
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos = get_lock_linenos("asyncio_condition_lock_events")
     expected_thread_id = _thread.get_ident()
@@ -425,7 +417,6 @@ def test_asyncio_lock_lock_events_tracer() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -452,12 +443,11 @@ def test_asyncio_lock_lock_events_tracer() -> None:
         return span_id
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_asyncio_lock_lock_events_tracer", version="my_version")
-        ddup.start()
-        span_id = asyncio.run(test_lock_events_tracer())
-        ddup.upload(tracer=tracer)
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.config(env="test", service="test_asyncio_lock_lock_events_tracer", version="my_version")
+    ddup.start()
+    span_id = asyncio.run(test_lock_events_tracer())
+    ddup.upload(tracer=tracer)
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos_1 = get_lock_linenos("asyncio_lock_events_tracer_1")
     linenos_2 = get_lock_linenos("asyncio_lock_events_tracer_2")
@@ -535,7 +525,6 @@ def test_asyncio_semaphore_lock_events_tracer() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -562,12 +551,11 @@ def test_asyncio_semaphore_lock_events_tracer() -> None:
         return span_id
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_asyncio_semaphore_lock_events_tracer", version="my_version")
-        ddup.start()
-        span_id = asyncio.run(test_lock_events_tracer())
-        ddup.upload(tracer=tracer)
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.config(env="test", service="test_asyncio_semaphore_lock_events_tracer", version="my_version")
+    ddup.start()
+    span_id = asyncio.run(test_lock_events_tracer())
+    ddup.upload(tracer=tracer)
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos_1 = get_lock_linenos("asyncio_semaphore_events_tracer_1")
     linenos_2 = get_lock_linenos("asyncio_semaphore_events_tracer_2")
@@ -645,7 +633,6 @@ def test_asyncio_bounded_semaphore_lock_events_tracer() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -672,12 +659,11 @@ def test_asyncio_bounded_semaphore_lock_events_tracer() -> None:
         return span_id
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_asyncio_bounded_semaphore_lock_events_tracer", version="my_version")
-        ddup.start()
-        span_id = asyncio.run(test_lock_events_tracer())
-        ddup.upload(tracer=tracer)
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.config(env="test", service="test_asyncio_bounded_semaphore_lock_events_tracer", version="my_version")
+    ddup.start()
+    span_id = asyncio.run(test_lock_events_tracer())
+    ddup.upload(tracer=tracer)
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos_1 = get_lock_linenos("asyncio_bsem_events_tracer_1")
     linenos_2 = get_lock_linenos("asyncio_bsem_events_tracer_2")
@@ -755,7 +741,6 @@ def test_asyncio_condition_lock_events_tracer() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -782,12 +767,11 @@ def test_asyncio_condition_lock_events_tracer() -> None:
         return span_id
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_asyncio_condition_lock_events_tracer", version="my_version")
-        ddup.start()
-        span_id = asyncio.run(test_lock_events_tracer())
-        ddup.upload(tracer=tracer)
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.config(env="test", service="test_asyncio_condition_lock_events_tracer", version="my_version")
+    ddup.start()
+    span_id = asyncio.run(test_lock_events_tracer())
+    ddup.upload(tracer=tracer)
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos_1 = get_lock_linenos("asyncio_condition_events_tracer_1")
     linenos_2 = get_lock_linenos("asyncio_condition_events_tracer_2")

--- a/tests/profiling/collector/test_asyncio.py
+++ b/tests/profiling/collector/test_asyncio.py
@@ -1,28 +1,18 @@
 from __future__ import annotations
 
-import _thread
 import asyncio
-import glob
-import os
 import sys
-from typing import Any
-from typing import Callable
 from typing import Union
-import uuid
 
 import pytest
 
-from ddtrace import ext
-from ddtrace.internal.datadog.profiling import ddup
 from ddtrace.profiling.collector._lock import _LockAllocatorWrapper as LockAllocatorWrapper
 from ddtrace.profiling.collector.asyncio import AsyncioBoundedSemaphoreCollector
 from ddtrace.profiling.collector.asyncio import AsyncioConditionCollector
 from ddtrace.profiling.collector.asyncio import AsyncioLockCollector
 from ddtrace.profiling.collector.asyncio import AsyncioSemaphoreCollector
-from tests.profiling.collector import pprof_utils
 from tests.profiling.collector import test_collector
 from tests.profiling.collector.lock_test_common import assert_pep604_type_union_syntax
-from tests.profiling.collector.lock_utils import get_lock_linenos
 from tests.profiling.collector.lock_utils import init_linenos
 
 
@@ -65,13 +55,17 @@ def test_collector_repr(collector_class: CollectorTypeClass, expected_repr: str)
     test_collector._test_repr(collector_class, expected_repr)
 
 
+# ---------------------------------------------------------------------------
+# BaseAsyncioLockCollectorTest — non-ddup tests kept as a class
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 class BaseAsyncioLockCollectorTest:
-    """Base test class for asyncio lock collectors.
+    """Base test class for asyncio lock collectors — non-ddup-upload tests only.
 
-    Child classes must implement:
-        - collector_class: The collector class to test
-        - lock_class: The asyncio lock class to test
+    Tests that call ddup.upload() are converted to @pytest.mark.subprocess functions below.
+    Child classes must implement collector_class and lock_class.
     """
 
     @property
@@ -81,146 +75,6 @@ class BaseAsyncioLockCollectorTest:
     @property
     def lock_class(self) -> LockTypeClass:
         raise NotImplementedError("Child classes must implement lock_class")
-
-    def setup_method(self, method: Callable[..., Any]) -> None:
-        self.test_name: str = method.__qualname__ if PY_311_OR_ABOVE else method.__name__
-        self.output_prefix: str = "/tmp" + os.sep + self.test_name
-        self.output_filename: str = self.output_prefix + "." + str(os.getpid())
-
-        assert ddup.is_available, "ddup is not available"
-        ddup.config(
-            env="test",
-            service="test_asyncio",
-            version="my_version",
-            output_filename=self.output_prefix,
-        )
-        ddup.start()
-
-    def teardown_method(self) -> None:
-        for f in glob.glob(self.output_prefix + "*"):
-            try:
-                os.remove(f)
-            except Exception as e:
-                print("Error while deleting file: ", e)
-
-    async def test_lock_events(self) -> None:
-        """Test basic acquire/release event profiling."""
-        with self.collector_class(capture_pct=100):
-            lock = self.lock_class()  # !CREATE! asyncio_test_lock_events
-            await lock.acquire()  # !ACQUIRE! asyncio_test_lock_events
-            assert lock.locked()
-            lock.release()  # !RELEASE! asyncio_test_lock_events
-
-        ddup.upload()
-
-        linenos = get_lock_linenos("asyncio_test_lock_events")
-        profile = pprof_utils.parse_newest_profile(self.output_filename)
-        expected_thread_id = _thread.get_ident()
-        pprof_utils.assert_lock_events(
-            profile,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos,
-                    lock_name="lock",
-                    thread_id=expected_thread_id,
-                )
-            ],
-            expected_release_events=[
-                pprof_utils.LockReleaseEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos,
-                    lock_name="lock",
-                    thread_id=expected_thread_id,
-                )
-            ],
-        )
-
-    async def test_lock_events_tracer(self, tracer: Any) -> None:
-        """Test event profiling with tracer integration."""
-        tracer._endpoint_call_counter_span_processor.enable()
-        resource = str(uuid.uuid4())
-        span_type = ext.SpanTypes.WEB
-
-        with self.collector_class(capture_pct=100, tracer=tracer):
-            lock = self.lock_class()  # !CREATE! asyncio_test_lock_events_tracer_1
-            await lock.acquire()  # !ACQUIRE! asyncio_test_lock_events_tracer_1
-            with tracer.trace("test", resource=resource, span_type=span_type) as t:
-                lock2 = self.lock_class()  # !CREATE! asyncio_test_lock_events_tracer_2
-                await lock2.acquire()  # !ACQUIRE! asyncio_test_lock_events_tracer_2
-                lock.release()  # !RELEASE! asyncio_test_lock_events_tracer_1
-                span_id = t.span_id
-            lock2.release()  # !RELEASE! asyncio_test_lock_events_tracer_2
-
-            lock_ctx = self.lock_class()  # !CREATE! asyncio_test_lock_events_tracer_3
-            async with lock_ctx:  # !ACQUIRE! !RELEASE! asyncio_test_lock_events_tracer_3
-                pass
-        ddup.upload(tracer=tracer)
-
-        linenos_1 = get_lock_linenos("asyncio_test_lock_events_tracer_1")
-        linenos_2 = get_lock_linenos("asyncio_test_lock_events_tracer_2")
-        linenos_3 = get_lock_linenos("asyncio_test_lock_events_tracer_3", with_stmt=True)
-
-        profile = pprof_utils.parse_newest_profile(self.output_filename)
-        expected_thread_id = _thread.get_ident()
-
-        pprof_utils.assert_lock_events(
-            profile,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos_1,
-                    lock_name="lock",
-                    thread_id=expected_thread_id,
-                ),
-                pprof_utils.LockAcquireEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos_2,
-                    lock_name="lock2",
-                    span_id=span_id,
-                    trace_endpoint=resource,
-                    trace_type=span_type,
-                    thread_id=expected_thread_id,
-                ),
-                pprof_utils.LockAcquireEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos_3,
-                    lock_name="lock_ctx",
-                    thread_id=expected_thread_id,
-                ),
-            ],
-            expected_release_events=[
-                pprof_utils.LockReleaseEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos_1,
-                    lock_name="lock",
-                    span_id=span_id,
-                    trace_endpoint=resource,
-                    trace_type=span_type,
-                    thread_id=expected_thread_id,
-                ),
-                pprof_utils.LockReleaseEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos_2,
-                    lock_name="lock2",
-                    thread_id=expected_thread_id,
-                ),
-                pprof_utils.LockReleaseEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos_3,
-                    lock_name="lock_ctx",
-                    thread_id=expected_thread_id,
-                ),
-            ],
-        )
 
     async def test_subclassing_wrapped_lock(self) -> None:
         """Test that subclassing of a wrapped lock type when profiling is active."""
@@ -276,16 +130,12 @@ class TestAsyncioBoundedSemaphoreCollector(BaseAsyncioLockCollectorTest):
         return asyncio.BoundedSemaphore
 
     async def test_bounded_behavior_preserved(self) -> None:
-        """Test that profiling wrapper preserves BoundedSemaphore's bounded behavior.
-
-        This verifies the wrapper doesn't interfere with BoundedSemaphore's unique characteristic:
-        raising ValueError when releasing beyond the initial value.
-        """
+        """Test that profiling wrapper preserves BoundedSemaphore's bounded behavior."""
         with self.collector_class(capture_pct=100):
             bs = asyncio.BoundedSemaphore(1)
             await bs.acquire()
             bs.release()
-            # BoundedSemaphore should raise ValueError when releasing more than initial value
+            # BoundedSemaphore should raise ValueError when releasing beyond the initial value
             with pytest.raises(ValueError, match="BoundedSemaphore released too many times"):
                 bs.release()
 
@@ -325,3 +175,677 @@ class TestAsyncGenericLockProfiling:
         """
         with self.collector_class(capture_pct=100):
             assert_pep604_type_union_syntax(self.lock_class)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Subprocess versions of BaseAsyncioLockCollectorTest ddup-upload tests
+# Each function covers ONE (collector_class, lock_class, test_method) combination.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_asyncio_lock_lock_events() -> None:
+    import _thread
+    import asyncio
+    import os
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.asyncio import AsyncioLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    async def test_lock_events():
+        lock = asyncio.Lock()  # !CREATE! asyncio_test_lock_events
+        await lock.acquire()  # !ACQUIRE! asyncio_test_lock_events
+        assert lock.locked()
+        lock.release()  # !RELEASE! asyncio_test_lock_events
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_asyncio_lock_lock_events", version="my_version")
+        ddup.start()
+
+        with AsyncioLockCollector(capture_pct=100):
+            asyncio.run(test_lock_events())
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos = get_lock_linenos("asyncio_test_lock_events")
+    expected_thread_id = _thread.get_ident()
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events",
+                filename="test_asyncio.py",
+                linenos=linenos,
+                lock_name="lock",
+                thread_id=expected_thread_id,
+            )
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events",
+                filename="test_asyncio.py",
+                linenos=linenos,
+                lock_name="lock",
+                thread_id=expected_thread_id,
+            )
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_asyncio_semaphore_lock_events() -> None:
+    import _thread
+    import asyncio
+    import os
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.asyncio import AsyncioSemaphoreCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    async def test_lock_events():
+        lock = asyncio.Semaphore()  # !CREATE! asyncio_semaphore_lock_events
+        await lock.acquire()  # !ACQUIRE! asyncio_semaphore_lock_events
+        assert lock.locked()
+        lock.release()  # !RELEASE! asyncio_semaphore_lock_events
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_asyncio_semaphore_lock_events", version="my_version")
+        ddup.start()
+
+        with AsyncioSemaphoreCollector(capture_pct=100):
+            asyncio.run(test_lock_events())
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos = get_lock_linenos("asyncio_semaphore_lock_events")
+    expected_thread_id = _thread.get_ident()
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events",
+                filename="test_asyncio.py",
+                linenos=linenos,
+                lock_name="lock",
+                thread_id=expected_thread_id,
+            )
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events",
+                filename="test_asyncio.py",
+                linenos=linenos,
+                lock_name="lock",
+                thread_id=expected_thread_id,
+            )
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_asyncio_bounded_semaphore_lock_events() -> None:
+    import _thread
+    import asyncio
+    import os
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.asyncio import AsyncioBoundedSemaphoreCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    async def test_lock_events():
+        lock = asyncio.BoundedSemaphore()  # !CREATE! asyncio_bounded_semaphore_lock_events
+        await lock.acquire()  # !ACQUIRE! asyncio_bounded_semaphore_lock_events
+        assert lock.locked()
+        lock.release()  # !RELEASE! asyncio_bounded_semaphore_lock_events
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_asyncio_bounded_semaphore_lock_events", version="my_version")
+        ddup.start()
+
+        with AsyncioBoundedSemaphoreCollector(capture_pct=100):
+            asyncio.run(test_lock_events())
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos = get_lock_linenos("asyncio_bounded_semaphore_lock_events")
+    expected_thread_id = _thread.get_ident()
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events",
+                filename="test_asyncio.py",
+                linenos=linenos,
+                lock_name="lock",
+                thread_id=expected_thread_id,
+            )
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events",
+                filename="test_asyncio.py",
+                linenos=linenos,
+                lock_name="lock",
+                thread_id=expected_thread_id,
+            )
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_asyncio_condition_lock_events() -> None:
+    import _thread
+    import asyncio
+    import os
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.asyncio import AsyncioConditionCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    async def test_lock_events():
+        lock = asyncio.Condition()  # !CREATE! asyncio_condition_lock_events
+        await lock.acquire()  # !ACQUIRE! asyncio_condition_lock_events
+        assert lock.locked()
+        lock.release()  # !RELEASE! asyncio_condition_lock_events
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_asyncio_condition_lock_events", version="my_version")
+        ddup.start()
+
+        with AsyncioConditionCollector(capture_pct=100):
+            asyncio.run(test_lock_events())
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos = get_lock_linenos("asyncio_condition_lock_events")
+    expected_thread_id = _thread.get_ident()
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events",
+                filename="test_asyncio.py",
+                linenos=linenos,
+                lock_name="lock",
+                thread_id=expected_thread_id,
+            )
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events",
+                filename="test_asyncio.py",
+                linenos=linenos,
+                lock_name="lock",
+                thread_id=expected_thread_id,
+            )
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_asyncio_lock_lock_events_tracer() -> None:
+    import _thread
+    import asyncio
+    import os
+    import uuid
+
+    import ddtrace
+    from ddtrace import ext
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.asyncio import AsyncioLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    tracer = ddtrace.trace.tracer
+    resource = str(uuid.uuid4())
+    span_type = ext.SpanTypes.WEB
+
+    async def test_lock_events_tracer():
+        tracer._endpoint_call_counter_span_processor.enable()
+
+        with AsyncioLockCollector(capture_pct=100, tracer=tracer):
+            lock = asyncio.Lock()  # !CREATE! asyncio_lock_events_tracer_1
+            await lock.acquire()  # !ACQUIRE! asyncio_lock_events_tracer_1
+            with tracer.trace("test", resource=resource, span_type=span_type) as t:
+                lock2 = asyncio.Lock()  # !CREATE! asyncio_lock_events_tracer_2
+                await lock2.acquire()  # !ACQUIRE! asyncio_lock_events_tracer_2
+                lock.release()  # !RELEASE! asyncio_lock_events_tracer_1
+                span_id = t.span_id
+            lock2.release()  # !RELEASE! asyncio_lock_events_tracer_2
+
+            lock_ctx = asyncio.Lock()  # !CREATE! asyncio_lock_events_tracer_3
+            async with lock_ctx:  # !ACQUIRE! !RELEASE! asyncio_lock_events_tracer_3
+                pass
+        return span_id
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_asyncio_lock_lock_events_tracer", version="my_version")
+        ddup.start()
+        span_id = asyncio.run(test_lock_events_tracer())
+        ddup.upload(tracer=tracer)
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos_1 = get_lock_linenos("asyncio_lock_events_tracer_1")
+    linenos_2 = get_lock_linenos("asyncio_lock_events_tracer_2")
+    linenos_3 = get_lock_linenos("asyncio_lock_events_tracer_3", with_stmt=True)
+    expected_thread_id = _thread.get_ident()
+
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_1,
+                lock_name="lock",
+                thread_id=expected_thread_id,
+            ),
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_2,
+                lock_name="lock2",
+                span_id=span_id,
+                trace_endpoint=resource,
+                trace_type=span_type,
+                thread_id=expected_thread_id,
+            ),
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_3,
+                lock_name="lock_ctx",
+                thread_id=expected_thread_id,
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_1,
+                lock_name="lock",
+                span_id=span_id,
+                trace_endpoint=resource,
+                trace_type=span_type,
+                thread_id=expected_thread_id,
+            ),
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_2,
+                lock_name="lock2",
+                thread_id=expected_thread_id,
+            ),
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_3,
+                lock_name="lock_ctx",
+                thread_id=expected_thread_id,
+            ),
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_asyncio_semaphore_lock_events_tracer() -> None:
+    import _thread
+    import asyncio
+    import os
+    import uuid
+
+    import ddtrace
+    from ddtrace import ext
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.asyncio import AsyncioSemaphoreCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    tracer = ddtrace.trace.tracer
+    resource = str(uuid.uuid4())
+    span_type = ext.SpanTypes.WEB
+
+    async def test_lock_events_tracer():
+        tracer._endpoint_call_counter_span_processor.enable()
+
+        with AsyncioSemaphoreCollector(capture_pct=100, tracer=tracer):
+            lock = asyncio.Semaphore()  # !CREATE! asyncio_semaphore_events_tracer_1
+            await lock.acquire()  # !ACQUIRE! asyncio_semaphore_events_tracer_1
+            with tracer.trace("test", resource=resource, span_type=span_type) as t:
+                lock2 = asyncio.Semaphore()  # !CREATE! asyncio_semaphore_events_tracer_2
+                await lock2.acquire()  # !ACQUIRE! asyncio_semaphore_events_tracer_2
+                lock.release()  # !RELEASE! asyncio_semaphore_events_tracer_1
+                span_id = t.span_id
+            lock2.release()  # !RELEASE! asyncio_semaphore_events_tracer_2
+
+            lock_ctx = asyncio.Semaphore()  # !CREATE! asyncio_semaphore_events_tracer_3
+            async with lock_ctx:  # !ACQUIRE! !RELEASE! asyncio_semaphore_events_tracer_3
+                pass
+        return span_id
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_asyncio_semaphore_lock_events_tracer", version="my_version")
+        ddup.start()
+        span_id = asyncio.run(test_lock_events_tracer())
+        ddup.upload(tracer=tracer)
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos_1 = get_lock_linenos("asyncio_semaphore_events_tracer_1")
+    linenos_2 = get_lock_linenos("asyncio_semaphore_events_tracer_2")
+    linenos_3 = get_lock_linenos("asyncio_semaphore_events_tracer_3", with_stmt=True)
+    expected_thread_id = _thread.get_ident()
+
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_1,
+                lock_name="lock",
+                thread_id=expected_thread_id,
+            ),
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_2,
+                lock_name="lock2",
+                span_id=span_id,
+                trace_endpoint=resource,
+                trace_type=span_type,
+                thread_id=expected_thread_id,
+            ),
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_3,
+                lock_name="lock_ctx",
+                thread_id=expected_thread_id,
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_1,
+                lock_name="lock",
+                span_id=span_id,
+                trace_endpoint=resource,
+                trace_type=span_type,
+                thread_id=expected_thread_id,
+            ),
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_2,
+                lock_name="lock2",
+                thread_id=expected_thread_id,
+            ),
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_3,
+                lock_name="lock_ctx",
+                thread_id=expected_thread_id,
+            ),
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_asyncio_bounded_semaphore_lock_events_tracer() -> None:
+    import _thread
+    import asyncio
+    import os
+    import uuid
+
+    import ddtrace
+    from ddtrace import ext
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.asyncio import AsyncioBoundedSemaphoreCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    tracer = ddtrace.trace.tracer
+    resource = str(uuid.uuid4())
+    span_type = ext.SpanTypes.WEB
+
+    async def test_lock_events_tracer():
+        tracer._endpoint_call_counter_span_processor.enable()
+
+        with AsyncioBoundedSemaphoreCollector(capture_pct=100, tracer=tracer):
+            lock = asyncio.BoundedSemaphore()  # !CREATE! asyncio_bsem_events_tracer_1
+            await lock.acquire()  # !ACQUIRE! asyncio_bsem_events_tracer_1
+            with tracer.trace("test", resource=resource, span_type=span_type) as t:
+                lock2 = asyncio.BoundedSemaphore()  # !CREATE! asyncio_bsem_events_tracer_2
+                await lock2.acquire()  # !ACQUIRE! asyncio_bsem_events_tracer_2
+                lock.release()  # !RELEASE! asyncio_bsem_events_tracer_1
+                span_id = t.span_id
+            lock2.release()  # !RELEASE! asyncio_bsem_events_tracer_2
+
+            lock_ctx = asyncio.BoundedSemaphore()  # !CREATE! asyncio_bsem_events_tracer_3
+            async with lock_ctx:  # !ACQUIRE! !RELEASE! asyncio_bsem_events_tracer_3
+                pass
+        return span_id
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_asyncio_bounded_semaphore_lock_events_tracer", version="my_version")
+        ddup.start()
+        span_id = asyncio.run(test_lock_events_tracer())
+        ddup.upload(tracer=tracer)
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos_1 = get_lock_linenos("asyncio_bsem_events_tracer_1")
+    linenos_2 = get_lock_linenos("asyncio_bsem_events_tracer_2")
+    linenos_3 = get_lock_linenos("asyncio_bsem_events_tracer_3", with_stmt=True)
+    expected_thread_id = _thread.get_ident()
+
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_1,
+                lock_name="lock",
+                thread_id=expected_thread_id,
+            ),
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_2,
+                lock_name="lock2",
+                span_id=span_id,
+                trace_endpoint=resource,
+                trace_type=span_type,
+                thread_id=expected_thread_id,
+            ),
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_3,
+                lock_name="lock_ctx",
+                thread_id=expected_thread_id,
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_1,
+                lock_name="lock",
+                span_id=span_id,
+                trace_endpoint=resource,
+                trace_type=span_type,
+                thread_id=expected_thread_id,
+            ),
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_2,
+                lock_name="lock2",
+                thread_id=expected_thread_id,
+            ),
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_3,
+                lock_name="lock_ctx",
+                thread_id=expected_thread_id,
+            ),
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_asyncio_condition_lock_events_tracer() -> None:
+    import _thread
+    import asyncio
+    import os
+    import uuid
+
+    import ddtrace
+    from ddtrace import ext
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.asyncio import AsyncioConditionCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    tracer = ddtrace.trace.tracer
+    resource = str(uuid.uuid4())
+    span_type = ext.SpanTypes.WEB
+
+    async def test_lock_events_tracer():
+        tracer._endpoint_call_counter_span_processor.enable()
+
+        with AsyncioConditionCollector(capture_pct=100, tracer=tracer):
+            lock = asyncio.Condition()  # !CREATE! asyncio_condition_events_tracer_1
+            await lock.acquire()  # !ACQUIRE! asyncio_condition_events_tracer_1
+            with tracer.trace("test", resource=resource, span_type=span_type) as t:
+                lock2 = asyncio.Condition()  # !CREATE! asyncio_condition_events_tracer_2
+                await lock2.acquire()  # !ACQUIRE! asyncio_condition_events_tracer_2
+                lock.release()  # !RELEASE! asyncio_condition_events_tracer_1
+                span_id = t.span_id
+            lock2.release()  # !RELEASE! asyncio_condition_events_tracer_2
+
+            lock_ctx = asyncio.Condition()  # !CREATE! asyncio_condition_events_tracer_3
+            async with lock_ctx:  # !ACQUIRE! !RELEASE! asyncio_condition_events_tracer_3
+                pass
+        return span_id
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_asyncio_condition_lock_events_tracer", version="my_version")
+        ddup.start()
+        span_id = asyncio.run(test_lock_events_tracer())
+        ddup.upload(tracer=tracer)
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos_1 = get_lock_linenos("asyncio_condition_events_tracer_1")
+    linenos_2 = get_lock_linenos("asyncio_condition_events_tracer_2")
+    linenos_3 = get_lock_linenos("asyncio_condition_events_tracer_3", with_stmt=True)
+    expected_thread_id = _thread.get_ident()
+
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_1,
+                lock_name="lock",
+                thread_id=expected_thread_id,
+            ),
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_2,
+                lock_name="lock2",
+                span_id=span_id,
+                trace_endpoint=resource,
+                trace_type=span_type,
+                thread_id=expected_thread_id,
+            ),
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_3,
+                lock_name="lock_ctx",
+                thread_id=expected_thread_id,
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_1,
+                lock_name="lock",
+                span_id=span_id,
+                trace_endpoint=resource,
+                trace_type=span_type,
+                thread_id=expected_thread_id,
+            ),
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_2,
+                lock_name="lock2",
+                thread_id=expected_thread_id,
+            ),
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_asyncio.py",
+                linenos=linenos_3,
+                lock_name="lock_ctx",
+                thread_id=expected_thread_id,
+            ),
+        ],
+    )

--- a/tests/profiling/collector/test_asyncio_as_completed.py
+++ b/tests/profiling/collector/test_asyncio_as_completed.py
@@ -1,22 +1,16 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_as_completed",
-    ),
-    err=None,
-)
-# For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
+@pytest.mark.subprocess
 def test_asyncio_as_completed() -> None:
     import asyncio
-    import os
     import random
     from sys import version_info as PYVERSION
 
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -51,58 +45,57 @@ def test_asyncio_as_completed() -> None:
         # before returning x, and all tasks are started around the same time.
         assert sorted(result) == result
 
-    p = profiler.Profiler()
-    p.start()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler()
+        p.start()
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    loop.run_until_complete(main())
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(main())
 
-    p.stop()
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0
 
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0
-
-    locations = [
-        pprof_utils.StackLocation(
-            function_name="wait_and_return_delay",
-            filename="test_asyncio_as_completed.py",
-            line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
-        ),
-        pprof_utils.StackLocation(
-            function_name="main",
-            filename="test_asyncio_as_completed.py",
-            line_no=main.__code__.co_firstlineno + 17,
-        ),
-    ]
-
-    if PYVERSION < (3, 13):
         locations = [
             pprof_utils.StackLocation(
-                function_name="sleep",
-                filename="",
-                line_no=-1,
+                function_name="wait_and_return_delay",
+                filename="test_asyncio_as_completed.py",
+                line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
             ),
             pprof_utils.StackLocation(
-                function_name="other",
+                function_name="main",
                 filename="test_asyncio_as_completed.py",
-                line_no=other.__code__.co_firstlineno + 1,
+                line_no=main.__code__.co_firstlineno + 17,
             ),
-        ] + locations
+        ]
 
-    # Now, check that we have seen those locations for each Task we've created.
-    # (They should be named Task-2 .. Task-11, which is the automatic name assigned to Tasks by asyncio.create_task)
-    for i in range(2, 12):
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                task_name=f"Task-{i}",
-                thread_name="MainThread",
-                locations=locations,
-            ),
-        )
+        if PYVERSION < (3, 13):
+            locations = [
+                pprof_utils.StackLocation(
+                    function_name="sleep",
+                    filename="",
+                    line_no=-1,
+                ),
+                pprof_utils.StackLocation(
+                    function_name="other",
+                    filename="test_asyncio_as_completed.py",
+                    line_no=other.__code__.co_firstlineno + 1,
+                ),
+            ] + locations
+
+        # Now, check that we have seen those locations for each Task we've created.
+        # (They should be named Task-2 .. Task-11, which is the automatic name assigned to Tasks by asyncio.create_task)
+        for i in range(2, 12):
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples,
+                expected_sample=pprof_utils.StackEvent(
+                    task_name=f"Task-{i}",
+                    thread_name="MainThread",
+                    locations=locations,
+                ),
+            )

--- a/tests/profiling/collector/test_asyncio_as_completed.py
+++ b/tests/profiling/collector/test_asyncio_as_completed.py
@@ -10,7 +10,6 @@ def test_asyncio_as_completed() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -45,57 +44,56 @@ def test_asyncio_as_completed() -> None:
         # before returning x, and all tasks are started around the same time.
         assert sorted(result) == result
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler()
-        p.start()
+    p = profiler.Profiler()
+    p.start()
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(main())
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(main())
 
-        p.stop()
+    p.stop()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0
 
+    locations = [
+        pprof_utils.StackLocation(
+            function_name="wait_and_return_delay",
+            filename="test_asyncio_as_completed.py",
+            line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="main",
+            filename="test_asyncio_as_completed.py",
+            line_no=main.__code__.co_firstlineno + 17,
+        ),
+    ]
+
+    if PYVERSION < (3, 13):
         locations = [
             pprof_utils.StackLocation(
-                function_name="wait_and_return_delay",
-                filename="test_asyncio_as_completed.py",
-                line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
+                function_name="sleep",
+                filename="",
+                line_no=-1,
             ),
             pprof_utils.StackLocation(
-                function_name="main",
+                function_name="other",
                 filename="test_asyncio_as_completed.py",
-                line_no=main.__code__.co_firstlineno + 17,
+                line_no=other.__code__.co_firstlineno + 1,
             ),
-        ]
+        ] + locations
 
-        if PYVERSION < (3, 13):
-            locations = [
-                pprof_utils.StackLocation(
-                    function_name="sleep",
-                    filename="",
-                    line_no=-1,
-                ),
-                pprof_utils.StackLocation(
-                    function_name="other",
-                    filename="test_asyncio_as_completed.py",
-                    line_no=other.__code__.co_firstlineno + 1,
-                ),
-            ] + locations
-
-        # Now, check that we have seen those locations for each Task we've created.
-        # (They should be named Task-2 .. Task-11, which is the automatic name assigned to Tasks by asyncio.create_task)
-        for i in range(2, 12):
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples,
-                expected_sample=pprof_utils.StackEvent(
-                    task_name=f"Task-{i}",
-                    thread_name="MainThread",
-                    locations=locations,
-                ),
-            )
+    # Now, check that we have seen those locations for each Task we've created.
+    # (They should be named Task-2 .. Task-11, which is the automatic name assigned to Tasks by asyncio.create_task)
+    for i in range(2, 12):
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                task_name=f"Task-{i}",
+                thread_name="MainThread",
+                locations=locations,
+            ),
+        )

--- a/tests/profiling/collector/test_asyncio_async_generator.py
+++ b/tests/profiling/collector/test_asyncio_async_generator.py
@@ -9,7 +9,6 @@ def test_asyncio_executor_wall_time() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -42,44 +41,43 @@ def test_asyncio_executor_wall_time() -> None:
     async def main() -> None:
         await asynchronous_function()
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler()
-        p.start()
+    p = profiler.Profiler()
+    p.start()
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(main())
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(main())
 
-        p.stop()
+    p.stop()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
-        task_samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(task_samples) > 0
+    task_samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(task_samples) > 0
 
-        def loc(f_name: str) -> pprof_utils.StackLocation:
-            return pprof_utils.StackLocation(function_name=f_name, filename="", line_no=-1)
+    def loc(f_name: str) -> pprof_utils.StackLocation:
+        return pprof_utils.StackLocation(function_name=f_name, filename="", line_no=-1)
 
-        # Thread Pool Executor
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            task_samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="Task-1",
-                locations=list(
-                    reversed(
-                        [
-                            # loc("Task-1"),
-                            loc("main"),
-                            loc("asynchronous_function"),
-                            loc("async_generator"),
-                            loc("async_generator_dep"),
-                            loc("deep_dependency"),
-                            loc("sleep"),
-                        ]
-                    )
-                ),
+    # Thread Pool Executor
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        task_samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="Task-1",
+            locations=list(
+                reversed(
+                    [
+                        # loc("Task-1"),
+                        loc("main"),
+                        loc("asynchronous_function"),
+                        loc("async_generator"),
+                        loc("async_generator_dep"),
+                        loc("deep_dependency"),
+                        loc("sleep"),
+                    ]
+                )
             ),
-            print_samples_on_failure=True,
-        )
+        ),
+        print_samples_on_failure=True,
+    )

--- a/tests/profiling/collector/test_asyncio_async_generator.py
+++ b/tests/profiling/collector/test_asyncio_async_generator.py
@@ -1,23 +1,17 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_executor",
-    ),
-    err=None,
-)
-# For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
+@pytest.mark.subprocess
 def test_asyncio_executor_wall_time() -> None:
     import asyncio
-    import os
+    from typing import AsyncGenerator
 
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
-    from typing import AsyncGenerator
 
     async def deep_dependency() -> None:
         # This is a regular (non-generator) coroutine called
@@ -48,45 +42,44 @@ def test_asyncio_executor_wall_time() -> None:
     async def main() -> None:
         await asynchronous_function()
 
-    p = profiler.Profiler()
-    p.start()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler()
+        p.start()
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    loop.run_until_complete(main())
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(main())
 
-    p.stop()
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        task_samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(task_samples) > 0
 
-    task_samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(task_samples) > 0
+        def loc(f_name: str) -> pprof_utils.StackLocation:
+            return pprof_utils.StackLocation(function_name=f_name, filename="", line_no=-1)
 
-    def loc(f_name: str) -> pprof_utils.StackLocation:
-        return pprof_utils.StackLocation(function_name=f_name, filename="", line_no=-1)
-
-    # Thread Pool Executor
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        task_samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="Task-1",
-            locations=list(
-                reversed(
-                    [
-                        # loc("Task-1"),
-                        loc("main"),
-                        loc("asynchronous_function"),
-                        loc("async_generator"),
-                        loc("async_generator_dep"),
-                        loc("deep_dependency"),
-                        loc("sleep"),
-                    ]
-                )
+        # Thread Pool Executor
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            task_samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="Task-1",
+                locations=list(
+                    reversed(
+                        [
+                            # loc("Task-1"),
+                            loc("main"),
+                            loc("asynchronous_function"),
+                            loc("async_generator"),
+                            loc("async_generator_dep"),
+                            loc("deep_dependency"),
+                            loc("sleep"),
+                        ]
+                    )
+                ),
             ),
-        ),
-        print_samples_on_failure=True,
-    )
+            print_samples_on_failure=True,
+        )

--- a/tests/profiling/collector/test_asyncio_context_manager.py
+++ b/tests/profiling/collector/test_asyncio_context_manager.py
@@ -3,15 +3,11 @@ import pytest
 
 @pytest.mark.subprocess(
     env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_context_manager",
         _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED="0",
     ),
-    err=None,
 )
-# For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_asyncio_context_manager_wall_time() -> None:
     import asyncio
-    import os
     from sys import version_info as PYVERSION
     from types import TracebackType
     from typing import Union
@@ -19,6 +15,7 @@ def test_asyncio_context_manager_wall_time() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -47,191 +44,24 @@ def test_asyncio_context_manager_wall_time() -> None:
     async def main() -> None:
         await asynchronous_function()
 
-    p = profiler.Profiler()
-    p.start()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler()
+        p.start()
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    loop.run_until_complete(main())
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(main())
 
-    p.stop()
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0
 
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0
-
-    # Test that we see the context manager functions
-    if PYVERSION >= (3, 11):
-        # Context Manager Enter
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="sleep",
-                        filename="",
-                        line_no=-1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="context_manager_dep",
-                        filename="test_asyncio_context_manager.py",
-                        line_no=context_manager_dep.__code__.co_firstlineno + 1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="AsyncContextManager.__aenter__",
-                        filename="test_asyncio_context_manager.py",
-                        line_no=AsyncContextManager.__aenter__.__code__.co_firstlineno + 1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="asynchronous_function",
-                        filename="test_asyncio_context_manager.py",
-                        line_no=asynchronous_function.__code__.co_firstlineno + 1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="main",
-                        filename="test_asyncio_context_manager.py",
-                        line_no=main.__code__.co_firstlineno + 1,
-                    ),
-                ],
-            ),
-        )
-
-        # Actual function call
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="sleep",
-                        filename="",
-                        line_no=-1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="some_function",
-                        filename="test_asyncio_context_manager.py",
-                        line_no=some_function.__code__.co_firstlineno + 1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="asynchronous_function",
-                        filename="test_asyncio_context_manager.py",
-                        line_no=asynchronous_function.__code__.co_firstlineno + 2,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="main",
-                        filename="test_asyncio_context_manager.py",
-                        line_no=main.__code__.co_firstlineno + 1,
-                    ),
-                ],
-            ),
-        )
-
-        # Context Manager Exit
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="sleep",
-                        filename="",
-                        line_no=-1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="AsyncContextManager.__aexit__",
-                        filename="test_asyncio_context_manager.py",
-                        line_no=AsyncContextManager.__aexit__.__code__.co_firstlineno + 6,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="asynchronous_function",
-                        filename="test_asyncio_context_manager.py",
-                        line_no=asynchronous_function.__code__.co_firstlineno + 1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="main",
-                        filename="test_asyncio_context_manager.py",
-                        line_no=main.__code__.co_firstlineno + 1,
-                    ),
-                ],
-            ),
-        )
-    else:
-        # Context Manager Enter
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="sleep",
-                        filename="",
-                        line_no=-1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="context_manager_dep",
-                        filename="test_asyncio_context_manager.py",
-                        line_no=context_manager_dep.__code__.co_firstlineno + 1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="__aenter__",
-                        filename="test_asyncio_context_manager.py",
-                        line_no=AsyncContextManager.__aenter__.__code__.co_firstlineno + 1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="asynchronous_function",
-                        filename="test_asyncio_context_manager.py",
-                        line_no=asynchronous_function.__code__.co_firstlineno + 1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="main",
-                        filename="test_asyncio_context_manager.py",
-                        line_no=main.__code__.co_firstlineno + 1,
-                    ),
-                ],
-            ),
-        )
-
-        # Actual function call
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="sleep",
-                        filename="",
-                        line_no=-1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="some_function",
-                        filename="test_asyncio_context_manager.py",
-                        line_no=some_function.__code__.co_firstlineno + 1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="asynchronous_function",
-                        filename="test_asyncio_context_manager.py",
-                        line_no=asynchronous_function.__code__.co_firstlineno + 2,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="main",
-                        filename="test_asyncio_context_manager.py",
-                        line_no=main.__code__.co_firstlineno + 1,
-                    ),
-                ],
-            ),
-        )
-
-        # Context Manager Exit
-        if PYVERSION >= (3, 10):
+        # Test that we see the context manager functions
+        if PYVERSION >= (3, 11):
+            # Context Manager Enter
             pprof_utils.assert_profile_has_sample(
                 profile,
                 samples,
@@ -244,7 +74,74 @@ def test_asyncio_context_manager_wall_time() -> None:
                             line_no=-1,
                         ),
                         pprof_utils.StackLocation(
-                            function_name="__aexit__",
+                            function_name="context_manager_dep",
+                            filename="test_asyncio_context_manager.py",
+                            line_no=context_manager_dep.__code__.co_firstlineno + 1,
+                        ),
+                        pprof_utils.StackLocation(
+                            function_name="AsyncContextManager.__aenter__",
+                            filename="test_asyncio_context_manager.py",
+                            line_no=AsyncContextManager.__aenter__.__code__.co_firstlineno + 1,
+                        ),
+                        pprof_utils.StackLocation(
+                            function_name="asynchronous_function",
+                            filename="test_asyncio_context_manager.py",
+                            line_no=asynchronous_function.__code__.co_firstlineno + 1,
+                        ),
+                        pprof_utils.StackLocation(
+                            function_name="main",
+                            filename="test_asyncio_context_manager.py",
+                            line_no=main.__code__.co_firstlineno + 1,
+                        ),
+                    ],
+                ),
+            )
+
+            # Actual function call
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples,
+                expected_sample=pprof_utils.StackEvent(
+                    thread_name="MainThread",
+                    locations=[
+                        pprof_utils.StackLocation(
+                            function_name="sleep",
+                            filename="",
+                            line_no=-1,
+                        ),
+                        pprof_utils.StackLocation(
+                            function_name="some_function",
+                            filename="test_asyncio_context_manager.py",
+                            line_no=some_function.__code__.co_firstlineno + 1,
+                        ),
+                        pprof_utils.StackLocation(
+                            function_name="asynchronous_function",
+                            filename="test_asyncio_context_manager.py",
+                            line_no=asynchronous_function.__code__.co_firstlineno + 2,
+                        ),
+                        pprof_utils.StackLocation(
+                            function_name="main",
+                            filename="test_asyncio_context_manager.py",
+                            line_no=main.__code__.co_firstlineno + 1,
+                        ),
+                    ],
+                ),
+            )
+
+            # Context Manager Exit
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples,
+                expected_sample=pprof_utils.StackEvent(
+                    thread_name="MainThread",
+                    locations=[
+                        pprof_utils.StackLocation(
+                            function_name="sleep",
+                            filename="",
+                            line_no=-1,
+                        ),
+                        pprof_utils.StackLocation(
+                            function_name="AsyncContextManager.__aexit__",
                             filename="test_asyncio_context_manager.py",
                             line_no=AsyncContextManager.__aexit__.__code__.co_firstlineno + 6,
                         ),
@@ -262,6 +159,7 @@ def test_asyncio_context_manager_wall_time() -> None:
                 ),
             )
         else:
+            # Context Manager Enter
             pprof_utils.assert_profile_has_sample(
                 profile,
                 samples,
@@ -274,9 +172,45 @@ def test_asyncio_context_manager_wall_time() -> None:
                             line_no=-1,
                         ),
                         pprof_utils.StackLocation(
-                            function_name="__aexit__",
+                            function_name="context_manager_dep",
                             filename="test_asyncio_context_manager.py",
-                            line_no=AsyncContextManager.__aexit__.__code__.co_firstlineno + 6,
+                            line_no=context_manager_dep.__code__.co_firstlineno + 1,
+                        ),
+                        pprof_utils.StackLocation(
+                            function_name="__aenter__",
+                            filename="test_asyncio_context_manager.py",
+                            line_no=AsyncContextManager.__aenter__.__code__.co_firstlineno + 1,
+                        ),
+                        pprof_utils.StackLocation(
+                            function_name="asynchronous_function",
+                            filename="test_asyncio_context_manager.py",
+                            line_no=asynchronous_function.__code__.co_firstlineno + 1,
+                        ),
+                        pprof_utils.StackLocation(
+                            function_name="main",
+                            filename="test_asyncio_context_manager.py",
+                            line_no=main.__code__.co_firstlineno + 1,
+                        ),
+                    ],
+                ),
+            )
+
+            # Actual function call
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples,
+                expected_sample=pprof_utils.StackEvent(
+                    thread_name="MainThread",
+                    locations=[
+                        pprof_utils.StackLocation(
+                            function_name="sleep",
+                            filename="",
+                            line_no=-1,
+                        ),
+                        pprof_utils.StackLocation(
+                            function_name="some_function",
+                            filename="test_asyncio_context_manager.py",
+                            line_no=some_function.__code__.co_firstlineno + 1,
                         ),
                         pprof_utils.StackLocation(
                             function_name="asynchronous_function",
@@ -291,3 +225,65 @@ def test_asyncio_context_manager_wall_time() -> None:
                     ],
                 ),
             )
+
+            # Context Manager Exit
+            if PYVERSION >= (3, 10):
+                pprof_utils.assert_profile_has_sample(
+                    profile,
+                    samples,
+                    expected_sample=pprof_utils.StackEvent(
+                        thread_name="MainThread",
+                        locations=[
+                            pprof_utils.StackLocation(
+                                function_name="sleep",
+                                filename="",
+                                line_no=-1,
+                            ),
+                            pprof_utils.StackLocation(
+                                function_name="__aexit__",
+                                filename="test_asyncio_context_manager.py",
+                                line_no=AsyncContextManager.__aexit__.__code__.co_firstlineno + 6,
+                            ),
+                            pprof_utils.StackLocation(
+                                function_name="asynchronous_function",
+                                filename="test_asyncio_context_manager.py",
+                                line_no=asynchronous_function.__code__.co_firstlineno + 1,
+                            ),
+                            pprof_utils.StackLocation(
+                                function_name="main",
+                                filename="test_asyncio_context_manager.py",
+                                line_no=main.__code__.co_firstlineno + 1,
+                            ),
+                        ],
+                    ),
+                )
+            else:
+                pprof_utils.assert_profile_has_sample(
+                    profile,
+                    samples,
+                    expected_sample=pprof_utils.StackEvent(
+                        thread_name="MainThread",
+                        locations=[
+                            pprof_utils.StackLocation(
+                                function_name="sleep",
+                                filename="",
+                                line_no=-1,
+                            ),
+                            pprof_utils.StackLocation(
+                                function_name="__aexit__",
+                                filename="test_asyncio_context_manager.py",
+                                line_no=AsyncContextManager.__aexit__.__code__.co_firstlineno + 6,
+                            ),
+                            pprof_utils.StackLocation(
+                                function_name="asynchronous_function",
+                                filename="test_asyncio_context_manager.py",
+                                line_no=asynchronous_function.__code__.co_firstlineno + 2,
+                            ),
+                            pprof_utils.StackLocation(
+                                function_name="main",
+                                filename="test_asyncio_context_manager.py",
+                                line_no=main.__code__.co_firstlineno + 1,
+                            ),
+                        ],
+                    ),
+                )

--- a/tests/profiling/collector/test_asyncio_context_manager.py
+++ b/tests/profiling/collector/test_asyncio_context_manager.py
@@ -15,7 +15,6 @@ def test_asyncio_context_manager_wall_time() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -44,24 +43,189 @@ def test_asyncio_context_manager_wall_time() -> None:
     async def main() -> None:
         await asynchronous_function()
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler()
-        p.start()
+    p = profiler.Profiler()
+    p.start()
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(main())
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(main())
 
-        p.stop()
+    p.stop()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0
 
-        # Test that we see the context manager functions
-        if PYVERSION >= (3, 11):
-            # Context Manager Enter
+    # Test that we see the context manager functions
+    if PYVERSION >= (3, 11):
+        # Context Manager Enter
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="sleep",
+                        filename="",
+                        line_no=-1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="context_manager_dep",
+                        filename="test_asyncio_context_manager.py",
+                        line_no=context_manager_dep.__code__.co_firstlineno + 1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="AsyncContextManager.__aenter__",
+                        filename="test_asyncio_context_manager.py",
+                        line_no=AsyncContextManager.__aenter__.__code__.co_firstlineno + 1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="asynchronous_function",
+                        filename="test_asyncio_context_manager.py",
+                        line_no=asynchronous_function.__code__.co_firstlineno + 1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="main",
+                        filename="test_asyncio_context_manager.py",
+                        line_no=main.__code__.co_firstlineno + 1,
+                    ),
+                ],
+            ),
+        )
+
+        # Actual function call
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="sleep",
+                        filename="",
+                        line_no=-1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="some_function",
+                        filename="test_asyncio_context_manager.py",
+                        line_no=some_function.__code__.co_firstlineno + 1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="asynchronous_function",
+                        filename="test_asyncio_context_manager.py",
+                        line_no=asynchronous_function.__code__.co_firstlineno + 2,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="main",
+                        filename="test_asyncio_context_manager.py",
+                        line_no=main.__code__.co_firstlineno + 1,
+                    ),
+                ],
+            ),
+        )
+
+        # Context Manager Exit
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="sleep",
+                        filename="",
+                        line_no=-1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="AsyncContextManager.__aexit__",
+                        filename="test_asyncio_context_manager.py",
+                        line_no=AsyncContextManager.__aexit__.__code__.co_firstlineno + 6,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="asynchronous_function",
+                        filename="test_asyncio_context_manager.py",
+                        line_no=asynchronous_function.__code__.co_firstlineno + 1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="main",
+                        filename="test_asyncio_context_manager.py",
+                        line_no=main.__code__.co_firstlineno + 1,
+                    ),
+                ],
+            ),
+        )
+    else:
+        # Context Manager Enter
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="sleep",
+                        filename="",
+                        line_no=-1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="context_manager_dep",
+                        filename="test_asyncio_context_manager.py",
+                        line_no=context_manager_dep.__code__.co_firstlineno + 1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="__aenter__",
+                        filename="test_asyncio_context_manager.py",
+                        line_no=AsyncContextManager.__aenter__.__code__.co_firstlineno + 1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="asynchronous_function",
+                        filename="test_asyncio_context_manager.py",
+                        line_no=asynchronous_function.__code__.co_firstlineno + 1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="main",
+                        filename="test_asyncio_context_manager.py",
+                        line_no=main.__code__.co_firstlineno + 1,
+                    ),
+                ],
+            ),
+        )
+
+        # Actual function call
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="sleep",
+                        filename="",
+                        line_no=-1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="some_function",
+                        filename="test_asyncio_context_manager.py",
+                        line_no=some_function.__code__.co_firstlineno + 1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="asynchronous_function",
+                        filename="test_asyncio_context_manager.py",
+                        line_no=asynchronous_function.__code__.co_firstlineno + 2,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="main",
+                        filename="test_asyncio_context_manager.py",
+                        line_no=main.__code__.co_firstlineno + 1,
+                    ),
+                ],
+            ),
+        )
+
+        # Context Manager Exit
+        if PYVERSION >= (3, 10):
             pprof_utils.assert_profile_has_sample(
                 profile,
                 samples,
@@ -74,74 +238,7 @@ def test_asyncio_context_manager_wall_time() -> None:
                             line_no=-1,
                         ),
                         pprof_utils.StackLocation(
-                            function_name="context_manager_dep",
-                            filename="test_asyncio_context_manager.py",
-                            line_no=context_manager_dep.__code__.co_firstlineno + 1,
-                        ),
-                        pprof_utils.StackLocation(
-                            function_name="AsyncContextManager.__aenter__",
-                            filename="test_asyncio_context_manager.py",
-                            line_no=AsyncContextManager.__aenter__.__code__.co_firstlineno + 1,
-                        ),
-                        pprof_utils.StackLocation(
-                            function_name="asynchronous_function",
-                            filename="test_asyncio_context_manager.py",
-                            line_no=asynchronous_function.__code__.co_firstlineno + 1,
-                        ),
-                        pprof_utils.StackLocation(
-                            function_name="main",
-                            filename="test_asyncio_context_manager.py",
-                            line_no=main.__code__.co_firstlineno + 1,
-                        ),
-                    ],
-                ),
-            )
-
-            # Actual function call
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_name="MainThread",
-                    locations=[
-                        pprof_utils.StackLocation(
-                            function_name="sleep",
-                            filename="",
-                            line_no=-1,
-                        ),
-                        pprof_utils.StackLocation(
-                            function_name="some_function",
-                            filename="test_asyncio_context_manager.py",
-                            line_no=some_function.__code__.co_firstlineno + 1,
-                        ),
-                        pprof_utils.StackLocation(
-                            function_name="asynchronous_function",
-                            filename="test_asyncio_context_manager.py",
-                            line_no=asynchronous_function.__code__.co_firstlineno + 2,
-                        ),
-                        pprof_utils.StackLocation(
-                            function_name="main",
-                            filename="test_asyncio_context_manager.py",
-                            line_no=main.__code__.co_firstlineno + 1,
-                        ),
-                    ],
-                ),
-            )
-
-            # Context Manager Exit
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_name="MainThread",
-                    locations=[
-                        pprof_utils.StackLocation(
-                            function_name="sleep",
-                            filename="",
-                            line_no=-1,
-                        ),
-                        pprof_utils.StackLocation(
-                            function_name="AsyncContextManager.__aexit__",
+                            function_name="__aexit__",
                             filename="test_asyncio_context_manager.py",
                             line_no=AsyncContextManager.__aexit__.__code__.co_firstlineno + 6,
                         ),
@@ -159,7 +256,6 @@ def test_asyncio_context_manager_wall_time() -> None:
                 ),
             )
         else:
-            # Context Manager Enter
             pprof_utils.assert_profile_has_sample(
                 profile,
                 samples,
@@ -172,45 +268,9 @@ def test_asyncio_context_manager_wall_time() -> None:
                             line_no=-1,
                         ),
                         pprof_utils.StackLocation(
-                            function_name="context_manager_dep",
+                            function_name="__aexit__",
                             filename="test_asyncio_context_manager.py",
-                            line_no=context_manager_dep.__code__.co_firstlineno + 1,
-                        ),
-                        pprof_utils.StackLocation(
-                            function_name="__aenter__",
-                            filename="test_asyncio_context_manager.py",
-                            line_no=AsyncContextManager.__aenter__.__code__.co_firstlineno + 1,
-                        ),
-                        pprof_utils.StackLocation(
-                            function_name="asynchronous_function",
-                            filename="test_asyncio_context_manager.py",
-                            line_no=asynchronous_function.__code__.co_firstlineno + 1,
-                        ),
-                        pprof_utils.StackLocation(
-                            function_name="main",
-                            filename="test_asyncio_context_manager.py",
-                            line_no=main.__code__.co_firstlineno + 1,
-                        ),
-                    ],
-                ),
-            )
-
-            # Actual function call
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_name="MainThread",
-                    locations=[
-                        pprof_utils.StackLocation(
-                            function_name="sleep",
-                            filename="",
-                            line_no=-1,
-                        ),
-                        pprof_utils.StackLocation(
-                            function_name="some_function",
-                            filename="test_asyncio_context_manager.py",
-                            line_no=some_function.__code__.co_firstlineno + 1,
+                            line_no=AsyncContextManager.__aexit__.__code__.co_firstlineno + 6,
                         ),
                         pprof_utils.StackLocation(
                             function_name="asynchronous_function",
@@ -225,65 +285,3 @@ def test_asyncio_context_manager_wall_time() -> None:
                     ],
                 ),
             )
-
-            # Context Manager Exit
-            if PYVERSION >= (3, 10):
-                pprof_utils.assert_profile_has_sample(
-                    profile,
-                    samples,
-                    expected_sample=pprof_utils.StackEvent(
-                        thread_name="MainThread",
-                        locations=[
-                            pprof_utils.StackLocation(
-                                function_name="sleep",
-                                filename="",
-                                line_no=-1,
-                            ),
-                            pprof_utils.StackLocation(
-                                function_name="__aexit__",
-                                filename="test_asyncio_context_manager.py",
-                                line_no=AsyncContextManager.__aexit__.__code__.co_firstlineno + 6,
-                            ),
-                            pprof_utils.StackLocation(
-                                function_name="asynchronous_function",
-                                filename="test_asyncio_context_manager.py",
-                                line_no=asynchronous_function.__code__.co_firstlineno + 1,
-                            ),
-                            pprof_utils.StackLocation(
-                                function_name="main",
-                                filename="test_asyncio_context_manager.py",
-                                line_no=main.__code__.co_firstlineno + 1,
-                            ),
-                        ],
-                    ),
-                )
-            else:
-                pprof_utils.assert_profile_has_sample(
-                    profile,
-                    samples,
-                    expected_sample=pprof_utils.StackEvent(
-                        thread_name="MainThread",
-                        locations=[
-                            pprof_utils.StackLocation(
-                                function_name="sleep",
-                                filename="",
-                                line_no=-1,
-                            ),
-                            pprof_utils.StackLocation(
-                                function_name="__aexit__",
-                                filename="test_asyncio_context_manager.py",
-                                line_no=AsyncContextManager.__aexit__.__code__.co_firstlineno + 6,
-                            ),
-                            pprof_utils.StackLocation(
-                                function_name="asynchronous_function",
-                                filename="test_asyncio_context_manager.py",
-                                line_no=asynchronous_function.__code__.co_firstlineno + 2,
-                            ),
-                            pprof_utils.StackLocation(
-                                function_name="main",
-                                filename="test_asyncio_context_manager.py",
-                                line_no=main.__code__.co_firstlineno + 1,
-                            ),
-                        ],
-                    ),
-                )

--- a/tests/profiling/collector/test_asyncio_coroutines.py
+++ b/tests/profiling/collector/test_asyncio_coroutines.py
@@ -10,7 +10,6 @@ def test_asyncio_coroutines() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -48,104 +47,103 @@ def test_asyncio_coroutines() -> None:
         await background_task
         await math_task
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler()
-        p.start()
+    p = profiler.Profiler()
+    p.start()
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
 
-        main_task = loop.create_task(outer_function(), name="main")
-        loop.run_until_complete(main_task)
+    main_task = loop.create_task(outer_function(), name="main")
+    loop.run_until_complete(main_task)
 
-        p.stop()
+    p.stop()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
-        wall_time_samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
-        samples = wall_time_samples
+    wall_time_samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
+    samples = wall_time_samples
 
-        # Test that we see the sub_coro function
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="main",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="sleep",
-                        filename="",
-                        line_no=-1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="sub_coro",
-                        filename="test_asyncio_coroutines.py",
-                        line_no=sub_coro.__code__.co_firstlineno + 3,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="main_coro",
-                        filename="test_asyncio_coroutines.py",
-                        line_no=main_coro.__code__.co_firstlineno + 1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="outer_function",
-                        filename="test_asyncio_coroutines.py",
-                        line_no=outer_function.__code__.co_firstlineno + 5,
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    # Test that we see the sub_coro function
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="main",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="sleep",
+                    filename="",
+                    line_no=-1,
+                ),
+                pprof_utils.StackLocation(
+                    function_name="sub_coro",
+                    filename="test_asyncio_coroutines.py",
+                    line_no=sub_coro.__code__.co_firstlineno + 3,
+                ),
+                pprof_utils.StackLocation(
+                    function_name="main_coro",
+                    filename="test_asyncio_coroutines.py",
+                    line_no=main_coro.__code__.co_firstlineno + 1,
+                ),
+                pprof_utils.StackLocation(
+                    function_name="outer_function",
+                    filename="test_asyncio_coroutines.py",
+                    line_no=outer_function.__code__.co_firstlineno + 5,
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
-        # Test that we see the background_task_func task
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="background_wait",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="sleep",
-                        filename="",
-                        line_no=-1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="background_task_func",
-                        filename="test_asyncio_coroutines.py",
-                        line_no=background_task_func.__code__.co_firstlineno + 1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="outer_function",
-                        filename="test_asyncio_coroutines.py",
-                        line_no=outer_function.__code__.co_firstlineno + 7,
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    # Test that we see the background_task_func task
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="background_wait",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="sleep",
+                    filename="",
+                    line_no=-1,
+                ),
+                pprof_utils.StackLocation(
+                    function_name="background_task_func",
+                    filename="test_asyncio_coroutines.py",
+                    line_no=background_task_func.__code__.co_firstlineno + 1,
+                ),
+                pprof_utils.StackLocation(
+                    function_name="outer_function",
+                    filename="test_asyncio_coroutines.py",
+                    line_no=outer_function.__code__.co_firstlineno + 7,
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
-        # Test that we see the background_math_function task in stack (wall-time) samples
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            wall_time_samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="background_math",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="background_math_function",
-                        filename="test_asyncio_coroutines.py",
-                        line_no=-1,  # any line
-                    ),
-                    # TODO: We should see outer_function, but for some reason we simply do not...
-                    # pprof_utils.StackLocation(
-                    #     function_name="outer_function",
-                    #     filename="test_asyncio_coroutines.py",
-                    #     line_no=outer_function.__code__.co_firstlineno + 9,
-                    # ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    # Test that we see the background_math_function task in stack (wall-time) samples
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        wall_time_samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="background_math",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="background_math_function",
+                    filename="test_asyncio_coroutines.py",
+                    line_no=-1,  # any line
+                ),
+                # TODO: We should see outer_function, but for some reason we simply do not...
+                # pprof_utils.StackLocation(
+                #     function_name="outer_function",
+                #     filename="test_asyncio_coroutines.py",
+                #     line_no=outer_function.__code__.co_firstlineno + 9,
+                # ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )

--- a/tests/profiling/collector/test_asyncio_coroutines.py
+++ b/tests/profiling/collector/test_asyncio_coroutines.py
@@ -1,22 +1,16 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_coroutines",
-    ),
-    err=None,
-)
-# For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
+@pytest.mark.subprocess
 def test_asyncio_coroutines() -> None:
     import asyncio
     import math
-    import os
     import time
 
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -54,105 +48,104 @@ def test_asyncio_coroutines() -> None:
         await background_task
         await math_task
 
-    p = profiler.Profiler()
-    p.start()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler()
+        p.start()
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
-    main_task = loop.create_task(outer_function(), name="main")
-    loop.run_until_complete(main_task)
+        main_task = loop.create_task(outer_function(), name="main")
+        loop.run_until_complete(main_task)
 
-    p.stop()
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        wall_time_samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
+        samples = wall_time_samples
 
-    wall_time_samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
-    samples = wall_time_samples
+        # Test that we see the sub_coro function
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="main",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="sleep",
+                        filename="",
+                        line_no=-1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="sub_coro",
+                        filename="test_asyncio_coroutines.py",
+                        line_no=sub_coro.__code__.co_firstlineno + 3,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="main_coro",
+                        filename="test_asyncio_coroutines.py",
+                        line_no=main_coro.__code__.co_firstlineno + 1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="outer_function",
+                        filename="test_asyncio_coroutines.py",
+                        line_no=outer_function.__code__.co_firstlineno + 5,
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
-    # Test that we see the sub_coro function
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="main",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="sleep",
-                    filename="",
-                    line_no=-1,
-                ),
-                pprof_utils.StackLocation(
-                    function_name="sub_coro",
-                    filename="test_asyncio_coroutines.py",
-                    line_no=sub_coro.__code__.co_firstlineno + 3,
-                ),
-                pprof_utils.StackLocation(
-                    function_name="main_coro",
-                    filename="test_asyncio_coroutines.py",
-                    line_no=main_coro.__code__.co_firstlineno + 1,
-                ),
-                pprof_utils.StackLocation(
-                    function_name="outer_function",
-                    filename="test_asyncio_coroutines.py",
-                    line_no=outer_function.__code__.co_firstlineno + 5,
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        # Test that we see the background_task_func task
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="background_wait",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="sleep",
+                        filename="",
+                        line_no=-1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="background_task_func",
+                        filename="test_asyncio_coroutines.py",
+                        line_no=background_task_func.__code__.co_firstlineno + 1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="outer_function",
+                        filename="test_asyncio_coroutines.py",
+                        line_no=outer_function.__code__.co_firstlineno + 7,
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
-    # Test that we see the background_task_func task
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="background_wait",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="sleep",
-                    filename="",
-                    line_no=-1,
-                ),
-                pprof_utils.StackLocation(
-                    function_name="background_task_func",
-                    filename="test_asyncio_coroutines.py",
-                    line_no=background_task_func.__code__.co_firstlineno + 1,
-                ),
-                pprof_utils.StackLocation(
-                    function_name="outer_function",
-                    filename="test_asyncio_coroutines.py",
-                    line_no=outer_function.__code__.co_firstlineno + 7,
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
-
-    # Test that we see the background_math_function task in stack (wall-time) samples
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        wall_time_samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="background_math",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="background_math_function",
-                    filename="test_asyncio_coroutines.py",
-                    line_no=-1,  # any line
-                ),
-                # TODO: We should see outer_function, but for some reason we simply do not...
-                # pprof_utils.StackLocation(
-                #     function_name="outer_function",
-                #     filename="test_asyncio_coroutines.py",
-                #     line_no=outer_function.__code__.co_firstlineno + 9,
-                # ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        # Test that we see the background_math_function task in stack (wall-time) samples
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            wall_time_samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="background_math",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="background_math_function",
+                        filename="test_asyncio_coroutines.py",
+                        line_no=-1,  # any line
+                    ),
+                    # TODO: We should see outer_function, but for some reason we simply do not...
+                    # pprof_utils.StackLocation(
+                    #     function_name="outer_function",
+                    #     filename="test_asyncio_coroutines.py",
+                    #     line_no=outer_function.__code__.co_firstlineno + 9,
+                    # ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )

--- a/tests/profiling/collector/test_asyncio_deadlock.py
+++ b/tests/profiling/collector/test_asyncio_deadlock.py
@@ -1,19 +1,14 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_deadlock",
-    ),
-    err=None,
-)
-# For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
+@pytest.mark.subprocess
 def test_asyncio_deadlock() -> None:
     import asyncio
     from typing import Optional
 
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -53,14 +48,15 @@ def test_asyncio_deadlock() -> None:
         except RecursionError:
             pass
 
-    p = profiler.Profiler()
-    p.start()
+    with with_profiling_test_agent():
+        p = profiler.Profiler()
+        p.start()
 
-    try:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(main())
-    except RecursionError:
-        pass
+        try:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            loop.run_until_complete(main())
+        except RecursionError:
+            pass
 
-    p.stop()
+        p.stop()

--- a/tests/profiling/collector/test_asyncio_deadlock.py
+++ b/tests/profiling/collector/test_asyncio_deadlock.py
@@ -8,7 +8,6 @@ def test_asyncio_deadlock() -> None:
 
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -48,15 +47,14 @@ def test_asyncio_deadlock() -> None:
         except RecursionError:
             pass
 
-    with with_profiling_test_agent():
-        p = profiler.Profiler()
-        p.start()
+    p = profiler.Profiler()
+    p.start()
 
-        try:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            loop.run_until_complete(main())
-        except RecursionError:
-            pass
+    try:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(main())
+    except RecursionError:
+        pass
 
-        p.stop()
+    p.stop()

--- a/tests/profiling/collector/test_asyncio_executor.py
+++ b/tests/profiling/collector/test_asyncio_executor.py
@@ -7,6 +7,10 @@ def test_asyncio_executor_wall_time() -> None:
     import os
     from sys import version_info as PYVERSION
     import time
+    import warnings
+
+    # Need to filter deprecation warnings from asyncio
+    warnings.filterwarnings("ignore", message=".*iscoroutinefunction.*", category=DeprecationWarning)
 
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler

--- a/tests/profiling/collector/test_asyncio_executor.py
+++ b/tests/profiling/collector/test_asyncio_executor.py
@@ -12,7 +12,6 @@ def test_asyncio_executor_wall_time() -> None:
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_utils import async_run
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -25,138 +24,137 @@ def test_asyncio_executor_wall_time() -> None:
     async def main() -> None:
         await asynchronous_function()
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler()
-        p.start()
+    p = profiler.Profiler()
+    p.start()
 
-        async_run(main())
+    async_run(main())
 
-        p.stop()
+    p.stop()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
-        task_samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(task_samples) > 0
+    task_samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(task_samples) > 0
 
-        # Test that we see the asynchronous function stack
+    # Test that we see the asynchronous function stack
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        task_samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="asynchronous_function",
+                    filename="test_asyncio_executor.py",
+                    line_no=asynchronous_function.__code__.co_firstlineno + 1,
+                ),
+            ],
+        ),
+    )
+
+    samples = pprof_utils.get_samples_with_label_key(profile, "thread name")
+    assert len(samples) > 0
+
+    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+
+    # uvloop uses ThreadPoolExecutor naming instead of asyncio naming
+    if use_uvloop:
+        executor_thread_name = "ThreadPoolExecutor-0_0"
+    elif PYVERSION >= (3, 9):
+        executor_thread_name = "asyncio_0"
+    else:
+        executor_thread_name = "ThreadPoolExecutor-0_0"
+
+    if PYVERSION >= (3, 11):
+        # Thread Pool Executor
         pprof_utils.assert_profile_has_sample(
             profile,
-            task_samples,
+            samples,
             expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
+                thread_name=executor_thread_name,
                 locations=[
                     pprof_utils.StackLocation(
-                        function_name="asynchronous_function",
+                        function_name="slow_sync_function",
                         filename="test_asyncio_executor.py",
-                        line_no=asynchronous_function.__code__.co_firstlineno + 1,
+                        line_no=slow_sync_function.__code__.co_firstlineno + 1,
+                    ),
+                    # pprof_utils.StackLocation(
+                    #     function_name="_WorkItem.run",
+                    #     filename="",
+                    #     line_no=-1,
+                    # ),
+                    # pprof_utils.StackLocation(
+                    #     function_name="_worker",
+                    #     filename="",
+                    #     line_no=-1,
+                    # ),
+                    # pprof_utils.StackLocation(
+                    #     function_name="Thread.run",
+                    #     filename="",
+                    #     line_no=-1,
+                    # ),
+                ],
+            ),
+        )
+    elif PYVERSION >= (3, 9):
+        # Thread Pool Executor
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name=executor_thread_name,
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="slow_sync_function",
+                        filename="test_asyncio_executor.py",
+                        line_no=slow_sync_function.__code__.co_firstlineno + 1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="run",
+                        filename="",
+                        line_no=-1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="_worker",
+                        filename="",
+                        line_no=-1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="run",
+                        filename="",
+                        line_no=-1,
                     ),
                 ],
             ),
         )
-
-        samples = pprof_utils.get_samples_with_label_key(profile, "thread name")
-        assert len(samples) > 0
-
-        use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
-
-        # uvloop uses ThreadPoolExecutor naming instead of asyncio naming
-        if use_uvloop:
-            executor_thread_name = "ThreadPoolExecutor-0_0"
-        elif PYVERSION >= (3, 9):
-            executor_thread_name = "asyncio_0"
-        else:
-            executor_thread_name = "ThreadPoolExecutor-0_0"
-
-        if PYVERSION >= (3, 11):
-            # Thread Pool Executor
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_name=executor_thread_name,
-                    locations=[
-                        pprof_utils.StackLocation(
-                            function_name="slow_sync_function",
-                            filename="test_asyncio_executor.py",
-                            line_no=slow_sync_function.__code__.co_firstlineno + 1,
-                        ),
-                        # pprof_utils.StackLocation(
-                        #     function_name="_WorkItem.run",
-                        #     filename="",
-                        #     line_no=-1,
-                        # ),
-                        # pprof_utils.StackLocation(
-                        #     function_name="_worker",
-                        #     filename="",
-                        #     line_no=-1,
-                        # ),
-                        # pprof_utils.StackLocation(
-                        #     function_name="Thread.run",
-                        #     filename="",
-                        #     line_no=-1,
-                        # ),
-                    ],
-                ),
-            )
-        elif PYVERSION >= (3, 9):
-            # Thread Pool Executor
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_name=executor_thread_name,
-                    locations=[
-                        pprof_utils.StackLocation(
-                            function_name="slow_sync_function",
-                            filename="test_asyncio_executor.py",
-                            line_no=slow_sync_function.__code__.co_firstlineno + 1,
-                        ),
-                        pprof_utils.StackLocation(
-                            function_name="run",
-                            filename="",
-                            line_no=-1,
-                        ),
-                        pprof_utils.StackLocation(
-                            function_name="_worker",
-                            filename="",
-                            line_no=-1,
-                        ),
-                        pprof_utils.StackLocation(
-                            function_name="run",
-                            filename="",
-                            line_no=-1,
-                        ),
-                    ],
-                ),
-            )
-        else:
-            # Thread Pool Executor
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_name=executor_thread_name,
-                    locations=[
-                        pprof_utils.StackLocation(
-                            function_name="slow_sync_function",
-                            filename="test_asyncio_executor.py",
-                            line_no=slow_sync_function.__code__.co_firstlineno + 1,
-                        ),
-                        pprof_utils.StackLocation(
-                            function_name="run",
-                            filename="",
-                            line_no=-1,
-                        ),
-                        pprof_utils.StackLocation(
-                            function_name="_worker",
-                            filename="",
-                            line_no=-1,
-                        ),
-                        pprof_utils.StackLocation(
-                            function_name="run",
-                            filename="",
-                            line_no=-1,
-                        ),
-                    ],
-                ),
-            )
+    else:
+        # Thread Pool Executor
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name=executor_thread_name,
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="slow_sync_function",
+                        filename="test_asyncio_executor.py",
+                        line_no=slow_sync_function.__code__.co_firstlineno + 1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="run",
+                        filename="",
+                        line_no=-1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="_worker",
+                        filename="",
+                        line_no=-1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="run",
+                        filename="",
+                        line_no=-1,
+                    ),
+                ],
+            ),
+        )

--- a/tests/profiling/collector/test_asyncio_executor.py
+++ b/tests/profiling/collector/test_asyncio_executor.py
@@ -1,13 +1,7 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_executor",
-    ),
-    err=None,
-)
-# For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
+@pytest.mark.subprocess
 def test_asyncio_executor_wall_time() -> None:
     import asyncio
     import os
@@ -18,6 +12,7 @@ def test_asyncio_executor_wall_time() -> None:
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_utils import async_run
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -30,139 +25,138 @@ def test_asyncio_executor_wall_time() -> None:
     async def main() -> None:
         await asynchronous_function()
 
-    p = profiler.Profiler()
-    p.start()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler()
+        p.start()
 
-    async_run(main())
+        async_run(main())
 
-    p.stop()
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        task_samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(task_samples) > 0
 
-    task_samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(task_samples) > 0
+        # Test that we see the asynchronous function stack
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            task_samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="asynchronous_function",
+                        filename="test_asyncio_executor.py",
+                        line_no=asynchronous_function.__code__.co_firstlineno + 1,
+                    ),
+                ],
+            ),
+        )
 
-    # Test that we see the asynchronous function stack
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        task_samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="asynchronous_function",
-                    filename="test_asyncio_executor.py",
-                    line_no=asynchronous_function.__code__.co_firstlineno + 1,
+        samples = pprof_utils.get_samples_with_label_key(profile, "thread name")
+        assert len(samples) > 0
+
+        use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+
+        # uvloop uses ThreadPoolExecutor naming instead of asyncio naming
+        if use_uvloop:
+            executor_thread_name = "ThreadPoolExecutor-0_0"
+        elif PYVERSION >= (3, 9):
+            executor_thread_name = "asyncio_0"
+        else:
+            executor_thread_name = "ThreadPoolExecutor-0_0"
+
+        if PYVERSION >= (3, 11):
+            # Thread Pool Executor
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples,
+                expected_sample=pprof_utils.StackEvent(
+                    thread_name=executor_thread_name,
+                    locations=[
+                        pprof_utils.StackLocation(
+                            function_name="slow_sync_function",
+                            filename="test_asyncio_executor.py",
+                            line_no=slow_sync_function.__code__.co_firstlineno + 1,
+                        ),
+                        # pprof_utils.StackLocation(
+                        #     function_name="_WorkItem.run",
+                        #     filename="",
+                        #     line_no=-1,
+                        # ),
+                        # pprof_utils.StackLocation(
+                        #     function_name="_worker",
+                        #     filename="",
+                        #     line_no=-1,
+                        # ),
+                        # pprof_utils.StackLocation(
+                        #     function_name="Thread.run",
+                        #     filename="",
+                        #     line_no=-1,
+                        # ),
+                    ],
                 ),
-            ],
-        ),
-    )
-
-    samples = pprof_utils.get_samples_with_label_key(profile, "thread name")
-    assert len(samples) > 0
-
-    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
-
-    # uvloop uses ThreadPoolExecutor naming instead of asyncio naming
-    if use_uvloop:
-        executor_thread_name = "ThreadPoolExecutor-0_0"
-    elif PYVERSION >= (3, 9):
-        executor_thread_name = "asyncio_0"
-    else:
-        executor_thread_name = "ThreadPoolExecutor-0_0"
-
-    if PYVERSION >= (3, 11):
-        # Thread Pool Executor
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name=executor_thread_name,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="slow_sync_function",
-                        filename="test_asyncio_executor.py",
-                        line_no=slow_sync_function.__code__.co_firstlineno + 1,
-                    ),
-                    # pprof_utils.StackLocation(
-                    #     function_name="_WorkItem.run",
-                    #     filename="",
-                    #     line_no=-1,
-                    # ),
-                    # pprof_utils.StackLocation(
-                    #     function_name="_worker",
-                    #     filename="",
-                    #     line_no=-1,
-                    # ),
-                    # pprof_utils.StackLocation(
-                    #     function_name="Thread.run",
-                    #     filename="",
-                    #     line_no=-1,
-                    # ),
-                ],
-            ),
-        )
-    elif PYVERSION >= (3, 9):
-        # Thread Pool Executor
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name=executor_thread_name,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="slow_sync_function",
-                        filename="test_asyncio_executor.py",
-                        line_no=slow_sync_function.__code__.co_firstlineno + 1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="run",
-                        filename="",
-                        line_no=-1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="_worker",
-                        filename="",
-                        line_no=-1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="run",
-                        filename="",
-                        line_no=-1,
-                    ),
-                ],
-            ),
-        )
-    else:
-        # Thread Pool Executor
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name=executor_thread_name,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="slow_sync_function",
-                        filename="test_asyncio_executor.py",
-                        line_no=slow_sync_function.__code__.co_firstlineno + 1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="run",
-                        filename="",
-                        line_no=-1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="_worker",
-                        filename="",
-                        line_no=-1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="run",
-                        filename="",
-                        line_no=-1,
-                    ),
-                ],
-            ),
-        )
+            )
+        elif PYVERSION >= (3, 9):
+            # Thread Pool Executor
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples,
+                expected_sample=pprof_utils.StackEvent(
+                    thread_name=executor_thread_name,
+                    locations=[
+                        pprof_utils.StackLocation(
+                            function_name="slow_sync_function",
+                            filename="test_asyncio_executor.py",
+                            line_no=slow_sync_function.__code__.co_firstlineno + 1,
+                        ),
+                        pprof_utils.StackLocation(
+                            function_name="run",
+                            filename="",
+                            line_no=-1,
+                        ),
+                        pprof_utils.StackLocation(
+                            function_name="_worker",
+                            filename="",
+                            line_no=-1,
+                        ),
+                        pprof_utils.StackLocation(
+                            function_name="run",
+                            filename="",
+                            line_no=-1,
+                        ),
+                    ],
+                ),
+            )
+        else:
+            # Thread Pool Executor
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples,
+                expected_sample=pprof_utils.StackEvent(
+                    thread_name=executor_thread_name,
+                    locations=[
+                        pprof_utils.StackLocation(
+                            function_name="slow_sync_function",
+                            filename="test_asyncio_executor.py",
+                            line_no=slow_sync_function.__code__.co_firstlineno + 1,
+                        ),
+                        pprof_utils.StackLocation(
+                            function_name="run",
+                            filename="",
+                            line_no=-1,
+                        ),
+                        pprof_utils.StackLocation(
+                            function_name="_worker",
+                            filename="",
+                            line_no=-1,
+                        ),
+                        pprof_utils.StackLocation(
+                            function_name="run",
+                            filename="",
+                            line_no=-1,
+                        ),
+                    ],
+                ),
+            )

--- a/tests/profiling/collector/test_asyncio_fork.py
+++ b/tests/profiling/collector/test_asyncio_fork.py
@@ -1,12 +1,7 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_fork",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess
 def test_asyncio_fork() -> None:
     """Test that asyncio event loop behaves as we assume on fork.
 

--- a/tests/profiling/collector/test_asyncio_gather.py
+++ b/tests/profiling/collector/test_asyncio_gather.py
@@ -12,7 +12,6 @@ def test_asyncio_gather() -> None:
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -37,97 +36,96 @@ def test_asyncio_gather() -> None:
     resource = str(uuid.uuid4())
     span_type = ext.SpanTypes.WEB
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler(tracer=tracer)
-        p.start()
-        with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
-            span_id = span.span_id
-            local_root_span_id = span._local_root.span_id
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+    with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
+        span_id = span.span_id
+        local_root_span_id = span._local_root.span_id
 
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            main_task = loop.create_task(outer(), name="outer")
-            loop.run_until_complete(main_task)
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        main_task = loop.create_task(outer(), name="outer")
+        loop.run_until_complete(main_task)
 
-        p.stop()
+    p.stop()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
-        samples_with_span_id = pprof_utils.get_samples_with_label_key(profile, "span id")
-        assert len(samples_with_span_id) > 0
+    samples_with_span_id = pprof_utils.get_samples_with_label_key(profile, "span id")
+    assert len(samples_with_span_id) > 0
 
-        # get samples with task_name
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        # The next fails if stack is not properly configured with asyncio task
-        # tracking via ddtrace.profiling._asyncio
-        assert len(samples) > 0
+    # get samples with task_name
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    # The next fails if stack is not properly configured with asyncio task
+    # tracking via ddtrace.profiling._asyncio
+    assert len(samples) > 0
 
-        # TODO: Currently, we never report Parent Tasks awaiting a Child Task as part of their own.
-        # This means we never see the 'await asyncio.gather(...)' tagged with Task name "outer"
-        # because it is always reported as part of the Stack of a Child Task.
-        # We will fix this in the future.
-        # pprof_utils.assert_profile_has_sample(
-        #     profile,
-        #     samples,
-        #     expected_sample=pprof_utils.StackEvent(
-        #         thread_name="MainThread",
-        #         task_name="outer",
-        #         span_id=span_id,
-        #         local_root_span_id=local_root_span_id,
-        #         locations=[
-        #             pprof_utils.StackLocation(
-        #                 function_name="outer"
-        #                 filename="test_asyncio_gather.py"
-        #                 line_no=outer.__code__.co_firstlineno+3
-        #             ),
-        #         ],
-        #     ),
-        # )
+    # TODO: Currently, we never report Parent Tasks awaiting a Child Task as part of their own.
+    # This means we never see the 'await asyncio.gather(...)' tagged with Task name "outer"
+    # because it is always reported as part of the Stack of a Child Task.
+    # We will fix this in the future.
+    # pprof_utils.assert_profile_has_sample(
+    #     profile,
+    #     samples,
+    #     expected_sample=pprof_utils.StackEvent(
+    #         thread_name="MainThread",
+    #         task_name="outer",
+    #         span_id=span_id,
+    #         local_root_span_id=local_root_span_id,
+    #         locations=[
+    #             pprof_utils.StackLocation(
+    #                 function_name="outer"
+    #                 filename="test_asyncio_gather.py"
+    #                 line_no=outer.__code__.co_firstlineno+3
+    #             ),
+    #         ],
+    #     ),
+    # )
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="inner 1",
-                span_id=span_id,
-                local_root_span_id=local_root_span_id,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="inner1",
-                        filename="test_asyncio_gather.py",
-                        line_no=inner1.__code__.co_firstlineno + 3,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="outer",
-                        filename="test_asyncio_gather.py",
-                        line_no=outer.__code__.co_firstlineno + 3,
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="inner 1",
+            span_id=span_id,
+            local_root_span_id=local_root_span_id,
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="inner1",
+                    filename="test_asyncio_gather.py",
+                    line_no=inner1.__code__.co_firstlineno + 3,
+                ),
+                pprof_utils.StackLocation(
+                    function_name="outer",
+                    filename="test_asyncio_gather.py",
+                    line_no=outer.__code__.co_firstlineno + 3,
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="inner 2",
-                span_id=span_id,
-                local_root_span_id=local_root_span_id,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="inner2",
-                        filename="test_asyncio_gather.py",
-                        line_no=inner2.__code__.co_firstlineno + 3,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="outer",
-                        filename="test_asyncio_gather.py",
-                        line_no=outer.__code__.co_firstlineno + 3,
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="inner 2",
+            span_id=span_id,
+            local_root_span_id=local_root_span_id,
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="inner2",
+                    filename="test_asyncio_gather.py",
+                    line_no=inner2.__code__.co_firstlineno + 3,
+                ),
+                pprof_utils.StackLocation(
+                    function_name="outer",
+                    filename="test_asyncio_gather.py",
+                    line_no=outer.__code__.co_firstlineno + 3,
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )

--- a/tests/profiling/collector/test_asyncio_gather.py
+++ b/tests/profiling/collector/test_asyncio_gather.py
@@ -1,16 +1,9 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_utils_gather",
-    ),
-    err=None,
-)
-# For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
+@pytest.mark.subprocess(err=None)
 def test_asyncio_gather() -> None:
     import asyncio
-    import os
     import time
     import uuid
 
@@ -19,6 +12,7 @@ def test_asyncio_gather() -> None:
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -43,96 +37,97 @@ def test_asyncio_gather() -> None:
     resource = str(uuid.uuid4())
     span_type = ext.SpanTypes.WEB
 
-    p = profiler.Profiler(tracer=tracer)
-    p.start()
-    with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
-        span_id = span.span_id
-        local_root_span_id = span._local_root.span_id
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler(tracer=tracer)
+        p.start()
+        with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
+            span_id = span.span_id
+            local_root_span_id = span._local_root.span_id
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        main_task = loop.create_task(outer(), name="outer")
-        loop.run_until_complete(main_task)
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            main_task = loop.create_task(outer(), name="outer")
+            loop.run_until_complete(main_task)
 
-    p.stop()
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        samples_with_span_id = pprof_utils.get_samples_with_label_key(profile, "span id")
+        assert len(samples_with_span_id) > 0
 
-    samples_with_span_id = pprof_utils.get_samples_with_label_key(profile, "span id")
-    assert len(samples_with_span_id) > 0
+        # get samples with task_name
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        # The next fails if stack is not properly configured with asyncio task
+        # tracking via ddtrace.profiling._asyncio
+        assert len(samples) > 0
 
-    # get samples with task_name
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    # The next fails if stack is not properly configured with asyncio task
-    # tracking via ddtrace.profiling._asyncio
-    assert len(samples) > 0
+        # TODO: Currently, we never report Parent Tasks awaiting a Child Task as part of their own.
+        # This means we never see the 'await asyncio.gather(...)' tagged with Task name "outer"
+        # because it is always reported as part of the Stack of a Child Task.
+        # We will fix this in the future.
+        # pprof_utils.assert_profile_has_sample(
+        #     profile,
+        #     samples,
+        #     expected_sample=pprof_utils.StackEvent(
+        #         thread_name="MainThread",
+        #         task_name="outer",
+        #         span_id=span_id,
+        #         local_root_span_id=local_root_span_id,
+        #         locations=[
+        #             pprof_utils.StackLocation(
+        #                 function_name="outer"
+        #                 filename="test_asyncio_gather.py"
+        #                 line_no=outer.__code__.co_firstlineno+3
+        #             ),
+        #         ],
+        #     ),
+        # )
 
-    # TODO: Currently, we never report Parent Tasks awaiting a Child Task as part of their own.
-    # This means we never see the 'await asyncio.gather(...)' tagged with Task name "outer"
-    # because it is always reported as part of the Stack of a Child Task.
-    # We will fix this in the future.
-    # pprof_utils.assert_profile_has_sample(
-    #     profile,
-    #     samples,
-    #     expected_sample=pprof_utils.StackEvent(
-    #         thread_name="MainThread",
-    #         task_name="outer",
-    #         span_id=span_id,
-    #         local_root_span_id=local_root_span_id,
-    #         locations=[
-    #             pprof_utils.StackLocation(
-    #                 function_name="outer", filename="test_asyncio_gather.py", line_no=outer.__code__.co_firstlineno+3
-    #             ),
-    #         ],
-    #     ),
-    # )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="inner 1",
+                span_id=span_id,
+                local_root_span_id=local_root_span_id,
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="inner1",
+                        filename="test_asyncio_gather.py",
+                        line_no=inner1.__code__.co_firstlineno + 3,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="outer",
+                        filename="test_asyncio_gather.py",
+                        line_no=outer.__code__.co_firstlineno + 3,
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="inner 1",
-            span_id=span_id,
-            local_root_span_id=local_root_span_id,
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="inner1",
-                    filename="test_asyncio_gather.py",
-                    line_no=inner1.__code__.co_firstlineno + 3,
-                ),
-                pprof_utils.StackLocation(
-                    function_name="outer",
-                    filename="test_asyncio_gather.py",
-                    line_no=outer.__code__.co_firstlineno + 3,
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
-
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="inner 2",
-            span_id=span_id,
-            local_root_span_id=local_root_span_id,
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="inner2",
-                    filename="test_asyncio_gather.py",
-                    line_no=inner2.__code__.co_firstlineno + 3,
-                ),
-                pprof_utils.StackLocation(
-                    function_name="outer",
-                    filename="test_asyncio_gather.py",
-                    line_no=outer.__code__.co_firstlineno + 3,
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="inner 2",
+                span_id=span_id,
+                local_root_span_id=local_root_span_id,
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="inner2",
+                        filename="test_asyncio_gather.py",
+                        line_no=inner2.__code__.co_firstlineno + 3,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="outer",
+                        filename="test_asyncio_gather.py",
+                        line_no=outer.__code__.co_firstlineno + 3,
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )

--- a/tests/profiling/collector/test_asyncio_gather_coroutines.py
+++ b/tests/profiling/collector/test_asyncio_gather_coroutines.py
@@ -1,20 +1,14 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_gather_coroutines",
-    ),
-    err=None,
-)
-# For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
+@pytest.mark.subprocess
 def test_asyncio_gather_wall_time() -> None:
     import asyncio
-    import os
 
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -27,69 +21,68 @@ def test_asyncio_gather_wall_time() -> None:
     async def main() -> None:
         await asyncio.gather(inner_1(), inner_2())
 
-    p = profiler.Profiler()
-    p.start()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler()
+        p.start()
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    loop.run_until_complete(main())
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(main())
 
-    p.stop()
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0
 
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0
+        # Test that we see stacks for inner_1 and inner_2
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="sleep",
+                        filename="",
+                        line_no=-1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="inner_1",
+                        filename="test_asyncio_gather_coroutines.py",
+                        line_no=inner_1.__code__.co_firstlineno + 1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="main",
+                        filename="test_asyncio_gather_coroutines.py",
+                        line_no=main.__code__.co_firstlineno + 1,
+                    ),
+                ],
+            ),
+        )
 
-    # Test that we see stacks for inner_1 and inner_2
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="sleep",
-                    filename="",
-                    line_no=-1,
-                ),
-                pprof_utils.StackLocation(
-                    function_name="inner_1",
-                    filename="test_asyncio_gather_coroutines.py",
-                    line_no=inner_1.__code__.co_firstlineno + 1,
-                ),
-                pprof_utils.StackLocation(
-                    function_name="main",
-                    filename="test_asyncio_gather_coroutines.py",
-                    line_no=main.__code__.co_firstlineno + 1,
-                ),
-            ],
-        ),
-    )
-
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="sleep",
-                    filename="",
-                    line_no=-1,
-                ),
-                pprof_utils.StackLocation(
-                    function_name="inner_2",
-                    filename="test_asyncio_gather_coroutines.py",
-                    line_no=inner_2.__code__.co_firstlineno + 1,
-                ),
-                pprof_utils.StackLocation(
-                    function_name="main",
-                    filename="test_asyncio_gather_coroutines.py",
-                    line_no=main.__code__.co_firstlineno + 1,
-                ),
-            ],
-        ),
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="sleep",
+                        filename="",
+                        line_no=-1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="inner_2",
+                        filename="test_asyncio_gather_coroutines.py",
+                        line_no=inner_2.__code__.co_firstlineno + 1,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="main",
+                        filename="test_asyncio_gather_coroutines.py",
+                        line_no=main.__code__.co_firstlineno + 1,
+                    ),
+                ],
+            ),
+        )

--- a/tests/profiling/collector/test_asyncio_gather_coroutines.py
+++ b/tests/profiling/collector/test_asyncio_gather_coroutines.py
@@ -8,7 +8,6 @@ def test_asyncio_gather_wall_time() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -21,68 +20,67 @@ def test_asyncio_gather_wall_time() -> None:
     async def main() -> None:
         await asyncio.gather(inner_1(), inner_2())
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler()
-        p.start()
+    p = profiler.Profiler()
+    p.start()
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(main())
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(main())
 
-        p.stop()
+    p.stop()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0
 
-        # Test that we see stacks for inner_1 and inner_2
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="sleep",
-                        filename="",
-                        line_no=-1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="inner_1",
-                        filename="test_asyncio_gather_coroutines.py",
-                        line_no=inner_1.__code__.co_firstlineno + 1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="main",
-                        filename="test_asyncio_gather_coroutines.py",
-                        line_no=main.__code__.co_firstlineno + 1,
-                    ),
-                ],
-            ),
-        )
+    # Test that we see stacks for inner_1 and inner_2
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="sleep",
+                    filename="",
+                    line_no=-1,
+                ),
+                pprof_utils.StackLocation(
+                    function_name="inner_1",
+                    filename="test_asyncio_gather_coroutines.py",
+                    line_no=inner_1.__code__.co_firstlineno + 1,
+                ),
+                pprof_utils.StackLocation(
+                    function_name="main",
+                    filename="test_asyncio_gather_coroutines.py",
+                    line_no=main.__code__.co_firstlineno + 1,
+                ),
+            ],
+        ),
+    )
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="sleep",
-                        filename="",
-                        line_no=-1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="inner_2",
-                        filename="test_asyncio_gather_coroutines.py",
-                        line_no=inner_2.__code__.co_firstlineno + 1,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="main",
-                        filename="test_asyncio_gather_coroutines.py",
-                        line_no=main.__code__.co_firstlineno + 1,
-                    ),
-                ],
-            ),
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="sleep",
+                    filename="",
+                    line_no=-1,
+                ),
+                pprof_utils.StackLocation(
+                    function_name="inner_2",
+                    filename="test_asyncio_gather_coroutines.py",
+                    line_no=inner_2.__code__.co_firstlineno + 1,
+                ),
+                pprof_utils.StackLocation(
+                    function_name="main",
+                    filename="test_asyncio_gather_coroutines.py",
+                    line_no=main.__code__.co_firstlineno + 1,
+                ),
+            ],
+        ),
+    )

--- a/tests/profiling/collector/test_asyncio_gather_deep_coroutines.py
+++ b/tests/profiling/collector/test_asyncio_gather_deep_coroutines.py
@@ -1,20 +1,14 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_gather_deep_coroutines",
-    ),
-    err=None,
-)
-# For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
+@pytest.mark.subprocess
 def test_asyncio_gather_deep_coroutines() -> None:
     import asyncio
-    import os
 
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -30,42 +24,41 @@ def test_asyncio_gather_deep_coroutines() -> None:
     async def main() -> None:
         await asyncio.gather(inner(), inner())
 
-    p = profiler.Profiler()
-    p.start()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler()
+        p.start()
 
-    asyncio.run(main())
+        asyncio.run(main())
 
-    p.stop()
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0
 
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0
+        def loc(f_name: str) -> pprof_utils.StackLocation:
+            return pprof_utils.StackLocation(function_name=f_name, filename="", line_no=-1)
 
-    def loc(f_name: str) -> pprof_utils.StackLocation:
-        return pprof_utils.StackLocation(function_name=f_name, filename="", line_no=-1)
-
-    # Test that we see stacks for inner_1 and inner_2
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            locations=list(
-                reversed(
-                    [
-                        # loc("Task-1"),
-                        loc("main"),
-                        # loc("Task-2"),
-                        loc("inner"),
-                        loc("deep"),
-                        loc("deeper"),
-                        loc("sleep"),
-                    ]
+        # Test that we see stacks for inner_1 and inner_2
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                locations=list(
+                    reversed(
+                        [
+                            # loc("Task-1"),
+                            loc("main"),
+                            # loc("Task-2"),
+                            loc("inner"),
+                            loc("deep"),
+                            loc("deeper"),
+                            loc("sleep"),
+                        ]
+                    ),
                 ),
             ),
-        ),
-        print_samples_on_failure=True,
-    )
+            print_samples_on_failure=True,
+        )

--- a/tests/profiling/collector/test_asyncio_gather_deep_coroutines.py
+++ b/tests/profiling/collector/test_asyncio_gather_deep_coroutines.py
@@ -8,7 +8,6 @@ def test_asyncio_gather_deep_coroutines() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -24,41 +23,40 @@ def test_asyncio_gather_deep_coroutines() -> None:
     async def main() -> None:
         await asyncio.gather(inner(), inner())
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler()
-        p.start()
+    p = profiler.Profiler()
+    p.start()
 
-        asyncio.run(main())
+    asyncio.run(main())
 
-        p.stop()
+    p.stop()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0
 
-        def loc(f_name: str) -> pprof_utils.StackLocation:
-            return pprof_utils.StackLocation(function_name=f_name, filename="", line_no=-1)
+    def loc(f_name: str) -> pprof_utils.StackLocation:
+        return pprof_utils.StackLocation(function_name=f_name, filename="", line_no=-1)
 
-        # Test that we see stacks for inner_1 and inner_2
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                locations=list(
-                    reversed(
-                        [
-                            # loc("Task-1"),
-                            loc("main"),
-                            # loc("Task-2"),
-                            loc("inner"),
-                            loc("deep"),
-                            loc("deeper"),
-                            loc("sleep"),
-                        ]
-                    ),
+    # Test that we see stacks for inner_1 and inner_2
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            locations=list(
+                reversed(
+                    [
+                        # loc("Task-1"),
+                        loc("main"),
+                        # loc("Task-2"),
+                        loc("inner"),
+                        loc("deep"),
+                        loc("deeper"),
+                        loc("sleep"),
+                    ]
                 ),
             ),
-            print_samples_on_failure=True,
-        )
+        ),
+        print_samples_on_failure=True,
+    )

--- a/tests/profiling/collector/test_asyncio_gather_tasks.py
+++ b/tests/profiling/collector/test_asyncio_gather_tasks.py
@@ -8,7 +8,6 @@ def test_asyncio_gather_tasks() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -33,43 +32,42 @@ def test_asyncio_gather_tasks() -> None:
     async def main() -> None:
         await asyncio.create_task(f1(), name="F1")
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler()
-        p.start()
+    p = profiler.Profiler()
+    p.start()
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(main())
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(main())
 
-        p.stop()
+    p.stop()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0
 
-        def fn_location(f: str) -> pprof_utils.StackLocation:
-            return pprof_utils.StackLocation(
-                function_name=f,
-                filename="",
-                line_no=-1,
-            )
+    def fn_location(f: str) -> pprof_utils.StackLocation:
+        return pprof_utils.StackLocation(
+            function_name=f,
+            filename="",
+            line_no=-1,
+        )
 
-        for f, t in (("f4_0", "F4_0"), ("f4_1", "F4_1")):
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_name="MainThread",
-                    task_name=t,
-                    locations=[
-                        fn_location("sleep"),
-                        fn_location("f5"),
-                        fn_location(f),
-                        fn_location("f3"),
-                        fn_location("f2"),
-                        fn_location("f1"),
-                        fn_location("main"),
-                    ],
-                ),
-            )
+    for f, t in (("f4_0", "F4_0"), ("f4_1", "F4_1")):
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name=t,
+                locations=[
+                    fn_location("sleep"),
+                    fn_location("f5"),
+                    fn_location(f),
+                    fn_location("f3"),
+                    fn_location("f2"),
+                    fn_location("f1"),
+                    fn_location("main"),
+                ],
+            ),
+        )

--- a/tests/profiling/collector/test_asyncio_gather_tasks.py
+++ b/tests/profiling/collector/test_asyncio_gather_tasks.py
@@ -1,20 +1,14 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_gather_tasks",
-    ),
-    err=None,
-)
-# For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
+@pytest.mark.subprocess
 def test_asyncio_gather_tasks() -> None:
     import asyncio
-    import os
 
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -39,44 +33,43 @@ def test_asyncio_gather_tasks() -> None:
     async def main() -> None:
         await asyncio.create_task(f1(), name="F1")
 
-    p = profiler.Profiler()
-    p.start()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler()
+        p.start()
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    loop.run_until_complete(main())
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(main())
 
-    p.stop()
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0
 
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0
+        def fn_location(f: str) -> pprof_utils.StackLocation:
+            return pprof_utils.StackLocation(
+                function_name=f,
+                filename="",
+                line_no=-1,
+            )
 
-    def fn_location(f: str) -> pprof_utils.StackLocation:
-        return pprof_utils.StackLocation(
-            function_name=f,
-            filename="",
-            line_no=-1,
-        )
-
-    for f, t in (("f4_0", "F4_0"), ("f4_1", "F4_1")):
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name=t,
-                locations=[
-                    fn_location("sleep"),
-                    fn_location("f5"),
-                    fn_location(f),
-                    fn_location("f3"),
-                    fn_location("f2"),
-                    fn_location("f1"),
-                    fn_location("main"),
-                ],
-            ),
-        )
+        for f, t in (("f4_0", "F4_0"), ("f4_1", "F4_1")):
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples,
+                expected_sample=pprof_utils.StackEvent(
+                    thread_name="MainThread",
+                    task_name=t,
+                    locations=[
+                        fn_location("sleep"),
+                        fn_location("f5"),
+                        fn_location(f),
+                        fn_location("f3"),
+                        fn_location("f2"),
+                        fn_location("f1"),
+                        fn_location("main"),
+                    ],
+                ),
+            )

--- a/tests/profiling/collector/test_asyncio_idle.py
+++ b/tests/profiling/collector/test_asyncio_idle.py
@@ -1,12 +1,7 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_run_frames_captured",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess
 def test_asyncio_run_frames_captured():
     """
     Regression test for bug where asyncio frames were not captured when using asyncio.run().
@@ -23,119 +18,124 @@ def test_asyncio_run_frames_captured():
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_utils import async_run
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    p = profiler.Profiler()
-    p.start()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler()
+        p.start()
 
-    async def my_coroutine(n: float) -> None:
-        await asyncio.sleep(n)
+        async def my_coroutine(n: float) -> None:
+            await asyncio.sleep(n)
 
-    async def main() -> None:
-        # Give the profiler some time to start up
-        await asyncio.sleep(0.5)
+        async def main() -> None:
+            # Give the profiler some time to start up
+            await asyncio.sleep(0.5)
 
-        execution_time_sec = 2.0
+            execution_time_sec = 2.0
 
-        short_task = asyncio.create_task(my_coroutine(execution_time_sec / 2), name="short_task")
+            short_task = asyncio.create_task(my_coroutine(execution_time_sec / 2), name="short_task")
 
-        # asyncio.gather will automatically wrap my_coroutine into a Task
-        await asyncio.gather(short_task, my_coroutine(execution_time_sec))
+            # asyncio.gather will automatically wrap my_coroutine into a Task
+            await asyncio.gather(short_task, my_coroutine(execution_time_sec))
 
-    async_run(main())
+        async_run(main())
 
-    p.stop()
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    # Get samples with task_name - this is the key check
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0, "No task names found - asyncio task tracking failed!"
+        # Get samples with task_name - this is the key check
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0, "No task names found - asyncio task tracking failed!"
 
-    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+        use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
 
-    # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
-    # so we only expect these frames when NOT using uvloop
-    if use_uvloop:
-        event_loop_frames = []
-    else:
-        base_event_loop_prefix = "BaseEventLoop." if sys.version_info >= (3, 11) else ""
-        selector_prefix = (
-            ("KqueueSelector." if sys.platform == "darwin" else "EpollSelector.") if sys.version_info >= (3, 11) else ""
-        )
-        event_loop_frames = [
-            pprof_utils.StackLocation(function_name=f"{selector_prefix}select", filename="", line_no=-1),
-            pprof_utils.StackLocation(function_name=f"{base_event_loop_prefix}_run_once", filename="", line_no=-1),
-            pprof_utils.StackLocation(function_name=f"{base_event_loop_prefix}run_forever", filename="", line_no=-1),
-            pprof_utils.StackLocation(
-                function_name=f"{base_event_loop_prefix}run_until_complete", filename="", line_no=-1
+        # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
+        # so we only expect these frames when NOT using uvloop
+        if use_uvloop:
+            event_loop_frames = []
+        else:
+            base_event_loop_prefix = "BaseEventLoop." if sys.version_info >= (3, 11) else ""
+            selector_prefix = (
+                ("KqueueSelector." if sys.platform == "darwin" else "EpollSelector.")
+                if sys.version_info >= (3, 11)
+                else ""
+            )
+            event_loop_frames = [
+                pprof_utils.StackLocation(function_name=f"{selector_prefix}select", filename="", line_no=-1),
+                pprof_utils.StackLocation(function_name=f"{base_event_loop_prefix}_run_once", filename="", line_no=-1),
+                pprof_utils.StackLocation(
+                    function_name=f"{base_event_loop_prefix}run_forever", filename="", line_no=-1
+                ),
+                pprof_utils.StackLocation(
+                    function_name=f"{base_event_loop_prefix}run_until_complete", filename="", line_no=-1
+                ),
+            ]
+
+        def loc(f_name: str, filename: str = "", line_no: int = -1) -> pprof_utils.StackLocation:
+            return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
+
+        # Check that we have main -> sleep (the one where we wait for the Profiler to be ready)
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="Task-1",
+                locations=[
+                    loc("sleep"),
+                    loc("main", filename="test_asyncio_idle.py", line_no=main.__code__.co_firstlineno + 2),
+                ]
+                + event_loop_frames
+                + ([loc("Runner.run")] if sys.version_info >= (3, 11) else [])
+                + [loc("run")],
             ),
-        ]
+            print_samples_on_failure=True,
+        )
 
-    def loc(f_name: str, filename: str = "", line_no: int = -1) -> pprof_utils.StackLocation:
-        return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
+        # Check that we have (asyncio) -> main -> my_coroutine -> sleep
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="short_task",
+                locations=[
+                    loc("sleep"),
+                    loc(
+                        my_coroutine.__name__,
+                        filename="test_asyncio_idle.py",
+                        line_no=my_coroutine.__code__.co_firstlineno + 1,
+                    ),
+                    loc("main", filename="test_asyncio_idle.py", line_no=main.__code__.co_firstlineno + 9),
+                ]
+                + event_loop_frames
+                + ([loc("Runner.run")] if sys.version_info >= (3, 11) else [])
+                + [loc("run")],
+            ),
+            print_samples_on_failure=True,
+        )
 
-    # Check that we have main -> sleep (the one where we wait for the Profiler to be ready)
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="Task-1",
-            locations=[
-                loc("sleep"),
-                loc("main", filename="test_asyncio_idle.py", line_no=main.__code__.co_firstlineno + 2),
-            ]
-            + event_loop_frames
-            + ([loc("Runner.run")] if sys.version_info >= (3, 11) else [])
-            + [loc("run")],
-        ),
-        print_samples_on_failure=True,
-    )
-
-    # Check that we have (asyncio) -> main -> my_coroutine -> sleep
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="short_task",
-            locations=[
-                loc("sleep"),
-                loc(
-                    my_coroutine.__name__,
-                    filename="test_asyncio_idle.py",
-                    line_no=my_coroutine.__code__.co_firstlineno + 1,
-                ),
-                loc("main", filename="test_asyncio_idle.py", line_no=main.__code__.co_firstlineno + 9),
-            ]
-            + event_loop_frames
-            + ([loc("Runner.run")] if sys.version_info >= (3, 11) else [])
-            + [loc("run")],
-        ),
-        print_samples_on_failure=True,
-    )
-
-    # Check that we have (asyncio) -> main -> my_coroutine -> sleep
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            locations=[
-                loc("sleep"),
-                loc(
-                    my_coroutine.__name__,
-                    filename="test_asyncio_idle.py",
-                    line_no=my_coroutine.__code__.co_firstlineno + 1,
-                ),
-                loc("main", filename="test_asyncio_idle.py", line_no=main.__code__.co_firstlineno + 9),
-            ]
-            + event_loop_frames
-            + ([loc("Runner.run")] if sys.version_info >= (3, 11) else [])
-            + [loc("run")],
-        ),
-        print_samples_on_failure=True,
-    )
+        # Check that we have (asyncio) -> main -> my_coroutine -> sleep
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                locations=[
+                    loc("sleep"),
+                    loc(
+                        my_coroutine.__name__,
+                        filename="test_asyncio_idle.py",
+                        line_no=my_coroutine.__code__.co_firstlineno + 1,
+                    ),
+                    loc("main", filename="test_asyncio_idle.py", line_no=main.__code__.co_firstlineno + 9),
+                ]
+                + event_loop_frames
+                + ([loc("Runner.run")] if sys.version_info >= (3, 11) else [])
+                + [loc("run")],
+            ),
+            print_samples_on_failure=True,
+        )

--- a/tests/profiling/collector/test_asyncio_idle.py
+++ b/tests/profiling/collector/test_asyncio_idle.py
@@ -18,124 +18,118 @@ def test_asyncio_run_frames_captured():
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_utils import async_run
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler()
-        p.start()
+    p = profiler.Profiler()
+    p.start()
 
-        async def my_coroutine(n: float) -> None:
-            await asyncio.sleep(n)
+    async def my_coroutine(n: float) -> None:
+        await asyncio.sleep(n)
 
-        async def main() -> None:
-            # Give the profiler some time to start up
-            await asyncio.sleep(0.5)
+    async def main() -> None:
+        # Give the profiler some time to start up
+        await asyncio.sleep(0.5)
 
-            execution_time_sec = 2.0
+        execution_time_sec = 2.0
 
-            short_task = asyncio.create_task(my_coroutine(execution_time_sec / 2), name="short_task")
+        short_task = asyncio.create_task(my_coroutine(execution_time_sec / 2), name="short_task")
 
-            # asyncio.gather will automatically wrap my_coroutine into a Task
-            await asyncio.gather(short_task, my_coroutine(execution_time_sec))
+        # asyncio.gather will automatically wrap my_coroutine into a Task
+        await asyncio.gather(short_task, my_coroutine(execution_time_sec))
 
-        async_run(main())
+    async_run(main())
 
-        p.stop()
+    p.stop()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
-        # Get samples with task_name - this is the key check
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0, "No task names found - asyncio task tracking failed!"
+    # Get samples with task_name - this is the key check
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0, "No task names found - asyncio task tracking failed!"
 
-        use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
 
-        # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
-        # so we only expect these frames when NOT using uvloop
-        if use_uvloop:
-            event_loop_frames = []
-        else:
-            base_event_loop_prefix = "BaseEventLoop." if sys.version_info >= (3, 11) else ""
-            selector_prefix = (
-                ("KqueueSelector." if sys.platform == "darwin" else "EpollSelector.")
-                if sys.version_info >= (3, 11)
-                else ""
-            )
-            event_loop_frames = [
-                pprof_utils.StackLocation(function_name=f"{selector_prefix}select", filename="", line_no=-1),
-                pprof_utils.StackLocation(function_name=f"{base_event_loop_prefix}_run_once", filename="", line_no=-1),
-                pprof_utils.StackLocation(
-                    function_name=f"{base_event_loop_prefix}run_forever", filename="", line_no=-1
-                ),
-                pprof_utils.StackLocation(
-                    function_name=f"{base_event_loop_prefix}run_until_complete", filename="", line_no=-1
-                ),
+    # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
+    # so we only expect these frames when NOT using uvloop
+    if use_uvloop:
+        event_loop_frames = []
+    else:
+        base_event_loop_prefix = "BaseEventLoop." if sys.version_info >= (3, 11) else ""
+        selector_prefix = (
+            ("KqueueSelector." if sys.platform == "darwin" else "EpollSelector.") if sys.version_info >= (3, 11) else ""
+        )
+        event_loop_frames = [
+            pprof_utils.StackLocation(function_name=f"{selector_prefix}select", filename="", line_no=-1),
+            pprof_utils.StackLocation(function_name=f"{base_event_loop_prefix}_run_once", filename="", line_no=-1),
+            pprof_utils.StackLocation(function_name=f"{base_event_loop_prefix}run_forever", filename="", line_no=-1),
+            pprof_utils.StackLocation(
+                function_name=f"{base_event_loop_prefix}run_until_complete", filename="", line_no=-1
+            ),
+        ]
+
+    def loc(f_name: str, filename: str = "", line_no: int = -1) -> pprof_utils.StackLocation:
+        return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
+
+    # Check that we have main -> sleep (the one where we wait for the Profiler to be ready)
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="Task-1",
+            locations=[
+                loc("sleep"),
+                loc("main", filename="test_asyncio_idle.py", line_no=main.__code__.co_firstlineno + 2),
             ]
+            + event_loop_frames
+            + ([loc("Runner.run")] if sys.version_info >= (3, 11) else [])
+            + [loc("run")],
+        ),
+        print_samples_on_failure=True,
+    )
 
-        def loc(f_name: str, filename: str = "", line_no: int = -1) -> pprof_utils.StackLocation:
-            return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
+    # Check that we have (asyncio) -> main -> my_coroutine -> sleep
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="short_task",
+            locations=[
+                loc("sleep"),
+                loc(
+                    my_coroutine.__name__,
+                    filename="test_asyncio_idle.py",
+                    line_no=my_coroutine.__code__.co_firstlineno + 1,
+                ),
+                loc("main", filename="test_asyncio_idle.py", line_no=main.__code__.co_firstlineno + 9),
+            ]
+            + event_loop_frames
+            + ([loc("Runner.run")] if sys.version_info >= (3, 11) else [])
+            + [loc("run")],
+        ),
+        print_samples_on_failure=True,
+    )
 
-        # Check that we have main -> sleep (the one where we wait for the Profiler to be ready)
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="Task-1",
-                locations=[
-                    loc("sleep"),
-                    loc("main", filename="test_asyncio_idle.py", line_no=main.__code__.co_firstlineno + 2),
-                ]
-                + event_loop_frames
-                + ([loc("Runner.run")] if sys.version_info >= (3, 11) else [])
-                + [loc("run")],
-            ),
-            print_samples_on_failure=True,
-        )
-
-        # Check that we have (asyncio) -> main -> my_coroutine -> sleep
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="short_task",
-                locations=[
-                    loc("sleep"),
-                    loc(
-                        my_coroutine.__name__,
-                        filename="test_asyncio_idle.py",
-                        line_no=my_coroutine.__code__.co_firstlineno + 1,
-                    ),
-                    loc("main", filename="test_asyncio_idle.py", line_no=main.__code__.co_firstlineno + 9),
-                ]
-                + event_loop_frames
-                + ([loc("Runner.run")] if sys.version_info >= (3, 11) else [])
-                + [loc("run")],
-            ),
-            print_samples_on_failure=True,
-        )
-
-        # Check that we have (asyncio) -> main -> my_coroutine -> sleep
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                locations=[
-                    loc("sleep"),
-                    loc(
-                        my_coroutine.__name__,
-                        filename="test_asyncio_idle.py",
-                        line_no=my_coroutine.__code__.co_firstlineno + 1,
-                    ),
-                    loc("main", filename="test_asyncio_idle.py", line_no=main.__code__.co_firstlineno + 9),
-                ]
-                + event_loop_frames
-                + ([loc("Runner.run")] if sys.version_info >= (3, 11) else [])
-                + [loc("run")],
-            ),
-            print_samples_on_failure=True,
-        )
+    # Check that we have (asyncio) -> main -> my_coroutine -> sleep
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            locations=[
+                loc("sleep"),
+                loc(
+                    my_coroutine.__name__,
+                    filename="test_asyncio_idle.py",
+                    line_no=my_coroutine.__code__.co_firstlineno + 1,
+                ),
+                loc("main", filename="test_asyncio_idle.py", line_no=main.__code__.co_firstlineno + 9),
+            ]
+            + event_loop_frames
+            + ([loc("Runner.run")] if sys.version_info >= (3, 11) else [])
+            + [loc("run")],
+        ),
+        print_samples_on_failure=True,
+    )

--- a/tests/profiling/collector/test_asyncio_import_order.py
+++ b/tests/profiling/collector/test_asyncio_import_order.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.subprocess
+@pytest.mark.subprocess(err=None)
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_asyncio_start_profiler_from_process_before_importing_asyncio() -> None:
     from ddtrace.internal.datadog.profiling import stack
@@ -122,7 +122,7 @@ def test_asyncio_start_profiler_from_process_before_importing_asyncio() -> None:
     )
 
 
-@pytest.mark.subprocess
+@pytest.mark.subprocess(err=None)
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_asyncio_start_profiler_from_process_before_starting_loop() -> None:
     import asyncio
@@ -241,7 +241,7 @@ def test_asyncio_start_profiler_from_process_before_starting_loop() -> None:
 
 
 @pytest.mark.xfail(reason="No way to get the current loop if it is set but not running.")
-@pytest.mark.subprocess
+@pytest.mark.subprocess(err=None)
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_asyncio_start_profiler_from_process_after_creating_loop() -> None:
     import asyncio
@@ -361,7 +361,7 @@ def test_asyncio_start_profiler_from_process_after_creating_loop() -> None:
 
 
 @pytest.mark.xfail(reason="This test fails because there's no way to get the current loop if it's not already running.")
-@pytest.mark.subprocess
+@pytest.mark.subprocess(err=None)
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_asyncio_import_profiler_from_process_after_starting_loop() -> None:
     import asyncio

--- a/tests/profiling/collector/test_asyncio_import_order.py
+++ b/tests/profiling/collector/test_asyncio_import_order.py
@@ -6,122 +6,120 @@ import pytest
 def test_asyncio_start_profiler_from_process_before_importing_asyncio() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler()
-        p.start()
+    p = profiler.Profiler()
+    p.start()
 
-        import asyncio
-        import os
-        import sys
-        import time
+    import asyncio
+    import os
+    import sys
+    import time
 
-        from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector import pprof_utils
 
-        # Start an asyncio loop BEFORE importing profiler modules
-        # This simulates the bug scenario where a loop exists before profiling is enabled
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+    # Start an asyncio loop BEFORE importing profiler modules
+    # This simulates the bug scenario where a loop exists before profiling is enabled
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
 
-        async def my_function():
-            async def background_task_func() -> None:
-                """Background task that runs in the existing loop."""
-                await asyncio.sleep(1.5)
+    async def my_function():
+        async def background_task_func() -> None:
+            """Background task that runs in the existing loop."""
+            await asyncio.sleep(1.5)
 
-            # Create and start a task in the existing loop
-            background_task = loop.create_task(background_task_func(), name="background")
-            assert background_task is not None
+        # Create and start a task in the existing loop
+        background_task = loop.create_task(background_task_func(), name="background")
+        assert background_task is not None
 
-            # Run tasks that should be tracked
-            sleep_time = 0.2
-            loop_run_time = 0.75
+        # Run tasks that should be tracked
+        sleep_time = 0.2
+        loop_run_time = 0.75
 
-            async def tracked_task() -> None:
-                start_time = time.time()
-                while time.time() < start_time + loop_run_time:
-                    await asyncio.sleep(sleep_time)
+        async def tracked_task() -> None:
+            start_time = time.time()
+            while time.time() < start_time + loop_run_time:
+                await asyncio.sleep(sleep_time)
 
-            async def main_task():
-                t1 = asyncio.create_task(tracked_task(), name="tracked 1")
-                t2 = asyncio.create_task(tracked_task(), name="tracked 2")
-                await tracked_task()
-                await asyncio.sleep(0.25)
-                return t1, t2
+        async def main_task():
+            t1 = asyncio.create_task(tracked_task(), name="tracked 1")
+            t2 = asyncio.create_task(tracked_task(), name="tracked 2")
+            await tracked_task()
+            await asyncio.sleep(0.25)
+            return t1, t2
 
-            result = await main_task()
+        result = await main_task()
 
-            await background_task
+        await background_task
 
-            return tracked_task, background_task_func, result
+        return tracked_task, background_task_func, result
 
-        main_task = loop.create_task(my_function(), name="main")
-        tracked_task_def, background_task_def, (t1, t2) = loop.run_until_complete(main_task)
+    main_task = loop.create_task(my_function(), name="main")
+    tracked_task_def, background_task_def, (t1, t2) = loop.run_until_complete(main_task)
 
-        p.stop()
+    p.stop()
 
-        t1_name = t1.get_name()
-        t2_name = t2.get_name()
+    t1_name = t1.get_name()
+    t2_name = t2.get_name()
 
-        assert t1_name == "tracked 1"
-        assert t2_name == "tracked 2"
+    assert t1_name == "tracked 1"
+    assert t2_name == "tracked 2"
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0, "No task names found - existing loop was not tracked!"
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0, "No task names found - existing loop was not tracked!"
 
-        if sys.version_info >= (3, 11):
-            EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
-        else:
-            EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
+    if sys.version_info >= (3, 11):
+        EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
+    else:
+        EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
 
-        EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
-        EXPECTED_LINE_NO_BACKGROUND = -1  # any line
+    EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
+    EXPECTED_LINE_NO_BACKGROUND = -1  # any line
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="background",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
-                        filename=EXPECTED_FILENAME_BACKGROUND,
-                        line_no=EXPECTED_LINE_NO_BACKGROUND,
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="background",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
+                    filename=EXPECTED_FILENAME_BACKGROUND,
+                    line_no=EXPECTED_LINE_NO_BACKGROUND,
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
-        # Verify specific tasks are in the profile
-        if sys.version_info >= (3, 11):
-            EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
-        else:
-            EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
+    # Verify specific tasks are in the profile
+    if sys.version_info >= (3, 11):
+        EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
+    else:
+        EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
 
-        EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
+    EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name=t1_name,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name=EXPECTED_FUNCTION_NAME_TRACKED,
-                        filename=EXPECTED_FILENAME_TRACKED,
-                        line_no=-1,  # any line
-                    )
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name=t1_name,
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name=EXPECTED_FUNCTION_NAME_TRACKED,
+                    filename=EXPECTED_FILENAME_TRACKED,
+                    line_no=-1,  # any line
+                )
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.subprocess
@@ -135,113 +133,111 @@ def test_asyncio_start_profiler_from_process_before_starting_loop() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler()
-        p.start()
+    p = profiler.Profiler()
+    p.start()
 
-        # Start an asyncio loop BEFORE importing profiler modules
-        # This simulates the bug scenario where a loop exists before profiling is enabled
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+    # Start an asyncio loop BEFORE importing profiler modules
+    # This simulates the bug scenario where a loop exists before profiling is enabled
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
 
-        async def my_function():
-            async def background_task_func() -> None:
-                """Background task that runs in the existing loop."""
-                await asyncio.sleep(1.5)
+    async def my_function():
+        async def background_task_func() -> None:
+            """Background task that runs in the existing loop."""
+            await asyncio.sleep(1.5)
 
-            # Create and start a task in the existing loop
-            background_task = loop.create_task(background_task_func(), name="background")
-            assert background_task is not None
+        # Create and start a task in the existing loop
+        background_task = loop.create_task(background_task_func(), name="background")
+        assert background_task is not None
 
-            # Run tasks that should be tracked
-            sleep_time = 0.2
-            loop_run_time = 0.75
+        # Run tasks that should be tracked
+        sleep_time = 0.2
+        loop_run_time = 0.75
 
-            async def tracked_task() -> None:
-                start_time = time.time()
-                while time.time() < start_time + loop_run_time:
-                    await asyncio.sleep(sleep_time)
+        async def tracked_task() -> None:
+            start_time = time.time()
+            while time.time() < start_time + loop_run_time:
+                await asyncio.sleep(sleep_time)
 
-            async def main_task():
-                t1 = asyncio.create_task(tracked_task(), name="tracked 1")
-                t2 = asyncio.create_task(tracked_task(), name="tracked 2")
-                await tracked_task()
-                await asyncio.sleep(0.25)
-                return t1, t2
+        async def main_task():
+            t1 = asyncio.create_task(tracked_task(), name="tracked 1")
+            t2 = asyncio.create_task(tracked_task(), name="tracked 2")
+            await tracked_task()
+            await asyncio.sleep(0.25)
+            return t1, t2
 
-            result = await main_task()
+        result = await main_task()
 
-            await background_task
+        await background_task
 
-            return tracked_task, background_task_func, result
+        return tracked_task, background_task_func, result
 
-        main_task = loop.create_task(my_function(), name="main")
-        tracked_task_def, background_task_def, (t1, t2) = loop.run_until_complete(main_task)
+    main_task = loop.create_task(my_function(), name="main")
+    tracked_task_def, background_task_def, (t1, t2) = loop.run_until_complete(main_task)
 
-        p.stop()
+    p.stop()
 
-        t1_name = t1.get_name()
-        t2_name = t2.get_name()
+    t1_name = t1.get_name()
+    t2_name = t2.get_name()
 
-        assert t1_name == "tracked 1"
-        assert t2_name == "tracked 2"
+    assert t1_name == "tracked 1"
+    assert t2_name == "tracked 2"
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0, "No task names found - existing loop was not tracked!"
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0, "No task names found - existing loop was not tracked!"
 
-        if sys.version_info >= (3, 11):
-            EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
-        else:
-            EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
-        EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
-        EXPECTED_LINE_NO_BACKGROUND = -1  # any line
+    if sys.version_info >= (3, 11):
+        EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
+    else:
+        EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
+    EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
+    EXPECTED_LINE_NO_BACKGROUND = -1  # any line
 
-        # Verify specific tasks are in the profile
-        if sys.version_info >= (3, 11):
-            EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
-        else:
-            EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
-        EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
+    # Verify specific tasks are in the profile
+    if sys.version_info >= (3, 11):
+        EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
+    else:
+        EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
+    EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="background",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
-                        filename=EXPECTED_FILENAME_BACKGROUND,
-                        line_no=EXPECTED_LINE_NO_BACKGROUND,
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="background",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
+                    filename=EXPECTED_FILENAME_BACKGROUND,
+                    line_no=EXPECTED_LINE_NO_BACKGROUND,
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name=t1_name,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name=EXPECTED_FUNCTION_NAME_TRACKED,
-                        filename=EXPECTED_FILENAME_TRACKED,
-                        line_no=-1,  # any line
-                    )
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name=t1_name,
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name=EXPECTED_FUNCTION_NAME_TRACKED,
+                    filename=EXPECTED_FILENAME_TRACKED,
+                    line_no=-1,  # any line
+                )
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.xfail(reason="No way to get the current loop if it is set but not running.")
@@ -256,7 +252,6 @@ def test_asyncio_start_profiler_from_process_after_creating_loop() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     # Start an asyncio loop BEFORE importing profiler modules
     # This simulates the bug scenario where a loop exists before profiling is enabled
@@ -265,105 +260,104 @@ def test_asyncio_start_profiler_from_process_after_creating_loop() -> None:
 
     assert stack.is_available, stack.failure_msg
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler()
-        p.start()
+    p = profiler.Profiler()
+    p.start()
 
-        async def my_function():
-            async def background_task_func() -> None:
-                """Background task that runs in the existing loop."""
-                await asyncio.sleep(1.5)
+    async def my_function():
+        async def background_task_func() -> None:
+            """Background task that runs in the existing loop."""
+            await asyncio.sleep(1.5)
 
-            # Create and start a task in the existing loop
-            background_task = loop.create_task(background_task_func(), name="background")
-            assert background_task is not None
+        # Create and start a task in the existing loop
+        background_task = loop.create_task(background_task_func(), name="background")
+        assert background_task is not None
 
-            # Run tasks that should be tracked
-            sleep_time = 0.2
-            loop_run_time = 0.75
+        # Run tasks that should be tracked
+        sleep_time = 0.2
+        loop_run_time = 0.75
 
-            async def tracked_task() -> None:
-                start_time = time.time()
-                while time.time() < start_time + loop_run_time:
-                    await asyncio.sleep(sleep_time)
+        async def tracked_task() -> None:
+            start_time = time.time()
+            while time.time() < start_time + loop_run_time:
+                await asyncio.sleep(sleep_time)
 
-            async def main_task():
-                t1 = asyncio.create_task(tracked_task(), name="tracked 1")
-                t2 = asyncio.create_task(tracked_task(), name="tracked 2")
-                await tracked_task()
-                await asyncio.sleep(0.25)
-                return t1, t2
+        async def main_task():
+            t1 = asyncio.create_task(tracked_task(), name="tracked 1")
+            t2 = asyncio.create_task(tracked_task(), name="tracked 2")
+            await tracked_task()
+            await asyncio.sleep(0.25)
+            return t1, t2
 
-            result = await main_task()
+        result = await main_task()
 
-            await background_task
+        await background_task
 
-            return tracked_task, background_task_func, result
+        return tracked_task, background_task_func, result
 
-        main_task = loop.create_task(my_function(), name="main")
-        tracked_task_def, background_task_def, (t1, t2) = loop.run_until_complete(main_task)
+    main_task = loop.create_task(my_function(), name="main")
+    tracked_task_def, background_task_def, (t1, t2) = loop.run_until_complete(main_task)
 
-        p.stop()
+    p.stop()
 
-        t1_name = t1.get_name()
-        t2_name = t2.get_name()
+    t1_name = t1.get_name()
+    t2_name = t2.get_name()
 
-        assert t1_name == "tracked 1"
-        assert t2_name == "tracked 2"
+    assert t1_name == "tracked 1"
+    assert t2_name == "tracked 2"
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0, "No task names found - existing loop was not tracked!"
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0, "No task names found - existing loop was not tracked!"
 
-        EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
-        EXPECTED_LINE_NO_BACKGROUND = -1  # any line
-        if sys.version_info >= (3, 11):
-            EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
-        else:
-            EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
+    EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
+    EXPECTED_LINE_NO_BACKGROUND = -1  # any line
+    if sys.version_info >= (3, 11):
+        EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
+    else:
+        EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="background",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
-                        filename=EXPECTED_FILENAME_BACKGROUND,
-                        line_no=EXPECTED_LINE_NO_BACKGROUND,
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="background",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
+                    filename=EXPECTED_FILENAME_BACKGROUND,
+                    line_no=EXPECTED_LINE_NO_BACKGROUND,
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
-        # Verify specific tasks are in the profile
-        EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
+    # Verify specific tasks are in the profile
+    EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
 
-        if sys.version_info >= (3, 11):
-            EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
-        else:
-            EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
+    if sys.version_info >= (3, 11):
+        EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
+    else:
+        EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name=t1_name,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name=EXPECTED_FUNCTION_NAME_TRACKED,
-                        filename=EXPECTED_FILENAME_TRACKED,
-                        line_no=-1,  # any line
-                    )
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name=t1_name,
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name=EXPECTED_FUNCTION_NAME_TRACKED,
+                    filename=EXPECTED_FILENAME_TRACKED,
+                    line_no=-1,  # any line
+                )
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.xfail(reason="This test fails because there's no way to get the current loop if it's not already running.")
@@ -376,7 +370,6 @@ def test_asyncio_import_profiler_from_process_after_starting_loop() -> None:
     import time
 
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     # Start an asyncio loop BEFORE importing profiler modules
     # This simulates the bug scenario where a loop exists before profiling is enabled
@@ -388,105 +381,104 @@ def test_asyncio_import_profiler_from_process_after_starting_loop() -> None:
 
     assert stack.is_available, stack.failure_msg
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler()
-        p.start()
+    p = profiler.Profiler()
+    p.start()
 
-        async def my_function():
-            async def background_task_func() -> None:
-                """Background task that runs in the existing loop."""
-                await asyncio.sleep(1.5)
+    async def my_function():
+        async def background_task_func() -> None:
+            """Background task that runs in the existing loop."""
+            await asyncio.sleep(1.5)
 
-            # Create and start a task in the existing loop
-            background_task = loop.create_task(background_task_func(), name="background")
-            assert background_task is not None
+        # Create and start a task in the existing loop
+        background_task = loop.create_task(background_task_func(), name="background")
+        assert background_task is not None
 
-            # Run tasks that should be tracked
-            sleep_time = 0.2
-            loop_run_time = 0.75
+        # Run tasks that should be tracked
+        sleep_time = 0.2
+        loop_run_time = 0.75
 
-            async def tracked_task() -> None:
-                start_time = time.time()
-                while time.time() < start_time + loop_run_time:
-                    await asyncio.sleep(sleep_time)
+        async def tracked_task() -> None:
+            start_time = time.time()
+            while time.time() < start_time + loop_run_time:
+                await asyncio.sleep(sleep_time)
 
-            async def main_task():
-                t1 = asyncio.create_task(tracked_task(), name="tracked 1")
-                t2 = asyncio.create_task(tracked_task(), name="tracked 2")
-                await tracked_task()
-                await asyncio.sleep(0.25)
-                return t1, t2
+        async def main_task():
+            t1 = asyncio.create_task(tracked_task(), name="tracked 1")
+            t2 = asyncio.create_task(tracked_task(), name="tracked 2")
+            await tracked_task()
+            await asyncio.sleep(0.25)
+            return t1, t2
 
-            result = await main_task()
+        result = await main_task()
 
-            await background_task
+        await background_task
 
-            return tracked_task, background_task_func, result
+        return tracked_task, background_task_func, result
 
-        main_task = loop.create_task(my_function(), name="main")
-        tracked_task_def, background_task_def, (t1, t2) = loop.run_until_complete(main_task)
+    main_task = loop.create_task(my_function(), name="main")
+    tracked_task_def, background_task_def, (t1, t2) = loop.run_until_complete(main_task)
 
-        p.stop()
+    p.stop()
 
-        t1_name = t1.get_name()
-        t2_name = t2.get_name()
+    t1_name = t1.get_name()
+    t2_name = t2.get_name()
 
-        assert t1_name == "tracked 1"
-        assert t2_name == "tracked 2"
+    assert t1_name == "tracked 1"
+    assert t2_name == "tracked 2"
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0, "No task names found - existing loop was not tracked!"
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0, "No task names found - existing loop was not tracked!"
 
-        EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
-        EXPECTED_LINE_NO_BACKGROUND = -1  # any line
-        if sys.version_info >= (3, 11):
-            EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
-        else:
-            EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
+    EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
+    EXPECTED_LINE_NO_BACKGROUND = -1  # any line
+    if sys.version_info >= (3, 11):
+        EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
+    else:
+        EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="background",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
-                        filename=EXPECTED_FILENAME_BACKGROUND,
-                        line_no=EXPECTED_LINE_NO_BACKGROUND,
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="background",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
+                    filename=EXPECTED_FILENAME_BACKGROUND,
+                    line_no=EXPECTED_LINE_NO_BACKGROUND,
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
-        # Verify specific tasks are in the profile
-        EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
+    # Verify specific tasks are in the profile
+    EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
 
-        if sys.version_info >= (3, 11):
-            EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
-        else:
-            EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
+    if sys.version_info >= (3, 11):
+        EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
+    else:
+        EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name=t1_name,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name=EXPECTED_FUNCTION_NAME_TRACKED,
-                        filename=EXPECTED_FILENAME_TRACKED,
-                        line_no=-1,  # any line
-                    )
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name=t1_name,
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name=EXPECTED_FUNCTION_NAME_TRACKED,
+                    filename=EXPECTED_FILENAME_TRACKED,
+                    line_no=-1,  # any line
+                )
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.subprocess
@@ -500,137 +492,134 @@ def test_asyncio_start_profiler_from_process_after_task_start() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     # Start an asyncio loop BEFORE importing profiler modules
     # This simulates the bug scenario where a loop exists before profiling is enabled
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
-    with with_profiling_test_agent() as agent_client:
+    async def my_function():
+        async def background_task_func() -> None:
+            """Background task that runs in the existing loop."""
+            await asyncio.sleep(2.5)
 
-        async def my_function():
-            async def background_task_func() -> None:
-                """Background task that runs in the existing loop."""
-                await asyncio.sleep(2.5)
+        # Create and start a task in the existing loop
+        background_task = loop.create_task(background_task_func(), name="background")
+        assert background_task is not None
 
-            # Create and start a task in the existing loop
-            background_task = loop.create_task(background_task_func(), name="background")
-            assert background_task is not None
+        # Start profiler after loop is already running
+        assert asyncio.get_running_loop() is loop
 
-            # Start profiler after loop is already running
-            assert asyncio.get_running_loop() is loop
+        assert stack.is_available, stack.failure_msg
 
-            assert stack.is_available, stack.failure_msg
+        p = profiler.Profiler()
+        p.start()
 
-            p = profiler.Profiler()
-            p.start()
+        # Run tasks that should be tracked
+        sleep_time = 0.2
+        loop_run_time = 0.75
 
-            # Run tasks that should be tracked
-            sleep_time = 0.2
-            loop_run_time = 0.75
+        async def tracked_task() -> None:
+            start_time = time.time()
+            while time.time() < start_time + loop_run_time:
+                await asyncio.sleep(sleep_time)
 
-            async def tracked_task() -> None:
-                start_time = time.time()
-                while time.time() < start_time + loop_run_time:
-                    await asyncio.sleep(sleep_time)
+        async def main_task():
+            t1 = asyncio.create_task(tracked_task(), name="tracked 1")
+            t2 = asyncio.create_task(tracked_task(), name="tracked 2")
+            await tracked_task()
+            await asyncio.sleep(0.25)
+            return t1, t2
 
-            async def main_task():
-                t1 = asyncio.create_task(tracked_task(), name="tracked 1")
-                t2 = asyncio.create_task(tracked_task(), name="tracked 2")
-                await tracked_task()
-                await asyncio.sleep(0.25)
-                return t1, t2
+        result = await main_task()
 
-            result = await main_task()
+        await background_task
 
-            await background_task
+        return tracked_task, background_task_func, p, result
 
-            return tracked_task, background_task_func, p, result
+    main_task = loop.create_task(my_function(), name="main")
+    tracked_task_def, background_task_def, p, (t1, t2) = loop.run_until_complete(main_task)
 
-        main_task = loop.create_task(my_function(), name="main")
-        tracked_task_def, background_task_def, p, (t1, t2) = loop.run_until_complete(main_task)
+    p.stop()
 
-        p.stop()
+    t1_name = t1.get_name()
+    t2_name = t2.get_name()
 
-        t1_name = t1.get_name()
-        t2_name = t2.get_name()
+    assert t1_name == "tracked 1"
+    assert t2_name == "tracked 2"
 
-        assert t1_name == "tracked 1"
-        assert t2_name == "tracked 2"
+    profile = pprof_utils.get_profile_from_agent()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0, "No task names found - existing loop was not tracked!"
 
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0, "No task names found - existing loop was not tracked!"
+    EXPECTED_FILENAME_MAIN = os.path.basename(my_function.__code__.co_filename)
+    EXPECTED_LINE_NO_MAIN = -1  # any line
+    EXPECTED_FUNCTION_NAME_MAIN = my_function.__name__
 
-        EXPECTED_FILENAME_MAIN = os.path.basename(my_function.__code__.co_filename)
-        EXPECTED_LINE_NO_MAIN = -1  # any line
-        EXPECTED_FUNCTION_NAME_MAIN = my_function.__name__
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="main",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name=EXPECTED_FUNCTION_NAME_MAIN,
+                    filename=EXPECTED_FILENAME_MAIN,
+                    line_no=EXPECTED_LINE_NO_MAIN,
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="main",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name=EXPECTED_FUNCTION_NAME_MAIN,
-                        filename=EXPECTED_FILENAME_MAIN,
-                        line_no=EXPECTED_LINE_NO_MAIN,
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
+    EXPECTED_LINE_NO_BACKGROUND = -1  # any line
+    if sys.version_info >= (3, 11):
+        EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
+    else:
+        EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
 
-        EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
-        EXPECTED_LINE_NO_BACKGROUND = -1  # any line
-        if sys.version_info >= (3, 11):
-            EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
-        else:
-            EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="background",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
+                    filename=EXPECTED_FILENAME_BACKGROUND,
+                    line_no=EXPECTED_LINE_NO_BACKGROUND,
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="background",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
-                        filename=EXPECTED_FILENAME_BACKGROUND,
-                        line_no=EXPECTED_LINE_NO_BACKGROUND,
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    # Verify specific tasks are in the profile
+    EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
 
-        # Verify specific tasks are in the profile
-        EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
+    if sys.version_info >= (3, 11):
+        EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
+    else:
+        EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
 
-        if sys.version_info >= (3, 11):
-            EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
-        else:
-            EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
-
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name=EXPECTED_FUNCTION_NAME_TRACKED,
-                        filename=EXPECTED_FILENAME_TRACKED,
-                        line_no=-1,  # any line
-                    )
-                ],
-            ),
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name=EXPECTED_FUNCTION_NAME_TRACKED,
+                    filename=EXPECTED_FILENAME_TRACKED,
+                    line_no=-1,  # any line
+                )
+            ],
+        ),
+    )
 
 
 @pytest.mark.subprocess
@@ -641,117 +630,114 @@ def test_asyncio_import_and_start_profiler_from_process_after_task_start() -> No
     import time
 
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     # Start an asyncio loop BEFORE importing profiler modules
     # This simulates the bug scenario where a loop exists before profiling is enabled
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
-    with with_profiling_test_agent() as agent_client:
+    async def my_function():
+        async def background_task_func() -> None:
+            """Background task that runs in the existing loop."""
+            await asyncio.sleep(1.5)
 
-        async def my_function():
-            async def background_task_func() -> None:
-                """Background task that runs in the existing loop."""
-                await asyncio.sleep(1.5)
+        # Create and start a task in the existing loop
+        background_task = loop.create_task(background_task_func(), name="background")
+        assert background_task is not None
 
-            # Create and start a task in the existing loop
-            background_task = loop.create_task(background_task_func(), name="background")
-            assert background_task is not None
+        # Start profiler after loop is already running
+        assert asyncio.get_running_loop() is loop
 
-            # Start profiler after loop is already running
-            assert asyncio.get_running_loop() is loop
+        # NOW import profiling modules - this should track the existing loop
+        from ddtrace.internal.datadog.profiling import stack
+        from ddtrace.profiling import profiler
 
-            # NOW import profiling modules - this should track the existing loop
-            from ddtrace.internal.datadog.profiling import stack
-            from ddtrace.profiling import profiler
+        assert stack.is_available, stack.failure_msg
 
-            assert stack.is_available, stack.failure_msg
+        p = profiler.Profiler()
+        p.start()
 
-            p = profiler.Profiler()
-            p.start()
+        # Run tasks that should be tracked
+        sleep_time = 0.2
+        loop_run_time = 0.75
 
-            # Run tasks that should be tracked
-            sleep_time = 0.2
-            loop_run_time = 0.75
+        async def tracked_task() -> None:
+            start_time = time.time()
+            while time.time() < start_time + loop_run_time:
+                await asyncio.sleep(sleep_time)
 
-            async def tracked_task() -> None:
-                start_time = time.time()
-                while time.time() < start_time + loop_run_time:
-                    await asyncio.sleep(sleep_time)
+        async def main_task():
+            t1 = asyncio.create_task(tracked_task(), name="tracked 1")
+            t2 = asyncio.create_task(tracked_task(), name="tracked 2")
+            await tracked_task()
+            await asyncio.sleep(0.25)
+            return t1, t2
 
-            async def main_task():
-                t1 = asyncio.create_task(tracked_task(), name="tracked 1")
-                t2 = asyncio.create_task(tracked_task(), name="tracked 2")
-                await tracked_task()
-                await asyncio.sleep(0.25)
-                return t1, t2
+        result = await main_task()
 
-            result = await main_task()
+        await background_task
 
-            await background_task
+        return tracked_task, background_task_func, p, result
 
-            return tracked_task, background_task_func, p, result
+    main_task = loop.create_task(my_function(), name="main")
+    tracked_task_def, background_task_def, p, (t1, t2) = loop.run_until_complete(main_task)
 
-        main_task = loop.create_task(my_function(), name="main")
-        tracked_task_def, background_task_def, p, (t1, t2) = loop.run_until_complete(main_task)
+    p.stop()
 
-        p.stop()
+    t1_name = t1.get_name()
+    t2_name = t2.get_name()
 
-        t1_name = t1.get_name()
-        t2_name = t2.get_name()
+    assert t1_name == "tracked 1"
+    assert t2_name == "tracked 2"
 
-        assert t1_name == "tracked 1"
-        assert t2_name == "tracked 2"
+    profile = pprof_utils.get_profile_from_agent()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0, "No task names found - existing loop was not tracked!"
 
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0, "No task names found - existing loop was not tracked!"
+    if sys.version_info >= (3, 11):
+        EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
+    else:
+        EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
+    EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
+    EXPECTED_LINE_NO_BACKGROUND = -1  # any line
 
-        if sys.version_info >= (3, 11):
-            EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
-        else:
-            EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
-        EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
-        EXPECTED_LINE_NO_BACKGROUND = -1  # any line
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="background",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
+                    filename=EXPECTED_FILENAME_BACKGROUND,
+                    line_no=EXPECTED_LINE_NO_BACKGROUND,
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="background",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
-                        filename=EXPECTED_FILENAME_BACKGROUND,
-                        line_no=EXPECTED_LINE_NO_BACKGROUND,
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    # Verify specific tasks are in the profile
+    if sys.version_info >= (3, 11):
+        EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
+    else:
+        EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
+    EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
 
-        # Verify specific tasks are in the profile
-        if sys.version_info >= (3, 11):
-            EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
-        else:
-            EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
-        EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
-
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name=EXPECTED_FUNCTION_NAME_TRACKED,
-                        filename=EXPECTED_FILENAME_TRACKED,
-                        line_no=-1,  # any line
-                    )
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name=EXPECTED_FUNCTION_NAME_TRACKED,
+                    filename=EXPECTED_FILENAME_TRACKED,
+                    line_no=-1,  # any line
+                )
+            ],
+        ),
+        print_samples_on_failure=True,
+    )

--- a/tests/profiling/collector/test_asyncio_import_order.py
+++ b/tests/profiling/collector/test_asyncio_import_order.py
@@ -1,139 +1,130 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_start_profiler_from_process_before_importing_asyncio",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_asyncio_start_profiler_from_process_before_importing_asyncio() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    p = profiler.Profiler()
-    p.start()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler()
+        p.start()
 
-    import asyncio
-    import os
-    import sys
-    import time
+        import asyncio
+        import os
+        import sys
+        import time
 
-    from tests.profiling.collector import pprof_utils
+        from tests.profiling.collector import pprof_utils
 
-    # Start an asyncio loop BEFORE importing profiler modules
-    # This simulates the bug scenario where a loop exists before profiling is enabled
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
+        # Start an asyncio loop BEFORE importing profiler modules
+        # This simulates the bug scenario where a loop exists before profiling is enabled
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
-    async def my_function():
-        async def background_task_func() -> None:
-            """Background task that runs in the existing loop."""
-            await asyncio.sleep(1.5)
+        async def my_function():
+            async def background_task_func() -> None:
+                """Background task that runs in the existing loop."""
+                await asyncio.sleep(1.5)
 
-        # Create and start a task in the existing loop
-        background_task = loop.create_task(background_task_func(), name="background")
-        assert background_task is not None
+            # Create and start a task in the existing loop
+            background_task = loop.create_task(background_task_func(), name="background")
+            assert background_task is not None
 
-        # Run tasks that should be tracked
-        sleep_time = 0.2
-        loop_run_time = 0.75
+            # Run tasks that should be tracked
+            sleep_time = 0.2
+            loop_run_time = 0.75
 
-        async def tracked_task() -> None:
-            start_time = time.time()
-            while time.time() < start_time + loop_run_time:
-                await asyncio.sleep(sleep_time)
+            async def tracked_task() -> None:
+                start_time = time.time()
+                while time.time() < start_time + loop_run_time:
+                    await asyncio.sleep(sleep_time)
 
-        async def main_task():
-            t1 = asyncio.create_task(tracked_task(), name="tracked 1")
-            t2 = asyncio.create_task(tracked_task(), name="tracked 2")
-            await tracked_task()
-            await asyncio.sleep(0.25)
-            return t1, t2
+            async def main_task():
+                t1 = asyncio.create_task(tracked_task(), name="tracked 1")
+                t2 = asyncio.create_task(tracked_task(), name="tracked 2")
+                await tracked_task()
+                await asyncio.sleep(0.25)
+                return t1, t2
 
-        result = await main_task()
+            result = await main_task()
 
-        await background_task
+            await background_task
 
-        return tracked_task, background_task_func, result
+            return tracked_task, background_task_func, result
 
-    main_task = loop.create_task(my_function(), name="main")
-    tracked_task_def, background_task_def, (t1, t2) = loop.run_until_complete(main_task)
+        main_task = loop.create_task(my_function(), name="main")
+        tracked_task_def, background_task_def, (t1, t2) = loop.run_until_complete(main_task)
 
-    p.stop()
+        p.stop()
 
-    t1_name = t1.get_name()
-    t2_name = t2.get_name()
+        t1_name = t1.get_name()
+        t2_name = t2.get_name()
 
-    assert t1_name == "tracked 1"
-    assert t2_name == "tracked 2"
+        assert t1_name == "tracked 1"
+        assert t2_name == "tracked 2"
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0, "No task names found - existing loop was not tracked!"
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0, "No task names found - existing loop was not tracked!"
 
-    if sys.version_info >= (3, 11):
-        EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
-    else:
-        EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
+        if sys.version_info >= (3, 11):
+            EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
+        else:
+            EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
 
-    EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
-    EXPECTED_LINE_NO_BACKGROUND = -1  # any line
+        EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
+        EXPECTED_LINE_NO_BACKGROUND = -1  # any line
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="background",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
-                    filename=EXPECTED_FILENAME_BACKGROUND,
-                    line_no=EXPECTED_LINE_NO_BACKGROUND,
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="background",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
+                        filename=EXPECTED_FILENAME_BACKGROUND,
+                        line_no=EXPECTED_LINE_NO_BACKGROUND,
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
-    # Verify specific tasks are in the profile
-    if sys.version_info >= (3, 11):
-        EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
-    else:
-        EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
+        # Verify specific tasks are in the profile
+        if sys.version_info >= (3, 11):
+            EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
+        else:
+            EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
 
-    EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
+        EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name=t1_name,
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name=EXPECTED_FUNCTION_NAME_TRACKED,
-                    filename=EXPECTED_FILENAME_TRACKED,
-                    line_no=-1,  # any line
-                )
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name=t1_name,
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name=EXPECTED_FUNCTION_NAME_TRACKED,
+                        filename=EXPECTED_FILENAME_TRACKED,
+                        line_no=-1,  # any line
+                    )
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_start_profiler_from_process_before_starting_loop",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_asyncio_start_profiler_from_process_before_starting_loop() -> None:
     import asyncio
@@ -144,121 +135,117 @@ def test_asyncio_start_profiler_from_process_before_starting_loop() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    p = profiler.Profiler()
-    p.start()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler()
+        p.start()
 
-    # Start an asyncio loop BEFORE importing profiler modules
-    # This simulates the bug scenario where a loop exists before profiling is enabled
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
+        # Start an asyncio loop BEFORE importing profiler modules
+        # This simulates the bug scenario where a loop exists before profiling is enabled
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
-    async def my_function():
-        async def background_task_func() -> None:
-            """Background task that runs in the existing loop."""
-            await asyncio.sleep(1.5)
+        async def my_function():
+            async def background_task_func() -> None:
+                """Background task that runs in the existing loop."""
+                await asyncio.sleep(1.5)
 
-        # Create and start a task in the existing loop
-        background_task = loop.create_task(background_task_func(), name="background")
-        assert background_task is not None
+            # Create and start a task in the existing loop
+            background_task = loop.create_task(background_task_func(), name="background")
+            assert background_task is not None
 
-        # Run tasks that should be tracked
-        sleep_time = 0.2
-        loop_run_time = 0.75
+            # Run tasks that should be tracked
+            sleep_time = 0.2
+            loop_run_time = 0.75
 
-        async def tracked_task() -> None:
-            start_time = time.time()
-            while time.time() < start_time + loop_run_time:
-                await asyncio.sleep(sleep_time)
+            async def tracked_task() -> None:
+                start_time = time.time()
+                while time.time() < start_time + loop_run_time:
+                    await asyncio.sleep(sleep_time)
 
-        async def main_task():
-            t1 = asyncio.create_task(tracked_task(), name="tracked 1")
-            t2 = asyncio.create_task(tracked_task(), name="tracked 2")
-            await tracked_task()
-            await asyncio.sleep(0.25)
-            return t1, t2
+            async def main_task():
+                t1 = asyncio.create_task(tracked_task(), name="tracked 1")
+                t2 = asyncio.create_task(tracked_task(), name="tracked 2")
+                await tracked_task()
+                await asyncio.sleep(0.25)
+                return t1, t2
 
-        result = await main_task()
+            result = await main_task()
 
-        await background_task
+            await background_task
 
-        return tracked_task, background_task_func, result
+            return tracked_task, background_task_func, result
 
-    main_task = loop.create_task(my_function(), name="main")
-    tracked_task_def, background_task_def, (t1, t2) = loop.run_until_complete(main_task)
+        main_task = loop.create_task(my_function(), name="main")
+        tracked_task_def, background_task_def, (t1, t2) = loop.run_until_complete(main_task)
 
-    p.stop()
+        p.stop()
 
-    t1_name = t1.get_name()
-    t2_name = t2.get_name()
+        t1_name = t1.get_name()
+        t2_name = t2.get_name()
 
-    assert t1_name == "tracked 1"
-    assert t2_name == "tracked 2"
+        assert t1_name == "tracked 1"
+        assert t2_name == "tracked 2"
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0, "No task names found - existing loop was not tracked!"
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0, "No task names found - existing loop was not tracked!"
 
-    if sys.version_info >= (3, 11):
-        EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
-    else:
-        EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
-    EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
-    EXPECTED_LINE_NO_BACKGROUND = -1  # any line
+        if sys.version_info >= (3, 11):
+            EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
+        else:
+            EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
+        EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
+        EXPECTED_LINE_NO_BACKGROUND = -1  # any line
 
-    # Verify specific tasks are in the profile
-    if sys.version_info >= (3, 11):
-        EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
-    else:
-        EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
-    EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
+        # Verify specific tasks are in the profile
+        if sys.version_info >= (3, 11):
+            EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
+        else:
+            EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
+        EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="background",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
-                    filename=EXPECTED_FILENAME_BACKGROUND,
-                    line_no=EXPECTED_LINE_NO_BACKGROUND,
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="background",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
+                        filename=EXPECTED_FILENAME_BACKGROUND,
+                        line_no=EXPECTED_LINE_NO_BACKGROUND,
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name=t1_name,
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name=EXPECTED_FUNCTION_NAME_TRACKED,
-                    filename=EXPECTED_FILENAME_TRACKED,
-                    line_no=-1,  # any line
-                )
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name=t1_name,
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name=EXPECTED_FUNCTION_NAME_TRACKED,
+                        filename=EXPECTED_FILENAME_TRACKED,
+                        line_no=-1,  # any line
+                    )
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.xfail(reason="No way to get the current loop if it is set but not running.")
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_start_profiler_from_process_after_creating_loop",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_asyncio_start_profiler_from_process_after_creating_loop() -> None:
     import asyncio
@@ -269,6 +256,7 @@ def test_asyncio_start_profiler_from_process_after_creating_loop() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     # Start an asyncio loop BEFORE importing profiler modules
     # This simulates the bug scenario where a loop exists before profiling is enabled
@@ -277,114 +265,109 @@ def test_asyncio_start_profiler_from_process_after_creating_loop() -> None:
 
     assert stack.is_available, stack.failure_msg
 
-    p = profiler.Profiler()
-    p.start()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler()
+        p.start()
 
-    async def my_function():
-        async def background_task_func() -> None:
-            """Background task that runs in the existing loop."""
-            await asyncio.sleep(1.5)
+        async def my_function():
+            async def background_task_func() -> None:
+                """Background task that runs in the existing loop."""
+                await asyncio.sleep(1.5)
 
-        # Create and start a task in the existing loop
-        background_task = loop.create_task(background_task_func(), name="background")
-        assert background_task is not None
+            # Create and start a task in the existing loop
+            background_task = loop.create_task(background_task_func(), name="background")
+            assert background_task is not None
 
-        # Run tasks that should be tracked
-        sleep_time = 0.2
-        loop_run_time = 0.75
+            # Run tasks that should be tracked
+            sleep_time = 0.2
+            loop_run_time = 0.75
 
-        async def tracked_task() -> None:
-            start_time = time.time()
-            while time.time() < start_time + loop_run_time:
-                await asyncio.sleep(sleep_time)
+            async def tracked_task() -> None:
+                start_time = time.time()
+                while time.time() < start_time + loop_run_time:
+                    await asyncio.sleep(sleep_time)
 
-        async def main_task():
-            t1 = asyncio.create_task(tracked_task(), name="tracked 1")
-            t2 = asyncio.create_task(tracked_task(), name="tracked 2")
-            await tracked_task()
-            await asyncio.sleep(0.25)
-            return t1, t2
+            async def main_task():
+                t1 = asyncio.create_task(tracked_task(), name="tracked 1")
+                t2 = asyncio.create_task(tracked_task(), name="tracked 2")
+                await tracked_task()
+                await asyncio.sleep(0.25)
+                return t1, t2
 
-        result = await main_task()
+            result = await main_task()
 
-        await background_task
+            await background_task
 
-        return tracked_task, background_task_func, result
+            return tracked_task, background_task_func, result
 
-    main_task = loop.create_task(my_function(), name="main")
-    tracked_task_def, background_task_def, (t1, t2) = loop.run_until_complete(main_task)
+        main_task = loop.create_task(my_function(), name="main")
+        tracked_task_def, background_task_def, (t1, t2) = loop.run_until_complete(main_task)
 
-    p.stop()
+        p.stop()
 
-    t1_name = t1.get_name()
-    t2_name = t2.get_name()
+        t1_name = t1.get_name()
+        t2_name = t2.get_name()
 
-    assert t1_name == "tracked 1"
-    assert t2_name == "tracked 2"
+        assert t1_name == "tracked 1"
+        assert t2_name == "tracked 2"
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0, "No task names found - existing loop was not tracked!"
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0, "No task names found - existing loop was not tracked!"
 
-    EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
-    EXPECTED_LINE_NO_BACKGROUND = -1  # any line
-    if sys.version_info >= (3, 11):
-        EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
-    else:
-        EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
+        EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
+        EXPECTED_LINE_NO_BACKGROUND = -1  # any line
+        if sys.version_info >= (3, 11):
+            EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
+        else:
+            EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="background",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
-                    filename=EXPECTED_FILENAME_BACKGROUND,
-                    line_no=EXPECTED_LINE_NO_BACKGROUND,
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="background",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
+                        filename=EXPECTED_FILENAME_BACKGROUND,
+                        line_no=EXPECTED_LINE_NO_BACKGROUND,
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
-    # Verify specific tasks are in the profile
-    EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
+        # Verify specific tasks are in the profile
+        EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
 
-    if sys.version_info >= (3, 11):
-        EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
-    else:
-        EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
+        if sys.version_info >= (3, 11):
+            EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
+        else:
+            EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name=t1_name,
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name=EXPECTED_FUNCTION_NAME_TRACKED,
-                    filename=EXPECTED_FILENAME_TRACKED,
-                    line_no=-1,  # any line
-                )
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name=t1_name,
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name=EXPECTED_FUNCTION_NAME_TRACKED,
+                        filename=EXPECTED_FILENAME_TRACKED,
+                        line_no=-1,  # any line
+                    )
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.xfail(reason="This test fails because there's no way to get the current loop if it's not already running.")
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_import_profiler_from_process_after_starting_loop",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_asyncio_import_profiler_from_process_after_starting_loop() -> None:
     import asyncio
@@ -393,6 +376,7 @@ def test_asyncio_import_profiler_from_process_after_starting_loop() -> None:
     import time
 
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     # Start an asyncio loop BEFORE importing profiler modules
     # This simulates the bug scenario where a loop exists before profiling is enabled
@@ -404,113 +388,108 @@ def test_asyncio_import_profiler_from_process_after_starting_loop() -> None:
 
     assert stack.is_available, stack.failure_msg
 
-    p = profiler.Profiler()
-    p.start()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler()
+        p.start()
 
-    async def my_function():
-        async def background_task_func() -> None:
-            """Background task that runs in the existing loop."""
-            await asyncio.sleep(1.5)
+        async def my_function():
+            async def background_task_func() -> None:
+                """Background task that runs in the existing loop."""
+                await asyncio.sleep(1.5)
 
-        # Create and start a task in the existing loop
-        background_task = loop.create_task(background_task_func(), name="background")
-        assert background_task is not None
+            # Create and start a task in the existing loop
+            background_task = loop.create_task(background_task_func(), name="background")
+            assert background_task is not None
 
-        # Run tasks that should be tracked
-        sleep_time = 0.2
-        loop_run_time = 0.75
+            # Run tasks that should be tracked
+            sleep_time = 0.2
+            loop_run_time = 0.75
 
-        async def tracked_task() -> None:
-            start_time = time.time()
-            while time.time() < start_time + loop_run_time:
-                await asyncio.sleep(sleep_time)
+            async def tracked_task() -> None:
+                start_time = time.time()
+                while time.time() < start_time + loop_run_time:
+                    await asyncio.sleep(sleep_time)
 
-        async def main_task():
-            t1 = asyncio.create_task(tracked_task(), name="tracked 1")
-            t2 = asyncio.create_task(tracked_task(), name="tracked 2")
-            await tracked_task()
-            await asyncio.sleep(0.25)
-            return t1, t2
+            async def main_task():
+                t1 = asyncio.create_task(tracked_task(), name="tracked 1")
+                t2 = asyncio.create_task(tracked_task(), name="tracked 2")
+                await tracked_task()
+                await asyncio.sleep(0.25)
+                return t1, t2
 
-        result = await main_task()
+            result = await main_task()
 
-        await background_task
+            await background_task
 
-        return tracked_task, background_task_func, result
+            return tracked_task, background_task_func, result
 
-    main_task = loop.create_task(my_function(), name="main")
-    tracked_task_def, background_task_def, (t1, t2) = loop.run_until_complete(main_task)
+        main_task = loop.create_task(my_function(), name="main")
+        tracked_task_def, background_task_def, (t1, t2) = loop.run_until_complete(main_task)
 
-    p.stop()
+        p.stop()
 
-    t1_name = t1.get_name()
-    t2_name = t2.get_name()
+        t1_name = t1.get_name()
+        t2_name = t2.get_name()
 
-    assert t1_name == "tracked 1"
-    assert t2_name == "tracked 2"
+        assert t1_name == "tracked 1"
+        assert t2_name == "tracked 2"
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0, "No task names found - existing loop was not tracked!"
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0, "No task names found - existing loop was not tracked!"
 
-    EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
-    EXPECTED_LINE_NO_BACKGROUND = -1  # any line
-    if sys.version_info >= (3, 11):
-        EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
-    else:
-        EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
+        EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
+        EXPECTED_LINE_NO_BACKGROUND = -1  # any line
+        if sys.version_info >= (3, 11):
+            EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
+        else:
+            EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="background",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
-                    filename=EXPECTED_FILENAME_BACKGROUND,
-                    line_no=EXPECTED_LINE_NO_BACKGROUND,
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="background",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
+                        filename=EXPECTED_FILENAME_BACKGROUND,
+                        line_no=EXPECTED_LINE_NO_BACKGROUND,
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
-    # Verify specific tasks are in the profile
-    EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
+        # Verify specific tasks are in the profile
+        EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
 
-    if sys.version_info >= (3, 11):
-        EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
-    else:
-        EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
+        if sys.version_info >= (3, 11):
+            EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
+        else:
+            EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name=t1_name,
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name=EXPECTED_FUNCTION_NAME_TRACKED,
-                    filename=EXPECTED_FILENAME_TRACKED,
-                    line_no=-1,  # any line
-                )
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name=t1_name,
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name=EXPECTED_FUNCTION_NAME_TRACKED,
+                        filename=EXPECTED_FILENAME_TRACKED,
+                        line_no=-1,  # any line
+                    )
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_start_profiler_from_process_after_creating_loop_and_task",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess
 def test_asyncio_start_profiler_from_process_after_task_start() -> None:
     # NOW import profiling modules - this should track the existing loop
     import asyncio
@@ -521,143 +500,140 @@ def test_asyncio_start_profiler_from_process_after_task_start() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     # Start an asyncio loop BEFORE importing profiler modules
     # This simulates the bug scenario where a loop exists before profiling is enabled
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
-    async def my_function():
-        async def background_task_func() -> None:
-            """Background task that runs in the existing loop."""
-            await asyncio.sleep(2.5)
+    with with_profiling_test_agent() as agent_client:
 
-        # Create and start a task in the existing loop
-        background_task = loop.create_task(background_task_func(), name="background")
-        assert background_task is not None
+        async def my_function():
+            async def background_task_func() -> None:
+                """Background task that runs in the existing loop."""
+                await asyncio.sleep(2.5)
 
-        # Start profiler after loop is already running
-        assert asyncio.get_running_loop() is loop
+            # Create and start a task in the existing loop
+            background_task = loop.create_task(background_task_func(), name="background")
+            assert background_task is not None
 
-        assert stack.is_available, stack.failure_msg
+            # Start profiler after loop is already running
+            assert asyncio.get_running_loop() is loop
 
-        p = profiler.Profiler()
-        p.start()
+            assert stack.is_available, stack.failure_msg
 
-        # Run tasks that should be tracked
-        sleep_time = 0.2
-        loop_run_time = 0.75
+            p = profiler.Profiler()
+            p.start()
 
-        async def tracked_task() -> None:
-            start_time = time.time()
-            while time.time() < start_time + loop_run_time:
-                await asyncio.sleep(sleep_time)
+            # Run tasks that should be tracked
+            sleep_time = 0.2
+            loop_run_time = 0.75
 
-        async def main_task():
-            t1 = asyncio.create_task(tracked_task(), name="tracked 1")
-            t2 = asyncio.create_task(tracked_task(), name="tracked 2")
-            await tracked_task()
-            await asyncio.sleep(0.25)
-            return t1, t2
+            async def tracked_task() -> None:
+                start_time = time.time()
+                while time.time() < start_time + loop_run_time:
+                    await asyncio.sleep(sleep_time)
 
-        result = await main_task()
+            async def main_task():
+                t1 = asyncio.create_task(tracked_task(), name="tracked 1")
+                t2 = asyncio.create_task(tracked_task(), name="tracked 2")
+                await tracked_task()
+                await asyncio.sleep(0.25)
+                return t1, t2
 
-        await background_task
+            result = await main_task()
 
-        return tracked_task, background_task_func, p, result
+            await background_task
 
-    main_task = loop.create_task(my_function(), name="main")
-    tracked_task_def, background_task_def, p, (t1, t2) = loop.run_until_complete(main_task)
+            return tracked_task, background_task_func, p, result
 
-    p.stop()
+        main_task = loop.create_task(my_function(), name="main")
+        tracked_task_def, background_task_def, p, (t1, t2) = loop.run_until_complete(main_task)
 
-    t1_name = t1.get_name()
-    t2_name = t2.get_name()
+        p.stop()
 
-    assert t1_name == "tracked 1"
-    assert t2_name == "tracked 2"
+        t1_name = t1.get_name()
+        t2_name = t2.get_name()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        assert t1_name == "tracked 1"
+        assert t2_name == "tracked 2"
 
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0, "No task names found - existing loop was not tracked!"
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    EXPECTED_FILENAME_MAIN = os.path.basename(my_function.__code__.co_filename)
-    EXPECTED_LINE_NO_MAIN = -1  # any line
-    EXPECTED_FUNCTION_NAME_MAIN = my_function.__name__
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0, "No task names found - existing loop was not tracked!"
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="main",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name=EXPECTED_FUNCTION_NAME_MAIN,
-                    filename=EXPECTED_FILENAME_MAIN,
-                    line_no=EXPECTED_LINE_NO_MAIN,
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        EXPECTED_FILENAME_MAIN = os.path.basename(my_function.__code__.co_filename)
+        EXPECTED_LINE_NO_MAIN = -1  # any line
+        EXPECTED_FUNCTION_NAME_MAIN = my_function.__name__
 
-    EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
-    EXPECTED_LINE_NO_BACKGROUND = -1  # any line
-    if sys.version_info >= (3, 11):
-        EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
-    else:
-        EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="main",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name=EXPECTED_FUNCTION_NAME_MAIN,
+                        filename=EXPECTED_FILENAME_MAIN,
+                        line_no=EXPECTED_LINE_NO_MAIN,
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="background",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
-                    filename=EXPECTED_FILENAME_BACKGROUND,
-                    line_no=EXPECTED_LINE_NO_BACKGROUND,
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
+        EXPECTED_LINE_NO_BACKGROUND = -1  # any line
+        if sys.version_info >= (3, 11):
+            EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
+        else:
+            EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
 
-    # Verify specific tasks are in the profile
-    EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="background",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
+                        filename=EXPECTED_FILENAME_BACKGROUND,
+                        line_no=EXPECTED_LINE_NO_BACKGROUND,
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
-    if sys.version_info >= (3, 11):
-        EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
-    else:
-        EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
+        # Verify specific tasks are in the profile
+        EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name=EXPECTED_FUNCTION_NAME_TRACKED,
-                    filename=EXPECTED_FILENAME_TRACKED,
-                    line_no=-1,  # any line
-                )
-            ],
-        ),
-    )
+        if sys.version_info >= (3, 11):
+            EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
+        else:
+            EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
+
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name=EXPECTED_FUNCTION_NAME_TRACKED,
+                        filename=EXPECTED_FILENAME_TRACKED,
+                        line_no=-1,  # any line
+                    )
+                ],
+            ),
+        )
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_start_profiler_from_process_after_task_start",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess
 def test_asyncio_import_and_start_profiler_from_process_after_task_start() -> None:
     import asyncio
     import os
@@ -665,115 +641,117 @@ def test_asyncio_import_and_start_profiler_from_process_after_task_start() -> No
     import time
 
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     # Start an asyncio loop BEFORE importing profiler modules
     # This simulates the bug scenario where a loop exists before profiling is enabled
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
-    async def my_function():
-        async def background_task_func() -> None:
-            """Background task that runs in the existing loop."""
-            await asyncio.sleep(1.5)
+    with with_profiling_test_agent() as agent_client:
 
-        # Create and start a task in the existing loop
-        background_task = loop.create_task(background_task_func(), name="background")
-        assert background_task is not None
+        async def my_function():
+            async def background_task_func() -> None:
+                """Background task that runs in the existing loop."""
+                await asyncio.sleep(1.5)
 
-        # Start profiler after loop is already running
-        assert asyncio.get_running_loop() is loop
+            # Create and start a task in the existing loop
+            background_task = loop.create_task(background_task_func(), name="background")
+            assert background_task is not None
 
-        # NOW import profiling modules - this should track the existing loop
-        from ddtrace.internal.datadog.profiling import stack
-        from ddtrace.profiling import profiler
+            # Start profiler after loop is already running
+            assert asyncio.get_running_loop() is loop
 
-        assert stack.is_available, stack.failure_msg
+            # NOW import profiling modules - this should track the existing loop
+            from ddtrace.internal.datadog.profiling import stack
+            from ddtrace.profiling import profiler
 
-        p = profiler.Profiler()
-        p.start()
+            assert stack.is_available, stack.failure_msg
 
-        # Run tasks that should be tracked
-        sleep_time = 0.2
-        loop_run_time = 0.75
+            p = profiler.Profiler()
+            p.start()
 
-        async def tracked_task() -> None:
-            start_time = time.time()
-            while time.time() < start_time + loop_run_time:
-                await asyncio.sleep(sleep_time)
+            # Run tasks that should be tracked
+            sleep_time = 0.2
+            loop_run_time = 0.75
 
-        async def main_task():
-            t1 = asyncio.create_task(tracked_task(), name="tracked 1")
-            t2 = asyncio.create_task(tracked_task(), name="tracked 2")
-            await tracked_task()
-            await asyncio.sleep(0.25)
-            return t1, t2
+            async def tracked_task() -> None:
+                start_time = time.time()
+                while time.time() < start_time + loop_run_time:
+                    await asyncio.sleep(sleep_time)
 
-        result = await main_task()
+            async def main_task():
+                t1 = asyncio.create_task(tracked_task(), name="tracked 1")
+                t2 = asyncio.create_task(tracked_task(), name="tracked 2")
+                await tracked_task()
+                await asyncio.sleep(0.25)
+                return t1, t2
 
-        await background_task
+            result = await main_task()
 
-        return tracked_task, background_task_func, p, result
+            await background_task
 
-    main_task = loop.create_task(my_function(), name="main")
-    tracked_task_def, background_task_def, p, (t1, t2) = loop.run_until_complete(main_task)
+            return tracked_task, background_task_func, p, result
 
-    p.stop()
+        main_task = loop.create_task(my_function(), name="main")
+        tracked_task_def, background_task_def, p, (t1, t2) = loop.run_until_complete(main_task)
 
-    t1_name = t1.get_name()
-    t2_name = t2.get_name()
+        p.stop()
 
-    assert t1_name == "tracked 1"
-    assert t2_name == "tracked 2"
+        t1_name = t1.get_name()
+        t2_name = t2.get_name()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        assert t1_name == "tracked 1"
+        assert t2_name == "tracked 2"
 
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0, "No task names found - existing loop was not tracked!"
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    if sys.version_info >= (3, 11):
-        EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
-    else:
-        EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
-    EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
-    EXPECTED_LINE_NO_BACKGROUND = -1  # any line
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0, "No task names found - existing loop was not tracked!"
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="background",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
-                    filename=EXPECTED_FILENAME_BACKGROUND,
-                    line_no=EXPECTED_LINE_NO_BACKGROUND,
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        if sys.version_info >= (3, 11):
+            EXPECTED_FUNCTION_NAME_BACKGROUND = f"{my_function.__name__}.<locals>.{background_task_def.__name__}"
+        else:
+            EXPECTED_FUNCTION_NAME_BACKGROUND = background_task_def.__name__
+        EXPECTED_FILENAME_BACKGROUND = os.path.basename(background_task_def.__code__.co_filename)
+        EXPECTED_LINE_NO_BACKGROUND = -1  # any line
 
-    # Verify specific tasks are in the profile
-    if sys.version_info >= (3, 11):
-        EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
-    else:
-        EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
-    EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="background",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name=EXPECTED_FUNCTION_NAME_BACKGROUND,
+                        filename=EXPECTED_FILENAME_BACKGROUND,
+                        line_no=EXPECTED_LINE_NO_BACKGROUND,
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name=EXPECTED_FUNCTION_NAME_TRACKED,
-                    filename=EXPECTED_FILENAME_TRACKED,
-                    line_no=-1,  # any line
-                )
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        # Verify specific tasks are in the profile
+        if sys.version_info >= (3, 11):
+            EXPECTED_FUNCTION_NAME_TRACKED = f"{my_function.__name__}.<locals>.{tracked_task_def.__name__}"
+        else:
+            EXPECTED_FUNCTION_NAME_TRACKED = tracked_task_def.__name__
+        EXPECTED_FILENAME_TRACKED = os.path.basename(tracked_task_def.__code__.co_filename)
+
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name=EXPECTED_FUNCTION_NAME_TRACKED,
+                        filename=EXPECTED_FILENAME_TRACKED,
+                        line_no=-1,  # any line
+                    )
+                ],
+            ),
+            print_samples_on_failure=True,
+        )

--- a/tests/profiling/collector/test_asyncio_mixed_workload.py
+++ b/tests/profiling/collector/test_asyncio_mixed_workload.py
@@ -2,126 +2,121 @@ import pytest
 
 
 @pytest.mark.skip(reason="This is flaky in CI")
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_mixed_workload",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_asyncio_mixed_workload() -> None:
     import asyncio
     import math
-    import os
     import sys
 
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    async def dependency(t: float) -> None:
-        await asyncio.sleep(t)
+    with with_profiling_test_agent() as agent_client:
 
-    def heavy_computation() -> int:
-        result = 1
-        for i in range(150):
-            result *= math.factorial(i)
-        return result
+        async def dependency(t: float) -> None:
+            await asyncio.sleep(t)
 
-    async def mixed_workload() -> int:
-        await dependency(0.5)
+        def heavy_computation() -> int:
+            result = 1
+            for i in range(150):
+                result *= math.factorial(i)
+            return result
 
-        result = heavy_computation()
+        async def mixed_workload() -> int:
+            await dependency(0.5)
 
-        await dependency(0.25)
-        return result
+            result = heavy_computation()
 
-    async def async_main() -> None:
-        result = await mixed_workload()
-        assert result > 0
+            await dependency(0.25)
+            return result
 
-    def main() -> None:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(async_main())
+        async def async_main() -> None:
+            result = await mixed_workload()
+            assert result > 0
 
-    p = profiler.Profiler()
-    p.start()
-    main()
-    p.stop()
+        def main() -> None:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            loop.run_until_complete(async_main())
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+        p = profiler.Profiler()
+        p.start()
+        main()
+        p.stop()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0
 
-    def loc(f: str, filename: str = "", line: int = -1) -> pprof_utils.StackLocation:
-        return pprof_utils.StackLocation(
-            function_name=f,
-            filename=filename,
-            line_no=line,
+        def loc(f: str, filename: str = "", line: int = -1) -> pprof_utils.StackLocation:
+            return pprof_utils.StackLocation(
+                function_name=f,
+                filename=filename,
+                line_no=line,
+            )
+
+        handle = "Handle." if sys.version_info >= (3, 11) else ""
+        base_event_loop = "BaseEventLoop." if sys.version_info >= (3, 11) else ""
+        selector = (
+            ("KqueueSelector." if sys.platform == "darwin" else "EpollSelector.") if sys.version_info >= (3, 11) else ""
         )
 
-    handle = "Handle." if sys.version_info >= (3, 11) else ""
-    base_event_loop = "BaseEventLoop." if sys.version_info >= (3, 11) else ""
-    selector = (
-        ("KqueueSelector." if sys.platform == "darwin" else "EpollSelector.") if sys.version_info >= (3, 11) else ""
-    )
-
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            locations=list(
-                reversed(
-                    [
-                        loc("<module>"),
-                        loc("main"),
-                        loc(f"{base_event_loop}run_until_complete"),
-                        loc(f"{base_event_loop}run_forever"),
-                        loc(f"{base_event_loop}_run_once"),
-                        # This is select because we are EITHER running the idle coroutine OR the heavy computation
-                        # one, never both. So if we are in dependency/sleep, we are only running the idle coroutine,
-                        # so we will see select.
-                        loc(f"{selector}select"),
-                        # loc("Task-1"),
-                        loc("async_main"),
-                        loc("mixed_workload"),
-                        loc("dependency"),
-                        loc("sleep"),
-                    ]
-                )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                locations=list(
+                    reversed(
+                        [
+                            loc("<module>"),
+                            loc("main"),
+                            loc(f"{base_event_loop}run_until_complete"),
+                            loc(f"{base_event_loop}run_forever"),
+                            loc(f"{base_event_loop}_run_once"),
+                            # This is select because we are EITHER running the idle coroutine OR the heavy computation
+                            # one, never both. So if we are in dependency/sleep, we are only running the idle coroutine,
+                            # so we will see select.
+                            loc(f"{selector}select"),
+                            # loc("Task-1"),
+                            loc("async_main"),
+                            loc("mixed_workload"),
+                            loc("dependency"),
+                            loc("sleep"),
+                        ]
+                    )
+                ),
             ),
-        ),
-        print_samples_on_failure=True,
-    )
+            print_samples_on_failure=True,
+        )
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            locations=list(
-                reversed(
-                    [
-                        loc("<module>"),
-                        loc("main"),
-                        loc(f"{base_event_loop}run_until_complete"),
-                        loc(f"{base_event_loop}run_forever"),
-                        loc(f"{base_event_loop}_run_once"),
-                        loc(f"{handle}_run"),
-                        # loc("Task-1"),
-                        loc("async_main"),
-                        loc("mixed_workload"),
-                        loc("heavy_computation"),
-                    ]
-                )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                locations=list(
+                    reversed(
+                        [
+                            loc("<module>"),
+                            loc("main"),
+                            loc(f"{base_event_loop}run_until_complete"),
+                            loc(f"{base_event_loop}run_forever"),
+                            loc(f"{base_event_loop}_run_once"),
+                            loc(f"{handle}_run"),
+                            # loc("Task-1"),
+                            loc("async_main"),
+                            loc("mixed_workload"),
+                            loc("heavy_computation"),
+                        ]
+                    )
+                ),
             ),
-        ),
-        print_samples_on_failure=True,
-    )
+            print_samples_on_failure=True,
+        )

--- a/tests/profiling/collector/test_asyncio_mixed_workload.py
+++ b/tests/profiling/collector/test_asyncio_mixed_workload.py
@@ -12,111 +12,108 @@ def test_asyncio_mixed_workload() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    with with_profiling_test_agent() as agent_client:
+    async def dependency(t: float) -> None:
+        await asyncio.sleep(t)
 
-        async def dependency(t: float) -> None:
-            await asyncio.sleep(t)
+    def heavy_computation() -> int:
+        result = 1
+        for i in range(150):
+            result *= math.factorial(i)
+        return result
 
-        def heavy_computation() -> int:
-            result = 1
-            for i in range(150):
-                result *= math.factorial(i)
-            return result
+    async def mixed_workload() -> int:
+        await dependency(0.5)
 
-        async def mixed_workload() -> int:
-            await dependency(0.5)
+        result = heavy_computation()
 
-            result = heavy_computation()
+        await dependency(0.25)
+        return result
 
-            await dependency(0.25)
-            return result
+    async def async_main() -> None:
+        result = await mixed_workload()
+        assert result > 0
 
-        async def async_main() -> None:
-            result = await mixed_workload()
-            assert result > 0
+    def main() -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(async_main())
 
-        def main() -> None:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            loop.run_until_complete(async_main())
+    p = profiler.Profiler()
+    p.start()
+    main()
+    p.stop()
 
-        p = profiler.Profiler()
-        p.start()
-        main()
-        p.stop()
+    profile = pprof_utils.get_profile_from_agent()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0
 
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0
-
-        def loc(f: str, filename: str = "", line: int = -1) -> pprof_utils.StackLocation:
-            return pprof_utils.StackLocation(
-                function_name=f,
-                filename=filename,
-                line_no=line,
-            )
-
-        handle = "Handle." if sys.version_info >= (3, 11) else ""
-        base_event_loop = "BaseEventLoop." if sys.version_info >= (3, 11) else ""
-        selector = (
-            ("KqueueSelector." if sys.platform == "darwin" else "EpollSelector.") if sys.version_info >= (3, 11) else ""
+    def loc(f: str, filename: str = "", line: int = -1) -> pprof_utils.StackLocation:
+        return pprof_utils.StackLocation(
+            function_name=f,
+            filename=filename,
+            line_no=line,
         )
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                locations=list(
-                    reversed(
-                        [
-                            loc("<module>"),
-                            loc("main"),
-                            loc(f"{base_event_loop}run_until_complete"),
-                            loc(f"{base_event_loop}run_forever"),
-                            loc(f"{base_event_loop}_run_once"),
-                            # This is select because we are EITHER running the idle coroutine OR the heavy computation
-                            # one, never both. So if we are in dependency/sleep, we are only running the idle coroutine,
-                            # so we will see select.
-                            loc(f"{selector}select"),
-                            # loc("Task-1"),
-                            loc("async_main"),
-                            loc("mixed_workload"),
-                            loc("dependency"),
-                            loc("sleep"),
-                        ]
-                    )
-                ),
+    handle = "Handle." if sys.version_info >= (3, 11) else ""
+    base_event_loop = "BaseEventLoop." if sys.version_info >= (3, 11) else ""
+    selector = (
+        ("KqueueSelector." if sys.platform == "darwin" else "EpollSelector.") if sys.version_info >= (3, 11) else ""
+    )
+
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            locations=list(
+                reversed(
+                    [
+                        loc("<module>"),
+                        loc("main"),
+                        loc(f"{base_event_loop}run_until_complete"),
+                        loc(f"{base_event_loop}run_forever"),
+                        loc(f"{base_event_loop}_run_once"),
+                        # This is select because we are EITHER running the idle coroutine OR the heavy computation
+                        # one, never both. So if we are in dependency/sleep, we are only running the idle coroutine,
+                        # so we will see select.
+                        loc(f"{selector}select"),
+                        # loc("Task-1"),
+                        loc("async_main"),
+                        loc("mixed_workload"),
+                        loc("dependency"),
+                        loc("sleep"),
+                    ]
+                )
             ),
-            print_samples_on_failure=True,
-        )
+        ),
+        print_samples_on_failure=True,
+    )
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                locations=list(
-                    reversed(
-                        [
-                            loc("<module>"),
-                            loc("main"),
-                            loc(f"{base_event_loop}run_until_complete"),
-                            loc(f"{base_event_loop}run_forever"),
-                            loc(f"{base_event_loop}_run_once"),
-                            loc(f"{handle}_run"),
-                            # loc("Task-1"),
-                            loc("async_main"),
-                            loc("mixed_workload"),
-                            loc("heavy_computation"),
-                        ]
-                    )
-                ),
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            locations=list(
+                reversed(
+                    [
+                        loc("<module>"),
+                        loc("main"),
+                        loc(f"{base_event_loop}run_until_complete"),
+                        loc(f"{base_event_loop}run_forever"),
+                        loc(f"{base_event_loop}_run_once"),
+                        loc(f"{handle}_run"),
+                        # loc("Task-1"),
+                        loc("async_main"),
+                        loc("mixed_workload"),
+                        loc("heavy_computation"),
+                    ]
+                )
             ),
-            print_samples_on_failure=True,
-        )
+        ),
+        print_samples_on_failure=True,
+    )

--- a/tests/profiling/collector/test_asyncio_param_forwarding.py
+++ b/tests/profiling/collector/test_asyncio_param_forwarding.py
@@ -16,151 +16,148 @@ def test_asyncio_param_forwarding() -> None:
 
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    with with_profiling_test_agent():
+    async def noop() -> int:
+        await asyncio.sleep(0)
+        return 42
 
-        async def noop() -> int:
-            await asyncio.sleep(0)
-            return 42
+    # -- as_completed --------------------------------------------------------
 
-        # -- as_completed --------------------------------------------------------
+    async def test_as_completed_positional() -> None:
+        coros = [noop() for _ in range(3)]
+        results: list[int] = []
+        for fut in asyncio.as_completed(coros):
+            results.append(await fut)
+        assert sorted(results) == [42, 42, 42]
 
-        async def test_as_completed_positional() -> None:
-            coros = [noop() for _ in range(3)]
-            results: list[int] = []
-            for fut in asyncio.as_completed(coros):
-                results.append(await fut)
-            assert sorted(results) == [42, 42, 42]
+    async def test_as_completed_keyword() -> None:
+        coros = [noop() for _ in range(3)]
+        results: list[int] = []
+        for fut in asyncio.as_completed(fs=coros):
+            results.append(await fut)
+        assert sorted(results) == [42, 42, 42]
 
-        async def test_as_completed_keyword() -> None:
-            coros = [noop() for _ in range(3)]
-            results: list[int] = []
-            for fut in asyncio.as_completed(fs=coros):
-                results.append(await fut)
-            assert sorted(results) == [42, 42, 42]
+    async def test_as_completed_positional_with_timeout() -> None:
+        coros = [noop() for _ in range(3)]
+        results: list[int] = []
+        for fut in asyncio.as_completed(coros, timeout=10):
+            results.append(await fut)
+        assert sorted(results) == [42, 42, 42]
 
-        async def test_as_completed_positional_with_timeout() -> None:
-            coros = [noop() for _ in range(3)]
-            results: list[int] = []
-            for fut in asyncio.as_completed(coros, timeout=10):
-                results.append(await fut)
-            assert sorted(results) == [42, 42, 42]
+    async def test_as_completed_keyword_with_timeout() -> None:
+        coros = [noop() for _ in range(3)]
+        results: list[int] = []
+        for fut in asyncio.as_completed(fs=coros, timeout=10):
+            results.append(await fut)
+        assert sorted(results) == [42, 42, 42]
 
-        async def test_as_completed_keyword_with_timeout() -> None:
-            coros = [noop() for _ in range(3)]
-            results: list[int] = []
-            for fut in asyncio.as_completed(fs=coros, timeout=10):
-                results.append(await fut)
-            assert sorted(results) == [42, 42, 42]
+    # -- as_completed with loop (Python < 3.10) ------------------------------
 
-        # -- as_completed with loop (Python < 3.10) ------------------------------
+    async def test_as_completed_positional_with_loop() -> None:
+        loop = asyncio.get_running_loop()
+        coros = [noop() for _ in range(3)]
+        results: list[int] = []
+        for fut in asyncio.as_completed(coros, loop=loop):  # type: ignore[call-arg]
+            results.append(await fut)
+        assert sorted(results) == [42, 42, 42]
 
-        async def test_as_completed_positional_with_loop() -> None:
-            loop = asyncio.get_running_loop()
-            coros = [noop() for _ in range(3)]
-            results: list[int] = []
-            for fut in asyncio.as_completed(coros, loop=loop):  # type: ignore[call-arg]
-                results.append(await fut)
-            assert sorted(results) == [42, 42, 42]
+    async def test_as_completed_keyword_with_loop() -> None:
+        loop = asyncio.get_running_loop()
+        coros = [noop() for _ in range(3)]
+        results: list[int] = []
+        for fut in asyncio.as_completed(fs=coros, loop=loop):  # type: ignore[call-arg]
+            results.append(await fut)
+        assert sorted(results) == [42, 42, 42]
 
-        async def test_as_completed_keyword_with_loop() -> None:
-            loop = asyncio.get_running_loop()
-            coros = [noop() for _ in range(3)]
-            results: list[int] = []
-            for fut in asyncio.as_completed(fs=coros, loop=loop):  # type: ignore[call-arg]
-                results.append(await fut)
-            assert sorted(results) == [42, 42, 42]
+    # -- shield --------------------------------------------------------------
 
-        # -- shield --------------------------------------------------------------
+    async def test_shield_positional() -> None:
+        task = asyncio.create_task(noop())
+        result: int = await asyncio.shield(task)
+        assert result == 42
 
-        async def test_shield_positional() -> None:
-            task = asyncio.create_task(noop())
-            result: int = await asyncio.shield(task)
-            assert result == 42
+    async def test_shield_keyword() -> None:
+        task = asyncio.create_task(noop())
+        result: int = await asyncio.shield(arg=task)
+        assert result == 42
 
-        async def test_shield_keyword() -> None:
-            task = asyncio.create_task(noop())
-            result: int = await asyncio.shield(arg=task)
-            assert result == 42
+    # -- shield with loop (Python < 3.10) ------------------------------------
 
-        # -- shield with loop (Python < 3.10) ------------------------------------
+    async def test_shield_positional_with_loop() -> None:
+        loop = asyncio.get_running_loop()
+        task = asyncio.create_task(noop())
+        result: int = await asyncio.shield(task, loop=loop)  # type: ignore[call-arg]
+        assert result == 42
 
-        async def test_shield_positional_with_loop() -> None:
-            loop = asyncio.get_running_loop()
-            task = asyncio.create_task(noop())
-            result: int = await asyncio.shield(task, loop=loop)  # type: ignore[call-arg]
-            assert result == 42
+    async def test_shield_keyword_with_loop() -> None:
+        loop = asyncio.get_running_loop()
+        task = asyncio.create_task(noop())
+        result: int = await asyncio.shield(arg=task, loop=loop)  # type: ignore[call-arg]
+        assert result == 42
 
-        async def test_shield_keyword_with_loop() -> None:
-            loop = asyncio.get_running_loop()
-            task = asyncio.create_task(noop())
-            result: int = await asyncio.shield(arg=task, loop=loop)  # type: ignore[call-arg]
-            assert result == 42
+    # -- wait ----------------------------------------------------------------
 
-        # -- wait ----------------------------------------------------------------
+    async def test_wait_positional() -> None:
+        tasks = {asyncio.create_task(noop()) for _ in range(3)}
+        done, pending = await asyncio.wait(tasks)
+        assert len(done) == 3
+        assert len(pending) == 0
+        assert all(t.result() == 42 for t in done)
 
-        async def test_wait_positional() -> None:
-            tasks = {asyncio.create_task(noop()) for _ in range(3)}
-            done, pending = await asyncio.wait(tasks)
-            assert len(done) == 3
-            assert len(pending) == 0
-            assert all(t.result() == 42 for t in done)
+    async def test_wait_keyword() -> None:
+        tasks = {asyncio.create_task(noop()) for _ in range(3)}
+        done, pending = await asyncio.wait(fs=tasks)
+        assert len(done) == 3
+        assert len(pending) == 0
+        assert all(t.result() == 42 for t in done)
 
-        async def test_wait_keyword() -> None:
-            tasks = {asyncio.create_task(noop()) for _ in range(3)}
-            done, pending = await asyncio.wait(fs=tasks)
-            assert len(done) == 3
-            assert len(pending) == 0
-            assert all(t.result() == 42 for t in done)
+    # -- create_task ---------------------------------------------------------
 
-        # -- create_task ---------------------------------------------------------
+    async def test_create_task_positional() -> None:
+        task = asyncio.create_task(noop())
+        assert await task == 42
 
-        async def test_create_task_positional() -> None:
-            task = asyncio.create_task(noop())
-            assert await task == 42
+    async def test_create_task_keyword() -> None:
+        task = asyncio.create_task(noop(), name="test-task")
+        assert await task == 42
+        assert task.get_name() == "test-task"
 
-        async def test_create_task_keyword() -> None:
-            task = asyncio.create_task(noop(), name="test-task")
-            assert await task == 42
-            assert task.get_name() == "test-task"
+    # -- Run all tests -------------------------------------------------------
 
-        # -- Run all tests -------------------------------------------------------
+    p = profiler.Profiler()
+    p.start()
 
-        p = profiler.Profiler()
-        p.start()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+    tests = [
+        test_as_completed_positional,
+        test_as_completed_keyword,
+        test_as_completed_positional_with_timeout,
+        test_as_completed_keyword_with_timeout,
+        test_shield_positional,
+        test_shield_keyword,
+        test_wait_positional,
+        test_wait_keyword,
+        test_create_task_positional,
+        test_create_task_keyword,
+    ]
 
-        tests = [
-            test_as_completed_positional,
-            test_as_completed_keyword,
-            test_as_completed_positional_with_timeout,
-            test_as_completed_keyword_with_timeout,
-            test_shield_positional,
-            test_shield_keyword,
-            test_wait_positional,
-            test_wait_keyword,
-            test_create_task_positional,
-            test_create_task_keyword,
+    # loop parameter was removed from as_completed and shield in Python 3.10
+    if sys.hexversion < 0x030A0000:
+        tests += [
+            test_as_completed_positional_with_loop,
+            test_as_completed_keyword_with_loop,
+            test_shield_positional_with_loop,
+            test_shield_keyword_with_loop,
         ]
 
-        # loop parameter was removed from as_completed and shield in Python 3.10
-        if sys.hexversion < 0x030A0000:
-            tests += [
-                test_as_completed_positional_with_loop,
-                test_as_completed_keyword_with_loop,
-                test_shield_positional_with_loop,
-                test_shield_keyword_with_loop,
-            ]
+    for test in tests:
+        try:
+            loop.run_until_complete(test())
+        except Exception as e:
+            raise AssertionError(f"{test.__name__} failed: {e}") from e
 
-        for test in tests:
-            try:
-                loop.run_until_complete(test())
-            except Exception as e:
-                raise AssertionError(f"{test.__name__} failed: {e}") from e
-
-        p.stop()
+    p.stop()

--- a/tests/profiling/collector/test_asyncio_param_forwarding.py
+++ b/tests/profiling/collector/test_asyncio_param_forwarding.py
@@ -1,12 +1,7 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_param_forwarding",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess
 def test_asyncio_param_forwarding() -> None:
     """Verify that asyncio wrappers correctly forward parameters regardless of
     whether they are passed as positional args or keyword args.
@@ -21,148 +16,151 @@ def test_asyncio_param_forwarding() -> None:
 
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    async def noop() -> int:
-        await asyncio.sleep(0)
-        return 42
+    with with_profiling_test_agent():
 
-    # -- as_completed --------------------------------------------------------
+        async def noop() -> int:
+            await asyncio.sleep(0)
+            return 42
 
-    async def test_as_completed_positional() -> None:
-        coros = [noop() for _ in range(3)]
-        results: list[int] = []
-        for fut in asyncio.as_completed(coros):
-            results.append(await fut)
-        assert sorted(results) == [42, 42, 42]
+        # -- as_completed --------------------------------------------------------
 
-    async def test_as_completed_keyword() -> None:
-        coros = [noop() for _ in range(3)]
-        results: list[int] = []
-        for fut in asyncio.as_completed(fs=coros):
-            results.append(await fut)
-        assert sorted(results) == [42, 42, 42]
+        async def test_as_completed_positional() -> None:
+            coros = [noop() for _ in range(3)]
+            results: list[int] = []
+            for fut in asyncio.as_completed(coros):
+                results.append(await fut)
+            assert sorted(results) == [42, 42, 42]
 
-    async def test_as_completed_positional_with_timeout() -> None:
-        coros = [noop() for _ in range(3)]
-        results: list[int] = []
-        for fut in asyncio.as_completed(coros, timeout=10):
-            results.append(await fut)
-        assert sorted(results) == [42, 42, 42]
+        async def test_as_completed_keyword() -> None:
+            coros = [noop() for _ in range(3)]
+            results: list[int] = []
+            for fut in asyncio.as_completed(fs=coros):
+                results.append(await fut)
+            assert sorted(results) == [42, 42, 42]
 
-    async def test_as_completed_keyword_with_timeout() -> None:
-        coros = [noop() for _ in range(3)]
-        results: list[int] = []
-        for fut in asyncio.as_completed(fs=coros, timeout=10):
-            results.append(await fut)
-        assert sorted(results) == [42, 42, 42]
+        async def test_as_completed_positional_with_timeout() -> None:
+            coros = [noop() for _ in range(3)]
+            results: list[int] = []
+            for fut in asyncio.as_completed(coros, timeout=10):
+                results.append(await fut)
+            assert sorted(results) == [42, 42, 42]
 
-    # -- as_completed with loop (Python < 3.10) ------------------------------
+        async def test_as_completed_keyword_with_timeout() -> None:
+            coros = [noop() for _ in range(3)]
+            results: list[int] = []
+            for fut in asyncio.as_completed(fs=coros, timeout=10):
+                results.append(await fut)
+            assert sorted(results) == [42, 42, 42]
 
-    async def test_as_completed_positional_with_loop() -> None:
-        loop = asyncio.get_running_loop()
-        coros = [noop() for _ in range(3)]
-        results: list[int] = []
-        for fut in asyncio.as_completed(coros, loop=loop):  # type: ignore[call-arg]
-            results.append(await fut)
-        assert sorted(results) == [42, 42, 42]
+        # -- as_completed with loop (Python < 3.10) ------------------------------
 
-    async def test_as_completed_keyword_with_loop() -> None:
-        loop = asyncio.get_running_loop()
-        coros = [noop() for _ in range(3)]
-        results: list[int] = []
-        for fut in asyncio.as_completed(fs=coros, loop=loop):  # type: ignore[call-arg]
-            results.append(await fut)
-        assert sorted(results) == [42, 42, 42]
+        async def test_as_completed_positional_with_loop() -> None:
+            loop = asyncio.get_running_loop()
+            coros = [noop() for _ in range(3)]
+            results: list[int] = []
+            for fut in asyncio.as_completed(coros, loop=loop):  # type: ignore[call-arg]
+                results.append(await fut)
+            assert sorted(results) == [42, 42, 42]
 
-    # -- shield --------------------------------------------------------------
+        async def test_as_completed_keyword_with_loop() -> None:
+            loop = asyncio.get_running_loop()
+            coros = [noop() for _ in range(3)]
+            results: list[int] = []
+            for fut in asyncio.as_completed(fs=coros, loop=loop):  # type: ignore[call-arg]
+                results.append(await fut)
+            assert sorted(results) == [42, 42, 42]
 
-    async def test_shield_positional() -> None:
-        task = asyncio.create_task(noop())
-        result: int = await asyncio.shield(task)
-        assert result == 42
+        # -- shield --------------------------------------------------------------
 
-    async def test_shield_keyword() -> None:
-        task = asyncio.create_task(noop())
-        result: int = await asyncio.shield(arg=task)
-        assert result == 42
+        async def test_shield_positional() -> None:
+            task = asyncio.create_task(noop())
+            result: int = await asyncio.shield(task)
+            assert result == 42
 
-    # -- shield with loop (Python < 3.10) ------------------------------------
+        async def test_shield_keyword() -> None:
+            task = asyncio.create_task(noop())
+            result: int = await asyncio.shield(arg=task)
+            assert result == 42
 
-    async def test_shield_positional_with_loop() -> None:
-        loop = asyncio.get_running_loop()
-        task = asyncio.create_task(noop())
-        result: int = await asyncio.shield(task, loop=loop)  # type: ignore[call-arg]
-        assert result == 42
+        # -- shield with loop (Python < 3.10) ------------------------------------
 
-    async def test_shield_keyword_with_loop() -> None:
-        loop = asyncio.get_running_loop()
-        task = asyncio.create_task(noop())
-        result: int = await asyncio.shield(arg=task, loop=loop)  # type: ignore[call-arg]
-        assert result == 42
+        async def test_shield_positional_with_loop() -> None:
+            loop = asyncio.get_running_loop()
+            task = asyncio.create_task(noop())
+            result: int = await asyncio.shield(task, loop=loop)  # type: ignore[call-arg]
+            assert result == 42
 
-    # -- wait ----------------------------------------------------------------
+        async def test_shield_keyword_with_loop() -> None:
+            loop = asyncio.get_running_loop()
+            task = asyncio.create_task(noop())
+            result: int = await asyncio.shield(arg=task, loop=loop)  # type: ignore[call-arg]
+            assert result == 42
 
-    async def test_wait_positional() -> None:
-        tasks = {asyncio.create_task(noop()) for _ in range(3)}
-        done, pending = await asyncio.wait(tasks)
-        assert len(done) == 3
-        assert len(pending) == 0
-        assert all(t.result() == 42 for t in done)
+        # -- wait ----------------------------------------------------------------
 
-    async def test_wait_keyword() -> None:
-        tasks = {asyncio.create_task(noop()) for _ in range(3)}
-        done, pending = await asyncio.wait(fs=tasks)
-        assert len(done) == 3
-        assert len(pending) == 0
-        assert all(t.result() == 42 for t in done)
+        async def test_wait_positional() -> None:
+            tasks = {asyncio.create_task(noop()) for _ in range(3)}
+            done, pending = await asyncio.wait(tasks)
+            assert len(done) == 3
+            assert len(pending) == 0
+            assert all(t.result() == 42 for t in done)
 
-    # -- create_task ---------------------------------------------------------
+        async def test_wait_keyword() -> None:
+            tasks = {asyncio.create_task(noop()) for _ in range(3)}
+            done, pending = await asyncio.wait(fs=tasks)
+            assert len(done) == 3
+            assert len(pending) == 0
+            assert all(t.result() == 42 for t in done)
 
-    async def test_create_task_positional() -> None:
-        task = asyncio.create_task(noop())
-        assert await task == 42
+        # -- create_task ---------------------------------------------------------
 
-    async def test_create_task_keyword() -> None:
-        task = asyncio.create_task(noop(), name="test-task")
-        assert await task == 42
-        assert task.get_name() == "test-task"
+        async def test_create_task_positional() -> None:
+            task = asyncio.create_task(noop())
+            assert await task == 42
 
-    # -- Run all tests -------------------------------------------------------
+        async def test_create_task_keyword() -> None:
+            task = asyncio.create_task(noop(), name="test-task")
+            assert await task == 42
+            assert task.get_name() == "test-task"
 
-    p = profiler.Profiler()
-    p.start()
+        # -- Run all tests -------------------------------------------------------
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
+        p = profiler.Profiler()
+        p.start()
 
-    tests = [
-        test_as_completed_positional,
-        test_as_completed_keyword,
-        test_as_completed_positional_with_timeout,
-        test_as_completed_keyword_with_timeout,
-        test_shield_positional,
-        test_shield_keyword,
-        test_wait_positional,
-        test_wait_keyword,
-        test_create_task_positional,
-        test_create_task_keyword,
-    ]
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
-    # loop parameter was removed from as_completed and shield in Python 3.10
-    if sys.hexversion < 0x030A0000:
-        tests += [
-            test_as_completed_positional_with_loop,
-            test_as_completed_keyword_with_loop,
-            test_shield_positional_with_loop,
-            test_shield_keyword_with_loop,
+        tests = [
+            test_as_completed_positional,
+            test_as_completed_keyword,
+            test_as_completed_positional_with_timeout,
+            test_as_completed_keyword_with_timeout,
+            test_shield_positional,
+            test_shield_keyword,
+            test_wait_positional,
+            test_wait_keyword,
+            test_create_task_positional,
+            test_create_task_keyword,
         ]
 
-    for test in tests:
-        try:
-            loop.run_until_complete(test())
-        except Exception as e:
-            raise AssertionError(f"{test.__name__} failed: {e}") from e
+        # loop parameter was removed from as_completed and shield in Python 3.10
+        if sys.hexversion < 0x030A0000:
+            tests += [
+                test_as_completed_positional_with_loop,
+                test_as_completed_keyword_with_loop,
+                test_shield_positional_with_loop,
+                test_shield_keyword_with_loop,
+            ]
 
-    p.stop()
+        for test in tests:
+            try:
+                loop.run_until_complete(test())
+            except Exception as e:
+                raise AssertionError(f"{test.__name__} failed: {e}") from e
+
+        p.stop()

--- a/tests/profiling/collector/test_asyncio_recursive_on_cpu_coros.py
+++ b/tests/profiling/collector/test_asyncio_recursive_on_cpu_coros.py
@@ -16,111 +16,108 @@ def test_asyncio_recursive_on_cpu_coros():
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.pprof_utils import StackLocation
     from tests.profiling.collector.test_utils import async_run
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    with with_profiling_test_agent() as agent_client:
+    def sync_code() -> int:
+        target = time.time() + 1
+        result = 0
+        while time.time() < target:
+            result += 1
 
-        def sync_code() -> int:
-            target = time.time() + 1
-            result = 0
-            while time.time() < target:
-                result += 1
+        return result
 
-            return result
+    def sync_code_outer() -> int:
+        return sync_code()
 
-        def sync_code_outer() -> int:
-            return sync_code()
+    async def inner3() -> int:
+        return sync_code_outer()
 
-        async def inner3() -> int:
-            return sync_code_outer()
+    async def inner2() -> int:
+        return await inner3()
 
-        async def inner2() -> int:
-            return await inner3()
+    async def inner1() -> int:
+        return await inner2()
 
-        async def inner1() -> int:
-            return await inner2()
+    async def outer():
+        return await inner1()
 
-        async def outer():
-            return await inner1()
+    async def async_main():
+        return await outer()
 
-        async def async_main():
-            return await outer()
+    def main_sync():
+        async_run(async_main())
 
-        def main_sync():
-            async_run(async_main())
+    resource = str(uuid.uuid4())
+    span_type = ext.SpanTypes.WEB
 
-        resource = str(uuid.uuid4())
-        span_type = ext.SpanTypes.WEB
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+    with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
+        span_id = span.span_id
+        local_root_span_id = span._local_root.span_id
 
-        p = profiler.Profiler(tracer=tracer)
-        p.start()
-        with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
-            span_id = span.span_id
-            local_root_span_id = span._local_root.span_id
+        main_sync()
 
-            main_sync()
+    p.stop()
 
-        p.stop()
+    profile = pprof_utils.get_profile_from_agent()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    def loc(f_name: str, filename: str = "", line_no: int = -1) -> StackLocation:
+        return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
 
-        def loc(f_name: str, filename: str = "", line_no: int = -1) -> StackLocation:
-            return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
+    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
 
-        use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+    # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
+    # With uvloop, the stack has: main_sync → async_run → run (uvloop) → Runner.run → async_main
+    # Without uvloop: main_sync → run → Runner.run →
+    #                             run_until_complete → run_forever → _run_once → _run → async_main
+    if use_uvloop:
+        runner_frames = [
+            loc("async_run"),
+            loc("run"),  # uvloop run
+        ]
+        if PYVERSION >= (3, 11):
+            runner_frames += [loc("Runner.run")]
+        event_loop_frames = []
+    else:
+        base_event_loop_prefix = "BaseEventLoop." if PYVERSION >= (3, 11) else ""
+        handle_prefix = "Handle." if PYVERSION >= (3, 11) else ""
+        runner_prefix = "Runner." if PYVERSION >= (3, 11) else ""
+        runner_frames = [loc("run")] + ([loc(f"{runner_prefix}run")] if PYVERSION >= (3, 11) else [])
+        event_loop_frames = [
+            loc(f"{base_event_loop_prefix}run_until_complete"),
+            loc(f"{base_event_loop_prefix}run_forever"),
+            loc(f"{base_event_loop_prefix}_run_once"),
+            loc(f"{handle_prefix}_run"),
+        ]
 
-        # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
-        # With uvloop, the stack has: main_sync → async_run → run (uvloop) → Runner.run → async_main
-        # Without uvloop: main_sync → run → Runner.run →
-        #                             run_until_complete → run_forever → _run_once → _run → async_main
-        if use_uvloop:
-            runner_frames = [
-                loc("async_run"),
-                loc("run"),  # uvloop run
-            ]
-            if PYVERSION >= (3, 11):
-                runner_frames += [loc("Runner.run")]
-            event_loop_frames = []
-        else:
-            base_event_loop_prefix = "BaseEventLoop." if PYVERSION >= (3, 11) else ""
-            handle_prefix = "Handle." if PYVERSION >= (3, 11) else ""
-            runner_prefix = "Runner." if PYVERSION >= (3, 11) else ""
-            runner_frames = [loc("run")] + ([loc(f"{runner_prefix}run")] if PYVERSION >= (3, 11) else [])
-            event_loop_frames = [
-                loc(f"{base_event_loop_prefix}run_until_complete"),
-                loc(f"{base_event_loop_prefix}run_forever"),
-                loc(f"{base_event_loop_prefix}_run_once"),
-                loc(f"{handle_prefix}_run"),
-            ]
-
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            list(profile.sample),
-            pprof_utils.StackEvent(
-                thread_name="MainThread",
-                span_id=span_id,
-                local_root_span_id=local_root_span_id,
-                locations=list(
-                    reversed(
-                        [
-                            loc("<module>"),
-                            loc("main_sync"),
-                        ]
-                        + runner_frames
-                        + event_loop_frames
-                        + [
-                            loc("async_main"),
-                            loc("outer"),
-                            loc("inner1"),
-                            loc("inner2"),
-                            loc("inner3"),
-                            loc("sync_code_outer"),
-                            loc("sync_code"),
-                        ]
-                    )
-                ),
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        list(profile.sample),
+        pprof_utils.StackEvent(
+            thread_name="MainThread",
+            span_id=span_id,
+            local_root_span_id=local_root_span_id,
+            locations=list(
+                reversed(
+                    [
+                        loc("<module>"),
+                        loc("main_sync"),
+                    ]
+                    + runner_frames
+                    + event_loop_frames
+                    + [
+                        loc("async_main"),
+                        loc("outer"),
+                        loc("inner1"),
+                        loc("inner2"),
+                        loc("inner3"),
+                        loc("sync_code_outer"),
+                        loc("sync_code"),
+                    ]
+                )
             ),
-            print_samples_on_failure=True,
-        )
+        ),
+        print_samples_on_failure=True,
+    )

--- a/tests/profiling/collector/test_asyncio_recursive_on_cpu_coros.py
+++ b/tests/profiling/collector/test_asyncio_recursive_on_cpu_coros.py
@@ -1,12 +1,7 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_recursive_on_cpu_coros",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess(err=None)
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_asyncio_recursive_on_cpu_coros():
     import os
@@ -21,108 +16,111 @@ def test_asyncio_recursive_on_cpu_coros():
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.pprof_utils import StackLocation
     from tests.profiling.collector.test_utils import async_run
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    def sync_code() -> int:
-        target = time.time() + 1
-        result = 0
-        while time.time() < target:
-            result += 1
+    with with_profiling_test_agent() as agent_client:
 
-        return result
+        def sync_code() -> int:
+            target = time.time() + 1
+            result = 0
+            while time.time() < target:
+                result += 1
 
-    def sync_code_outer() -> int:
-        return sync_code()
+            return result
 
-    async def inner3() -> int:
-        return sync_code_outer()
+        def sync_code_outer() -> int:
+            return sync_code()
 
-    async def inner2() -> int:
-        return await inner3()
+        async def inner3() -> int:
+            return sync_code_outer()
 
-    async def inner1() -> int:
-        return await inner2()
+        async def inner2() -> int:
+            return await inner3()
 
-    async def outer():
-        return await inner1()
+        async def inner1() -> int:
+            return await inner2()
 
-    async def async_main():
-        return await outer()
+        async def outer():
+            return await inner1()
 
-    def main_sync():
-        async_run(async_main())
+        async def async_main():
+            return await outer()
 
-    resource = str(uuid.uuid4())
-    span_type = ext.SpanTypes.WEB
+        def main_sync():
+            async_run(async_main())
 
-    p = profiler.Profiler(tracer=tracer)
-    p.start()
-    with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
-        span_id = span.span_id
-        local_root_span_id = span._local_root.span_id
+        resource = str(uuid.uuid4())
+        span_type = ext.SpanTypes.WEB
 
-        main_sync()
+        p = profiler.Profiler(tracer=tracer)
+        p.start()
+        with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
+            span_id = span.span_id
+            local_root_span_id = span._local_root.span_id
 
-    p.stop()
+            main_sync()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        p.stop()
 
-    def loc(f_name: str, filename: str = "", line_no: int = -1) -> StackLocation:
-        return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+        def loc(f_name: str, filename: str = "", line_no: int = -1) -> StackLocation:
+            return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
 
-    # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
-    # With uvloop, the stack has: main_sync → async_run → run (uvloop) → Runner.run → async_main
-    # Without uvloop: main_sync → run → Runner.run → run_until_complete → run_forever → _run_once → _run → async_main
-    if use_uvloop:
-        runner_frames = [
-            loc("async_run"),
-            loc("run"),  # uvloop run
-        ]
-        if PYVERSION >= (3, 11):
-            runner_frames += [loc("Runner.run")]
-        event_loop_frames = []
-    else:
-        base_event_loop_prefix = "BaseEventLoop." if PYVERSION >= (3, 11) else ""
-        handle_prefix = "Handle." if PYVERSION >= (3, 11) else ""
-        runner_prefix = "Runner." if PYVERSION >= (3, 11) else ""
-        runner_frames = [loc("run")] + ([loc(f"{runner_prefix}run")] if PYVERSION >= (3, 11) else [])
-        event_loop_frames = [
-            loc(f"{base_event_loop_prefix}run_until_complete"),
-            loc(f"{base_event_loop_prefix}run_forever"),
-            loc(f"{base_event_loop_prefix}_run_once"),
-            loc(f"{handle_prefix}_run"),
-        ]
+        use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        list(profile.sample),
-        pprof_utils.StackEvent(
-            thread_name="MainThread",
-            span_id=span_id,
-            local_root_span_id=local_root_span_id,
-            locations=list(
-                reversed(
-                    [
-                        loc("<module>"),
-                        loc("main_sync"),
-                    ]
-                    + runner_frames
-                    + event_loop_frames
-                    + [
-                        loc("async_main"),
-                        loc("outer"),
-                        loc("inner1"),
-                        loc("inner2"),
-                        loc("inner3"),
-                        loc("sync_code_outer"),
-                        loc("sync_code"),
-                    ]
-                )
+        # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
+        # With uvloop, the stack has: main_sync → async_run → run (uvloop) → Runner.run → async_main
+        # Without uvloop: main_sync → run → Runner.run →
+        #                             run_until_complete → run_forever → _run_once → _run → async_main
+        if use_uvloop:
+            runner_frames = [
+                loc("async_run"),
+                loc("run"),  # uvloop run
+            ]
+            if PYVERSION >= (3, 11):
+                runner_frames += [loc("Runner.run")]
+            event_loop_frames = []
+        else:
+            base_event_loop_prefix = "BaseEventLoop." if PYVERSION >= (3, 11) else ""
+            handle_prefix = "Handle." if PYVERSION >= (3, 11) else ""
+            runner_prefix = "Runner." if PYVERSION >= (3, 11) else ""
+            runner_frames = [loc("run")] + ([loc(f"{runner_prefix}run")] if PYVERSION >= (3, 11) else [])
+            event_loop_frames = [
+                loc(f"{base_event_loop_prefix}run_until_complete"),
+                loc(f"{base_event_loop_prefix}run_forever"),
+                loc(f"{base_event_loop_prefix}_run_once"),
+                loc(f"{handle_prefix}_run"),
+            ]
+
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            list(profile.sample),
+            pprof_utils.StackEvent(
+                thread_name="MainThread",
+                span_id=span_id,
+                local_root_span_id=local_root_span_id,
+                locations=list(
+                    reversed(
+                        [
+                            loc("<module>"),
+                            loc("main_sync"),
+                        ]
+                        + runner_frames
+                        + event_loop_frames
+                        + [
+                            loc("async_main"),
+                            loc("outer"),
+                            loc("inner1"),
+                            loc("inner2"),
+                            loc("inner3"),
+                            loc("sync_code_outer"),
+                            loc("sync_code"),
+                        ]
+                    )
+                ),
             ),
-        ),
-        print_samples_on_failure=True,
-    )
+            print_samples_on_failure=True,
+        )

--- a/tests/profiling/collector/test_asyncio_recursive_on_cpu_tasks.py
+++ b/tests/profiling/collector/test_asyncio_recursive_on_cpu_tasks.py
@@ -17,151 +17,148 @@ def test_asyncio_recursive_on_cpu_tasks():
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.pprof_utils import StackLocation
     from tests.profiling.collector.test_utils import async_run
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    with with_profiling_test_agent() as agent_client:
+    def sync_code() -> int:
+        target = time.time() + 1
+        result = 0
+        while time.time() < target:
+            result += 1
 
-        def sync_code() -> int:
-            target = time.time() + 1
-            result = 0
-            while time.time() < target:
-                result += 1
+        return result
 
-            return result
+    def sync_code_outer() -> int:
+        return sync_code()
 
-        def sync_code_outer() -> int:
-            return sync_code()
+    async def inner3() -> int:
+        return sync_code_outer()
 
-        async def inner3() -> int:
-            return sync_code_outer()
+    async def inner2() -> int:
+        return await inner3()
 
-        async def inner2() -> int:
-            return await inner3()
+    async def inner1() -> int:
+        t = asyncio.create_task(inner2())
 
-        async def inner1() -> int:
-            t = asyncio.create_task(inner2())
+        return await t
 
-            return await t
+    async def outer():
+        return await inner1()
 
-        async def outer():
-            return await inner1()
+    async def async_main():
+        return await outer()
 
-        async def async_main():
-            return await outer()
+    def main_sync():
+        async_run(async_main())
 
-        def main_sync():
-            async_run(async_main())
+    resource = str(uuid.uuid4())
+    span_type = ext.SpanTypes.WEB
 
-        resource = str(uuid.uuid4())
-        span_type = ext.SpanTypes.WEB
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+    with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
+        span_id = span.span_id
+        local_root_span_id = span._local_root.span_id
 
-        p = profiler.Profiler(tracer=tracer)
-        p.start()
-        with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
-            span_id = span.span_id
-            local_root_span_id = span._local_root.span_id
+        main_sync()
 
-            main_sync()
+    p.stop()
 
-        p.stop()
+    profile = pprof_utils.get_profile_from_agent()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    def loc(f_name: str, filename: str = "", line_no: int = -1) -> StackLocation:
+        return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
 
-        def loc(f_name: str, filename: str = "", line_no: int = -1) -> StackLocation:
-            return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
+    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
 
-        use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+    # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
+    # With uvloop, the stack has: main_sync → async_run → run (uvloop) → Runner.run → async_main
+    # Without uvloop: main_sync → run → Runner.run →
+    #                             run_until_complete → run_forever → _run_once → _run → async_main
+    if use_uvloop:
+        runner_frames = [
+            loc("async_run"),
+            loc("run"),  # uvloop run
+        ]
+        if PYVERSION >= (3, 11):
+            runner_frames += [loc("Runner.run")]
+        event_loop_frames = []
+    else:
+        base_event_loop_prefix = "BaseEventLoop." if PYVERSION >= (3, 11) else ""
+        handle_prefix = "Handle." if PYVERSION >= (3, 11) else ""
+        runner_prefix = "Runner." if PYVERSION >= (3, 11) else ""
+        runner_frames = [loc("run")] + ([loc(f"{runner_prefix}run")] if PYVERSION >= (3, 11) else [])
+        event_loop_frames = [
+            loc(f"{base_event_loop_prefix}run_until_complete"),
+            loc(f"{base_event_loop_prefix}run_forever"),
+            loc(f"{base_event_loop_prefix}_run_once"),
+            loc(f"{handle_prefix}_run"),
+        ]
 
-        # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
-        # With uvloop, the stack has: main_sync → async_run → run (uvloop) → Runner.run → async_main
-        # Without uvloop: main_sync → run → Runner.run →
-        #                             run_until_complete → run_forever → _run_once → _run → async_main
-        if use_uvloop:
-            runner_frames = [
-                loc("async_run"),
-                loc("run"),  # uvloop run
-            ]
-            if PYVERSION >= (3, 11):
-                runner_frames += [loc("Runner.run")]
-            event_loop_frames = []
-        else:
-            base_event_loop_prefix = "BaseEventLoop." if PYVERSION >= (3, 11) else ""
-            handle_prefix = "Handle." if PYVERSION >= (3, 11) else ""
-            runner_prefix = "Runner." if PYVERSION >= (3, 11) else ""
-            runner_frames = [loc("run")] + ([loc(f"{runner_prefix}run")] if PYVERSION >= (3, 11) else [])
-            event_loop_frames = [
-                loc(f"{base_event_loop_prefix}run_until_complete"),
-                loc(f"{base_event_loop_prefix}run_forever"),
-                loc(f"{base_event_loop_prefix}_run_once"),
-                loc(f"{handle_prefix}_run"),
-            ]
-
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            list(profile.sample),
-            pprof_utils.StackEvent(
-                thread_name="MainThread",
-                span_id=span_id,
-                local_root_span_id=local_root_span_id,
-                locations=list(
-                    reversed(
-                        [
-                            loc("<module>"),
-                            loc("main_sync"),
-                        ]
-                        + runner_frames
-                        + event_loop_frames
-                        + [
-                            # loc("Task-1"),
-                            loc("async_main"),
-                            loc("outer"),
-                            loc("inner1"),
-                            # loc("Task-2"),
-                            loc("inner2"),
-                            loc("inner3"),
-                            loc("sync_code_outer"),
-                            loc("sync_code"),
-                        ]
-                    )
-                ),
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        list(profile.sample),
+        pprof_utils.StackEvent(
+            thread_name="MainThread",
+            span_id=span_id,
+            local_root_span_id=local_root_span_id,
+            locations=list(
+                reversed(
+                    [
+                        loc("<module>"),
+                        loc("main_sync"),
+                    ]
+                    + runner_frames
+                    + event_loop_frames
+                    + [
+                        # loc("Task-1"),
+                        loc("async_main"),
+                        loc("outer"),
+                        loc("inner1"),
+                        # loc("Task-2"),
+                        loc("inner2"),
+                        loc("inner3"),
+                        loc("sync_code_outer"),
+                        loc("sync_code"),
+                    ]
+                )
             ),
-            print_samples_on_failure=True,
-        )
+        ),
+        print_samples_on_failure=True,
+    )
 
-        # Same test, but with a specific task_name - "Task-2".
-        # Task-1 is the "root"/parent Task, Task-2 is the one created by inner1.
-        # Since we label Samples with the Leaf Task's name, we want to see "Task-2".
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            list(profile.sample),
-            pprof_utils.StackEvent(
-                thread_name="MainThread",
-                span_id=span_id,
-                local_root_span_id=local_root_span_id,
-                task_name="Task-2",
-                locations=list(
-                    reversed(
-                        [
-                            loc("<module>"),
-                            loc("main_sync"),
-                        ]
-                        + runner_frames
-                        + event_loop_frames
-                        + [
-                            # loc("Task-1"),
-                            loc("async_main"),
-                            loc("outer"),
-                            loc("inner1"),
-                            # loc("Task-2"),
-                            loc("inner2"),
-                            loc("inner3"),
-                            loc("sync_code_outer"),
-                            loc("sync_code"),
-                        ]
-                    )
-                ),
+    # Same test, but with a specific task_name - "Task-2".
+    # Task-1 is the "root"/parent Task, Task-2 is the one created by inner1.
+    # Since we label Samples with the Leaf Task's name, we want to see "Task-2".
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        list(profile.sample),
+        pprof_utils.StackEvent(
+            thread_name="MainThread",
+            span_id=span_id,
+            local_root_span_id=local_root_span_id,
+            task_name="Task-2",
+            locations=list(
+                reversed(
+                    [
+                        loc("<module>"),
+                        loc("main_sync"),
+                    ]
+                    + runner_frames
+                    + event_loop_frames
+                    + [
+                        # loc("Task-1"),
+                        loc("async_main"),
+                        loc("outer"),
+                        loc("inner1"),
+                        # loc("Task-2"),
+                        loc("inner2"),
+                        loc("inner3"),
+                        loc("sync_code_outer"),
+                        loc("sync_code"),
+                    ]
+                )
             ),
-            print_samples_on_failure=True,
-        )
+        ),
+        print_samples_on_failure=True,
+    )

--- a/tests/profiling/collector/test_asyncio_recursive_on_cpu_tasks.py
+++ b/tests/profiling/collector/test_asyncio_recursive_on_cpu_tasks.py
@@ -1,12 +1,7 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_recursive_on_cpu_tasks",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess(err=None)
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_asyncio_recursive_on_cpu_tasks():
     import asyncio
@@ -22,148 +17,151 @@ def test_asyncio_recursive_on_cpu_tasks():
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.pprof_utils import StackLocation
     from tests.profiling.collector.test_utils import async_run
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    def sync_code() -> int:
-        target = time.time() + 1
-        result = 0
-        while time.time() < target:
-            result += 1
+    with with_profiling_test_agent() as agent_client:
 
-        return result
+        def sync_code() -> int:
+            target = time.time() + 1
+            result = 0
+            while time.time() < target:
+                result += 1
 
-    def sync_code_outer() -> int:
-        return sync_code()
+            return result
 
-    async def inner3() -> int:
-        return sync_code_outer()
+        def sync_code_outer() -> int:
+            return sync_code()
 
-    async def inner2() -> int:
-        return await inner3()
+        async def inner3() -> int:
+            return sync_code_outer()
 
-    async def inner1() -> int:
-        t = asyncio.create_task(inner2())
+        async def inner2() -> int:
+            return await inner3()
 
-        return await t
+        async def inner1() -> int:
+            t = asyncio.create_task(inner2())
 
-    async def outer():
-        return await inner1()
+            return await t
 
-    async def async_main():
-        return await outer()
+        async def outer():
+            return await inner1()
 
-    def main_sync():
-        async_run(async_main())
+        async def async_main():
+            return await outer()
 
-    resource = str(uuid.uuid4())
-    span_type = ext.SpanTypes.WEB
+        def main_sync():
+            async_run(async_main())
 
-    p = profiler.Profiler(tracer=tracer)
-    p.start()
-    with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
-        span_id = span.span_id
-        local_root_span_id = span._local_root.span_id
+        resource = str(uuid.uuid4())
+        span_type = ext.SpanTypes.WEB
 
-        main_sync()
+        p = profiler.Profiler(tracer=tracer)
+        p.start()
+        with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
+            span_id = span.span_id
+            local_root_span_id = span._local_root.span_id
 
-    p.stop()
+            main_sync()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        p.stop()
 
-    def loc(f_name: str, filename: str = "", line_no: int = -1) -> StackLocation:
-        return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+        def loc(f_name: str, filename: str = "", line_no: int = -1) -> StackLocation:
+            return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
 
-    # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
-    # With uvloop, the stack has: main_sync → async_run → run (uvloop) → Runner.run → async_main
-    # Without uvloop: main_sync → run → Runner.run → run_until_complete → run_forever → _run_once → _run → async_main
-    if use_uvloop:
-        runner_frames = [
-            loc("async_run"),
-            loc("run"),  # uvloop run
-        ]
-        if PYVERSION >= (3, 11):
-            runner_frames += [loc("Runner.run")]
-        event_loop_frames = []
-    else:
-        base_event_loop_prefix = "BaseEventLoop." if PYVERSION >= (3, 11) else ""
-        handle_prefix = "Handle." if PYVERSION >= (3, 11) else ""
-        runner_prefix = "Runner." if PYVERSION >= (3, 11) else ""
-        runner_frames = [loc("run")] + ([loc(f"{runner_prefix}run")] if PYVERSION >= (3, 11) else [])
-        event_loop_frames = [
-            loc(f"{base_event_loop_prefix}run_until_complete"),
-            loc(f"{base_event_loop_prefix}run_forever"),
-            loc(f"{base_event_loop_prefix}_run_once"),
-            loc(f"{handle_prefix}_run"),
-        ]
+        use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        list(profile.sample),
-        pprof_utils.StackEvent(
-            thread_name="MainThread",
-            span_id=span_id,
-            local_root_span_id=local_root_span_id,
-            locations=list(
-                reversed(
-                    [
-                        loc("<module>"),
-                        loc("main_sync"),
-                    ]
-                    + runner_frames
-                    + event_loop_frames
-                    + [
-                        # loc("Task-1"),
-                        loc("async_main"),
-                        loc("outer"),
-                        loc("inner1"),
-                        # loc("Task-2"),
-                        loc("inner2"),
-                        loc("inner3"),
-                        loc("sync_code_outer"),
-                        loc("sync_code"),
-                    ]
-                )
+        # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
+        # With uvloop, the stack has: main_sync → async_run → run (uvloop) → Runner.run → async_main
+        # Without uvloop: main_sync → run → Runner.run →
+        #                             run_until_complete → run_forever → _run_once → _run → async_main
+        if use_uvloop:
+            runner_frames = [
+                loc("async_run"),
+                loc("run"),  # uvloop run
+            ]
+            if PYVERSION >= (3, 11):
+                runner_frames += [loc("Runner.run")]
+            event_loop_frames = []
+        else:
+            base_event_loop_prefix = "BaseEventLoop." if PYVERSION >= (3, 11) else ""
+            handle_prefix = "Handle." if PYVERSION >= (3, 11) else ""
+            runner_prefix = "Runner." if PYVERSION >= (3, 11) else ""
+            runner_frames = [loc("run")] + ([loc(f"{runner_prefix}run")] if PYVERSION >= (3, 11) else [])
+            event_loop_frames = [
+                loc(f"{base_event_loop_prefix}run_until_complete"),
+                loc(f"{base_event_loop_prefix}run_forever"),
+                loc(f"{base_event_loop_prefix}_run_once"),
+                loc(f"{handle_prefix}_run"),
+            ]
+
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            list(profile.sample),
+            pprof_utils.StackEvent(
+                thread_name="MainThread",
+                span_id=span_id,
+                local_root_span_id=local_root_span_id,
+                locations=list(
+                    reversed(
+                        [
+                            loc("<module>"),
+                            loc("main_sync"),
+                        ]
+                        + runner_frames
+                        + event_loop_frames
+                        + [
+                            # loc("Task-1"),
+                            loc("async_main"),
+                            loc("outer"),
+                            loc("inner1"),
+                            # loc("Task-2"),
+                            loc("inner2"),
+                            loc("inner3"),
+                            loc("sync_code_outer"),
+                            loc("sync_code"),
+                        ]
+                    )
+                ),
             ),
-        ),
-        print_samples_on_failure=True,
-    )
+            print_samples_on_failure=True,
+        )
 
-    # Same test, but with a specific task_name - "Task-2".
-    # Task-1 is the "root"/parent Task, Task-2 is the one created by inner1.
-    # Since we label Samples with the Leaf Task's name, we want to see "Task-2".
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        list(profile.sample),
-        pprof_utils.StackEvent(
-            thread_name="MainThread",
-            span_id=span_id,
-            local_root_span_id=local_root_span_id,
-            task_name="Task-2",
-            locations=list(
-                reversed(
-                    [
-                        loc("<module>"),
-                        loc("main_sync"),
-                    ]
-                    + runner_frames
-                    + event_loop_frames
-                    + [
-                        # loc("Task-1"),
-                        loc("async_main"),
-                        loc("outer"),
-                        loc("inner1"),
-                        # loc("Task-2"),
-                        loc("inner2"),
-                        loc("inner3"),
-                        loc("sync_code_outer"),
-                        loc("sync_code"),
-                    ]
-                )
+        # Same test, but with a specific task_name - "Task-2".
+        # Task-1 is the "root"/parent Task, Task-2 is the one created by inner1.
+        # Since we label Samples with the Leaf Task's name, we want to see "Task-2".
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            list(profile.sample),
+            pprof_utils.StackEvent(
+                thread_name="MainThread",
+                span_id=span_id,
+                local_root_span_id=local_root_span_id,
+                task_name="Task-2",
+                locations=list(
+                    reversed(
+                        [
+                            loc("<module>"),
+                            loc("main_sync"),
+                        ]
+                        + runner_frames
+                        + event_loop_frames
+                        + [
+                            # loc("Task-1"),
+                            loc("async_main"),
+                            loc("outer"),
+                            loc("inner1"),
+                            # loc("Task-2"),
+                            loc("inner2"),
+                            loc("inner3"),
+                            loc("sync_code_outer"),
+                            loc("sync_code"),
+                        ]
+                    )
+                ),
             ),
-        ),
-        print_samples_on_failure=True,
-    )
+            print_samples_on_failure=True,
+        )

--- a/tests/profiling/collector/test_asyncio_shield.py
+++ b/tests/profiling/collector/test_asyncio_shield.py
@@ -9,89 +9,86 @@ def test_asyncio_shield() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    with with_profiling_test_agent() as agent_client:
+    async def other(t: float) -> None:
+        await asyncio.sleep(t)
 
-        async def other(t: float) -> None:
-            await asyncio.sleep(t)
+    async def wait_and_return_delay(t: float) -> float:
+        await other(t)
+        return t
 
-        async def wait_and_return_delay(t: float) -> float:
-            await other(t)
-            return t
+    async def main() -> None:
+        # Create tasks and shield them
+        tasks = [asyncio.create_task(wait_and_return_delay(float(i) / 10)) for i in range(2, 7)]
 
-        async def main() -> None:
-            # Create tasks and shield them
-            tasks = [asyncio.create_task(wait_and_return_delay(float(i) / 10)) for i in range(2, 7)]
+        # Shield each task
+        shielded_tasks = [asyncio.shield(task) for task in tasks]
 
-            # Shield each task
-            shielded_tasks = [asyncio.shield(task) for task in tasks]
+        # Wait for all shielded tasks to complete
+        results = await asyncio.gather(*shielded_tasks)
+        assert len(results) == 5
+        assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
 
-            # Wait for all shielded tasks to complete
-            results = await asyncio.gather(*shielded_tasks)
-            assert len(results) == 5
-            assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
+    p = profiler.Profiler()
+    p.start()
 
-        p = profiler.Profiler()
-        p.start()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(main())
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(main())
+    p.stop()
 
-        p.stop()
+    profile = pprof_utils.get_profile_from_agent()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0
 
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0
+    locations = [
+        pprof_utils.StackLocation(
+            function_name="sleep",
+            filename="",
+            line_no=-1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="other",
+            filename="test_asyncio_shield.py",
+            line_no=other.__code__.co_firstlineno + 1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="wait_and_return_delay",
+            filename="test_asyncio_shield.py",
+            line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="main",
+            filename="test_asyncio_shield.py",
+            line_no=main.__code__.co_firstlineno + 8,
+        ),
+    ]
 
-        locations = [
-            pprof_utils.StackLocation(
-                function_name="sleep",
-                filename="",
-                line_no=-1,
-            ),
-            pprof_utils.StackLocation(
-                function_name="other",
-                filename="test_asyncio_shield.py",
-                line_no=other.__code__.co_firstlineno + 1,
-            ),
-            pprof_utils.StackLocation(
-                function_name="wait_and_return_delay",
-                filename="test_asyncio_shield.py",
-                line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
-            ),
-            pprof_utils.StackLocation(
-                function_name="main",
-                filename="test_asyncio_shield.py",
-                line_no=main.__code__.co_firstlineno + 8,
-            ),
-        ]
+    # Check that we have seen samples for the shielded tasks (Task-2 .. Task-6)
+    seen_task_names: set[str] = set()
+    exceptions: list[AssertionError] = []
+    for i in range(2, 7):
+        try:
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples,
+                expected_sample=pprof_utils.StackEvent(
+                    task_name=f"Task-{i}",
+                    thread_name="MainThread",
+                    locations=locations,
+                ),
+            )
+            seen_task_names.add(f"Task-{i}")
+        except AssertionError as e:
+            exceptions.append(e)
 
-        # Check that we have seen samples for the shielded tasks (Task-2 .. Task-6)
-        seen_task_names: set[str] = set()
-        exceptions: list[AssertionError] = []
-        for i in range(2, 7):
-            try:
-                pprof_utils.assert_profile_has_sample(
-                    profile,
-                    samples,
-                    expected_sample=pprof_utils.StackEvent(
-                        task_name=f"Task-{i}",
-                        thread_name="MainThread",
-                        locations=locations,
-                    ),
-                )
-                seen_task_names.add(f"Task-{i}")
-            except AssertionError as e:
-                exceptions.append(e)
+    if len(exceptions) > 0:
+        pprof_utils.print_all_samples(profile)
+        for exc in exceptions:
+            print(exc)
 
-        if len(exceptions) > 0:
-            pprof_utils.print_all_samples(profile)
-            for exc in exceptions:
-                print(exc)
-
-            raise exceptions[0]
+        raise exceptions[0]

--- a/tests/profiling/collector/test_asyncio_shield.py
+++ b/tests/profiling/collector/test_asyncio_shield.py
@@ -1,102 +1,97 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_shield",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_asyncio_shield() -> None:
     import asyncio
-    import os
 
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    async def other(t: float) -> None:
-        await asyncio.sleep(t)
+    with with_profiling_test_agent() as agent_client:
 
-    async def wait_and_return_delay(t: float) -> float:
-        await other(t)
-        return t
+        async def other(t: float) -> None:
+            await asyncio.sleep(t)
 
-    async def main() -> None:
-        # Create tasks and shield them
-        tasks = [asyncio.create_task(wait_and_return_delay(float(i) / 10)) for i in range(2, 7)]
+        async def wait_and_return_delay(t: float) -> float:
+            await other(t)
+            return t
 
-        # Shield each task
-        shielded_tasks = [asyncio.shield(task) for task in tasks]
+        async def main() -> None:
+            # Create tasks and shield them
+            tasks = [asyncio.create_task(wait_and_return_delay(float(i) / 10)) for i in range(2, 7)]
 
-        # Wait for all shielded tasks to complete
-        results = await asyncio.gather(*shielded_tasks)
-        assert len(results) == 5
-        assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
+            # Shield each task
+            shielded_tasks = [asyncio.shield(task) for task in tasks]
 
-    p = profiler.Profiler()
-    p.start()
+            # Wait for all shielded tasks to complete
+            results = await asyncio.gather(*shielded_tasks)
+            assert len(results) == 5
+            assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    loop.run_until_complete(main())
+        p = profiler.Profiler()
+        p.start()
 
-    p.stop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(main())
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+        p.stop()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0
 
-    locations = [
-        pprof_utils.StackLocation(
-            function_name="sleep",
-            filename="",
-            line_no=-1,
-        ),
-        pprof_utils.StackLocation(
-            function_name="other",
-            filename="test_asyncio_shield.py",
-            line_no=other.__code__.co_firstlineno + 1,
-        ),
-        pprof_utils.StackLocation(
-            function_name="wait_and_return_delay",
-            filename="test_asyncio_shield.py",
-            line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
-        ),
-        pprof_utils.StackLocation(
-            function_name="main",
-            filename="test_asyncio_shield.py",
-            line_no=main.__code__.co_firstlineno + 8,
-        ),
-    ]
+        locations = [
+            pprof_utils.StackLocation(
+                function_name="sleep",
+                filename="",
+                line_no=-1,
+            ),
+            pprof_utils.StackLocation(
+                function_name="other",
+                filename="test_asyncio_shield.py",
+                line_no=other.__code__.co_firstlineno + 1,
+            ),
+            pprof_utils.StackLocation(
+                function_name="wait_and_return_delay",
+                filename="test_asyncio_shield.py",
+                line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
+            ),
+            pprof_utils.StackLocation(
+                function_name="main",
+                filename="test_asyncio_shield.py",
+                line_no=main.__code__.co_firstlineno + 8,
+            ),
+        ]
 
-    # Check that we have seen samples for the shielded tasks (Task-2 .. Task-6)
-    seen_task_names: set[str] = set()
-    exceptions: list[AssertionError] = []
-    for i in range(2, 7):
-        try:
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples,
-                expected_sample=pprof_utils.StackEvent(
-                    task_name=f"Task-{i}",
-                    thread_name="MainThread",
-                    locations=locations,
-                ),
-            )
-            seen_task_names.add(f"Task-{i}")
-        except AssertionError as e:
-            exceptions.append(e)
+        # Check that we have seen samples for the shielded tasks (Task-2 .. Task-6)
+        seen_task_names: set[str] = set()
+        exceptions: list[AssertionError] = []
+        for i in range(2, 7):
+            try:
+                pprof_utils.assert_profile_has_sample(
+                    profile,
+                    samples,
+                    expected_sample=pprof_utils.StackEvent(
+                        task_name=f"Task-{i}",
+                        thread_name="MainThread",
+                        locations=locations,
+                    ),
+                )
+                seen_task_names.add(f"Task-{i}")
+            except AssertionError as e:
+                exceptions.append(e)
 
-    if len(exceptions) > 0:
-        pprof_utils.print_all_samples(profile)
-        for exc in exceptions:
-            print(exc)
+        if len(exceptions) > 0:
+            pprof_utils.print_all_samples(profile)
+            for exc in exceptions:
+                print(exc)
 
-        raise exceptions[0]
+            raise exceptions[0]

--- a/tests/profiling/collector/test_asyncio_task_count.py
+++ b/tests/profiling/collector/test_asyncio_task_count.py
@@ -16,7 +16,6 @@ def test_asyncio_task_count_present():
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
     from tests.profiling.utils import get_all_metadata_from_agent
-    from tests.profiling.utils import with_profiling_test_agent
 
     async def worker():
         await asyncio.sleep(0.5)
@@ -25,27 +24,26 @@ def test_asyncio_task_count_present():
         tasks = [asyncio.create_task(worker(), name=f"worker-{i}") for i in range(10)]
         await asyncio.gather(*tasks)
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler(tracer=tracer)
-        p.start()
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        # Run multiple rounds to ensure tasks are active during profiling
-        for _ in range(4):
-            loop.run_until_complete(main())
-        time.sleep(1)
-        p.stop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    # Run multiple rounds to ensure tasks are active during profiling
+    for _ in range(4):
+        loop.run_until_complete(main())
+    time.sleep(1)
+    p.stop()
 
-        all_metadata = get_all_metadata_from_agent(agent_client, min_count=1)
-        assert all_metadata, "Expected at least one internal_metadata entry"
+    all_metadata = get_all_metadata_from_agent(min_count=1)
+    assert all_metadata, "Expected at least one internal_metadata entry"
 
-        found_positive = False
-        for metadata in all_metadata:
-            if "asyncio_task_count" in metadata:
-                assert isinstance(metadata["asyncio_task_count"], int)
-                assert metadata["asyncio_task_count"] >= 0
-                if metadata["asyncio_task_count"] > 0:
-                    found_positive = True
+    found_positive = False
+    for metadata in all_metadata:
+        if "asyncio_task_count" in metadata:
+            assert isinstance(metadata["asyncio_task_count"], int)
+            assert metadata["asyncio_task_count"] >= 0
+            if metadata["asyncio_task_count"] > 0:
+                found_positive = True
 
-        assert found_positive, "Expected at least one metadata file with asyncio_task_count > 0"
+    assert found_positive, "Expected at least one metadata file with asyncio_task_count > 0"

--- a/tests/profiling/collector/test_asyncio_task_count.py
+++ b/tests/profiling/collector/test_asyncio_task_count.py
@@ -2,22 +2,21 @@ import pytest
 
 
 @pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_task_count",
-        DD_PROFILING_UPLOAD_INTERVAL="1",
-    ),
-    err=None,
+    # DD_PROFILING_UPLOAD_INTERVAL=1 is required: asyncio_task_count in the stats
+    # reflects only the LAST sampling pass before upload. Without a 1s interval the
+    # only upload is at p.stop() when all tasks have already finished (count = 0).
+    # With 1s interval at least one upload captures tasks that are still active.
+    env=dict(DD_PROFILING_UPLOAD_INTERVAL="1"),
 )
 def test_asyncio_task_count_present():
     """asyncio_task_count is present and positive when asyncio tasks are active."""
     import asyncio
-    import glob
-    import json
-    import os
     import time
 
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
+    from tests.profiling.utils import get_all_metadata_from_agent
+    from tests.profiling.utils import with_profiling_test_agent
 
     async def worker():
         await asyncio.sleep(0.5)
@@ -26,29 +25,27 @@ def test_asyncio_task_count_present():
         tasks = [asyncio.create_task(worker(), name=f"worker-{i}") for i in range(10)]
         await asyncio.gather(*tasks)
 
-    p = profiler.Profiler(tracer=tracer)
-    p.start()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler(tracer=tracer)
+        p.start()
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    # Run multiple rounds to ensure tasks are active during profiling
-    for _ in range(4):
-        loop.run_until_complete(main())
-    time.sleep(1)
-    p.stop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        # Run multiple rounds to ensure tasks are active during profiling
+        for _ in range(4):
+            loop.run_until_complete(main())
+        time.sleep(1)
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
-    assert files, "Expected at least one internal_metadata.json file"
+        all_metadata = get_all_metadata_from_agent(agent_client, min_count=1)
+        assert all_metadata, "Expected at least one internal_metadata entry"
 
-    found_positive = False
-    for f in files:
-        with open(f) as fp:
-            metadata = json.load(fp)
-        if "asyncio_task_count" in metadata:
-            assert isinstance(metadata["asyncio_task_count"], int)
-            assert metadata["asyncio_task_count"] >= 0
-            if metadata["asyncio_task_count"] > 0:
-                found_positive = True
+        found_positive = False
+        for metadata in all_metadata:
+            if "asyncio_task_count" in metadata:
+                assert isinstance(metadata["asyncio_task_count"], int)
+                assert metadata["asyncio_task_count"] >= 0
+                if metadata["asyncio_task_count"] > 0:
+                    found_positive = True
 
-    assert found_positive, "Expected at least one metadata file with asyncio_task_count > 0"
+        assert found_positive, "Expected at least one metadata file with asyncio_task_count > 0"

--- a/tests/profiling/collector/test_asyncio_taskgroup.py
+++ b/tests/profiling/collector/test_asyncio_taskgroup.py
@@ -2,10 +2,6 @@ import pytest
 
 
 @pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_taskgroup",
-    ),
-    err=None,
     pytest_args=["-k", "test_asyncio_taskgroup"],
 )
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
@@ -15,99 +11,99 @@ import pytest
 )
 def test_asyncio_taskgroup() -> None:
     import asyncio
-    import os
 
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    async def other(t: float) -> None:
-        await asyncio.sleep(t)
+    with with_profiling_test_agent() as agent_client:
 
-    async def wait_and_return_delay(t: float) -> float:
-        await other(t)
-        return t
+        async def other(t: float) -> None:
+            await asyncio.sleep(t)
 
-    async def task_with_taskgroup(delay: float) -> float:
-        async with asyncio.TaskGroup() as tg:  # type: ignore[attr-defined]
-            task = tg.create_task(wait_and_return_delay(delay))
-            return await task  # type: ignore[no-any-return]
+        async def wait_and_return_delay(t: float) -> float:
+            await other(t)
+            return t
 
-    async def main() -> None:
-        # Create tasks that will use TaskGroup
-        tasks = [asyncio.create_task(task_with_taskgroup(float(i) / 10)) for i in range(2, 7)]
+        async def task_with_taskgroup(delay: float) -> float:
+            async with asyncio.TaskGroup() as tg:  # type: ignore[attr-defined]
+                task = tg.create_task(wait_and_return_delay(delay))
+                return await task  # type: ignore[no-any-return]
 
-        # Wait for all tasks to complete
-        results = await asyncio.gather(*tasks)
-        assert len(results) == 5
-        assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
+        async def main() -> None:
+            # Create tasks that will use TaskGroup
+            tasks = [asyncio.create_task(task_with_taskgroup(float(i) / 10)) for i in range(2, 7)]
 
-    p = profiler.Profiler()
-    p.start()
+            # Wait for all tasks to complete
+            results = await asyncio.gather(*tasks)
+            assert len(results) == 5
+            assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    loop.run_until_complete(main())
+        p = profiler.Profiler()
+        p.start()
 
-    p.stop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(main())
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+        p.stop()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0
 
-    locations = [
-        pprof_utils.StackLocation(
-            function_name="sleep",
-            filename="",
-            line_no=-1,
-        ),
-        pprof_utils.StackLocation(
-            function_name="other",
-            filename="test_asyncio_taskgroup.py",
-            line_no=other.__code__.co_firstlineno + 1,
-        ),
-        pprof_utils.StackLocation(
-            function_name="wait_and_return_delay",
-            filename="test_asyncio_taskgroup.py",
-            line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
-        ),
-        pprof_utils.StackLocation(
-            function_name="task_with_taskgroup",
-            filename="test_asyncio_taskgroup.py",
-            line_no=task_with_taskgroup.__code__.co_firstlineno + 3,
-        ),
-        pprof_utils.StackLocation(
-            function_name="main",
-            filename="test_asyncio_taskgroup.py",
-            line_no=main.__code__.co_firstlineno + 5,
-        ),
-    ]
+        locations = [
+            pprof_utils.StackLocation(
+                function_name="sleep",
+                filename="",
+                line_no=-1,
+            ),
+            pprof_utils.StackLocation(
+                function_name="other",
+                filename="test_asyncio_taskgroup.py",
+                line_no=other.__code__.co_firstlineno + 1,
+            ),
+            pprof_utils.StackLocation(
+                function_name="wait_and_return_delay",
+                filename="test_asyncio_taskgroup.py",
+                line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
+            ),
+            pprof_utils.StackLocation(
+                function_name="task_with_taskgroup",
+                filename="test_asyncio_taskgroup.py",
+                line_no=task_with_taskgroup.__code__.co_firstlineno + 3,
+            ),
+            pprof_utils.StackLocation(
+                function_name="main",
+                filename="test_asyncio_taskgroup.py",
+                line_no=main.__code__.co_firstlineno + 5,
+            ),
+        ]
 
-    # Check that we have seen samples for the tasks created by TaskGroup
-    # TaskGroup creates tasks Task-7 through Task-11 (after the main tasks Task-2 through Task-6)
-    exceptions: list[AssertionError] = []
-    for i in range(7, 12):
-        try:
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples,
-                expected_sample=pprof_utils.StackEvent(
-                    task_name=f"Task-{i}",
-                    thread_name="MainThread",
-                    locations=locations,
-                ),
-            )
-        except AssertionError as e:
-            exceptions.append(e)
+        # Check that we have seen samples for the tasks created by TaskGroup
+        # TaskGroup creates tasks Task-7 through Task-11 (after the main tasks Task-2 through Task-6)
+        exceptions: list[AssertionError] = []
+        for i in range(7, 12):
+            try:
+                pprof_utils.assert_profile_has_sample(
+                    profile,
+                    samples,
+                    expected_sample=pprof_utils.StackEvent(
+                        task_name=f"Task-{i}",
+                        thread_name="MainThread",
+                        locations=locations,
+                    ),
+                )
+            except AssertionError as e:
+                exceptions.append(e)
 
-    if len(exceptions) > 0:
-        pprof_utils.print_all_samples(profile)
-        for exc in exceptions:
-            print(exc)
+        if len(exceptions) > 0:
+            pprof_utils.print_all_samples(profile)
+            for exc in exceptions:
+                print(exc)
 
-        raise exceptions[0]
+            raise exceptions[0]

--- a/tests/profiling/collector/test_asyncio_taskgroup.py
+++ b/tests/profiling/collector/test_asyncio_taskgroup.py
@@ -15,95 +15,92 @@ def test_asyncio_taskgroup() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    with with_profiling_test_agent() as agent_client:
+    async def other(t: float) -> None:
+        await asyncio.sleep(t)
 
-        async def other(t: float) -> None:
-            await asyncio.sleep(t)
+    async def wait_and_return_delay(t: float) -> float:
+        await other(t)
+        return t
 
-        async def wait_and_return_delay(t: float) -> float:
-            await other(t)
-            return t
+    async def task_with_taskgroup(delay: float) -> float:
+        async with asyncio.TaskGroup() as tg:  # type: ignore[attr-defined]
+            task = tg.create_task(wait_and_return_delay(delay))
+            return await task  # type: ignore[no-any-return]
 
-        async def task_with_taskgroup(delay: float) -> float:
-            async with asyncio.TaskGroup() as tg:  # type: ignore[attr-defined]
-                task = tg.create_task(wait_and_return_delay(delay))
-                return await task  # type: ignore[no-any-return]
+    async def main() -> None:
+        # Create tasks that will use TaskGroup
+        tasks = [asyncio.create_task(task_with_taskgroup(float(i) / 10)) for i in range(2, 7)]
 
-        async def main() -> None:
-            # Create tasks that will use TaskGroup
-            tasks = [asyncio.create_task(task_with_taskgroup(float(i) / 10)) for i in range(2, 7)]
+        # Wait for all tasks to complete
+        results = await asyncio.gather(*tasks)
+        assert len(results) == 5
+        assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
 
-            # Wait for all tasks to complete
-            results = await asyncio.gather(*tasks)
-            assert len(results) == 5
-            assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
+    p = profiler.Profiler()
+    p.start()
 
-        p = profiler.Profiler()
-        p.start()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(main())
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(main())
+    p.stop()
 
-        p.stop()
+    profile = pprof_utils.get_profile_from_agent()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0
 
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0
+    locations = [
+        pprof_utils.StackLocation(
+            function_name="sleep",
+            filename="",
+            line_no=-1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="other",
+            filename="test_asyncio_taskgroup.py",
+            line_no=other.__code__.co_firstlineno + 1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="wait_and_return_delay",
+            filename="test_asyncio_taskgroup.py",
+            line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="task_with_taskgroup",
+            filename="test_asyncio_taskgroup.py",
+            line_no=task_with_taskgroup.__code__.co_firstlineno + 3,
+        ),
+        pprof_utils.StackLocation(
+            function_name="main",
+            filename="test_asyncio_taskgroup.py",
+            line_no=main.__code__.co_firstlineno + 5,
+        ),
+    ]
 
-        locations = [
-            pprof_utils.StackLocation(
-                function_name="sleep",
-                filename="",
-                line_no=-1,
-            ),
-            pprof_utils.StackLocation(
-                function_name="other",
-                filename="test_asyncio_taskgroup.py",
-                line_no=other.__code__.co_firstlineno + 1,
-            ),
-            pprof_utils.StackLocation(
-                function_name="wait_and_return_delay",
-                filename="test_asyncio_taskgroup.py",
-                line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
-            ),
-            pprof_utils.StackLocation(
-                function_name="task_with_taskgroup",
-                filename="test_asyncio_taskgroup.py",
-                line_no=task_with_taskgroup.__code__.co_firstlineno + 3,
-            ),
-            pprof_utils.StackLocation(
-                function_name="main",
-                filename="test_asyncio_taskgroup.py",
-                line_no=main.__code__.co_firstlineno + 5,
-            ),
-        ]
+    # Check that we have seen samples for the tasks created by TaskGroup
+    # TaskGroup creates tasks Task-7 through Task-11 (after the main tasks Task-2 through Task-6)
+    exceptions: list[AssertionError] = []
+    for i in range(7, 12):
+        try:
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples,
+                expected_sample=pprof_utils.StackEvent(
+                    task_name=f"Task-{i}",
+                    thread_name="MainThread",
+                    locations=locations,
+                ),
+            )
+        except AssertionError as e:
+            exceptions.append(e)
 
-        # Check that we have seen samples for the tasks created by TaskGroup
-        # TaskGroup creates tasks Task-7 through Task-11 (after the main tasks Task-2 through Task-6)
-        exceptions: list[AssertionError] = []
-        for i in range(7, 12):
-            try:
-                pprof_utils.assert_profile_has_sample(
-                    profile,
-                    samples,
-                    expected_sample=pprof_utils.StackEvent(
-                        task_name=f"Task-{i}",
-                        thread_name="MainThread",
-                        locations=locations,
-                    ),
-                )
-            except AssertionError as e:
-                exceptions.append(e)
+    if len(exceptions) > 0:
+        pprof_utils.print_all_samples(profile)
+        for exc in exceptions:
+            print(exc)
 
-        if len(exceptions) > 0:
-            pprof_utils.print_all_samples(profile)
-            for exc in exceptions:
-                print(exc)
-
-            raise exceptions[0]
+        raise exceptions[0]

--- a/tests/profiling/collector/test_asyncio_timeout.py
+++ b/tests/profiling/collector/test_asyncio_timeout.py
@@ -2,10 +2,6 @@ import pytest
 
 
 @pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_timeout",
-    ),
-    err=None,
     pytest_args=["-k", "test_asyncio_timeout"],
 )
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
@@ -15,97 +11,97 @@ import pytest
 )
 def test_asyncio_timeout() -> None:
     import asyncio
-    import os
 
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    async def other(t: float) -> None:
-        await asyncio.sleep(t)
+    with with_profiling_test_agent() as agent_client:
 
-    async def wait_and_return_delay(t: float) -> float:
-        await other(t)
-        return t
+        async def other(t: float) -> None:
+            await asyncio.sleep(t)
 
-    async def task_with_timeout(delay: float) -> float:
-        async with asyncio.timeout(10.0):  # type: ignore[attr-defined]  # Long timeout, won't trigger
-            return await wait_and_return_delay(delay)
+        async def wait_and_return_delay(t: float) -> float:
+            await other(t)
+            return t
 
-    async def main() -> None:
-        # Create tasks that will run within timeout contexts
-        tasks = [asyncio.create_task(task_with_timeout(float(i) / 10)) for i in range(2, 7)]
+        async def task_with_timeout(delay: float) -> float:
+            async with asyncio.timeout(10.0):  # type: ignore[attr-defined]  # Long timeout, won't trigger
+                return await wait_and_return_delay(delay)
 
-        # Wait for all tasks to complete
-        results = await asyncio.gather(*tasks)
-        assert len(results) == 5
-        assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
+        async def main() -> None:
+            # Create tasks that will run within timeout contexts
+            tasks = [asyncio.create_task(task_with_timeout(float(i) / 10)) for i in range(2, 7)]
 
-    p = profiler.Profiler()
-    p.start()
+            # Wait for all tasks to complete
+            results = await asyncio.gather(*tasks)
+            assert len(results) == 5
+            assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    loop.run_until_complete(main())
+        p = profiler.Profiler()
+        p.start()
 
-    p.stop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(main())
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+        p.stop()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0
 
-    locations = [
-        pprof_utils.StackLocation(
-            function_name="sleep",
-            filename="",
-            line_no=-1,
-        ),
-        pprof_utils.StackLocation(
-            function_name="other",
-            filename="test_asyncio_timeout.py",
-            line_no=other.__code__.co_firstlineno + 1,
-        ),
-        pprof_utils.StackLocation(
-            function_name="wait_and_return_delay",
-            filename="test_asyncio_timeout.py",
-            line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
-        ),
-        pprof_utils.StackLocation(
-            function_name="task_with_timeout",
-            filename="test_asyncio_timeout.py",
-            line_no=task_with_timeout.__code__.co_firstlineno + 2,
-        ),
-        pprof_utils.StackLocation(
-            function_name="main",
-            filename="test_asyncio_timeout.py",
-            line_no=main.__code__.co_firstlineno + 5,
-        ),
-    ]
+        locations = [
+            pprof_utils.StackLocation(
+                function_name="sleep",
+                filename="",
+                line_no=-1,
+            ),
+            pprof_utils.StackLocation(
+                function_name="other",
+                filename="test_asyncio_timeout.py",
+                line_no=other.__code__.co_firstlineno + 1,
+            ),
+            pprof_utils.StackLocation(
+                function_name="wait_and_return_delay",
+                filename="test_asyncio_timeout.py",
+                line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
+            ),
+            pprof_utils.StackLocation(
+                function_name="task_with_timeout",
+                filename="test_asyncio_timeout.py",
+                line_no=task_with_timeout.__code__.co_firstlineno + 2,
+            ),
+            pprof_utils.StackLocation(
+                function_name="main",
+                filename="test_asyncio_timeout.py",
+                line_no=main.__code__.co_firstlineno + 5,
+            ),
+        ]
 
-    # Check that we have seen samples for the tasks (Task-2 .. Task-6)
-    exceptions: list[AssertionError] = []
-    for i in range(2, 7):
-        try:
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples,
-                expected_sample=pprof_utils.StackEvent(
-                    task_name=f"Task-{i}",
-                    thread_name="MainThread",
-                    locations=locations,
-                ),
-            )
-        except AssertionError as e:
-            exceptions.append(e)
+        # Check that we have seen samples for the tasks (Task-2 .. Task-6)
+        exceptions: list[AssertionError] = []
+        for i in range(2, 7):
+            try:
+                pprof_utils.assert_profile_has_sample(
+                    profile,
+                    samples,
+                    expected_sample=pprof_utils.StackEvent(
+                        task_name=f"Task-{i}",
+                        thread_name="MainThread",
+                        locations=locations,
+                    ),
+                )
+            except AssertionError as e:
+                exceptions.append(e)
 
-    if len(exceptions) > 0:
-        pprof_utils.print_all_samples(profile)
-        for exc in exceptions:
-            print(exc)
+        if len(exceptions) > 0:
+            pprof_utils.print_all_samples(profile)
+            for exc in exceptions:
+                print(exc)
 
-        raise exceptions[0]
+            raise exceptions[0]

--- a/tests/profiling/collector/test_asyncio_timeout.py
+++ b/tests/profiling/collector/test_asyncio_timeout.py
@@ -15,93 +15,90 @@ def test_asyncio_timeout() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    with with_profiling_test_agent() as agent_client:
+    async def other(t: float) -> None:
+        await asyncio.sleep(t)
 
-        async def other(t: float) -> None:
-            await asyncio.sleep(t)
+    async def wait_and_return_delay(t: float) -> float:
+        await other(t)
+        return t
 
-        async def wait_and_return_delay(t: float) -> float:
-            await other(t)
-            return t
+    async def task_with_timeout(delay: float) -> float:
+        async with asyncio.timeout(10.0):  # type: ignore[attr-defined]  # Long timeout, won't trigger
+            return await wait_and_return_delay(delay)
 
-        async def task_with_timeout(delay: float) -> float:
-            async with asyncio.timeout(10.0):  # type: ignore[attr-defined]  # Long timeout, won't trigger
-                return await wait_and_return_delay(delay)
+    async def main() -> None:
+        # Create tasks that will run within timeout contexts
+        tasks = [asyncio.create_task(task_with_timeout(float(i) / 10)) for i in range(2, 7)]
 
-        async def main() -> None:
-            # Create tasks that will run within timeout contexts
-            tasks = [asyncio.create_task(task_with_timeout(float(i) / 10)) for i in range(2, 7)]
+        # Wait for all tasks to complete
+        results = await asyncio.gather(*tasks)
+        assert len(results) == 5
+        assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
 
-            # Wait for all tasks to complete
-            results = await asyncio.gather(*tasks)
-            assert len(results) == 5
-            assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
+    p = profiler.Profiler()
+    p.start()
 
-        p = profiler.Profiler()
-        p.start()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(main())
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(main())
+    p.stop()
 
-        p.stop()
+    profile = pprof_utils.get_profile_from_agent()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0
 
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0
+    locations = [
+        pprof_utils.StackLocation(
+            function_name="sleep",
+            filename="",
+            line_no=-1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="other",
+            filename="test_asyncio_timeout.py",
+            line_no=other.__code__.co_firstlineno + 1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="wait_and_return_delay",
+            filename="test_asyncio_timeout.py",
+            line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="task_with_timeout",
+            filename="test_asyncio_timeout.py",
+            line_no=task_with_timeout.__code__.co_firstlineno + 2,
+        ),
+        pprof_utils.StackLocation(
+            function_name="main",
+            filename="test_asyncio_timeout.py",
+            line_no=main.__code__.co_firstlineno + 5,
+        ),
+    ]
 
-        locations = [
-            pprof_utils.StackLocation(
-                function_name="sleep",
-                filename="",
-                line_no=-1,
-            ),
-            pprof_utils.StackLocation(
-                function_name="other",
-                filename="test_asyncio_timeout.py",
-                line_no=other.__code__.co_firstlineno + 1,
-            ),
-            pprof_utils.StackLocation(
-                function_name="wait_and_return_delay",
-                filename="test_asyncio_timeout.py",
-                line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
-            ),
-            pprof_utils.StackLocation(
-                function_name="task_with_timeout",
-                filename="test_asyncio_timeout.py",
-                line_no=task_with_timeout.__code__.co_firstlineno + 2,
-            ),
-            pprof_utils.StackLocation(
-                function_name="main",
-                filename="test_asyncio_timeout.py",
-                line_no=main.__code__.co_firstlineno + 5,
-            ),
-        ]
+    # Check that we have seen samples for the tasks (Task-2 .. Task-6)
+    exceptions: list[AssertionError] = []
+    for i in range(2, 7):
+        try:
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples,
+                expected_sample=pprof_utils.StackEvent(
+                    task_name=f"Task-{i}",
+                    thread_name="MainThread",
+                    locations=locations,
+                ),
+            )
+        except AssertionError as e:
+            exceptions.append(e)
 
-        # Check that we have seen samples for the tasks (Task-2 .. Task-6)
-        exceptions: list[AssertionError] = []
-        for i in range(2, 7):
-            try:
-                pprof_utils.assert_profile_has_sample(
-                    profile,
-                    samples,
-                    expected_sample=pprof_utils.StackEvent(
-                        task_name=f"Task-{i}",
-                        thread_name="MainThread",
-                        locations=locations,
-                    ),
-                )
-            except AssertionError as e:
-                exceptions.append(e)
+    if len(exceptions) > 0:
+        pprof_utils.print_all_samples(profile)
+        for exc in exceptions:
+            print(exc)
 
-        if len(exceptions) > 0:
-            pprof_utils.print_all_samples(profile)
-            for exc in exceptions:
-                print(exc)
-
-            raise exceptions[0]
+        raise exceptions[0]

--- a/tests/profiling/collector/test_asyncio_timeout_at.py
+++ b/tests/profiling/collector/test_asyncio_timeout_at.py
@@ -16,95 +16,92 @@ def test_asyncio_timeout_at() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    with with_profiling_test_agent() as agent_client:
+    async def other(t: float) -> None:
+        await asyncio.sleep(t)
 
-        async def other(t: float) -> None:
-            await asyncio.sleep(t)
+    async def wait_and_return_delay(t: float) -> float:
+        await other(t)
+        return t
 
-        async def wait_and_return_delay(t: float) -> float:
-            await other(t)
-            return t
+    async def task_with_timeout_at(delay: float) -> float:
+        # Set timeout far in the future
+        when = time.time() + 10.0
+        async with asyncio.timeout_at(when):  # type: ignore[attr-defined]
+            return await wait_and_return_delay(delay)
 
-        async def task_with_timeout_at(delay: float) -> float:
-            # Set timeout far in the future
-            when = time.time() + 10.0
-            async with asyncio.timeout_at(when):  # type: ignore[attr-defined]
-                return await wait_and_return_delay(delay)
+    async def main() -> None:
+        # Create tasks that will run within timeout_at contexts
+        tasks = [asyncio.create_task(task_with_timeout_at(float(i) / 10)) for i in range(2, 7)]
 
-        async def main() -> None:
-            # Create tasks that will run within timeout_at contexts
-            tasks = [asyncio.create_task(task_with_timeout_at(float(i) / 10)) for i in range(2, 7)]
+        # Wait for all tasks to complete
+        results = await asyncio.gather(*tasks)
+        assert len(results) == 5
+        assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
 
-            # Wait for all tasks to complete
-            results = await asyncio.gather(*tasks)
-            assert len(results) == 5
-            assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
+    p = profiler.Profiler()
+    p.start()
 
-        p = profiler.Profiler()
-        p.start()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(main())
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(main())
+    p.stop()
 
-        p.stop()
+    profile = pprof_utils.get_profile_from_agent()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0
 
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0
+    locations = [
+        pprof_utils.StackLocation(
+            function_name="sleep",
+            filename="",
+            line_no=-1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="other",
+            filename="test_asyncio_timeout_at.py",
+            line_no=other.__code__.co_firstlineno + 1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="wait_and_return_delay",
+            filename="test_asyncio_timeout_at.py",
+            line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
+        ),
+        pprof_utils.StackLocation(
+            function_name="task_with_timeout_at",
+            filename="test_asyncio_timeout_at.py",
+            line_no=task_with_timeout_at.__code__.co_firstlineno + 4,
+        ),
+        pprof_utils.StackLocation(
+            function_name="main",
+            filename="test_asyncio_timeout_at.py",
+            line_no=main.__code__.co_firstlineno + 5,
+        ),
+    ]
 
-        locations = [
-            pprof_utils.StackLocation(
-                function_name="sleep",
-                filename="",
-                line_no=-1,
-            ),
-            pprof_utils.StackLocation(
-                function_name="other",
-                filename="test_asyncio_timeout_at.py",
-                line_no=other.__code__.co_firstlineno + 1,
-            ),
-            pprof_utils.StackLocation(
-                function_name="wait_and_return_delay",
-                filename="test_asyncio_timeout_at.py",
-                line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
-            ),
-            pprof_utils.StackLocation(
-                function_name="task_with_timeout_at",
-                filename="test_asyncio_timeout_at.py",
-                line_no=task_with_timeout_at.__code__.co_firstlineno + 4,
-            ),
-            pprof_utils.StackLocation(
-                function_name="main",
-                filename="test_asyncio_timeout_at.py",
-                line_no=main.__code__.co_firstlineno + 5,
-            ),
-        ]
+    # Check that we have seen samples for the tasks (Task-2 .. Task-6)
+    exceptions: list[AssertionError] = []
+    for i in range(2, 7):
+        try:
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples,
+                expected_sample=pprof_utils.StackEvent(
+                    task_name=f"Task-{i}",
+                    thread_name="MainThread",
+                    locations=locations,
+                ),
+            )
+        except AssertionError as e:
+            exceptions.append(e)
 
-        # Check that we have seen samples for the tasks (Task-2 .. Task-6)
-        exceptions: list[AssertionError] = []
-        for i in range(2, 7):
-            try:
-                pprof_utils.assert_profile_has_sample(
-                    profile,
-                    samples,
-                    expected_sample=pprof_utils.StackEvent(
-                        task_name=f"Task-{i}",
-                        thread_name="MainThread",
-                        locations=locations,
-                    ),
-                )
-            except AssertionError as e:
-                exceptions.append(e)
+    if len(exceptions) > 0:
+        pprof_utils.print_all_samples(profile)
+        for exc in exceptions:
+            print(exc)
 
-        if len(exceptions) > 0:
-            pprof_utils.print_all_samples(profile)
-            for exc in exceptions:
-                print(exc)
-
-            raise exceptions[0]
+        raise exceptions[0]

--- a/tests/profiling/collector/test_asyncio_timeout_at.py
+++ b/tests/profiling/collector/test_asyncio_timeout_at.py
@@ -2,10 +2,6 @@ import pytest
 
 
 @pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_timeout_at",
-    ),
-    err=None,
     pytest_args=["-k", "test_asyncio_timeout_at"],
 )
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
@@ -15,100 +11,100 @@ import pytest
 )
 def test_asyncio_timeout_at() -> None:
     import asyncio
-    import os
     import time
 
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    async def other(t: float) -> None:
-        await asyncio.sleep(t)
+    with with_profiling_test_agent() as agent_client:
 
-    async def wait_and_return_delay(t: float) -> float:
-        await other(t)
-        return t
+        async def other(t: float) -> None:
+            await asyncio.sleep(t)
 
-    async def task_with_timeout_at(delay: float) -> float:
-        # Set timeout far in the future
-        when = time.time() + 10.0
-        async with asyncio.timeout_at(when):  # type: ignore[attr-defined]
-            return await wait_and_return_delay(delay)
+        async def wait_and_return_delay(t: float) -> float:
+            await other(t)
+            return t
 
-    async def main() -> None:
-        # Create tasks that will run within timeout_at contexts
-        tasks = [asyncio.create_task(task_with_timeout_at(float(i) / 10)) for i in range(2, 7)]
+        async def task_with_timeout_at(delay: float) -> float:
+            # Set timeout far in the future
+            when = time.time() + 10.0
+            async with asyncio.timeout_at(when):  # type: ignore[attr-defined]
+                return await wait_and_return_delay(delay)
 
-        # Wait for all tasks to complete
-        results = await asyncio.gather(*tasks)
-        assert len(results) == 5
-        assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
+        async def main() -> None:
+            # Create tasks that will run within timeout_at contexts
+            tasks = [asyncio.create_task(task_with_timeout_at(float(i) / 10)) for i in range(2, 7)]
 
-    p = profiler.Profiler()
-    p.start()
+            # Wait for all tasks to complete
+            results = await asyncio.gather(*tasks)
+            assert len(results) == 5
+            assert results == [0.2, 0.3, 0.4, 0.5, 0.6]
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    loop.run_until_complete(main())
+        p = profiler.Profiler()
+        p.start()
 
-    p.stop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(main())
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+        p.stop()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0
 
-    locations = [
-        pprof_utils.StackLocation(
-            function_name="sleep",
-            filename="",
-            line_no=-1,
-        ),
-        pprof_utils.StackLocation(
-            function_name="other",
-            filename="test_asyncio_timeout_at.py",
-            line_no=other.__code__.co_firstlineno + 1,
-        ),
-        pprof_utils.StackLocation(
-            function_name="wait_and_return_delay",
-            filename="test_asyncio_timeout_at.py",
-            line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
-        ),
-        pprof_utils.StackLocation(
-            function_name="task_with_timeout_at",
-            filename="test_asyncio_timeout_at.py",
-            line_no=task_with_timeout_at.__code__.co_firstlineno + 4,
-        ),
-        pprof_utils.StackLocation(
-            function_name="main",
-            filename="test_asyncio_timeout_at.py",
-            line_no=main.__code__.co_firstlineno + 5,
-        ),
-    ]
+        locations = [
+            pprof_utils.StackLocation(
+                function_name="sleep",
+                filename="",
+                line_no=-1,
+            ),
+            pprof_utils.StackLocation(
+                function_name="other",
+                filename="test_asyncio_timeout_at.py",
+                line_no=other.__code__.co_firstlineno + 1,
+            ),
+            pprof_utils.StackLocation(
+                function_name="wait_and_return_delay",
+                filename="test_asyncio_timeout_at.py",
+                line_no=wait_and_return_delay.__code__.co_firstlineno + 1,
+            ),
+            pprof_utils.StackLocation(
+                function_name="task_with_timeout_at",
+                filename="test_asyncio_timeout_at.py",
+                line_no=task_with_timeout_at.__code__.co_firstlineno + 4,
+            ),
+            pprof_utils.StackLocation(
+                function_name="main",
+                filename="test_asyncio_timeout_at.py",
+                line_no=main.__code__.co_firstlineno + 5,
+            ),
+        ]
 
-    # Check that we have seen samples for the tasks (Task-2 .. Task-6)
-    exceptions: list[AssertionError] = []
-    for i in range(2, 7):
-        try:
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples,
-                expected_sample=pprof_utils.StackEvent(
-                    task_name=f"Task-{i}",
-                    thread_name="MainThread",
-                    locations=locations,
-                ),
-            )
-        except AssertionError as e:
-            exceptions.append(e)
+        # Check that we have seen samples for the tasks (Task-2 .. Task-6)
+        exceptions: list[AssertionError] = []
+        for i in range(2, 7):
+            try:
+                pprof_utils.assert_profile_has_sample(
+                    profile,
+                    samples,
+                    expected_sample=pprof_utils.StackEvent(
+                        task_name=f"Task-{i}",
+                        thread_name="MainThread",
+                        locations=locations,
+                    ),
+                )
+            except AssertionError as e:
+                exceptions.append(e)
 
-    if len(exceptions) > 0:
-        pprof_utils.print_all_samples(profile)
-        for exc in exceptions:
-            print(exc)
+        if len(exceptions) > 0:
+            pprof_utils.print_all_samples(profile)
+            for exc in exceptions:
+                print(exc)
 
-        raise exceptions[0]
+            raise exceptions[0]

--- a/tests/profiling/collector/test_asyncio_wait.py
+++ b/tests/profiling/collector/test_asyncio_wait.py
@@ -14,91 +14,89 @@ def test_asyncio_wait() -> None:
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_utils import async_run
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    with with_profiling_test_agent() as agent_client:
-        sleep_time = 0.2
-        loop_run_time = 3
+    sleep_time = 0.2
+    loop_run_time = 3
 
-        async def inner1() -> None:
-            start_time = time.time()
-            while time.time() < start_time + loop_run_time:
-                await asyncio.sleep(sleep_time)
+    async def inner1() -> None:
+        start_time = time.time()
+        while time.time() < start_time + loop_run_time:
+            await asyncio.sleep(sleep_time)
 
-        async def inner2() -> None:
-            start_time = time.time()
-            while time.time() < start_time + loop_run_time:
-                await asyncio.sleep(sleep_time)
+    async def inner2() -> None:
+        start_time = time.time()
+        while time.time() < start_time + loop_run_time:
+            await asyncio.sleep(sleep_time)
 
-        async def outer() -> None:
-            t1 = asyncio.create_task(inner1(), name="inner 1")
-            t2 = asyncio.create_task(inner2(), name="inner 2")
-            await asyncio.wait(fs=(t1, t2), return_when=asyncio.ALL_COMPLETED)
+    async def outer() -> None:
+        t1 = asyncio.create_task(inner1(), name="inner 1")
+        t2 = asyncio.create_task(inner2(), name="inner 2")
+        await asyncio.wait(fs=(t1, t2), return_when=asyncio.ALL_COMPLETED)
 
-        resource = str(uuid.uuid4())
-        span_type = ext.SpanTypes.WEB
+    resource = str(uuid.uuid4())
+    span_type = ext.SpanTypes.WEB
 
-        p = profiler.Profiler(tracer=tracer)
-        p.start()
-        with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
-            span_id = span.span_id
-            local_root_span_id = span._local_root.span_id
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+    with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
+        span_id = span.span_id
+        local_root_span_id = span._local_root.span_id
 
-            async_run(outer())
+        async_run(outer())
 
-        p.stop()
+    p.stop()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="inner 1",
-                span_id=span_id,
-                local_root_span_id=local_root_span_id,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="inner1",
-                        filename="test_asyncio_wait.py",
-                        line_no=inner1.__code__.co_firstlineno + 3,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="outer",
-                        filename="test_asyncio_wait.py",
-                        line_no=outer.__code__.co_firstlineno + 3,
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="inner 1",
+            span_id=span_id,
+            local_root_span_id=local_root_span_id,
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="inner1",
+                    filename="test_asyncio_wait.py",
+                    line_no=inner1.__code__.co_firstlineno + 3,
+                ),
+                pprof_utils.StackLocation(
+                    function_name="outer",
+                    filename="test_asyncio_wait.py",
+                    line_no=outer.__code__.co_firstlineno + 3,
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="inner 2",
-                span_id=span_id,
-                local_root_span_id=local_root_span_id,
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="inner2",
-                        filename="test_asyncio_wait.py",
-                        line_no=inner2.__code__.co_firstlineno + 3,
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="outer",
-                        filename="test_asyncio_wait.py",
-                        line_no=outer.__code__.co_firstlineno + 3,
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="inner 2",
+            span_id=span_id,
+            local_root_span_id=local_root_span_id,
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="inner2",
+                    filename="test_asyncio_wait.py",
+                    line_no=inner2.__code__.co_firstlineno + 3,
+                ),
+                pprof_utils.StackLocation(
+                    function_name="outer",
+                    filename="test_asyncio_wait.py",
+                    line_no=outer.__code__.co_firstlineno + 3,
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )

--- a/tests/profiling/collector/test_asyncio_wait.py
+++ b/tests/profiling/collector/test_asyncio_wait.py
@@ -1,16 +1,10 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_wait",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess(err=None)
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_asyncio_wait() -> None:
     import asyncio
-    import os
     import time
     import uuid
 
@@ -20,90 +14,91 @@ def test_asyncio_wait() -> None:
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_utils import async_run
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    sleep_time = 0.2
-    loop_run_time = 3
+    with with_profiling_test_agent() as agent_client:
+        sleep_time = 0.2
+        loop_run_time = 3
 
-    async def inner1() -> None:
-        start_time = time.time()
-        while time.time() < start_time + loop_run_time:
-            await asyncio.sleep(sleep_time)
+        async def inner1() -> None:
+            start_time = time.time()
+            while time.time() < start_time + loop_run_time:
+                await asyncio.sleep(sleep_time)
 
-    async def inner2() -> None:
-        start_time = time.time()
-        while time.time() < start_time + loop_run_time:
-            await asyncio.sleep(sleep_time)
+        async def inner2() -> None:
+            start_time = time.time()
+            while time.time() < start_time + loop_run_time:
+                await asyncio.sleep(sleep_time)
 
-    async def outer() -> None:
-        t1 = asyncio.create_task(inner1(), name="inner 1")
-        t2 = asyncio.create_task(inner2(), name="inner 2")
-        await asyncio.wait(fs=(t1, t2), return_when=asyncio.ALL_COMPLETED)
+        async def outer() -> None:
+            t1 = asyncio.create_task(inner1(), name="inner 1")
+            t2 = asyncio.create_task(inner2(), name="inner 2")
+            await asyncio.wait(fs=(t1, t2), return_when=asyncio.ALL_COMPLETED)
 
-    resource = str(uuid.uuid4())
-    span_type = ext.SpanTypes.WEB
+        resource = str(uuid.uuid4())
+        span_type = ext.SpanTypes.WEB
 
-    p = profiler.Profiler(tracer=tracer)
-    p.start()
-    with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
-        span_id = span.span_id
-        local_root_span_id = span._local_root.span_id
+        p = profiler.Profiler(tracer=tracer)
+        p.start()
+        with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
+            span_id = span.span_id
+            local_root_span_id = span._local_root.span_id
 
-        async_run(outer())
+            async_run(outer())
 
-    p.stop()
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="inner 1",
-            span_id=span_id,
-            local_root_span_id=local_root_span_id,
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="inner1",
-                    filename="test_asyncio_wait.py",
-                    line_no=inner1.__code__.co_firstlineno + 3,
-                ),
-                pprof_utils.StackLocation(
-                    function_name="outer",
-                    filename="test_asyncio_wait.py",
-                    line_no=outer.__code__.co_firstlineno + 3,
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="inner 1",
+                span_id=span_id,
+                local_root_span_id=local_root_span_id,
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="inner1",
+                        filename="test_asyncio_wait.py",
+                        line_no=inner1.__code__.co_firstlineno + 3,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="outer",
+                        filename="test_asyncio_wait.py",
+                        line_no=outer.__code__.co_firstlineno + 3,
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="inner 2",
-            span_id=span_id,
-            local_root_span_id=local_root_span_id,
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="inner2",
-                    filename="test_asyncio_wait.py",
-                    line_no=inner2.__code__.co_firstlineno + 3,
-                ),
-                pprof_utils.StackLocation(
-                    function_name="outer",
-                    filename="test_asyncio_wait.py",
-                    line_no=outer.__code__.co_firstlineno + 3,
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="inner 2",
+                span_id=span_id,
+                local_root_span_id=local_root_span_id,
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="inner2",
+                        filename="test_asyncio_wait.py",
+                        line_no=inner2.__code__.co_firstlineno + 3,
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="outer",
+                        filename="test_asyncio_wait.py",
+                        line_no=outer.__code__.co_firstlineno + 3,
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )

--- a/tests/profiling/collector/test_asyncio_wall_time_on_and_off_cpu.py
+++ b/tests/profiling/collector/test_asyncio_wall_time_on_and_off_cpu.py
@@ -1,12 +1,7 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_wall_time_on_and_off_cpu",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess(err=None)
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_asyncio_wall_time_on_and_off_cpu() -> None:
     import asyncio
@@ -22,140 +17,142 @@ def test_asyncio_wall_time_on_and_off_cpu() -> None:
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_utils import async_run
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    def factorial(result: int, n: int) -> int:
-        result *= math.factorial(n)
-        return result
+    with with_profiling_test_agent() as agent_client:
 
-    async def cpu_bound_work(duration: float) -> None:
-        start = time.time()
-        end_time = start + duration
-        result = 1
-        while time.time() < end_time:
-            factorial(result, 1000)
+        def factorial(result: int, n: int) -> int:
+            result *= math.factorial(n)
+            return result
 
-    async def io_simulation(duration: float) -> None:
-        await asyncio.sleep(duration)
+        async def cpu_bound_work(duration: float) -> None:
+            start = time.time()
+            end_time = start + duration
+            result = 1
+            while time.time() < end_time:
+                factorial(result, 1000)
 
-    async def mixed_workload(cpu_duration: float, io_duration: float) -> None:
-        await cpu_bound_work(cpu_duration)
-        await io_simulation(io_duration)
+        async def io_simulation(duration: float) -> None:
+            await asyncio.sleep(duration)
 
-    async def main() -> None:
-        execution_time_sec = 2
+        async def mixed_workload(cpu_duration: float, io_duration: float) -> None:
+            await cpu_bound_work(cpu_duration)
+            await io_simulation(io_duration)
 
-        tasks = [
-            asyncio.create_task(cpu_bound_work(execution_time_sec), name="cpu_bound_work"),
-            asyncio.create_task(
-                mixed_workload(execution_time_sec * 0.5, execution_time_sec * 0.5), name="mixed_workload"
+        async def main() -> None:
+            execution_time_sec = 2
+
+            tasks = [
+                asyncio.create_task(cpu_bound_work(execution_time_sec), name="cpu_bound_work"),
+                asyncio.create_task(
+                    mixed_workload(execution_time_sec * 0.5, execution_time_sec * 0.5), name="mixed_workload"
+                ),
+                asyncio.create_task(io_simulation(execution_time_sec), name="io_simulation"),
+            ]
+
+            await asyncio.gather(*tasks)
+            await cpu_bound_work(execution_time_sec * 0.3)
+
+        resource = str(uuid.uuid4())
+        span_type = ext.SpanTypes.WEB
+
+        p = profiler.Profiler(tracer=tracer)
+        p.start()
+        with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
+            local_root_span_id = span._local_root.span_id
+
+            async_run(main())
+
+        p.stop()
+
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0
+
+        def loc(f_name: str, file: str = "", line_no: int = -1) -> pprof_utils.StackLocation:
+            return pprof_utils.StackLocation(function_name=f_name, filename=file, line_no=line_no)
+
+        # On Python < 3.11 with uvloop, the runner is uvloop/__init__.py, not asyncio/runners.py
+        # On Python >= 3.11, uvloop delegates to asyncio.Runner, so it's still runners.py
+        use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+        if use_uvloop and sys.version_info < (3, 11):
+            run_file = "__init__.py"
+        else:
+            run_file = "runners.py"
+
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="cpu_bound_work",
+                local_root_span_id=local_root_span_id,
+                locations=[
+                    loc("factorial", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                    loc("cpu_bound_work", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                    loc("main", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                    loc("run", run_file),
+                    loc("<module>", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                ],
             ),
-            asyncio.create_task(io_simulation(execution_time_sec), name="io_simulation"),
-        ]
+            print_samples_on_failure=True,
+        )
 
-        await asyncio.gather(*tasks)
-        await cpu_bound_work(execution_time_sec * 0.3)
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="io_simulation",
+                local_root_span_id=local_root_span_id,
+                locations=[
+                    loc("sleep", "tasks.py"),
+                    loc("io_simulation", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                    loc("main", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                    loc("run", run_file),
+                    loc("<module>", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
-    resource = str(uuid.uuid4())
-    span_type = ext.SpanTypes.WEB
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="mixed_workload",
+                local_root_span_id=local_root_span_id,
+                locations=[
+                    loc("factorial", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                    loc("cpu_bound_work", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                    loc("mixed_workload", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                    loc("main", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                    loc("run", run_file),
+                    loc("<module>", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
-    p = profiler.Profiler(tracer=tracer)
-    p.start()
-    with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
-        local_root_span_id = span._local_root.span_id
-
-        async_run(main())
-
-    p.stop()
-
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    profile = pprof_utils.parse_newest_profile(output_filename)
-
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0
-
-    def loc(f_name: str, file: str = "", line_no: int = -1) -> pprof_utils.StackLocation:
-        return pprof_utils.StackLocation(function_name=f_name, filename=file, line_no=line_no)
-
-    # On Python < 3.11 with uvloop, the runner is uvloop/__init__.py, not asyncio/runners.py
-    # On Python >= 3.11, uvloop delegates to asyncio.Runner, so it's still runners.py
-    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
-    if use_uvloop and sys.version_info < (3, 11):
-        run_file = "__init__.py"
-    else:
-        run_file = "runners.py"
-
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="cpu_bound_work",
-            local_root_span_id=local_root_span_id,
-            locations=[
-                loc("factorial", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                loc("cpu_bound_work", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                loc("main", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                loc("run", run_file),
-                loc("<module>", "test_asyncio_wall_time_on_and_off_cpu.py"),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
-
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="io_simulation",
-            local_root_span_id=local_root_span_id,
-            locations=[
-                loc("sleep", "tasks.py"),
-                loc("io_simulation", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                loc("main", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                loc("run", run_file),
-                loc("<module>", "test_asyncio_wall_time_on_and_off_cpu.py"),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
-
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="mixed_workload",
-            local_root_span_id=local_root_span_id,
-            locations=[
-                loc("factorial", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                loc("cpu_bound_work", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                loc("mixed_workload", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                loc("main", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                loc("run", run_file),
-                loc("<module>", "test_asyncio_wall_time_on_and_off_cpu.py"),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
-
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="mixed_workload",
-            local_root_span_id=local_root_span_id,
-            locations=[
-                loc("sleep", "tasks.py"),
-                loc("io_simulation", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                loc("mixed_workload", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                loc("main", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                loc("run", run_file),
-                loc("<module>", "test_asyncio_wall_time_on_and_off_cpu.py"),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="mixed_workload",
+                local_root_span_id=local_root_span_id,
+                locations=[
+                    loc("sleep", "tasks.py"),
+                    loc("io_simulation", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                    loc("mixed_workload", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                    loc("main", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                    loc("run", run_file),
+                    loc("<module>", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )

--- a/tests/profiling/collector/test_asyncio_wall_time_on_and_off_cpu.py
+++ b/tests/profiling/collector/test_asyncio_wall_time_on_and_off_cpu.py
@@ -17,142 +17,139 @@ def test_asyncio_wall_time_on_and_off_cpu() -> None:
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_utils import async_run
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    with with_profiling_test_agent() as agent_client:
+    def factorial(result: int, n: int) -> int:
+        result *= math.factorial(n)
+        return result
 
-        def factorial(result: int, n: int) -> int:
-            result *= math.factorial(n)
-            return result
+    async def cpu_bound_work(duration: float) -> None:
+        start = time.time()
+        end_time = start + duration
+        result = 1
+        while time.time() < end_time:
+            factorial(result, 1000)
 
-        async def cpu_bound_work(duration: float) -> None:
-            start = time.time()
-            end_time = start + duration
-            result = 1
-            while time.time() < end_time:
-                factorial(result, 1000)
+    async def io_simulation(duration: float) -> None:
+        await asyncio.sleep(duration)
 
-        async def io_simulation(duration: float) -> None:
-            await asyncio.sleep(duration)
+    async def mixed_workload(cpu_duration: float, io_duration: float) -> None:
+        await cpu_bound_work(cpu_duration)
+        await io_simulation(io_duration)
 
-        async def mixed_workload(cpu_duration: float, io_duration: float) -> None:
-            await cpu_bound_work(cpu_duration)
-            await io_simulation(io_duration)
+    async def main() -> None:
+        execution_time_sec = 2
 
-        async def main() -> None:
-            execution_time_sec = 2
-
-            tasks = [
-                asyncio.create_task(cpu_bound_work(execution_time_sec), name="cpu_bound_work"),
-                asyncio.create_task(
-                    mixed_workload(execution_time_sec * 0.5, execution_time_sec * 0.5), name="mixed_workload"
-                ),
-                asyncio.create_task(io_simulation(execution_time_sec), name="io_simulation"),
-            ]
-
-            await asyncio.gather(*tasks)
-            await cpu_bound_work(execution_time_sec * 0.3)
-
-        resource = str(uuid.uuid4())
-        span_type = ext.SpanTypes.WEB
-
-        p = profiler.Profiler(tracer=tracer)
-        p.start()
-        with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
-            local_root_span_id = span._local_root.span_id
-
-            async_run(main())
-
-        p.stop()
-
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0
-
-        def loc(f_name: str, file: str = "", line_no: int = -1) -> pprof_utils.StackLocation:
-            return pprof_utils.StackLocation(function_name=f_name, filename=file, line_no=line_no)
-
-        # On Python < 3.11 with uvloop, the runner is uvloop/__init__.py, not asyncio/runners.py
-        # On Python >= 3.11, uvloop delegates to asyncio.Runner, so it's still runners.py
-        use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
-        if use_uvloop and sys.version_info < (3, 11):
-            run_file = "__init__.py"
-        else:
-            run_file = "runners.py"
-
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="cpu_bound_work",
-                local_root_span_id=local_root_span_id,
-                locations=[
-                    loc("factorial", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                    loc("cpu_bound_work", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                    loc("main", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                    loc("run", run_file),
-                    loc("<module>", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                ],
+        tasks = [
+            asyncio.create_task(cpu_bound_work(execution_time_sec), name="cpu_bound_work"),
+            asyncio.create_task(
+                mixed_workload(execution_time_sec * 0.5, execution_time_sec * 0.5), name="mixed_workload"
             ),
-            print_samples_on_failure=True,
-        )
+            asyncio.create_task(io_simulation(execution_time_sec), name="io_simulation"),
+        ]
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="io_simulation",
-                local_root_span_id=local_root_span_id,
-                locations=[
-                    loc("sleep", "tasks.py"),
-                    loc("io_simulation", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                    loc("main", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                    loc("run", run_file),
-                    loc("<module>", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+        await asyncio.gather(*tasks)
+        await cpu_bound_work(execution_time_sec * 0.3)
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="mixed_workload",
-                local_root_span_id=local_root_span_id,
-                locations=[
-                    loc("factorial", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                    loc("cpu_bound_work", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                    loc("mixed_workload", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                    loc("main", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                    loc("run", run_file),
-                    loc("<module>", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    resource = str(uuid.uuid4())
+    span_type = ext.SpanTypes.WEB
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="mixed_workload",
-                local_root_span_id=local_root_span_id,
-                locations=[
-                    loc("sleep", "tasks.py"),
-                    loc("io_simulation", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                    loc("mixed_workload", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                    loc("main", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                    loc("run", run_file),
-                    loc("<module>", "test_asyncio_wall_time_on_and_off_cpu.py"),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+    with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
+        local_root_span_id = span._local_root.span_id
+
+        async_run(main())
+
+    p.stop()
+
+    profile = pprof_utils.get_profile_from_agent()
+
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0
+
+    def loc(f_name: str, file: str = "", line_no: int = -1) -> pprof_utils.StackLocation:
+        return pprof_utils.StackLocation(function_name=f_name, filename=file, line_no=line_no)
+
+    # On Python < 3.11 with uvloop, the runner is uvloop/__init__.py, not asyncio/runners.py
+    # On Python >= 3.11, uvloop delegates to asyncio.Runner, so it's still runners.py
+    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+    if use_uvloop and sys.version_info < (3, 11):
+        run_file = "__init__.py"
+    else:
+        run_file = "runners.py"
+
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="cpu_bound_work",
+            local_root_span_id=local_root_span_id,
+            locations=[
+                loc("factorial", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                loc("cpu_bound_work", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                loc("main", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                loc("run", run_file),
+                loc("<module>", "test_asyncio_wall_time_on_and_off_cpu.py"),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
+
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="io_simulation",
+            local_root_span_id=local_root_span_id,
+            locations=[
+                loc("sleep", "tasks.py"),
+                loc("io_simulation", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                loc("main", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                loc("run", run_file),
+                loc("<module>", "test_asyncio_wall_time_on_and_off_cpu.py"),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
+
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="mixed_workload",
+            local_root_span_id=local_root_span_id,
+            locations=[
+                loc("factorial", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                loc("cpu_bound_work", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                loc("mixed_workload", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                loc("main", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                loc("run", run_file),
+                loc("<module>", "test_asyncio_wall_time_on_and_off_cpu.py"),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
+
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="mixed_workload",
+            local_root_span_id=local_root_span_id,
+            locations=[
+                loc("sleep", "tasks.py"),
+                loc("io_simulation", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                loc("mixed_workload", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                loc("main", "test_asyncio_wall_time_on_and_off_cpu.py"),
+                loc("run", run_file),
+                loc("<module>", "test_asyncio_wall_time_on_and_off_cpu.py"),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )

--- a/tests/profiling/collector/test_asyncio_weak_links.py
+++ b/tests/profiling/collector/test_asyncio_weak_links.py
@@ -11,101 +11,99 @@ import pytest
 )
 @pytest.mark.subprocess(
     env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_weak_links",
         _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED="0",
     ),
-    err=None,
 )
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_asyncio_weak_links_wall_time() -> None:
     import asyncio
-    import os
 
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_utils import async_run
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    async def func_not_awaited() -> None:
-        await asyncio.sleep(0.5)
+    with with_profiling_test_agent() as agent_client:
 
-    async def func_awaited() -> None:
-        await asyncio.sleep(1)
+        async def func_not_awaited() -> None:
+            await asyncio.sleep(0.5)
 
-    async def parent() -> asyncio.Task[object]:
-        await asyncio.sleep(0.5)
+        async def func_awaited() -> None:
+            await asyncio.sleep(1)
 
-        t_not_awaited = asyncio.create_task(func_not_awaited(), name="Task-not_awaited")
-        t_awaited = asyncio.create_task(func_awaited(), name="Task-awaited")
+        async def parent() -> asyncio.Task[object]:
+            await asyncio.sleep(0.5)
 
-        await t_awaited
+            t_not_awaited = asyncio.create_task(func_not_awaited(), name="Task-not_awaited")
+            t_awaited = asyncio.create_task(func_awaited(), name="Task-awaited")
 
-        # At this point, we have not awaited t_not_awaited but it should have finished
-        # before t_awaited as the delay is much shorter.
-        # Returning it to avoid the warning on unused variable.
-        return t_not_awaited
+            await t_awaited
 
-    async def main() -> None:
-        await parent()
+            # At this point, we have not awaited t_not_awaited but it should have finished
+            # before t_awaited as the delay is much shorter.
+            # Returning it to avoid the warning on unused variable.
+            return t_not_awaited
 
-    p = profiler.Profiler()
-    p.start()
+        async def main() -> None:
+            await parent()
 
-    async_run(main())
+        p = profiler.Profiler()
+        p.start()
 
-    p.stop()
+        async_run(main())
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+        p.stop()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-    assert len(samples) > 0
+        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+        assert len(samples) > 0
 
-    def loc(fn: str, file: str = "", line: int = -1) -> pprof_utils.StackLocation:
-        return pprof_utils.StackLocation(
-            function_name=fn,
-            filename=file,
-            line_no=line,
+        def loc(fn: str, file: str = "", line: int = -1) -> pprof_utils.StackLocation:
+            return pprof_utils.StackLocation(
+                function_name=fn,
+                filename=file,
+                line_no=line,
+            )
+
+        # We should see a stack for (Task-1) / parent / (Task-not_awaited) / not_awaited / sleep
+        # Even though Task-1 does not await Task-not_awaited, the fact that there is a weak (parent - child) link
+        # means that Task-not_awaited is under Task-1.
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="Task-not_awaited",
+                locations=[
+                    loc("sleep"),
+                    loc("func_not_awaited", "test_asyncio_weak_links.py", func_not_awaited.__code__.co_firstlineno + 1),
+                    # loc("Task-not_awaited"),
+                    loc("parent", "test_asyncio_weak_links.py", parent.__code__.co_firstlineno + 6),
+                    # loc("Task-1"),
+                ],
+            ),
+            print_samples_on_failure=True,
         )
 
-    # We should see a stack for (Task-1) / parent / (Task-not_awaited) / not_awaited / sleep
-    # Even though Task-1 does not await Task-not_awaited, the fact that there is a weak (parent - child) link
-    # means that Task-not_awaited is under Task-1.
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="Task-not_awaited",
-            locations=[
-                loc("sleep"),
-                loc("func_not_awaited", "test_asyncio_weak_links.py", func_not_awaited.__code__.co_firstlineno + 1),
-                # loc("Task-not_awaited"),
-                loc("parent", "test_asyncio_weak_links.py", parent.__code__.co_firstlineno + 6),
-                # loc("Task-1"),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
-
-    # We should see a stack for Task-1 / parent / Task-awaited / awaited / sleep
-    # That is because Task-1 is awaiting Task-awaited.
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_name="MainThread",
-            task_name="Task-awaited",
-            locations=[
-                loc("sleep"),
-                loc("func_awaited", "test_asyncio_weak_links.py", func_awaited.__code__.co_firstlineno + 1),
-                # loc("Task-awaited"),
-                loc("parent", "test_asyncio_weak_links.py", parent.__code__.co_firstlineno + 6),
-                # loc("Task-1"),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        # We should see a stack for Task-1 / parent / Task-awaited / awaited / sleep
+        # That is because Task-1 is awaiting Task-awaited.
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_name="MainThread",
+                task_name="Task-awaited",
+                locations=[
+                    loc("sleep"),
+                    loc("func_awaited", "test_asyncio_weak_links.py", func_awaited.__code__.co_firstlineno + 1),
+                    # loc("Task-awaited"),
+                    loc("parent", "test_asyncio_weak_links.py", parent.__code__.co_firstlineno + 6),
+                    # loc("Task-1"),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )

--- a/tests/profiling/collector/test_asyncio_weak_links.py
+++ b/tests/profiling/collector/test_asyncio_weak_links.py
@@ -22,88 +22,85 @@ def test_asyncio_weak_links_wall_time() -> None:
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_utils import async_run
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    with with_profiling_test_agent() as agent_client:
+    async def func_not_awaited() -> None:
+        await asyncio.sleep(0.5)
 
-        async def func_not_awaited() -> None:
-            await asyncio.sleep(0.5)
+    async def func_awaited() -> None:
+        await asyncio.sleep(1)
 
-        async def func_awaited() -> None:
-            await asyncio.sleep(1)
+    async def parent() -> asyncio.Task[object]:
+        await asyncio.sleep(0.5)
 
-        async def parent() -> asyncio.Task[object]:
-            await asyncio.sleep(0.5)
+        t_not_awaited = asyncio.create_task(func_not_awaited(), name="Task-not_awaited")
+        t_awaited = asyncio.create_task(func_awaited(), name="Task-awaited")
 
-            t_not_awaited = asyncio.create_task(func_not_awaited(), name="Task-not_awaited")
-            t_awaited = asyncio.create_task(func_awaited(), name="Task-awaited")
+        await t_awaited
 
-            await t_awaited
+        # At this point, we have not awaited t_not_awaited but it should have finished
+        # before t_awaited as the delay is much shorter.
+        # Returning it to avoid the warning on unused variable.
+        return t_not_awaited
 
-            # At this point, we have not awaited t_not_awaited but it should have finished
-            # before t_awaited as the delay is much shorter.
-            # Returning it to avoid the warning on unused variable.
-            return t_not_awaited
+    async def main() -> None:
+        await parent()
 
-        async def main() -> None:
-            await parent()
+    p = profiler.Profiler()
+    p.start()
 
-        p = profiler.Profiler()
-        p.start()
+    async_run(main())
 
-        async_run(main())
+    p.stop()
 
-        p.stop()
+    profile = pprof_utils.get_profile_from_agent()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    samples = pprof_utils.get_samples_with_label_key(profile, "task name")
+    assert len(samples) > 0
 
-        samples = pprof_utils.get_samples_with_label_key(profile, "task name")
-        assert len(samples) > 0
-
-        def loc(fn: str, file: str = "", line: int = -1) -> pprof_utils.StackLocation:
-            return pprof_utils.StackLocation(
-                function_name=fn,
-                filename=file,
-                line_no=line,
-            )
-
-        # We should see a stack for (Task-1) / parent / (Task-not_awaited) / not_awaited / sleep
-        # Even though Task-1 does not await Task-not_awaited, the fact that there is a weak (parent - child) link
-        # means that Task-not_awaited is under Task-1.
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="Task-not_awaited",
-                locations=[
-                    loc("sleep"),
-                    loc("func_not_awaited", "test_asyncio_weak_links.py", func_not_awaited.__code__.co_firstlineno + 1),
-                    # loc("Task-not_awaited"),
-                    loc("parent", "test_asyncio_weak_links.py", parent.__code__.co_firstlineno + 6),
-                    # loc("Task-1"),
-                ],
-            ),
-            print_samples_on_failure=True,
+    def loc(fn: str, file: str = "", line: int = -1) -> pprof_utils.StackLocation:
+        return pprof_utils.StackLocation(
+            function_name=fn,
+            filename=file,
+            line_no=line,
         )
 
-        # We should see a stack for Task-1 / parent / Task-awaited / awaited / sleep
-        # That is because Task-1 is awaiting Task-awaited.
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_name="MainThread",
-                task_name="Task-awaited",
-                locations=[
-                    loc("sleep"),
-                    loc("func_awaited", "test_asyncio_weak_links.py", func_awaited.__code__.co_firstlineno + 1),
-                    # loc("Task-awaited"),
-                    loc("parent", "test_asyncio_weak_links.py", parent.__code__.co_firstlineno + 6),
-                    # loc("Task-1"),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    # We should see a stack for (Task-1) / parent / (Task-not_awaited) / not_awaited / sleep
+    # Even though Task-1 does not await Task-not_awaited, the fact that there is a weak (parent - child) link
+    # means that Task-not_awaited is under Task-1.
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="Task-not_awaited",
+            locations=[
+                loc("sleep"),
+                loc("func_not_awaited", "test_asyncio_weak_links.py", func_not_awaited.__code__.co_firstlineno + 1),
+                # loc("Task-not_awaited"),
+                loc("parent", "test_asyncio_weak_links.py", parent.__code__.co_firstlineno + 6),
+                # loc("Task-1"),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
+
+    # We should see a stack for Task-1 / parent / Task-awaited / awaited / sleep
+    # That is because Task-1 is awaiting Task-awaited.
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_name="MainThread",
+            task_name="Task-awaited",
+            locations=[
+                loc("sleep"),
+                loc("func_awaited", "test_asyncio_weak_links.py", func_awaited.__code__.co_firstlineno + 1),
+                # loc("Task-awaited"),
+                loc("parent", "test_asyncio_weak_links.py", parent.__code__.co_firstlineno + 6),
+                # loc("Task-1"),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )

--- a/tests/profiling/collector/test_asyncio_within_function.py
+++ b/tests/profiling/collector/test_asyncio_within_function.py
@@ -1,12 +1,7 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_within_function",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess(err=None)
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_asyncio_within_function() -> None:
     import asyncio
@@ -22,103 +17,105 @@ def test_asyncio_within_function() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.pprof_utils import StackLocation
     from tests.profiling.collector.test_utils import async_run
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    def synchronous_code_dep() -> None:
-        time.sleep(0.25)
+    with with_profiling_test_agent() as agent_client:
 
-    def synchronous_code() -> None:
-        synchronous_code_dep()
+        def synchronous_code_dep() -> None:
+            time.sleep(0.25)
 
-    async def inner() -> None:
-        synchronous_code()
+        def synchronous_code() -> None:
+            synchronous_code_dep()
 
-    async def outer() -> None:
-        await inner()
-        await asyncio.sleep(0.25)
+        async def inner() -> None:
+            synchronous_code()
 
-    async def async_main() -> None:
-        await outer()
+        async def outer() -> None:
+            await inner()
+            await asyncio.sleep(0.25)
 
-    def async_starter() -> None:
-        async_run(async_main())
+        async def async_main() -> None:
+            await outer()
 
-    def sync_main() -> None:
-        async_starter()
-        time.sleep(0.25)
+        def async_starter() -> None:
+            async_run(async_main())
 
-    resource = str(uuid.uuid4())
-    span_type = ext.SpanTypes.WEB
+        def sync_main() -> None:
+            async_starter()
+            time.sleep(0.25)
 
-    p = profiler.Profiler(tracer=tracer)
-    p.start()
-    with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
-        span_id = span.span_id
-        local_root_span_id = span._local_root.span_id
+        resource = str(uuid.uuid4())
+        span_type = ext.SpanTypes.WEB
 
-        sync_main()
+        p = profiler.Profiler(tracer=tracer)
+        p.start()
+        with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
+            span_id = span.span_id
+            local_root_span_id = span._local_root.span_id
 
-    p.stop()
+            sync_main()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        p.stop()
 
-    def loc(f_name: str, filename: str = "", line_no: int = -1) -> StackLocation:
-        return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+        def loc(f_name: str, filename: str = "", line_no: int = -1) -> StackLocation:
+            return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
 
-    # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
-    # With uvloop: async_starter → async_run → run (uvloop) → Runner.run → async_main
-    # Without uvloop: async_starter → run → Runner.run → ... → _run → async_main
-    if use_uvloop:
-        runner_frames = [
-            loc("async_run"),
-            loc("run"),  # uvloop run
-        ]
-        if PYVERSION >= (3, 11):
-            runner_frames += [loc("Runner.run")]
-        event_loop_frames = []
-    else:
-        base_event_loop_prefix = "BaseEventLoop." if PYVERSION >= (3, 11) else ""
-        handle_prefix = "Handle." if PYVERSION >= (3, 11) else ""
-        runner_prefix = "Runner." if PYVERSION >= (3, 11) else ""
-        runner_frames = [loc("run")] + ([loc(f"{runner_prefix}run")] if PYVERSION >= (3, 11) else [])
-        event_loop_frames = [
-            loc(f"{base_event_loop_prefix}run_until_complete"),
-            loc(f"{base_event_loop_prefix}run_forever"),
-            loc(f"{base_event_loop_prefix}_run_once"),
-            loc(f"{handle_prefix}_run"),
-        ]
+        use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        list(profile.sample),
-        pprof_utils.StackEvent(
-            thread_name="MainThread",
-            span_id=span_id,
-            local_root_span_id=local_root_span_id,
-            locations=list(
-                reversed(
-                    [
-                        loc("<module>"),
-                        loc("sync_main"),
-                        loc("async_starter"),
-                    ]
-                    + runner_frames
-                    + event_loop_frames
-                    + [
-                        # loc("Task-1"),
-                        loc("async_main"),
-                        loc("outer"),
-                        loc("inner"),
-                        loc("synchronous_code"),
-                        loc("synchronous_code_dep"),
-                        # We don't have time.sleep because it's a C function.
-                    ]
-                )
+        # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
+        # With uvloop: async_starter → async_run → run (uvloop) → Runner.run → async_main
+        # Without uvloop: async_starter → run → Runner.run → ... → _run → async_main
+        if use_uvloop:
+            runner_frames = [
+                loc("async_run"),
+                loc("run"),  # uvloop run
+            ]
+            if PYVERSION >= (3, 11):
+                runner_frames += [loc("Runner.run")]
+            event_loop_frames = []
+        else:
+            base_event_loop_prefix = "BaseEventLoop." if PYVERSION >= (3, 11) else ""
+            handle_prefix = "Handle." if PYVERSION >= (3, 11) else ""
+            runner_prefix = "Runner." if PYVERSION >= (3, 11) else ""
+            runner_frames = [loc("run")] + ([loc(f"{runner_prefix}run")] if PYVERSION >= (3, 11) else [])
+            event_loop_frames = [
+                loc(f"{base_event_loop_prefix}run_until_complete"),
+                loc(f"{base_event_loop_prefix}run_forever"),
+                loc(f"{base_event_loop_prefix}_run_once"),
+                loc(f"{handle_prefix}_run"),
+            ]
+
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            list(profile.sample),
+            pprof_utils.StackEvent(
+                thread_name="MainThread",
+                span_id=span_id,
+                local_root_span_id=local_root_span_id,
+                locations=list(
+                    reversed(
+                        [
+                            loc("<module>"),
+                            loc("sync_main"),
+                            loc("async_starter"),
+                        ]
+                        + runner_frames
+                        + event_loop_frames
+                        + [
+                            # loc("Task-1"),
+                            loc("async_main"),
+                            loc("outer"),
+                            loc("inner"),
+                            loc("synchronous_code"),
+                            loc("synchronous_code_dep"),
+                            # We don't have time.sleep because it's a C function.
+                        ]
+                    )
+                ),
             ),
-        ),
-        print_samples_on_failure=True,
-    )
+            print_samples_on_failure=True,
+        )

--- a/tests/profiling/collector/test_asyncio_within_function.py
+++ b/tests/profiling/collector/test_asyncio_within_function.py
@@ -17,105 +17,102 @@ def test_asyncio_within_function() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.pprof_utils import StackLocation
     from tests.profiling.collector.test_utils import async_run
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
-    with with_profiling_test_agent() as agent_client:
+    def synchronous_code_dep() -> None:
+        time.sleep(0.25)
 
-        def synchronous_code_dep() -> None:
-            time.sleep(0.25)
+    def synchronous_code() -> None:
+        synchronous_code_dep()
 
-        def synchronous_code() -> None:
-            synchronous_code_dep()
+    async def inner() -> None:
+        synchronous_code()
 
-        async def inner() -> None:
-            synchronous_code()
+    async def outer() -> None:
+        await inner()
+        await asyncio.sleep(0.25)
 
-        async def outer() -> None:
-            await inner()
-            await asyncio.sleep(0.25)
+    async def async_main() -> None:
+        await outer()
 
-        async def async_main() -> None:
-            await outer()
+    def async_starter() -> None:
+        async_run(async_main())
 
-        def async_starter() -> None:
-            async_run(async_main())
+    def sync_main() -> None:
+        async_starter()
+        time.sleep(0.25)
 
-        def sync_main() -> None:
-            async_starter()
-            time.sleep(0.25)
+    resource = str(uuid.uuid4())
+    span_type = ext.SpanTypes.WEB
 
-        resource = str(uuid.uuid4())
-        span_type = ext.SpanTypes.WEB
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+    with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
+        span_id = span.span_id
+        local_root_span_id = span._local_root.span_id
 
-        p = profiler.Profiler(tracer=tracer)
-        p.start()
-        with tracer.trace("test_asyncio", resource=resource, span_type=span_type) as span:
-            span_id = span.span_id
-            local_root_span_id = span._local_root.span_id
+        sync_main()
 
-            sync_main()
+    p.stop()
 
-        p.stop()
+    profile = pprof_utils.get_profile_from_agent()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    def loc(f_name: str, filename: str = "", line_no: int = -1) -> StackLocation:
+        return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
 
-        def loc(f_name: str, filename: str = "", line_no: int = -1) -> StackLocation:
-            return pprof_utils.StackLocation(function_name=f_name, filename=filename, line_no=line_no)
+    use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
 
-        use_uvloop = os.environ.get("USE_UVLOOP", "0") == "1"
+    # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
+    # With uvloop: async_starter → async_run → run (uvloop) → Runner.run → async_main
+    # Without uvloop: async_starter → run → Runner.run → ... → _run → async_main
+    if use_uvloop:
+        runner_frames = [
+            loc("async_run"),
+            loc("run"),  # uvloop run
+        ]
+        if PYVERSION >= (3, 11):
+            runner_frames += [loc("Runner.run")]
+        event_loop_frames = []
+    else:
+        base_event_loop_prefix = "BaseEventLoop." if PYVERSION >= (3, 11) else ""
+        handle_prefix = "Handle." if PYVERSION >= (3, 11) else ""
+        runner_prefix = "Runner." if PYVERSION >= (3, 11) else ""
+        runner_frames = [loc("run")] + ([loc(f"{runner_prefix}run")] if PYVERSION >= (3, 11) else [])
+        event_loop_frames = [
+            loc(f"{base_event_loop_prefix}run_until_complete"),
+            loc(f"{base_event_loop_prefix}run_forever"),
+            loc(f"{base_event_loop_prefix}_run_once"),
+            loc(f"{handle_prefix}_run"),
+        ]
 
-        # uvloop uses a C-based event loop that doesn't go through Python's BaseEventLoop methods
-        # With uvloop: async_starter → async_run → run (uvloop) → Runner.run → async_main
-        # Without uvloop: async_starter → run → Runner.run → ... → _run → async_main
-        if use_uvloop:
-            runner_frames = [
-                loc("async_run"),
-                loc("run"),  # uvloop run
-            ]
-            if PYVERSION >= (3, 11):
-                runner_frames += [loc("Runner.run")]
-            event_loop_frames = []
-        else:
-            base_event_loop_prefix = "BaseEventLoop." if PYVERSION >= (3, 11) else ""
-            handle_prefix = "Handle." if PYVERSION >= (3, 11) else ""
-            runner_prefix = "Runner." if PYVERSION >= (3, 11) else ""
-            runner_frames = [loc("run")] + ([loc(f"{runner_prefix}run")] if PYVERSION >= (3, 11) else [])
-            event_loop_frames = [
-                loc(f"{base_event_loop_prefix}run_until_complete"),
-                loc(f"{base_event_loop_prefix}run_forever"),
-                loc(f"{base_event_loop_prefix}_run_once"),
-                loc(f"{handle_prefix}_run"),
-            ]
-
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            list(profile.sample),
-            pprof_utils.StackEvent(
-                thread_name="MainThread",
-                span_id=span_id,
-                local_root_span_id=local_root_span_id,
-                locations=list(
-                    reversed(
-                        [
-                            loc("<module>"),
-                            loc("sync_main"),
-                            loc("async_starter"),
-                        ]
-                        + runner_frames
-                        + event_loop_frames
-                        + [
-                            # loc("Task-1"),
-                            loc("async_main"),
-                            loc("outer"),
-                            loc("inner"),
-                            loc("synchronous_code"),
-                            loc("synchronous_code_dep"),
-                            # We don't have time.sleep because it's a C function.
-                        ]
-                    )
-                ),
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        list(profile.sample),
+        pprof_utils.StackEvent(
+            thread_name="MainThread",
+            span_id=span_id,
+            local_root_span_id=local_root_span_id,
+            locations=list(
+                reversed(
+                    [
+                        loc("<module>"),
+                        loc("sync_main"),
+                        loc("async_starter"),
+                    ]
+                    + runner_frames
+                    + event_loop_frames
+                    + [
+                        # loc("Task-1"),
+                        loc("async_main"),
+                        loc("outer"),
+                        loc("inner"),
+                        loc("synchronous_code"),
+                        loc("synchronous_code_dep"),
+                        # We don't have time.sleep because it's a C function.
+                    ]
+                )
             ),
-            print_samples_on_failure=True,
-        )
+        ),
+        print_samples_on_failure=True,
+    )

--- a/tests/profiling/collector/test_copy_memory_stats.py
+++ b/tests/profiling/collector/test_copy_memory_stats.py
@@ -9,20 +9,18 @@ def test_copy_memory_error_count_present():
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
     from tests.profiling.utils import get_all_metadata_from_agent
-    from tests.profiling.utils import with_profiling_test_agent
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler(tracer=tracer)
-        p.start()
-        time.sleep(3)
-        p.stop()
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+    time.sleep(3)
+    p.stop()
 
-        files = get_all_metadata_from_agent(agent_client, min_count=1)
-        assert files, "Expected at least one metadata upload"
+    files = get_all_metadata_from_agent(min_count=1)
+    assert files, "Expected at least one metadata upload"
 
-        for metadata in files:
-            assert "copy_memory_error_count" in metadata, f"Missing copy_memory_error_count in metadata: {metadata}"
-            assert metadata["copy_memory_error_count"] >= 0, f"copy_memory_error_count must be non-negative: {metadata}"
+    for metadata in files:
+        assert "copy_memory_error_count" in metadata, f"Missing copy_memory_error_count in metadata: {metadata}"
+        assert metadata["copy_memory_error_count"] >= 0, f"copy_memory_error_count must be non-negative: {metadata}"
 
 
 @pytest.mark.subprocess(
@@ -37,26 +35,22 @@ def test_fast_copy_memory_disabled():
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
     from tests.profiling.utils import get_all_metadata_from_agent
-    from tests.profiling.utils import with_profiling_test_agent
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler(tracer=tracer)
-        p.start()
-        time.sleep(3)
-        p.stop()
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+    time.sleep(3)
+    p.stop()
 
-        files = get_all_metadata_from_agent(agent_client, min_count=1)
-        assert files, "Expected at least one metadata upload"
+    files = get_all_metadata_from_agent(min_count=1)
+    assert files, "Expected at least one metadata upload"
 
-        for i, metadata in enumerate(files):
-            is_last_file = i == len(files) - 1
-            if not is_last_file:
-                assert "fast_copy_memory_enabled" in metadata, (
-                    f"Missing fast_copy_memory_enabled in metadata: {metadata}"
-                )
-                assert metadata["fast_copy_memory_enabled"] is False, (
-                    f"Expected fast_copy_memory_enabled=false when _DD_PROFILING_STACK_FAST_COPY=false: {metadata}"
-                )
+    for i, metadata in enumerate(files):
+        is_last_file = i == len(files) - 1
+        if not is_last_file:
+            assert "fast_copy_memory_enabled" in metadata, f"Missing fast_copy_memory_enabled in metadata: {metadata}"
+            assert metadata["fast_copy_memory_enabled"] is False, (
+                f"Expected fast_copy_memory_enabled=false when _DD_PROFILING_STACK_FAST_COPY=false: {metadata}"
+            )
 
 
 @pytest.mark.subprocess(
@@ -71,23 +65,19 @@ def test_fast_copy_memory_enabled():
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
     from tests.profiling.utils import get_all_metadata_from_agent
-    from tests.profiling.utils import with_profiling_test_agent
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler(tracer=tracer)
-        p.start()
-        time.sleep(3)
-        p.stop()
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+    time.sleep(3)
+    p.stop()
 
-        files = get_all_metadata_from_agent(agent_client, min_count=1)
-        assert files, "Expected at least one metadata upload"
+    files = get_all_metadata_from_agent(min_count=1)
+    assert files, "Expected at least one metadata upload"
 
-        for i, metadata in enumerate(files):
-            is_last_file = i == len(files) - 1
-            if not is_last_file:
-                assert "fast_copy_memory_enabled" in metadata, (
-                    f"Missing fast_copy_memory_enabled in metadata: {metadata}"
-                )
-                assert metadata["fast_copy_memory_enabled"] is True, (
-                    f"Expected fast_copy_memory_enabled=true by default: {metadata}"
-                )
+    for i, metadata in enumerate(files):
+        is_last_file = i == len(files) - 1
+        if not is_last_file:
+            assert "fast_copy_memory_enabled" in metadata, f"Missing fast_copy_memory_enabled in metadata: {metadata}"
+            assert metadata["fast_copy_memory_enabled"] is True, (
+                f"Expected fast_copy_memory_enabled=true by default: {metadata}"
+            )

--- a/tests/profiling/collector/test_copy_memory_stats.py
+++ b/tests/profiling/collector/test_copy_memory_stats.py
@@ -1,110 +1,93 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_copy_memory_error_count",
-        DD_PROFILING_UPLOAD_INTERVAL="1",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess()
 def test_copy_memory_error_count_present():
     """copy_memory_error_count is always emitted (even when 0) and is non-negative."""
-    import glob
-    import json
-    import os
     import time
 
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
+    from tests.profiling.utils import get_all_metadata_from_agent
+    from tests.profiling.utils import with_profiling_test_agent
 
-    p = profiler.Profiler(tracer=tracer)
-    p.start()
-    time.sleep(3)
-    p.stop()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler(tracer=tracer)
+        p.start()
+        time.sleep(3)
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
-    assert files, "Expected at least one internal_metadata.json file"
+        files = get_all_metadata_from_agent(agent_client, min_count=1)
+        assert files, "Expected at least one metadata upload"
 
-    for f in files:
-        with open(f) as fp:
-            metadata = json.load(fp)
-        assert "copy_memory_error_count" in metadata, f"Missing copy_memory_error_count in {f}: {metadata}"
-        assert metadata["copy_memory_error_count"] >= 0, f"copy_memory_error_count must be non-negative: {metadata}"
+        for metadata in files:
+            assert "copy_memory_error_count" in metadata, f"Missing copy_memory_error_count in metadata: {metadata}"
+            assert metadata["copy_memory_error_count"] >= 0, f"copy_memory_error_count must be non-negative: {metadata}"
 
 
 @pytest.mark.subprocess(
     env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_fast_copy_memory_disabled",
-        DD_PROFILING_UPLOAD_INTERVAL="1",
         _DD_PROFILING_STACK_FAST_COPY="false",
     ),
-    err=None,
 )
 def test_fast_copy_memory_disabled():
     """fast_copy_memory_enabled is False when _DD_PROFILING_STACK_FAST_COPY=false."""
-    import glob
-    import json
-    import os
     import time
 
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
+    from tests.profiling.utils import get_all_metadata_from_agent
+    from tests.profiling.utils import with_profiling_test_agent
 
-    p = profiler.Profiler(tracer=tracer)
-    p.start()
-    time.sleep(3)
-    p.stop()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler(tracer=tracer)
+        p.start()
+        time.sleep(3)
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
-    assert files, "Expected at least one internal_metadata.json file"
+        files = get_all_metadata_from_agent(agent_client, min_count=1)
+        assert files, "Expected at least one metadata upload"
 
-    for i, f in enumerate(files):
-        is_last_file = i == len(files) - 1
-        with open(f) as fp:
-            metadata = json.load(fp)
-        if not is_last_file:
-            assert "fast_copy_memory_enabled" in metadata, f"Missing fast_copy_memory_enabled in {f}: {metadata}"
-            assert metadata["fast_copy_memory_enabled"] is False, (
-                f"Expected fast_copy_memory_enabled=false when _DD_PROFILING_STACK_FAST_COPY=false: {metadata}"
-            )
+        for i, metadata in enumerate(files):
+            is_last_file = i == len(files) - 1
+            if not is_last_file:
+                assert "fast_copy_memory_enabled" in metadata, (
+                    f"Missing fast_copy_memory_enabled in metadata: {metadata}"
+                )
+                assert metadata["fast_copy_memory_enabled"] is False, (
+                    f"Expected fast_copy_memory_enabled=false when _DD_PROFILING_STACK_FAST_COPY=false: {metadata}"
+                )
 
 
 @pytest.mark.subprocess(
     env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_fast_copy_memory_enabled",
-        DD_PROFILING_UPLOAD_INTERVAL="1",
         _DD_PROFILING_STACK_FAST_COPY="1",
     ),
-    err=None,
 )
 def test_fast_copy_memory_enabled():
     """fast_copy_memory_enabled is True when _DD_PROFILING_STACK_FAST_COPY=1."""
-    import glob
-    import json
-    import os
     import time
 
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
+    from tests.profiling.utils import get_all_metadata_from_agent
+    from tests.profiling.utils import with_profiling_test_agent
 
-    p = profiler.Profiler(tracer=tracer)
-    p.start()
-    time.sleep(3)
-    p.stop()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler(tracer=tracer)
+        p.start()
+        time.sleep(3)
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
-    assert files, "Expected at least one internal_metadata.json file"
+        files = get_all_metadata_from_agent(agent_client, min_count=1)
+        assert files, "Expected at least one metadata upload"
 
-    for i, f in enumerate(files):
-        is_last_file = i == len(files) - 1
-        with open(f) as fp:
-            metadata = json.load(fp)
-        if not is_last_file:
-            assert "fast_copy_memory_enabled" in metadata, f"Missing fast_copy_memory_enabled in {f}: {metadata}"
-            assert metadata["fast_copy_memory_enabled"] is True, (
-                f"Expected fast_copy_memory_enabled=true by default: {metadata}"
-            )
+        for i, metadata in enumerate(files):
+            is_last_file = i == len(files) - 1
+            if not is_last_file:
+                assert "fast_copy_memory_enabled" in metadata, (
+                    f"Missing fast_copy_memory_enabled in metadata: {metadata}"
+                )
+                assert metadata["fast_copy_memory_enabled"] is True, (
+                    f"Expected fast_copy_memory_enabled=true by default: {metadata}"
+                )

--- a/tests/profiling/collector/test_exception.py
+++ b/tests/profiling/collector/test_exception.py
@@ -1,36 +1,14 @@
-import _thread
 import inspect
-import os
-from pathlib import Path
 import sys
 import threading
 import time
-from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
 
-from ddtrace.internal.datadog.profiling import ddup
-from ddtrace.profiling.collector import exception
-from ddtrace.trace import Tracer
-from tests.profiling.collector import pprof_utils
-
-
-if TYPE_CHECKING:
-    from tests.profiling.collector import pprof_pb2
 
 # Exception profiling requires Python 3.12
 pytestmark = pytest.mark.skipif(sys.version_info < (3, 12), reason="Exception profiling requires Python 3.12+")
-
-
-def _setup_profiler(tmp_path: Path, test_name: str) -> str:
-    """Configure ddup and return the output filename for profile parsing."""
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
-    assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="1.0", output_filename=pprof_prefix)
-    ddup.start()
-    return output_filename
 
 
 # Helper functions to throw exceptions
@@ -175,311 +153,416 @@ def test_poisson_sampling_distribution() -> None:
 # Pprof profile tests
 
 
-def test_simple_exception_profiling(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_simple_exception_profiling() -> None:
     """Test that exception type, stack locations, and thread info are captured."""
-    output_filename = _setup_profiler(tmp_path, "test_simple_exception")
+    import _thread
 
-    with exception.ExceptionCollector(sampling_interval=1):
-        for _ in range(10):
-            _handle_value_error()
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import exception
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_exception import _handle_value_error
+    from tests.profiling.collector.test_exception import _lineno_of
+    from tests.profiling.collector.test_exception import _raise_value_error
+    from tests.profiling.utils import with_profiling_test_agent
 
-    ddup.upload()
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service="test_simple_exception", version="1.0")
+        ddup.start()
 
-    profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(output_filename)
-    samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-    assert len(samples) > 0
+        with exception.ExceptionCollector(sampling_interval=1):
+            for _ in range(10):
+                _handle_value_error()
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_id=_thread.get_ident(),
-            thread_name="MainThread",
-            exception_type="builtins\\.ValueError",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="_raise_value_error",
-                    filename="test_exception.py",
-                    line_no=_lineno_of(_raise_value_error, "raise ValueError"),
-                ),
-                pprof_utils.StackLocation(
-                    function_name="_handle_value_error",
-                    filename="test_exception.py",
-                    line_no=_lineno_of(_handle_value_error, "_raise_value_error()"),
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        ddup.upload()
+
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+        assert len(samples) > 0
+
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(),
+                thread_name="MainThread",
+                exception_type="builtins\\.ValueError",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="_raise_value_error",
+                        filename="test_exception.py",
+                        line_no=_lineno_of(_raise_value_error, "raise ValueError"),
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="_handle_value_error",
+                        filename="test_exception.py",
+                        line_no=_lineno_of(_handle_value_error, "_raise_value_error()"),
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
-def test_exception_stack_trace(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_exception_stack_trace() -> None:
     """Test that a multi-level call chain is captured in the stack trace."""
-    output_filename = _setup_profiler(tmp_path, "test_exception_stack")
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import exception
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_exception import _level_1
+    from tests.profiling.collector.test_exception import _level_2
+    from tests.profiling.collector.test_exception import _level_3
+    from tests.profiling.collector.test_exception import _lineno_of
+    from tests.profiling.utils import with_profiling_test_agent
 
-    with exception.ExceptionCollector(sampling_interval=1):
-        for _ in range(10):
-            _level_1()
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service="test_exception_stack", version="1.0")
+        ddup.start()
 
-    ddup.upload()
+        with exception.ExceptionCollector(sampling_interval=1):
+            for _ in range(10):
+                _level_1()
 
-    profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(output_filename)
-    samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-    assert len(samples) > 0
+        ddup.upload()
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            exception_type="builtins\\.RuntimeError",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="_level_3",
-                    filename="test_exception.py",
-                    line_no=_lineno_of(_level_3, "raise RuntimeError"),
-                ),
-                pprof_utils.StackLocation(
-                    function_name="_level_2",
-                    filename="test_exception.py",
-                    line_no=_lineno_of(_level_2, "_level_3()"),
-                ),
-                pprof_utils.StackLocation(
-                    function_name="_level_1",
-                    filename="test_exception.py",
-                    line_no=_lineno_of(_level_1, "_level_2()"),
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+        assert len(samples) > 0
+
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                exception_type="builtins\\.RuntimeError",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="_level_3",
+                        filename="test_exception.py",
+                        line_no=_lineno_of(_level_3, "raise RuntimeError"),
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="_level_2",
+                        filename="test_exception.py",
+                        line_no=_lineno_of(_level_2, "_level_3()"),
+                    ),
+                    pprof_utils.StackLocation(
+                        function_name="_level_1",
+                        filename="test_exception.py",
+                        line_no=_lineno_of(_level_1, "_level_2()"),
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
-def test_multiple_exception_types(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_multiple_exception_types() -> None:
     """Test that all distinct exception types are captured."""
-    output_filename = _setup_profiler(tmp_path, "test_multiple_exceptions")
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import exception
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_exception import _raise_runtime_error_handled
+    from tests.profiling.collector.test_exception import _raise_type_error_handled
+    from tests.profiling.collector.test_exception import _raise_value_error_handled
+    from tests.profiling.utils import with_profiling_test_agent
 
-    with exception.ExceptionCollector(sampling_interval=1):
-        for _ in range(10):
-            _raise_value_error_handled()
-            _raise_type_error_handled()
-            _raise_runtime_error_handled()
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service="test_multiple_exceptions", version="1.0")
+        ddup.start()
 
-    ddup.upload()
+        with exception.ExceptionCollector(sampling_interval=1):
+            for _ in range(10):
+                _raise_value_error_handled()
+                _raise_type_error_handled()
+                _raise_runtime_error_handled()
 
-    profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(output_filename)
-    samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-    assert len(samples) > 0
+        ddup.upload()
 
-    # Verify all three exception types are present
-    for exc_type in ["builtins\\.ValueError", "builtins\\.TypeError", "builtins\\.RuntimeError"]:
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(exception_type=exc_type),
-            print_samples_on_failure=True,
-        )
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+        assert len(samples) > 0
+
+        # Verify all three exception types are present
+        for exc_type in ["builtins\\.ValueError", "builtins\\.TypeError", "builtins\\.RuntimeError"]:
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples=samples,
+                expected_sample=pprof_utils.StackEvent(exception_type=exc_type),
+                print_samples_on_failure=True,
+            )
 
 
-def test_wrapped_exception_handling(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_wrapped_exception_handling() -> None:
     """Test that both inner and outer exceptions are captured in wrapped try-except."""
-    output_filename = _setup_profiler(tmp_path, "test_wrapped_exceptions")
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import exception
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_exception import _lineno_of
+    from tests.profiling.collector.test_exception import _wrapped_exception_handling
+    from tests.profiling.utils import with_profiling_test_agent
 
-    with exception.ExceptionCollector(sampling_interval=1):
-        for _ in range(10):
-            _wrapped_exception_handling()
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service="test_wrapped_exceptions", version="1.0")
+        ddup.start()
 
-    ddup.upload()
+        with exception.ExceptionCollector(sampling_interval=1):
+            for _ in range(10):
+                _wrapped_exception_handling()
 
-    profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(output_filename)
-    samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-    assert len(samples) > 0
+        ddup.upload()
 
-    # Both the inner ValueError and outer RuntimeError should be captured
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            exception_type="builtins\\.ValueError",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="_wrapped_exception_handling",
-                    filename="test_exception.py",
-                    line_no=_lineno_of(_wrapped_exception_handling, 'raise ValueError("inner error")'),
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+        assert len(samples) > 0
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            exception_type="builtins\\.RuntimeError",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="_wrapped_exception_handling",
-                    filename="test_exception.py",
-                    line_no=_lineno_of(_wrapped_exception_handling, 'raise RuntimeError("outer error")'),
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
-
-
-def test_custom_exception_class(tmp_path: Path) -> None:
-    """Test that custom exception classes are tracked with module-qualified names."""
-    output_filename = _setup_profiler(tmp_path, "test_custom_exception")
-
-    with exception.ExceptionCollector(sampling_interval=1):
-        for _ in range(10):
-            _raise_custom_error()
-
-    ddup.upload()
-
-    profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(output_filename)
-    samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-    assert len(samples) > 0
-
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            exception_type=".*\\.CustomError",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="_raise_custom_error",
-                    filename="test_exception.py",
-                    line_no=_lineno_of(_raise_custom_error, "raise CustomError"),
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
-
-
-def test_long_exception_message(tmp_path: Path) -> None:
-    """Test that long exception messages are truncated."""
-    output_filename = _setup_profiler(tmp_path, "test_long_exception_message")
-
-    with exception.ExceptionCollector(sampling_interval=1, collect_message=True):
-        for _ in range(10):
-            _raise_long_exception_message()
-
-    ddup.upload()
-
-    profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(output_filename)
-    samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-    assert len(samples) > 0
-
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(exception_message=f"{'a' * 128}\\.\\.\\. \\(truncated\\)"),
-        print_samples_on_failure=True,
-    )
-
-
-def test_multithreaded_exception_profiling(tmp_path: Path) -> None:
-    """Test exceptions from multiple threads are captured with correct types."""
-    output_filename = _setup_profiler(tmp_path, "test_multithreaded")
-
-    with exception.ExceptionCollector(sampling_interval=1):
-        threads: list[threading.Thread] = []
-        for i in range(3):
-            t_val = threading.Thread(target=_thread_raise_value_errors, name=f"ExcThread-{i}")
-            t_val.start()
-            threads.append(t_val)
-            t_rt = threading.Thread(target=_thread_raise_runtime_errors, name=f"RtThread-{i}")
-            t_rt.start()
-            threads.append(t_rt)
-
-        for t in threads:
-            t.join()
-
-    ddup.upload()
-
-    profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(output_filename)
-    samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-    assert len(samples) > 0
-
-    # Both exception types should be present
-    for exc_type in ["builtins\\.ValueError", "builtins\\.RuntimeError"]:
+        # Both the inner ValueError and outer RuntimeError should be captured
         pprof_utils.assert_profile_has_sample(
             profile,
             samples=samples,
-            expected_sample=pprof_utils.StackEvent(exception_type=exc_type),
+            expected_sample=pprof_utils.StackEvent(
+                exception_type="builtins\\.ValueError",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="_wrapped_exception_handling",
+                        filename="test_exception.py",
+                        line_no=_lineno_of(_wrapped_exception_handling, 'raise ValueError("inner error")'),
+                    ),
+                ],
+            ),
             print_samples_on_failure=True,
         )
 
-    # Verify samples came from multiple threads
-    thread_names: set[str] = set()
-    for sample in samples:
-        label = pprof_utils.get_label_with_key(profile.string_table, sample, "thread name")
-        if label:
-            thread_names.add(profile.string_table[label.str])
-    assert len(thread_names) > 1, f"Expected multiple thread names, got: {thread_names}"
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                exception_type="builtins\\.RuntimeError",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="_wrapped_exception_handling",
+                        filename="test_exception.py",
+                        line_no=_lineno_of(_wrapped_exception_handling, 'raise RuntimeError("outer error")'),
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
-def test_exception_with_tracer(tmp_path: Path, tracer: Tracer) -> None:
+@pytest.mark.subprocess(err=None)
+def test_custom_exception_class() -> None:
+    """Test that custom exception classes are tracked with module-qualified names."""
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import exception
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_exception import _lineno_of
+    from tests.profiling.collector.test_exception import _raise_custom_error
+    from tests.profiling.utils import with_profiling_test_agent
+
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service="test_custom_exception", version="1.0")
+        ddup.start()
+
+        with exception.ExceptionCollector(sampling_interval=1):
+            for _ in range(10):
+                _raise_custom_error()
+
+        ddup.upload()
+
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+        assert len(samples) > 0
+
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                exception_type=".*\\.CustomError",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="_raise_custom_error",
+                        filename="test_exception.py",
+                        line_no=_lineno_of(_raise_custom_error, "raise CustomError"),
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
+
+
+@pytest.mark.subprocess(err=None)
+def test_long_exception_message() -> None:
+    """Test that long exception messages are truncated."""
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import exception
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_exception import _raise_long_exception_message
+    from tests.profiling.utils import with_profiling_test_agent
+
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service="test_long_exception_message", version="1.0")
+        ddup.start()
+
+        with exception.ExceptionCollector(sampling_interval=1, collect_message=True):
+            for _ in range(10):
+                _raise_long_exception_message()
+
+        ddup.upload()
+
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+        assert len(samples) > 0
+
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(exception_message=f"{'a' * 128}\\.\\.\\. \\(truncated\\)"),
+            print_samples_on_failure=True,
+        )
+
+
+@pytest.mark.subprocess(err=None)
+def test_multithreaded_exception_profiling() -> None:
+    """Test exceptions from multiple threads are captured with correct types."""
+
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import exception
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_exception import _thread_raise_runtime_errors
+    from tests.profiling.collector.test_exception import _thread_raise_value_errors
+    from tests.profiling.utils import with_profiling_test_agent
+
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service="test_multithreaded", version="1.0")
+        ddup.start()
+
+        with exception.ExceptionCollector(sampling_interval=1):
+            threads: list[threading.Thread] = []
+            for i in range(3):
+                t_val = threading.Thread(target=_thread_raise_value_errors, name=f"ExcThread-{i}")
+                t_val.start()
+                threads.append(t_val)
+                t_rt = threading.Thread(target=_thread_raise_runtime_errors, name=f"RtThread-{i}")
+                t_rt.start()
+                threads.append(t_rt)
+
+            for t in threads:
+                t.join()
+
+        ddup.upload()
+
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+        assert len(samples) > 0
+
+        # Both exception types should be present
+        for exc_type in ["builtins\\.ValueError", "builtins\\.RuntimeError"]:
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples=samples,
+                expected_sample=pprof_utils.StackEvent(exception_type=exc_type),
+                print_samples_on_failure=True,
+            )
+
+        # Verify samples came from multiple threads
+        thread_names: set[str] = set()
+        for sample in samples:
+            label = pprof_utils.get_label_with_key(profile.string_table, sample, "thread name")
+            if label:
+                thread_names.add(profile.string_table[label.str])
+        assert len(thread_names) > 1, f"Expected multiple thread names, got: {thread_names}"
+
+
+@pytest.mark.subprocess(err=None)
+def test_exception_with_tracer() -> None:
     """Test exception profiling captures samples during active tracer spans."""
-    from ddtrace import ext
-    from ddtrace.profiling.collector import stack
+    import time
 
-    output_filename = _setup_profiler(tmp_path, "test_exception_with_tracer")
+    from ddtrace import ext
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import exception
+    from ddtrace.profiling.collector import stack
+    from ddtrace.trace import tracer
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
+
+    assert ddup.is_available
 
     tracer._endpoint_call_counter_span_processor.enable()
 
-    with exception.ExceptionCollector(sampling_interval=1):
-        with stack.StackCollector(tracer=tracer):
-            with tracer.trace("foobar", resource="resource", span_type=ext.SpanTypes.WEB):
-                for _ in range(10):
-                    try:
-                        raise ValueError("traced exception")
-                    except ValueError:
-                        pass
-                time.sleep(0.5)
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service="test_exception_with_tracer", version="1.0")
+        ddup.start()
 
-    ddup.upload(tracer=tracer)
+        with exception.ExceptionCollector(sampling_interval=1):
+            with stack.StackCollector(tracer=tracer):
+                with tracer.trace("foobar", resource="resource", span_type=ext.SpanTypes.WEB):
+                    for _ in range(10):
+                        try:
+                            raise ValueError("traced exception")
+                        except ValueError:
+                            pass
+                    time.sleep(0.5)
 
-    profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(output_filename)
-    samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-    assert len(samples) > 0
+        ddup.upload(tracer=tracer)
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            exception_type="builtins\\.ValueError",
-        ),
-        print_samples_on_failure=True,
-    )
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+        assert len(samples) > 0
+
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                exception_type="builtins\\.ValueError",
+            ),
+            print_samples_on_failure=True,
+        )
 
 
-def test_exception_message_collection(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_exception_message_collection() -> None:
     """Test that exception messages are collected."""
-    output_filename = _setup_profiler(tmp_path, "test_exception_message_collection")
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import exception
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
-    with exception.ExceptionCollector(sampling_interval=1, collect_message=True):
-        for _ in range(10):
-            try:
-                raise ValueError("test exception message")
-            except ValueError:
-                pass
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service="test_exception_message_collection", version="1.0")
+        ddup.start()
 
-    ddup.upload()
+        with exception.ExceptionCollector(sampling_interval=1, collect_message=True):
+            for _ in range(10):
+                try:
+                    raise ValueError("test exception message")
+                except ValueError:
+                    pass
 
-    profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(output_filename)
-    samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-    assert len(samples) > 0
+        ddup.upload()
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(exception_message="test exception message"),
-        print_samples_on_failure=True,
-    )
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+        assert len(samples) > 0
+
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(exception_message="test exception message"),
+            print_samples_on_failure=True,
+        )
 
 
 # Callable type helpers for instrumentation coverage tests
@@ -519,130 +602,174 @@ class _CallableWithException:
             pass
 
 
-def test_exception_in_instance_method(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_exception_in_instance_method() -> None:
     """Test that exceptions in instance methods are captured."""
-    output_filename = _setup_profiler(tmp_path, "test_instance_method")
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import exception
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_exception import _ExceptionInMethod
+    from tests.profiling.collector.test_exception import _lineno_of
+    from tests.profiling.utils import with_profiling_test_agent
 
-    obj = _ExceptionInMethod()
-    with exception.ExceptionCollector(sampling_interval=1):
-        for _ in range(10):
-            obj.handle()
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service="test_instance_method", version="1.0")
+        ddup.start()
 
-    ddup.upload()
+        obj = _ExceptionInMethod()
+        with exception.ExceptionCollector(sampling_interval=1):
+            for _ in range(10):
+                obj.handle()
 
-    profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(output_filename)
-    samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-    assert len(samples) > 0
+        ddup.upload()
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            exception_type="builtins\\.ValueError",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="handle",
-                    filename="test_exception.py",
-                    line_no=_lineno_of(_ExceptionInMethod.handle, "raise ValueError"),
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+        assert len(samples) > 0
+
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                exception_type="builtins\\.ValueError",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="handle",
+                        filename="test_exception.py",
+                        line_no=_lineno_of(_ExceptionInMethod.handle, "raise ValueError"),
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
-def test_exception_in_static_method(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_exception_in_static_method() -> None:
     """Test that exceptions in static methods are captured."""
-    output_filename = _setup_profiler(tmp_path, "test_static_method")
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import exception
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_exception import _ExceptionInStaticMethod
+    from tests.profiling.collector.test_exception import _lineno_of
+    from tests.profiling.utils import with_profiling_test_agent
 
-    with exception.ExceptionCollector(sampling_interval=1):
-        for _ in range(10):
-            _ExceptionInStaticMethod.handle()
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service="test_static_method", version="1.0")
+        ddup.start()
 
-    ddup.upload()
+        with exception.ExceptionCollector(sampling_interval=1):
+            for _ in range(10):
+                _ExceptionInStaticMethod.handle()
 
-    profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(output_filename)
-    samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-    assert len(samples) > 0
+        ddup.upload()
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            exception_type="builtins\\.ValueError",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="handle",
-                    filename="test_exception.py",
-                    line_no=_lineno_of(_ExceptionInStaticMethod.handle, "raise ValueError"),
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+        assert len(samples) > 0
+
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                exception_type="builtins\\.ValueError",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="handle",
+                        filename="test_exception.py",
+                        line_no=_lineno_of(_ExceptionInStaticMethod.handle, "raise ValueError"),
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
-def test_exception_in_class_method(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_exception_in_class_method() -> None:
     """Test that exceptions in class methods are captured."""
-    output_filename = _setup_profiler(tmp_path, "test_class_method")
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import exception
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_exception import _ExceptionInClassMethod
+    from tests.profiling.collector.test_exception import _lineno_of
+    from tests.profiling.utils import with_profiling_test_agent
 
-    with exception.ExceptionCollector(sampling_interval=1):
-        for _ in range(10):
-            _ExceptionInClassMethod.handle()
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service="test_class_method", version="1.0")
+        ddup.start()
 
-    ddup.upload()
+        with exception.ExceptionCollector(sampling_interval=1):
+            for _ in range(10):
+                _ExceptionInClassMethod.handle()
 
-    profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(output_filename)
-    samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-    assert len(samples) > 0
+        ddup.upload()
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            exception_type="builtins\\.ValueError",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="handle",
-                    filename="test_exception.py",
-                    line_no=_lineno_of(_ExceptionInClassMethod.handle, "raise ValueError"),
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+        assert len(samples) > 0
+
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                exception_type="builtins\\.ValueError",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="handle",
+                        filename="test_exception.py",
+                        line_no=_lineno_of(_ExceptionInClassMethod.handle, "raise ValueError"),
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
-def test_exception_in_callable_instance(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_exception_in_callable_instance() -> None:
     """Test that exceptions in callable instances (__call__) are captured."""
-    output_filename = _setup_profiler(tmp_path, "test_callable_instance")
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import exception
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_exception import _CallableWithException
+    from tests.profiling.collector.test_exception import _lineno_of
+    from tests.profiling.utils import with_profiling_test_agent
 
-    obj = _CallableWithException()
-    with exception.ExceptionCollector(sampling_interval=1):
-        for _ in range(10):
-            obj()
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service="test_callable_instance", version="1.0")
+        ddup.start()
 
-    ddup.upload()
+        obj = _CallableWithException()
+        with exception.ExceptionCollector(sampling_interval=1):
+            for _ in range(10):
+                obj()
 
-    profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(output_filename)
-    samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-    assert len(samples) > 0
+        ddup.upload()
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            exception_type="builtins\\.ValueError",
-            locations=[
-                pprof_utils.StackLocation(
-                    function_name="__call__",
-                    filename="test_exception.py",
-                    line_no=_lineno_of(_CallableWithException.__call__, "raise ValueError"),
-                ),
-            ],
-        ),
-        print_samples_on_failure=True,
-    )
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+        assert len(samples) > 0
+
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                exception_type="builtins\\.ValueError",
+                locations=[
+                    pprof_utils.StackLocation(
+                        function_name="__call__",
+                        filename="test_exception.py",
+                        line_no=_lineno_of(_CallableWithException.__call__, "raise ValueError"),
+                    ),
+                ],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 def test_exception_uses_push_monotonic_ns() -> None:

--- a/tests/profiling/collector/test_exception.py
+++ b/tests/profiling/collector/test_exception.py
@@ -1,6 +1,5 @@
 import inspect
 import sys
-import threading
 import time
 from unittest import mock
 
@@ -164,45 +163,43 @@ def test_simple_exception_profiling() -> None:
     from tests.profiling.collector.test_exception import _handle_value_error
     from tests.profiling.collector.test_exception import _lineno_of
     from tests.profiling.collector.test_exception import _raise_value_error
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service="test_simple_exception", version="1.0")
-        ddup.start()
+    ddup.config(env="test", service="test_simple_exception", version="1.0")
+    ddup.start()
 
-        with exception.ExceptionCollector(sampling_interval=1):
-            for _ in range(10):
-                _handle_value_error()
+    with exception.ExceptionCollector(sampling_interval=1):
+        for _ in range(10):
+            _handle_value_error()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(),
-                thread_name="MainThread",
-                exception_type="builtins\\.ValueError",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="_raise_value_error",
-                        filename="test_exception.py",
-                        line_no=_lineno_of(_raise_value_error, "raise ValueError"),
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="_handle_value_error",
-                        filename="test_exception.py",
-                        line_no=_lineno_of(_handle_value_error, "_raise_value_error()"),
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_id=_thread.get_ident(),
+            thread_name="MainThread",
+            exception_type="builtins\\.ValueError",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="_raise_value_error",
+                    filename="test_exception.py",
+                    line_no=_lineno_of(_raise_value_error, "raise ValueError"),
+                ),
+                pprof_utils.StackLocation(
+                    function_name="_handle_value_error",
+                    filename="test_exception.py",
+                    line_no=_lineno_of(_handle_value_error, "_raise_value_error()"),
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.subprocess(err=None)
@@ -215,48 +212,46 @@ def test_exception_stack_trace() -> None:
     from tests.profiling.collector.test_exception import _level_2
     from tests.profiling.collector.test_exception import _level_3
     from tests.profiling.collector.test_exception import _lineno_of
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service="test_exception_stack", version="1.0")
-        ddup.start()
+    ddup.config(env="test", service="test_exception_stack", version="1.0")
+    ddup.start()
 
-        with exception.ExceptionCollector(sampling_interval=1):
-            for _ in range(10):
-                _level_1()
+    with exception.ExceptionCollector(sampling_interval=1):
+        for _ in range(10):
+            _level_1()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                exception_type="builtins\\.RuntimeError",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="_level_3",
-                        filename="test_exception.py",
-                        line_no=_lineno_of(_level_3, "raise RuntimeError"),
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="_level_2",
-                        filename="test_exception.py",
-                        line_no=_lineno_of(_level_2, "_level_3()"),
-                    ),
-                    pprof_utils.StackLocation(
-                        function_name="_level_1",
-                        filename="test_exception.py",
-                        line_no=_lineno_of(_level_1, "_level_2()"),
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            exception_type="builtins\\.RuntimeError",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="_level_3",
+                    filename="test_exception.py",
+                    line_no=_lineno_of(_level_3, "raise RuntimeError"),
+                ),
+                pprof_utils.StackLocation(
+                    function_name="_level_2",
+                    filename="test_exception.py",
+                    line_no=_lineno_of(_level_2, "_level_3()"),
+                ),
+                pprof_utils.StackLocation(
+                    function_name="_level_1",
+                    filename="test_exception.py",
+                    line_no=_lineno_of(_level_1, "_level_2()"),
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.subprocess(err=None)
@@ -268,33 +263,31 @@ def test_multiple_exception_types() -> None:
     from tests.profiling.collector.test_exception import _raise_runtime_error_handled
     from tests.profiling.collector.test_exception import _raise_type_error_handled
     from tests.profiling.collector.test_exception import _raise_value_error_handled
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service="test_multiple_exceptions", version="1.0")
-        ddup.start()
+    ddup.config(env="test", service="test_multiple_exceptions", version="1.0")
+    ddup.start()
 
-        with exception.ExceptionCollector(sampling_interval=1):
-            for _ in range(10):
-                _raise_value_error_handled()
-                _raise_type_error_handled()
-                _raise_runtime_error_handled()
+    with exception.ExceptionCollector(sampling_interval=1):
+        for _ in range(10):
+            _raise_value_error_handled()
+            _raise_type_error_handled()
+            _raise_runtime_error_handled()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+    assert len(samples) > 0
 
-        # Verify all three exception types are present
-        for exc_type in ["builtins\\.ValueError", "builtins\\.TypeError", "builtins\\.RuntimeError"]:
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples=samples,
-                expected_sample=pprof_utils.StackEvent(exception_type=exc_type),
-                print_samples_on_failure=True,
-            )
+    # Verify all three exception types are present
+    for exc_type in ["builtins\\.ValueError", "builtins\\.TypeError", "builtins\\.RuntimeError"]:
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(exception_type=exc_type),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.subprocess(err=None)
@@ -305,55 +298,53 @@ def test_wrapped_exception_handling() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_exception import _lineno_of
     from tests.profiling.collector.test_exception import _wrapped_exception_handling
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service="test_wrapped_exceptions", version="1.0")
-        ddup.start()
+    ddup.config(env="test", service="test_wrapped_exceptions", version="1.0")
+    ddup.start()
 
-        with exception.ExceptionCollector(sampling_interval=1):
-            for _ in range(10):
-                _wrapped_exception_handling()
+    with exception.ExceptionCollector(sampling_interval=1):
+        for _ in range(10):
+            _wrapped_exception_handling()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+    assert len(samples) > 0
 
-        # Both the inner ValueError and outer RuntimeError should be captured
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                exception_type="builtins\\.ValueError",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="_wrapped_exception_handling",
-                        filename="test_exception.py",
-                        line_no=_lineno_of(_wrapped_exception_handling, 'raise ValueError("inner error")'),
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    # Both the inner ValueError and outer RuntimeError should be captured
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            exception_type="builtins\\.ValueError",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="_wrapped_exception_handling",
+                    filename="test_exception.py",
+                    line_no=_lineno_of(_wrapped_exception_handling, 'raise ValueError("inner error")'),
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                exception_type="builtins\\.RuntimeError",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="_wrapped_exception_handling",
-                        filename="test_exception.py",
-                        line_no=_lineno_of(_wrapped_exception_handling, 'raise RuntimeError("outer error")'),
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            exception_type="builtins\\.RuntimeError",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="_wrapped_exception_handling",
+                    filename="test_exception.py",
+                    line_no=_lineno_of(_wrapped_exception_handling, 'raise RuntimeError("outer error")'),
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.subprocess(err=None)
@@ -364,38 +355,36 @@ def test_custom_exception_class() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_exception import _lineno_of
     from tests.profiling.collector.test_exception import _raise_custom_error
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service="test_custom_exception", version="1.0")
-        ddup.start()
+    ddup.config(env="test", service="test_custom_exception", version="1.0")
+    ddup.start()
 
-        with exception.ExceptionCollector(sampling_interval=1):
-            for _ in range(10):
-                _raise_custom_error()
+    with exception.ExceptionCollector(sampling_interval=1):
+        for _ in range(10):
+            _raise_custom_error()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                exception_type=".*\\.CustomError",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="_raise_custom_error",
-                        filename="test_exception.py",
-                        line_no=_lineno_of(_raise_custom_error, "raise CustomError"),
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            exception_type=".*\\.CustomError",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="_raise_custom_error",
+                    filename="test_exception.py",
+                    line_no=_lineno_of(_raise_custom_error, "raise CustomError"),
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.subprocess(err=None)
@@ -405,83 +394,80 @@ def test_long_exception_message() -> None:
     from ddtrace.profiling.collector import exception
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_exception import _raise_long_exception_message
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service="test_long_exception_message", version="1.0")
-        ddup.start()
+    ddup.config(env="test", service="test_long_exception_message", version="1.0")
+    ddup.start()
 
-        with exception.ExceptionCollector(sampling_interval=1, collect_message=True):
-            for _ in range(10):
-                _raise_long_exception_message()
+    with exception.ExceptionCollector(sampling_interval=1, collect_message=True):
+        for _ in range(10):
+            _raise_long_exception_message()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(exception_message=f"{'a' * 128}\\.\\.\\. \\(truncated\\)"),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(exception_message=f"{'a' * 128}\\.\\.\\. \\(truncated\\)"),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.subprocess(err=None)
 def test_multithreaded_exception_profiling() -> None:
     """Test exceptions from multiple threads are captured with correct types."""
 
+    import threading
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import exception
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_exception import _thread_raise_runtime_errors
     from tests.profiling.collector.test_exception import _thread_raise_value_errors
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service="test_multithreaded", version="1.0")
-        ddup.start()
+    ddup.config(env="test", service="test_multithreaded", version="1.0")
+    ddup.start()
 
-        with exception.ExceptionCollector(sampling_interval=1):
-            threads: list[threading.Thread] = []
-            for i in range(3):
-                t_val = threading.Thread(target=_thread_raise_value_errors, name=f"ExcThread-{i}")
-                t_val.start()
-                threads.append(t_val)
-                t_rt = threading.Thread(target=_thread_raise_runtime_errors, name=f"RtThread-{i}")
-                t_rt.start()
-                threads.append(t_rt)
+    with exception.ExceptionCollector(sampling_interval=1):
+        threads: list[threading.Thread] = []
+        for i in range(3):
+            t_val = threading.Thread(target=_thread_raise_value_errors, name=f"ExcThread-{i}")
+            t_val.start()
+            threads.append(t_val)
+            t_rt = threading.Thread(target=_thread_raise_runtime_errors, name=f"RtThread-{i}")
+            t_rt.start()
+            threads.append(t_rt)
 
-            for t in threads:
-                t.join()
+        for t in threads:
+            t.join()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+    assert len(samples) > 0
 
-        # Both exception types should be present
-        for exc_type in ["builtins\\.ValueError", "builtins\\.RuntimeError"]:
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples=samples,
-                expected_sample=pprof_utils.StackEvent(exception_type=exc_type),
-                print_samples_on_failure=True,
-            )
+    # Both exception types should be present
+    for exc_type in ["builtins\\.ValueError", "builtins\\.RuntimeError"]:
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(exception_type=exc_type),
+            print_samples_on_failure=True,
+        )
 
-        # Verify samples came from multiple threads
-        thread_names: set[str] = set()
-        for sample in samples:
-            label = pprof_utils.get_label_with_key(profile.string_table, sample, "thread name")
-            if label:
-                thread_names.add(profile.string_table[label.str])
-        assert len(thread_names) > 1, f"Expected multiple thread names, got: {thread_names}"
+    # Verify samples came from multiple threads
+    thread_names: set[str] = set()
+    for sample in samples:
+        label = pprof_utils.get_label_with_key(profile.string_table, sample, "thread name")
+        if label:
+            thread_names.add(profile.string_table[label.str])
+    assert len(thread_names) > 1, f"Expected multiple thread names, got: {thread_names}"
 
 
 @pytest.mark.subprocess(err=None)
@@ -495,40 +481,38 @@ def test_exception_with_tracer() -> None:
     from ddtrace.profiling.collector import stack
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert ddup.is_available
 
     tracer._endpoint_call_counter_span_processor.enable()
 
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service="test_exception_with_tracer", version="1.0")
-        ddup.start()
+    ddup.config(env="test", service="test_exception_with_tracer", version="1.0")
+    ddup.start()
 
-        with exception.ExceptionCollector(sampling_interval=1):
-            with stack.StackCollector(tracer=tracer):
-                with tracer.trace("foobar", resource="resource", span_type=ext.SpanTypes.WEB):
-                    for _ in range(10):
-                        try:
-                            raise ValueError("traced exception")
-                        except ValueError:
-                            pass
-                    time.sleep(0.5)
+    with exception.ExceptionCollector(sampling_interval=1):
+        with stack.StackCollector(tracer=tracer):
+            with tracer.trace("foobar", resource="resource", span_type=ext.SpanTypes.WEB):
+                for _ in range(10):
+                    try:
+                        raise ValueError("traced exception")
+                    except ValueError:
+                        pass
+                time.sleep(0.5)
 
-        ddup.upload(tracer=tracer)
+    ddup.upload(tracer=tracer)
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                exception_type="builtins\\.ValueError",
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            exception_type="builtins\\.ValueError",
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.subprocess(err=None)
@@ -537,32 +521,30 @@ def test_exception_message_collection() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import exception
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service="test_exception_message_collection", version="1.0")
-        ddup.start()
+    ddup.config(env="test", service="test_exception_message_collection", version="1.0")
+    ddup.start()
 
-        with exception.ExceptionCollector(sampling_interval=1, collect_message=True):
-            for _ in range(10):
-                try:
-                    raise ValueError("test exception message")
-                except ValueError:
-                    pass
+    with exception.ExceptionCollector(sampling_interval=1, collect_message=True):
+        for _ in range(10):
+            try:
+                raise ValueError("test exception message")
+            except ValueError:
+                pass
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(exception_message="test exception message"),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(exception_message="test exception message"),
+        print_samples_on_failure=True,
+    )
 
 
 # Callable type helpers for instrumentation coverage tests
@@ -610,39 +592,37 @@ def test_exception_in_instance_method() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_exception import _ExceptionInMethod
     from tests.profiling.collector.test_exception import _lineno_of
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service="test_instance_method", version="1.0")
-        ddup.start()
+    ddup.config(env="test", service="test_instance_method", version="1.0")
+    ddup.start()
 
-        obj = _ExceptionInMethod()
-        with exception.ExceptionCollector(sampling_interval=1):
-            for _ in range(10):
-                obj.handle()
+    obj = _ExceptionInMethod()
+    with exception.ExceptionCollector(sampling_interval=1):
+        for _ in range(10):
+            obj.handle()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                exception_type="builtins\\.ValueError",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="handle",
-                        filename="test_exception.py",
-                        line_no=_lineno_of(_ExceptionInMethod.handle, "raise ValueError"),
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            exception_type="builtins\\.ValueError",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="handle",
+                    filename="test_exception.py",
+                    line_no=_lineno_of(_ExceptionInMethod.handle, "raise ValueError"),
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.subprocess(err=None)
@@ -653,38 +633,36 @@ def test_exception_in_static_method() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_exception import _ExceptionInStaticMethod
     from tests.profiling.collector.test_exception import _lineno_of
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service="test_static_method", version="1.0")
-        ddup.start()
+    ddup.config(env="test", service="test_static_method", version="1.0")
+    ddup.start()
 
-        with exception.ExceptionCollector(sampling_interval=1):
-            for _ in range(10):
-                _ExceptionInStaticMethod.handle()
+    with exception.ExceptionCollector(sampling_interval=1):
+        for _ in range(10):
+            _ExceptionInStaticMethod.handle()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                exception_type="builtins\\.ValueError",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="handle",
-                        filename="test_exception.py",
-                        line_no=_lineno_of(_ExceptionInStaticMethod.handle, "raise ValueError"),
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            exception_type="builtins\\.ValueError",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="handle",
+                    filename="test_exception.py",
+                    line_no=_lineno_of(_ExceptionInStaticMethod.handle, "raise ValueError"),
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.subprocess(err=None)
@@ -695,38 +673,36 @@ def test_exception_in_class_method() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_exception import _ExceptionInClassMethod
     from tests.profiling.collector.test_exception import _lineno_of
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service="test_class_method", version="1.0")
-        ddup.start()
+    ddup.config(env="test", service="test_class_method", version="1.0")
+    ddup.start()
 
-        with exception.ExceptionCollector(sampling_interval=1):
-            for _ in range(10):
-                _ExceptionInClassMethod.handle()
+    with exception.ExceptionCollector(sampling_interval=1):
+        for _ in range(10):
+            _ExceptionInClassMethod.handle()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                exception_type="builtins\\.ValueError",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="handle",
-                        filename="test_exception.py",
-                        line_no=_lineno_of(_ExceptionInClassMethod.handle, "raise ValueError"),
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            exception_type="builtins\\.ValueError",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="handle",
+                    filename="test_exception.py",
+                    line_no=_lineno_of(_ExceptionInClassMethod.handle, "raise ValueError"),
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.subprocess(err=None)
@@ -737,39 +713,37 @@ def test_exception_in_callable_instance() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_exception import _CallableWithException
     from tests.profiling.collector.test_exception import _lineno_of
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service="test_callable_instance", version="1.0")
-        ddup.start()
+    ddup.config(env="test", service="test_callable_instance", version="1.0")
+    ddup.start()
 
-        obj = _CallableWithException()
-        with exception.ExceptionCollector(sampling_interval=1):
-            for _ in range(10):
-                obj()
+    obj = _CallableWithException()
+    with exception.ExceptionCollector(sampling_interval=1):
+        for _ in range(10):
+            obj()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                exception_type="builtins\\.ValueError",
-                locations=[
-                    pprof_utils.StackLocation(
-                        function_name="__call__",
-                        filename="test_exception.py",
-                        line_no=_lineno_of(_CallableWithException.__call__, "raise ValueError"),
-                    ),
-                ],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            exception_type="builtins\\.ValueError",
+            locations=[
+                pprof_utils.StackLocation(
+                    function_name="__call__",
+                    filename="test_exception.py",
+                    line_no=_lineno_of(_CallableWithException.__call__, "raise ValueError"),
+                ),
+            ],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 def test_exception_uses_push_monotonic_ns() -> None:

--- a/tests/profiling/collector/test_generators.py
+++ b/tests/profiling/collector/test_generators.py
@@ -10,7 +10,6 @@ def test_generators_stacks() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -25,19 +24,18 @@ def test_generators_stacks() -> None:
         gen = generator()
         return next(gen)
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler()
-        p.start()
+    p = profiler.Profiler()
+    p.start()
 
-        # Run the generator code multiple times to ensure we get samples
-        for _ in range(10):
-            result = my_function()
-            assert result == 42
-            time.sleep(0.05)
+    # Run the generator code multiple times to ensure we get samples
+    for _ in range(10):
+        result = my_function()
+        assert result == 42
+        time.sleep(0.05)
 
-        p.stop()
+    p.stop()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     # Get all samples
     samples = list(profile.sample)

--- a/tests/profiling/collector/test_generators.py
+++ b/tests/profiling/collector/test_generators.py
@@ -1,21 +1,16 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_generators",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_generators_stacks() -> None:
-    import os
     import time
     from typing import Generator
 
     from ddtrace.internal.datadog.profiling import stack
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -30,20 +25,19 @@ def test_generators_stacks() -> None:
         gen = generator()
         return next(gen)
 
-    p = profiler.Profiler()
-    p.start()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler()
+        p.start()
 
-    # Run the generator code multiple times to ensure we get samples
-    for _ in range(10):
-        result = my_function()
-        assert result == 42
-        time.sleep(0.05)
+        # Run the generator code multiple times to ensure we get samples
+        for _ in range(10):
+            result = my_function()
+            assert result == 42
+            time.sleep(0.05)
 
-    p.stop()
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
     # Get all samples
     samples = list(profile.sample)

--- a/tests/profiling/collector/test_greenlet_count.py
+++ b/tests/profiling/collector/test_greenlet_count.py
@@ -13,22 +13,33 @@ GEVENT_COMPATIBLE_WITH_PYTHON_VERSION = os.getenv("DD_PROFILE_TEST_GEVENT", Fals
     not GEVENT_COMPATIBLE_WITH_PYTHON_VERSION,
     reason="gevent is not available or not compatible with this Python version",
 )
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_greenlet_count",
-        DD_PROFILING_UPLOAD_INTERVAL="1",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess(err=None)
 def test_greenlet_count_present():
     """greenlet_count is present and positive when gevent greenlets are active."""
+    # Start the capture server BEFORE monkey.patch_all() so that
+    # the server socket is created with standard Python sockets. After gevent
+    # patches Python sockets, a pre-existing server socket continues to work
+    # correctly with gevent's event loop.
+    import os
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from tests.profiling.utils import _ProfilingCaptureServer
+    from tests.profiling.utils import get_all_metadata_from_agent
+
+    _capture_server = _ProfilingCaptureServer()
+    _capture_server.start()
+    _url = f"http://127.0.0.1:{_capture_server.port}"
+    os.environ["_DD_PROFILING_TEST_AGENT_URL"] = _url
+    _config_url = getattr(ddup, "config_url", None)
+    if _config_url is not None:
+        _config_url(_url)
+    # Force 1s upload interval so we get multiple uploads during the 3s sleep.
+    os.environ["DD_PROFILING_UPLOAD_INTERVAL"] = "1"
+
     from gevent import monkey
 
     monkey.patch_all()
 
-    import glob
-    import json
-    import os
     import time
 
     import gevent
@@ -52,14 +63,11 @@ def test_greenlet_count_present():
     gevent.joinall(greenlets, timeout=5)
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
-    assert files, "Expected at least one internal_metadata.json file"
+    files = get_all_metadata_from_agent(_capture_server, min_count=2)
+    assert files, "Expected at least one metadata upload"
 
     found_positive = False
-    for f in files:
-        with open(f) as fp:
-            metadata = json.load(fp)
+    for metadata in files:
         if "greenlet_count" in metadata:
             assert isinstance(metadata["greenlet_count"], int)
             assert metadata["greenlet_count"] >= 0
@@ -67,3 +75,8 @@ def test_greenlet_count_present():
                 found_positive = True
 
     assert found_positive, "Expected at least one metadata file with greenlet_count > 0"
+
+    # Don't call _capture_server.stop() here: after monkey.patch_all(), calling
+    # socketserver.shutdown() deadlocks because threading.Event.wait() is gevent-patched
+    # and tries to switch to the gevent hub which no longer exists at this point.
+    # The capture server is a daemon thread and will be killed when the subprocess exits.

--- a/tests/profiling/collector/test_greenlet_count.py
+++ b/tests/profiling/collector/test_greenlet_count.py
@@ -13,41 +13,22 @@ GEVENT_COMPATIBLE_WITH_PYTHON_VERSION = os.getenv("DD_PROFILE_TEST_GEVENT", Fals
     not GEVENT_COMPATIBLE_WITH_PYTHON_VERSION,
     reason="gevent is not available or not compatible with this Python version",
 )
-@pytest.mark.subprocess(err=None)
+@pytest.mark.subprocess(
+    env=dict(
+        DD_PROFILING_OUTPUT_PPROF="/tmp/test_greenlet_count",
+        DD_PROFILING_UPLOAD_INTERVAL="1",
+    ),
+    err=None,
+)
 def test_greenlet_count_present():
     """greenlet_count is present and positive when gevent greenlets are active."""
-    # Start the mini agent BEFORE monkey.patch_all() so that its server socket is
-    # created with standard Python sockets. After gevent patches Python sockets,
-    # a pre-existing server socket continues to work correctly with gevent's
-    # event loop.  We also can't call server.stop() after monkey.patch_all()
-    # because socketserver.shutdown() deadlocks with gevent-patched threading.
-    # The server runs on a daemon thread and will be killed when the subprocess exits.
-    import os
-    import uuid
-
-    from ddtrace.internal.datadog.profiling import ddup
-    from tests.profiling.utils import _ProfilingMiniAgent
-    from tests.profiling.utils import _ProfilingMiniAgentClient
-    from tests.profiling.utils import get_all_metadata_from_agent
-
-    _token = str(uuid.uuid4())
-    _server = _ProfilingMiniAgent()
-    _server.start()
-    _base_url = f"http://127.0.0.1:{_server.port}"
-
-    os.environ["_DD_PROFILING_TEST_TOKEN"] = _token
-    os.environ["_DD_PROFILING_TEST_PROXY_URL"] = _base_url
-    _config_test_token = getattr(ddup, "config_test_token", None)
-    if _config_test_token is not None:
-        _config_test_token(_token, _base_url)
-
-    # Force 1s upload interval so we get multiple uploads during the 3s sleep.
-    os.environ["DD_PROFILING_UPLOAD_INTERVAL"] = "1"
-
     from gevent import monkey
 
     monkey.patch_all()
 
+    import glob
+    import json
+    import os
     import time
 
     import gevent
@@ -71,12 +52,14 @@ def test_greenlet_count_present():
     gevent.joinall(greenlets, timeout=5)
     p.stop()
 
-    _client = _ProfilingMiniAgentClient(base_url=_base_url, token=_token)
-    files = get_all_metadata_from_agent(_client, min_count=2)
-    assert files, "Expected at least one metadata upload"
+    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
+    assert files, "Expected at least one internal_metadata.json file"
 
     found_positive = False
-    for metadata in files:
+    for f in files:
+        with open(f) as fp:
+            metadata = json.load(fp)
         if "greenlet_count" in metadata:
             assert isinstance(metadata["greenlet_count"], int)
             assert metadata["greenlet_count"] >= 0
@@ -84,8 +67,3 @@ def test_greenlet_count_present():
                 found_positive = True
 
     assert found_positive, "Expected at least one metadata file with greenlet_count > 0"
-
-    # Don't call _server.stop() here: after monkey.patch_all(), calling
-    # socketserver.shutdown() deadlocks because threading.Event.wait() is gevent-patched
-    # and tries to switch to the gevent hub which no longer exists at this point.
-    # The server runs on a daemon thread and will be killed when the subprocess exits.

--- a/tests/profiling/collector/test_greenlet_count.py
+++ b/tests/profiling/collector/test_greenlet_count.py
@@ -16,23 +16,31 @@ GEVENT_COMPATIBLE_WITH_PYTHON_VERSION = os.getenv("DD_PROFILE_TEST_GEVENT", Fals
 @pytest.mark.subprocess(err=None)
 def test_greenlet_count_present():
     """greenlet_count is present and positive when gevent greenlets are active."""
-    # Start the capture server BEFORE monkey.patch_all() so that
-    # the server socket is created with standard Python sockets. After gevent
-    # patches Python sockets, a pre-existing server socket continues to work
-    # correctly with gevent's event loop.
+    # Start the mini agent BEFORE monkey.patch_all() so that its server socket is
+    # created with standard Python sockets. After gevent patches Python sockets,
+    # a pre-existing server socket continues to work correctly with gevent's
+    # event loop.  We also can't call server.stop() after monkey.patch_all()
+    # because socketserver.shutdown() deadlocks with gevent-patched threading.
+    # The server runs on a daemon thread and will be killed when the subprocess exits.
     import os
+    import uuid
 
     from ddtrace.internal.datadog.profiling import ddup
-    from tests.profiling.utils import _ProfilingCaptureServer
+    from tests.profiling.utils import _ProfilingMiniAgent
+    from tests.profiling.utils import _ProfilingMiniAgentClient
     from tests.profiling.utils import get_all_metadata_from_agent
 
-    _capture_server = _ProfilingCaptureServer()
-    _capture_server.start()
-    _url = f"http://127.0.0.1:{_capture_server.port}"
-    os.environ["_DD_PROFILING_TEST_AGENT_URL"] = _url
-    _config_url = getattr(ddup, "config_url", None)
-    if _config_url is not None:
-        _config_url(_url)
+    _token = str(uuid.uuid4())
+    _server = _ProfilingMiniAgent()
+    _server.start()
+    _base_url = f"http://127.0.0.1:{_server.port}"
+
+    os.environ["_DD_PROFILING_TEST_TOKEN"] = _token
+    os.environ["_DD_PROFILING_TEST_PROXY_URL"] = _base_url
+    _config_test_token = getattr(ddup, "config_test_token", None)
+    if _config_test_token is not None:
+        _config_test_token(_token, _base_url)
+
     # Force 1s upload interval so we get multiple uploads during the 3s sleep.
     os.environ["DD_PROFILING_UPLOAD_INTERVAL"] = "1"
 
@@ -63,7 +71,8 @@ def test_greenlet_count_present():
     gevent.joinall(greenlets, timeout=5)
     p.stop()
 
-    files = get_all_metadata_from_agent(_capture_server, min_count=2)
+    _client = _ProfilingMiniAgentClient(base_url=_base_url, token=_token)
+    files = get_all_metadata_from_agent(_client, min_count=2)
     assert files, "Expected at least one metadata upload"
 
     found_positive = False
@@ -76,7 +85,7 @@ def test_greenlet_count_present():
 
     assert found_positive, "Expected at least one metadata file with greenlet_count > 0"
 
-    # Don't call _capture_server.stop() here: after monkey.patch_all(), calling
+    # Don't call _server.stop() here: after monkey.patch_all(), calling
     # socketserver.shutdown() deadlocks because threading.Event.wait() is gevent-patched
     # and tries to switch to the gevent hub which no longer exists at this point.
-    # The capture server is a daemon thread and will be killed when the subprocess exits.
+    # The server runs on a daemon thread and will be killed when the subprocess exits.

--- a/tests/profiling/collector/test_heap_tracker_count.py
+++ b/tests/profiling/collector/test_heap_tracker_count.py
@@ -3,56 +3,49 @@ import pytest
 
 @pytest.mark.subprocess(
     env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_heap_tracker_count",
-        DD_PROFILING_UPLOAD_INTERVAL="1",
         DD_PROFILING_HEAP_SAMPLE_SIZE="64",
     ),
-    err=None,
 )
 def test_heap_tracker_count_present():
     """heap_tracker_count is present and non-zero when memory profiling is enabled."""
-    import glob
-    import json
-    import os
     import time
 
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
+    from tests.profiling.utils import get_all_metadata_from_agent
+    from tests.profiling.utils import with_profiling_test_agent
 
-    p = profiler.Profiler(tracer=tracer)
-    p.start()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler(tracer=tracer)
+        p.start()
 
-    time.sleep(0.3)
+        time.sleep(0.3)
 
-    # Allocate objects after the profiler starts so the heap tracker sees them.
-    # With DD_PROFILING_HEAP_SAMPLE_SIZE=64, even small allocations trigger samples.
-    held = [bytearray(1024) for _ in range(100)]
+        # Allocate objects after the profiler starts so the heap tracker sees them.
+        # With DD_PROFILING_HEAP_SAMPLE_SIZE=64, even small allocations trigger samples.
+        held = [bytearray(1024) for _ in range(100)]
 
-    time.sleep(0.3)
+        time.sleep(0.3)
 
-    p.stop()
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
-    assert files, "Expected at least one internal_metadata.json file"
+        files = get_all_metadata_from_agent(agent_client, min_count=1)
+        assert files, "Expected at least one metadata upload"
 
-    for f in files:
-        with open(f) as fp:
-            metadata = json.load(fp)
-        assert "heap_tracker_count" in metadata, f"Missing heap_tracker_count in {f}: {metadata}"
-        assert isinstance(metadata["heap_tracker_count"], int), f"heap_tracker_count must be an integer: {metadata}"
-        assert metadata["heap_tracker_count"] >= 0, f"heap_tracker_count must be non-negative: {metadata}"
-        assert "heap_tracker_cap_drops" in metadata, f"Missing heap_tracker_cap_drops in {f}: {metadata}"
-        assert isinstance(metadata["heap_tracker_cap_drops"], int), (
-            f"heap_tracker_cap_drops must be an integer: {metadata}"
-        )
+        for metadata in files:
+            assert "heap_tracker_count" in metadata, f"Missing heap_tracker_count in metadata: {metadata}"
+            assert isinstance(metadata["heap_tracker_count"], int), f"heap_tracker_count must be an integer: {metadata}"
+            assert metadata["heap_tracker_count"] >= 0, f"heap_tracker_count must be non-negative: {metadata}"
+            assert "heap_tracker_cap_drops" in metadata, f"Missing heap_tracker_cap_drops in metadata: {metadata}"
+            assert isinstance(metadata["heap_tracker_cap_drops"], int), (
+                f"heap_tracker_cap_drops must be an integer: {metadata}"
+            )
 
-    # The last file may be a partial flush, so check the penultimate one has tracked allocations
-    if len(files) >= 2:
-        with open(files[-2]) as fp:
-            metadata = json.load(fp)
-        assert metadata["heap_tracker_count"] > 0, (
-            f"Expected heap_tracker_count > 0 in penultimate file, got {metadata}. held={len(held)}"
-        )
+        # The last file may be a partial flush, so check the penultimate one has tracked allocations
+        if len(files) >= 2:
+            metadata = files[-2]
+            assert metadata["heap_tracker_count"] > 0, (
+                f"Expected heap_tracker_count > 0 in penultimate metadata, got {metadata}. held={len(held)}"
+            )
 
     del held

--- a/tests/profiling/collector/test_heap_tracker_count.py
+++ b/tests/profiling/collector/test_heap_tracker_count.py
@@ -13,39 +13,37 @@ def test_heap_tracker_count_present():
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
     from tests.profiling.utils import get_all_metadata_from_agent
-    from tests.profiling.utils import with_profiling_test_agent
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler(tracer=tracer)
-        p.start()
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
 
-        time.sleep(0.3)
+    time.sleep(0.3)
 
-        # Allocate objects after the profiler starts so the heap tracker sees them.
-        # With DD_PROFILING_HEAP_SAMPLE_SIZE=64, even small allocations trigger samples.
-        held = [bytearray(1024) for _ in range(100)]
+    # Allocate objects after the profiler starts so the heap tracker sees them.
+    # With DD_PROFILING_HEAP_SAMPLE_SIZE=64, even small allocations trigger samples.
+    held = [bytearray(1024) for _ in range(100)]
 
-        time.sleep(0.3)
+    time.sleep(0.3)
 
-        p.stop()
+    p.stop()
 
-        files = get_all_metadata_from_agent(agent_client, min_count=1)
-        assert files, "Expected at least one metadata upload"
+    files = get_all_metadata_from_agent(min_count=1)
+    assert files, "Expected at least one metadata upload"
 
-        for metadata in files:
-            assert "heap_tracker_count" in metadata, f"Missing heap_tracker_count in metadata: {metadata}"
-            assert isinstance(metadata["heap_tracker_count"], int), f"heap_tracker_count must be an integer: {metadata}"
-            assert metadata["heap_tracker_count"] >= 0, f"heap_tracker_count must be non-negative: {metadata}"
-            assert "heap_tracker_cap_drops" in metadata, f"Missing heap_tracker_cap_drops in metadata: {metadata}"
-            assert isinstance(metadata["heap_tracker_cap_drops"], int), (
-                f"heap_tracker_cap_drops must be an integer: {metadata}"
-            )
+    for metadata in files:
+        assert "heap_tracker_count" in metadata, f"Missing heap_tracker_count in metadata: {metadata}"
+        assert isinstance(metadata["heap_tracker_count"], int), f"heap_tracker_count must be an integer: {metadata}"
+        assert metadata["heap_tracker_count"] >= 0, f"heap_tracker_count must be non-negative: {metadata}"
+        assert "heap_tracker_cap_drops" in metadata, f"Missing heap_tracker_cap_drops in metadata: {metadata}"
+        assert isinstance(metadata["heap_tracker_cap_drops"], int), (
+            f"heap_tracker_cap_drops must be an integer: {metadata}"
+        )
 
-        # The last file may be a partial flush, so check the penultimate one has tracked allocations
-        if len(files) >= 2:
-            metadata = files[-2]
-            assert metadata["heap_tracker_count"] > 0, (
-                f"Expected heap_tracker_count > 0 in penultimate metadata, got {metadata}. held={len(held)}"
-            )
+    # The last file may be a partial flush, so check the penultimate one has tracked allocations
+    if len(files) >= 2:
+        metadata = files[-2]
+        assert metadata["heap_tracker_count"] > 0, (
+            f"Expected heap_tracker_count > 0 in penultimate metadata, got {metadata}. held={len(held)}"
+        )
 
     del held

--- a/tests/profiling/collector/test_internal_adaptive_sampling.py
+++ b/tests/profiling/collector/test_internal_adaptive_sampling.py
@@ -17,7 +17,6 @@ def test_internal_adaptive_sampling():
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
     from tests.profiling.utils import get_all_metadata_from_agent
-    from tests.profiling.utils import with_profiling_test_agent
 
     sleep_time = 0.2
     loop_run_time = 4
@@ -38,17 +37,16 @@ def test_internal_adaptive_sampling():
     resource = str(uuid.uuid4())
     span_type = ext.SpanTypes.WEB
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler(tracer=tracer)
-        p.start()
-        with tracer.trace("test_asyncio", resource=resource, span_type=span_type):
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            main_task = loop.create_task(hello(), name="main")
-            loop.run_until_complete(main_task)
-        p.stop()
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+    with tracer.trace("test_asyncio", resource=resource, span_type=span_type):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        main_task = loop.create_task(hello(), name="main")
+        loop.run_until_complete(main_task)
+    p.stop()
 
-        files = get_all_metadata_from_agent(agent_client, min_count=1)
+    files = get_all_metadata_from_agent(min_count=1)
 
     # With adaptive sampling enabled, the sampling interval can grow up to 1 second
     # (g_max_sampling_period_us). Since the upload interval is also 1 second, the

--- a/tests/profiling/collector/test_internal_adaptive_sampling.py
+++ b/tests/profiling/collector/test_internal_adaptive_sampling.py
@@ -3,9 +3,6 @@ import pytest
 
 @pytest.mark.subprocess(
     env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_internal_adaptive_sampling",
-        # Upload every second
-        DD_PROFILING_UPLOAD_INTERVAL="1",
         # Enable adaptive sampling to test sampling_interval_us field
         _DD_PROFILING_STACK_V2_ADAPTIVE_SAMPLING_ENABLED="1",
     ),
@@ -13,15 +10,14 @@ import pytest
 )
 def test_internal_adaptive_sampling():
     import asyncio
-    import glob
-    import json
-    import os
     import time
     import uuid
 
     from ddtrace import ext
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
+    from tests.profiling.utils import get_all_metadata_from_agent
+    from tests.profiling.utils import with_profiling_test_agent
 
     sleep_time = 0.2
     loop_run_time = 4
@@ -42,17 +38,17 @@ def test_internal_adaptive_sampling():
     resource = str(uuid.uuid4())
     span_type = ext.SpanTypes.WEB
 
-    p = profiler.Profiler(tracer=tracer)
-    p.start()
-    with tracer.trace("test_asyncio", resource=resource, span_type=span_type):
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        main_task = loop.create_task(hello(), name="main")
-        loop.run_until_complete(main_task)
-    p.stop()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler(tracer=tracer)
+        p.start()
+        with tracer.trace("test_asyncio", resource=resource, span_type=span_type):
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            main_task = loop.create_task(hello(), name="main")
+            loop.run_until_complete(main_task)
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
+        files = get_all_metadata_from_agent(agent_client, min_count=1)
 
     # With adaptive sampling enabled, the sampling interval can grow up to 1 second
     # (g_max_sampling_period_us). Since the upload interval is also 1 second, the
@@ -62,27 +58,24 @@ def test_internal_adaptive_sampling():
     found_at_least_one_with_more_samples_than_sampling_events = False
     found_at_least_one_with_sampling_interval = False
     total_sample_count = 0
-    for f in files:
-        with open(f, "r") as fp:
-            internal_metadata = json.load(fp)
+    for internal_metadata in files:
+        assert internal_metadata is not None
+        assert "sample_count" in internal_metadata
+        assert "sampling_event_count" in internal_metadata
+        assert internal_metadata["sampling_event_count"] <= internal_metadata["sample_count"]
 
-            assert internal_metadata is not None
-            assert "sample_count" in internal_metadata
-            assert "sampling_event_count" in internal_metadata
-            assert internal_metadata["sampling_event_count"] <= internal_metadata["sample_count"]
+        total_sample_count += internal_metadata["sample_count"]
 
-            total_sample_count += internal_metadata["sample_count"]
+        # With adaptive sampling enabled, we should have the sampling_interval_us field
+        # in files that have samples
+        if "sampling_interval_us" in internal_metadata:
+            assert internal_metadata["sampling_interval_us"] > 0, (
+                f"Sampling interval should be positive: {internal_metadata['sampling_interval_us']}"
+            )
+            found_at_least_one_with_sampling_interval = True
 
-            # With adaptive sampling enabled, we should have the sampling_interval_us field
-            # in files that have samples
-            if "sampling_interval_us" in internal_metadata:
-                assert internal_metadata["sampling_interval_us"] > 0, (
-                    f"Sampling interval should be positive: {internal_metadata['sampling_interval_us']}"
-                )
-                found_at_least_one_with_sampling_interval = True
-
-            if internal_metadata["sample_count"] > internal_metadata["sampling_event_count"]:
-                found_at_least_one_with_more_samples_than_sampling_events = True
+        if internal_metadata["sample_count"] > internal_metadata["sampling_event_count"]:
+            found_at_least_one_with_more_samples_than_sampling_events = True
 
         # Early exit if we have already found all the required conditions
         if (

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -600,6 +600,7 @@ def test_memory_collector_allocation_tracking_across_snapshots() -> None:
 @pytest.mark.subprocess(err=None)
 def test_memory_collector_python_interface_with_allocation_tracking() -> None:
     import gc
+    from typing import Union  # noqa: F401
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import memalloc
@@ -712,6 +713,8 @@ def test_memory_collector_python_interface_with_allocation_tracking() -> None:
 
 @pytest.mark.subprocess(err=None)
 def test_memory_collector_python_interface_with_allocation_tracking_no_deletion() -> None:
+    from typing import Union  # noqa: F401
+
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import memalloc
     from tests.profiling.collector import pprof_utils
@@ -830,6 +833,7 @@ def test_memory_collector_python_interface_with_allocation_tracking_no_deletion(
 def test_heap_live_samples_drops_after_free() -> None:
     """Verify heap-live-samples disappear from a stack after its objects are freed."""
     import gc
+    from typing import Union  # noqa: F401
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import memalloc
@@ -912,13 +916,15 @@ def test_heap_live_samples_drops_after_free() -> None:
         del batch_two
 
 
-@pytest.mark.subprocess(err=None)
+@pytest.mark.subprocess(err=None, out=None)
 def test_heap_live_samples_aggregate_accuracy() -> None:
     """Verify the sum of heap-live-samples is a reasonable estimate of actual live object count.
 
     With a small sampling interval and many allocations, the aggregate heap-live-samples
     should approximate the real number of live objects within a tolerance.
     """
+    from typing import Union  # noqa: F401
+
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import memalloc
     from tests.profiling.collector import pprof_utils
@@ -957,10 +963,6 @@ def test_heap_live_samples_aggregate_accuracy() -> None:
         assert len(one_live_samples) > 0, "Expected live samples from 'one'"
 
         total_heap_live_count = sum(s.value[heap_live_idx] for s in one_live_samples)
-
-        print(f"Actual live objects: {num_objects}")
-        print(f"Reported heap-live-samples: {total_heap_live_count}")
-        print(f"Count ratio: {total_heap_live_count / num_objects:.2f}")
 
         # The aggregate should be close to the actual count.
         # With the Horvitz-Thompson estimator w = 1/(1-exp(-S/R)), the weight
@@ -1069,6 +1071,7 @@ def test_memory_collector_buffer_pool_exhaustion() -> None:
     stack traces, which could potentially exhaust internal buffer pools.
     """
     import threading
+    from typing import Union  # noqa: F401
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import memalloc
@@ -1084,7 +1087,7 @@ def test_memory_collector_buffer_pool_exhaustion() -> None:
     mc = memalloc.MemoryCollector(heap_sample_size=64)
 
     # Store reference to nested function for later qualname access
-    deep_alloc_func = None
+    deep_alloc_ref: list = [None]
 
     num_threads = 10
     thread_ids: set[int] = set()
@@ -1106,8 +1109,7 @@ def test_memory_collector_buffer_pool_exhaustion() -> None:
                 return deep_alloc(depth - 1)
 
             # Capture reference to deep_alloc for later use
-            nonlocal deep_alloc_func
-            deep_alloc_func = deep_alloc
+            deep_alloc_ref[0] = deep_alloc
             # Multiple allocations per thread to make sampling more reliable
             for _ in range(5):
                 data = deep_alloc(50)
@@ -1139,7 +1141,7 @@ def test_memory_collector_buffer_pool_exhaustion() -> None:
             stack_depth = len(sample.location_id)
             max_stack_depth = max(max_stack_depth, stack_depth)
 
-            if deep_alloc_func and has_function_in_profile_sample(profile, sample, deep_alloc_func):
+            if deep_alloc_ref[0] and has_function_in_profile_sample(profile, sample, deep_alloc_ref[0]):
                 # Samples with identical stack traces are merged in pprof profiles,
                 # so we need to sum the alloc-samples count value
                 deep_alloc_total_count += sample.value[alloc_count_idx]
@@ -1429,6 +1431,7 @@ def test_memory_collector_stack_order() -> None:
     reported in the order: inner, middle, outer (leaf-to-root).
     """
     import threading
+    from typing import Union  # noqa: F401
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import memalloc

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import gc
 import inspect
 import os
-from pathlib import Path
 import struct
 import sys
 import threading
@@ -42,51 +40,23 @@ def _allocate_1k() -> list[object]:
 _ALLOC_LINE_NUMBER = _allocate_1k.__code__.co_firstlineno + 1
 
 
-def _setup_profiling_prelude(tmp_path: Path, test_name: str) -> str:
-    """Setup ddup configuration and return the output filename for pprof parsing.
-
-    Args:
-        tmp_path: pytest tmp_path fixture
-        test_name: Name of the test (used for service name and output filename)
-
-    Returns:
-        output_filename: The full path to the pprof output file (with PID suffix)
-    """
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
-
-    ddup.config(
-        service=test_name,
-        version="test",
-        env="test",
-        output_filename=pprof_prefix,
-    )
-    ddup.start()
-
-    return output_filename
-
-
 # This test is marked as subprocess as it changes default heap sample size
-@pytest.mark.subprocess(
-    env=dict(DD_PROFILING_HEAP_SAMPLE_SIZE="1024", DD_PROFILING_OUTPUT_PPROF="/tmp/test_heap_samples_collected")
-)
+@pytest.mark.subprocess(env=dict(DD_PROFILING_HEAP_SAMPLE_SIZE="1024"))
 def test_heap_samples_collected() -> None:
-    import os
-
     from ddtrace.profiling.profiler import Profiler
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_memalloc import _allocate_1k
+    from tests.profiling.utils import with_profiling_test_agent
 
     # Test for https://github.com/DataDog/dd-trace-py/issues/11069
-    pprof_prefix = os.environ["DD_PROFILING_OUTPUT_PPROF"]
-    output_filename = pprof_prefix + "." + str(os.getpid())
+    with with_profiling_test_agent() as agent_client:
+        p = Profiler()
+        p.start()
+        x = _allocate_1k()  # noqa: F841
+        p.stop()
 
-    p = Profiler()
-    p.start()
-    x = _allocate_1k()  # noqa: F841
-    p.stop()
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
     samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
     assert len(samples) > 0
 
@@ -95,17 +65,31 @@ def test_heap_samples_collected() -> None:
     assert len(heap_live_samples) > 0
 
 
-def test_memory_collector(tmp_path: Path) -> None:
-    output_filename = _setup_profiling_prelude(tmp_path, "test_memory_collector")
+@pytest.mark.subprocess(err=None)
+def test_memory_collector() -> None:
+    import threading
 
-    mc = memalloc.MemoryCollector(heap_sample_size=256)
-    with mc:
-        live_objects = _allocate_1k()  # noqa: F841
-        mc.snapshot()
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import memalloc
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_memalloc import _ALLOC_LINE_NUMBER
+    from tests.profiling.collector.test_memalloc import _allocate_1k
+    from tests.profiling.utils import with_profiling_test_agent
 
-    ddup.upload()
+    test_name = "test_memory_collector"
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(service=test_name, version="test", env="test")
+        ddup.start()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        mc = memalloc.MemoryCollector(heap_sample_size=256)
+        with mc:
+            live_objects = _allocate_1k()  # noqa: F841
+            mc.snapshot()
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+
     # Gets samples with alloc-space > 0
     samples = pprof_utils.get_samples_with_value_type(profile, "alloc-space")
 
@@ -141,40 +125,48 @@ def test_memory_collector(tmp_path: Path) -> None:
     )
 
 
-def test_memory_collector_ignore_profiler(tmp_path: Path) -> None:
-    output_filename = _setup_profiling_prelude(tmp_path, "test_memory_collector_ignore_profiler")
+@pytest.mark.subprocess(err=None)
+def test_memory_collector_ignore_profiler() -> None:
+    import threading
 
-    mc = memalloc.MemoryCollector(ignore_profiler=True)
-    quit_thread = threading.Event()
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import memalloc
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_memalloc import _allocate_1k
+    from tests.profiling.utils import with_profiling_test_agent
 
-    with mc:
+    test_name = "test_memory_collector_ignore_profiler"
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(service=test_name, version="test", env="test")
+        ddup.start()
 
-        def alloc() -> None:
-            _allocate_1k()
-            quit_thread.wait()
+        mc = memalloc.MemoryCollector(ignore_profiler=True)
+        quit_thread = threading.Event()
 
-        alloc_thread = threading.Thread(name="allocator", target=alloc)
-        alloc_thread._ddtrace_profiling_ignore = True  # type: ignore[attr-defined]
-        alloc_thread.start()
+        with mc:
 
-        mc.snapshot()
+            def alloc() -> None:
+                _allocate_1k()
+                quit_thread.wait()
 
-    # We need to wait for the data collection to happen so it gets the `_ddtrace_profiling_ignore` Thread attribute from
-    # the global thread list.
-    quit_thread.set()
-    alloc_thread.join()
+            alloc_thread = threading.Thread(name="allocator", target=alloc)
+            alloc_thread._ddtrace_profiling_ignore = True  # type: ignore[attr-defined]
+            alloc_thread.start()
 
-    ddup.upload()
+            mc.snapshot()
 
-    try:
-        pprof_utils.parse_newest_profile(output_filename)
-    except AssertionError as e:
-        assert "No samples found" in str(e)
+        # We need to wait for the data collection to happen so it gets the
+        # `_ddtrace_profiling_ignore` Thread attribute from the global thread list.
+        quit_thread.set()
+        alloc_thread.join()
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent_client, assert_samples=False)
+    assert len(profile.sample) == 0, "Expected no samples in profile when profiler is ignored"
 
 
-@pytest.mark.subprocess(
-    env=dict(DD_PROFILING_HEAP_SAMPLE_SIZE="8", DD_PROFILING_OUTPUT_PPROF="/tmp/test_heap_profiler_large_heap_overhead")
-)
+@pytest.mark.subprocess(env=dict(DD_PROFILING_HEAP_SAMPLE_SIZE="8"))
 def test_heap_profiler_large_heap_overhead() -> None:
     # NOTE: A regression test for integer arithmetic bugs.
     from ddtrace.profiling.profiler import Profiler
@@ -379,11 +371,13 @@ def test_memalloc_data_race_regression() -> None:
 
 @pytest.mark.skip(reason="This test makes the CI timeout. Skipping it to unblock PRs.")
 @pytest.mark.parametrize("sample_interval", (256, 512, 1024))
-def test_memory_collector_allocation_accuracy_with_tracemalloc(sample_interval: int, tmp_path: Path) -> None:
+def test_memory_collector_allocation_accuracy_with_tracemalloc(sample_interval: int, profiling_test_agent) -> None:
     import tracemalloc
 
     test_name = f"test_memory_collector_allocation_accuracy_with_tracemalloc_{sample_interval}"
-    output_filename = _setup_profiling_prelude(tmp_path, test_name)
+    assert ddup.is_available
+    ddup.config(service=test_name, version="test", env="test")
+    ddup.start()
 
     old = os.environ.get("_DD_MEMALLOC_DEBUG_RNG_SEED")
     os.environ["_DD_MEMALLOC_DEBUG_RNG_SEED"] = "42"
@@ -407,7 +401,9 @@ def test_memory_collector_allocation_accuracy_with_tracemalloc(sample_interval: 
 
             del junk
 
-            profile = mc.snapshot_and_parse_pprof(output_filename)
+            mc.snapshot()
+            ddup.upload()
+            profile = pprof_utils.get_profile_from_agent(profiling_test_agent)
 
     finally:
         if old is not None:
@@ -524,112 +520,150 @@ def test_memory_collector_allocation_accuracy_with_tracemalloc(sample_interval: 
     print(f"Captured {len(allocation_samples)} allocation samples representing {total_allocation_count} allocations")
 
 
-def test_memory_collector_allocation_tracking_across_snapshots(tmp_path: Path) -> None:
-    output_filename = _setup_profiling_prelude(tmp_path, "test_memory_collector_allocation_tracking_across_snapshots")
+@pytest.mark.subprocess(err=None)
+def test_memory_collector_allocation_tracking_across_snapshots() -> None:
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import memalloc
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_memalloc import has_function_in_profile_sample
+    from tests.profiling.collector.test_memalloc import one
+    from tests.profiling.collector.test_memalloc import two
+    from tests.profiling.utils import with_profiling_test_agent
 
-    mc = memalloc.MemoryCollector(heap_sample_size=64)
+    test_name = "test_memory_collector_allocation_tracking_across_snapshots"
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(service=test_name, version="test", env="test")
+        ddup.start()
 
-    with mc:
-        data_to_free = []
-        for _ in range(10):
-            data_to_free.append(one(256))
+        mc = memalloc.MemoryCollector(heap_sample_size=64)
 
-        data_to_keep = []
-        for _ in range(10):
-            data_to_keep.append(two(512))
+        with mc:
+            data_to_free = []
+            for _ in range(10):
+                data_to_free.append(one(256))
 
-        del data_to_free
+            data_to_keep = []
+            for _ in range(10):
+                data_to_keep.append(two(512))
 
-        profile = mc.snapshot_and_parse_pprof(output_filename)
+            del data_to_free
 
-        # Get sample type indices
-        heap_space_idx = pprof_utils.get_sample_type_index(profile, "heap-space")
-        alloc_space_idx = pprof_utils.get_sample_type_index(profile, "alloc-space")
-        alloc_count_idx = pprof_utils.get_sample_type_index(profile, "alloc-samples")
+            mc.snapshot()
+            ddup.upload()
+            profile = pprof_utils.get_profile_from_agent(agent_client)
 
-        # Assert that required sample types exist
-        assert heap_space_idx >= 0, "heap-space sample type not found in profile"
-        assert alloc_space_idx >= 0, "alloc-space sample type not found in profile"
-        assert alloc_count_idx >= 0, "alloc-samples sample type not found in profile"
+            # Get sample type indices
+            heap_space_idx = pprof_utils.get_sample_type_index(profile, "heap-space")
+            alloc_space_idx = pprof_utils.get_sample_type_index(profile, "alloc-space")
+            alloc_count_idx = pprof_utils.get_sample_type_index(profile, "alloc-samples")
 
-        initial_allocations_valid = all(sample.value[alloc_space_idx] > 0 for sample in profile.sample)
-        assert initial_allocations_valid, "Initial snapshot should have alloc-space>0 (new allocations)"
+            # Assert that required sample types exist
+            assert heap_space_idx >= 0, "heap-space sample type not found in profile"
+            assert alloc_space_idx >= 0, "alloc-space sample type not found in profile"
+            assert alloc_count_idx >= 0, "alloc-samples sample type not found in profile"
 
-        # Get freed samples (alloc-space > 0, heap-space == 0)
-        freed_samples = [s for s in profile.sample if s.value[alloc_space_idx] > 0 and s.value[heap_space_idx] == 0]
-        # Get live samples (heap-space > 0)
-        live_samples = [s for s in profile.sample if s.value[heap_space_idx] > 0]
+            initial_allocations_valid = all(sample.value[alloc_space_idx] > 0 for sample in profile.sample)
+            assert initial_allocations_valid, "Initial snapshot should have alloc-space>0 (new allocations)"
 
-        assert len(freed_samples) > 0, "Should have some freed samples after deletion"
+            # Get freed samples (alloc-space > 0, heap-space == 0)
+            freed_samples = [s for s in profile.sample if s.value[alloc_space_idx] > 0 and s.value[heap_space_idx] == 0]
+            # Get live samples (heap-space > 0)
+            live_samples = [s for s in profile.sample if s.value[heap_space_idx] > 0]
 
-        assert len(live_samples) > 0, "Should have some live samples"
+            assert len(freed_samples) > 0, "Should have some freed samples after deletion"
 
-        # Validate all samples have valid values
-        for sample in profile.sample:
-            has_heap = sample.value[heap_space_idx] > 0
-            has_alloc = sample.value[alloc_space_idx] > 0
-            assert has_heap or has_alloc, "Sample should have either heap-space or alloc-space > 0"
-            assert sample.value[alloc_count_idx] >= 0, (
-                f"alloc-samples should be non-negative, got {sample.value[alloc_count_idx]}"
+            assert len(live_samples) > 0, "Should have some live samples"
+
+            # Validate all samples have valid values
+            for sample in profile.sample:
+                has_heap = sample.value[heap_space_idx] > 0
+                has_alloc = sample.value[alloc_space_idx] > 0
+                assert has_heap or has_alloc, "Sample should have either heap-space or alloc-space > 0"
+                assert sample.value[alloc_count_idx] >= 0, (
+                    f"alloc-samples should be non-negative, got {sample.value[alloc_count_idx]}"
+                )
+
+            one_freed_samples = [
+                sample for sample in freed_samples if has_function_in_profile_sample(profile, sample, one)
+            ]
+
+            assert len(one_freed_samples) > 0, "Should have freed samples from function 'one'"
+            one_freed_samples_valid = all(
+                sample.value[heap_space_idx] == 0 and sample.value[alloc_space_idx] > 0 for sample in one_freed_samples
+            )
+            assert one_freed_samples_valid, (
+                "Freed samples from function 'one' should have heap-space == 0 and alloc-space > 0"
             )
 
-        one_freed_samples = [sample for sample in freed_samples if has_function_in_profile_sample(profile, sample, one)]
+            two_live_samples = [
+                sample for sample in live_samples if has_function_in_profile_sample(profile, sample, two)
+            ]
 
-        assert len(one_freed_samples) > 0, "Should have freed samples from function 'one'"
-        one_freed_samples_valid = all(
-            sample.value[heap_space_idx] == 0 and sample.value[alloc_space_idx] > 0 for sample in one_freed_samples
-        )
-        assert one_freed_samples_valid, (
-            "Freed samples from function 'one' should have heap-space == 0 and alloc-space > 0"
-        )
+            assert len(two_live_samples) > 0, "Should have live samples from function 'two'"
+            two_live_samples_valid = all(
+                sample.value[heap_space_idx] > 0 and sample.value[alloc_space_idx] > 0 for sample in two_live_samples
+            )
+            assert two_live_samples_valid, (
+                "Live samples from function 'two' should have heap-space > 0 and alloc-space > 0"
+            )
 
-        two_live_samples = [sample for sample in live_samples if has_function_in_profile_sample(profile, sample, two)]
-
-        assert len(two_live_samples) > 0, "Should have live samples from function 'two'"
-        two_live_samples_valid = all(
-            sample.value[heap_space_idx] > 0 and sample.value[alloc_space_idx] > 0 for sample in two_live_samples
-        )
-        assert two_live_samples_valid, "Live samples from function 'two' should have heap-space > 0 and alloc-space > 0"
-
-        del data_to_keep
+            del data_to_keep
 
 
-def test_memory_collector_python_interface_with_allocation_tracking(tmp_path: Path) -> None:
-    output_filename = _setup_profiling_prelude(
-        tmp_path, "test_memory_collector_python_interface_with_allocation_tracking"
-    )
+@pytest.mark.subprocess(err=None)
+def test_memory_collector_python_interface_with_allocation_tracking() -> None:
+    import gc
 
-    mc = memalloc.MemoryCollector(heap_sample_size=32)
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import memalloc
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_memalloc import has_function_in_profile_sample
+    from tests.profiling.collector.test_memalloc import one
+    from tests.profiling.collector.test_memalloc import two
+    from tests.profiling.utils import with_profiling_test_agent
 
-    with mc:
-        first_batch: list[Union[tuple[None, ...], bytearray]] = []
-        for _ in range(20):
-            first_batch.append(one(256))
+    test_name = "test_memory_collector_python_interface_with_allocation_tracking"
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(service=test_name, version="test", env="test")
+        ddup.start()
 
-        # We're taking a snapshot here to ensure that in the next snapshot, we don't see any "one" allocations
-        mc.snapshot_and_parse_pprof(output_filename)
+        mc = memalloc.MemoryCollector(heap_sample_size=32)
 
-        second_batch: list[Union[tuple[None, ...], bytearray]] = []
-        for _ in range(15):
-            second_batch.append(two(512))
+        with mc:
+            first_batch: list[Union[tuple[None, ...], bytearray]] = []
+            for _ in range(20):
+                first_batch.append(one(256))
 
-        del first_batch
+            # We're taking a snapshot here to ensure that in the next snapshot, we don't see any "one" allocations
+            mc.snapshot()
+            ddup.upload()
+            agent_client.clear()
 
-        # Force a full GC collection to clear CPython's internal free lists
-        # (tuple, float, list, dict, etc.).  On Python < 3.13, calling
-        # bytearray(256) inside one() goes through _PyObject_MakeTpCall,
-        # which creates a temporary 1-element args tuple (256,).  When that
-        # tuple's refcount drops to zero, tupledealloc caches it in the
-        # tuple free list WITHOUT calling PyObject_Free, so the profiler's
-        # memalloc_free hook is never triggered and the allocation stays
-        # tracked as "live" in allocs_m even though the Python object is
-        # logically dead.  gc.collect(generation=2) calls clear_freelists()
-        # -> _PyTuple_ClearFreeList() -> PyObject_GC_Del() -> PyObject_Free(),
-        # which properly fires memalloc_free -> untrack and removes these
-        # ghost entries.
-        gc.collect()
+            second_batch: list[Union[tuple[None, ...], bytearray]] = []
+            for _ in range(15):
+                second_batch.append(two(512))
 
-        final_profile = mc.snapshot_and_parse_pprof(output_filename)
+            del first_batch
+
+            # Force a full GC collection to clear CPython's internal free lists
+            # (tuple, float, list, dict, etc.).  On Python < 3.13, calling
+            # bytearray(256) inside one() goes through _PyObject_MakeTpCall,
+            # which creates a temporary 1-element args tuple (256,).  When that
+            # tuple's refcount drops to zero, tupledealloc caches it in the
+            # tuple free list WITHOUT calling PyObject_Free, so the profiler's
+            # memalloc_free hook is never triggered and the allocation stays
+            # tracked as "live" in allocs_m even though the Python object is
+            # logically dead.  gc.collect(generation=2) calls clear_freelists()
+            # -> _PyTuple_ClearFreeList() -> PyObject_GC_Del() -> PyObject_Free(),
+            # which properly fires memalloc_free -> untrack and removes these
+            # ghost entries.
+            gc.collect()
+
+            mc.snapshot()
+            ddup.upload()
+            final_profile = pprof_utils.get_profile_from_agent(agent_client)
 
         assert len(final_profile.sample) > 0, "Final snapshot should have samples"
 
@@ -691,238 +725,312 @@ def test_memory_collector_python_interface_with_allocation_tracking(tmp_path: Pa
         del second_batch
 
 
-def test_memory_collector_python_interface_with_allocation_tracking_no_deletion(tmp_path: Path) -> None:
-    output_filename = _setup_profiling_prelude(
-        tmp_path, "test_memory_collector_python_interface_with_allocation_tracking_no_deletion"
-    )
+@pytest.mark.subprocess(err=None)
+def test_memory_collector_python_interface_with_allocation_tracking_no_deletion() -> None:
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import memalloc
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_memalloc import has_function_in_profile_sample
+    from tests.profiling.collector.test_memalloc import one
+    from tests.profiling.collector.test_memalloc import two
+    from tests.profiling.utils import with_profiling_test_agent
 
-    mc = memalloc.MemoryCollector(heap_sample_size=32)
+    test_name = "test_memory_collector_python_interface_with_allocation_tracking_no_deletion"
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(service=test_name, version="test", env="test")
+        ddup.start()
 
-    with mc:
-        # Take initial snapshot to reset allocation tracking (may have no samples)
-        mc.snapshot_and_parse_pprof(output_filename, assert_samples=False)
+        mc = memalloc.MemoryCollector(heap_sample_size=32)
 
-        first_batch: list[Union[tuple[None, ...], bytearray]] = []
-        for _ in range(20):
-            first_batch.append(one(256))
+        with mc:
+            # Take initial snapshot to reset allocation tracking (may have no samples)
+            mc.snapshot()
+            ddup.upload()
+            agent_client.clear()
 
-        after_first_batch_profile = mc.snapshot_and_parse_pprof(output_filename)
+            first_batch: list[Union[tuple[None, ...], bytearray]] = []
+            for _ in range(20):
+                first_batch.append(one(256))
 
-        second_batch: list[Union[tuple[None, ...], bytearray]] = []
-        for _ in range(15):
-            second_batch.append(two(512))
+            mc.snapshot()
+            ddup.upload()
+            after_first_batch_profile = pprof_utils.get_profile_from_agent(agent_client)
+            agent_client.clear()
 
-        final_profile = mc.snapshot_and_parse_pprof(output_filename)
+            second_batch: list[Union[tuple[None, ...], bytearray]] = []
+            for _ in range(15):
+                second_batch.append(two(512))
 
-        # After initial snapshot, allocation tracking resets
-        # So after_first_batch should have samples from the 20 allocations since last snapshot
-        after_first_batch_count = len(after_first_batch_profile.sample)
-        final_count = len(final_profile.sample)
+            mc.snapshot()
+            ddup.upload()
+            final_profile = pprof_utils.get_profile_from_agent(agent_client)
 
-        assert after_first_batch_count > 0, (
-            f"Should have samples from first batch allocations. Got {after_first_batch_count}"
-        )
-        assert final_count > 0, f"Final snapshot should have samples. Got {final_count}"
+            # After initial snapshot, allocation tracking resets
+            # So after_first_batch should have samples from the 20 allocations since last snapshot
+            after_first_batch_count = len(after_first_batch_profile.sample)
+            final_count = len(final_profile.sample)
 
-        # Get sample type indices
-        heap_space_idx = pprof_utils.get_sample_type_index(final_profile, "heap-space")
-        alloc_space_idx = pprof_utils.get_sample_type_index(final_profile, "alloc-space")
-        alloc_count_idx = pprof_utils.get_sample_type_index(final_profile, "alloc-samples")
+            assert after_first_batch_count > 0, (
+                f"Should have samples from first batch allocations. Got {after_first_batch_count}"
+            )
+            assert final_count > 0, f"Final snapshot should have samples. Got {final_count}"
 
-        # Assert that required sample types exist
-        assert heap_space_idx >= 0, "heap-space sample type not found in profile"
-        assert alloc_space_idx >= 0, "alloc-space sample type not found in profile"
-        assert alloc_count_idx >= 0, "alloc-samples sample type not found in profile"
+            # Get sample type indices
+            heap_space_idx = pprof_utils.get_sample_type_index(final_profile, "heap-space")
+            alloc_space_idx = pprof_utils.get_sample_type_index(final_profile, "alloc-space")
+            alloc_count_idx = pprof_utils.get_sample_type_index(final_profile, "alloc-samples")
 
-        # Since no objects were deleted, heap samples should accumulate (first_batch + second_batch)
-        # Count heap samples in both profiles
-        after_first_heap_samples = [s for s in after_first_batch_profile.sample if s.value[heap_space_idx] > 0]
-        final_heap_samples = [s for s in final_profile.sample if s.value[heap_space_idx] > 0]
+            # Assert that required sample types exist
+            assert heap_space_idx >= 0, "heap-space sample type not found in profile"
+            assert alloc_space_idx >= 0, "alloc-space sample type not found in profile"
+            assert alloc_count_idx >= 0, "alloc-samples sample type not found in profile"
 
-        assert len(final_heap_samples) > len(after_first_heap_samples), (
-            f"Final should have more heap samples than after first batch (nothing deleted). "
-            f"Got final={len(final_heap_samples)}, after_first={len(after_first_heap_samples)}"
-        )
+            # Since no objects were deleted, heap samples should accumulate (first_batch + second_batch)
+            # Count heap samples in both profiles
+            after_first_heap_samples = [s for s in after_first_batch_profile.sample if s.value[heap_space_idx] > 0]
+            final_heap_samples = [s for s in final_profile.sample if s.value[heap_space_idx] > 0]
 
-        # Validate all samples in final profile have valid values
-        for sample in final_profile.sample:
-            has_heap = sample.value[heap_space_idx] > 0
-            has_alloc = sample.value[alloc_space_idx] > 0
-            assert has_heap or has_alloc, "Sample should have either heap-space or alloc-space > 0"
-            assert sample.value[alloc_count_idx] >= 0, (
-                f"alloc-samples should be non-negative, got {sample.value[alloc_count_idx]}"
+            assert len(final_heap_samples) > len(after_first_heap_samples), (
+                f"Final should have more heap samples than after first batch (nothing deleted). "
+                f"Got final={len(final_heap_samples)}, after_first={len(after_first_heap_samples)}"
             )
 
-        # Get live samples (heap-space > 0)
-        live_samples = [s for s in final_profile.sample if s.value[heap_space_idx] > 0]
+            # Validate all samples in final profile have valid values
+            for sample in final_profile.sample:
+                has_heap = sample.value[heap_space_idx] > 0
+                has_alloc = sample.value[alloc_space_idx] > 0
+                assert has_heap or has_alloc, "Sample should have either heap-space or alloc-space > 0"
+                assert sample.value[alloc_count_idx] >= 0, (
+                    f"alloc-samples should be non-negative, got {sample.value[alloc_count_idx]}"
+                )
 
-        batch_one_live_samples = [
-            sample for sample in live_samples if has_function_in_profile_sample(final_profile, sample, one)
-        ]
+            # Get live samples (heap-space > 0)
+            live_samples = [s for s in final_profile.sample if s.value[heap_space_idx] > 0]
 
-        batch_two_live_samples = [
-            sample for sample in live_samples if has_function_in_profile_sample(final_profile, sample, two)
-        ]
+            batch_one_live_samples = [
+                sample for sample in live_samples if has_function_in_profile_sample(final_profile, sample, one)
+            ]
 
-        assert len(batch_one_live_samples) > 0, (
-            f"Should have live samples from batch one, got {len(batch_one_live_samples)}"
-        )
-        assert len(batch_two_live_samples) > 0, (
-            f"Should have live samples from batch two, got {len(batch_two_live_samples)}"
-        )
+            batch_two_live_samples = [
+                sample for sample in live_samples if has_function_in_profile_sample(final_profile, sample, two)
+            ]
 
-        # batch_one samples were reported in first snapshot, so alloc-space should be 0 in later snapshots
-        # batch_two samples are new allocations, so alloc-space should be > 0
-        batch_one_valid = all(
-            sample.value[heap_space_idx] > 0 and sample.value[alloc_space_idx] == 0 for sample in batch_one_live_samples
-        )
-        assert batch_one_valid, "Batch one samples should have heap-space > 0 and alloc-space == 0 (already reported)"
+            assert len(batch_one_live_samples) > 0, (
+                f"Should have live samples from batch one, got {len(batch_one_live_samples)}"
+            )
+            assert len(batch_two_live_samples) > 0, (
+                f"Should have live samples from batch two, got {len(batch_two_live_samples)}"
+            )
 
-        batch_two_valid = all(
-            sample.value[heap_space_idx] > 0 and sample.value[alloc_space_idx] > 0 for sample in batch_two_live_samples
-        )
-        assert batch_two_valid, "Batch two samples should have heap-space > 0 and alloc-space > 0 (new allocations)"
+            # batch_one samples were reported in first snapshot, so alloc-space should be 0 in later snapshots
+            # batch_two samples are new allocations, so alloc-space should be > 0
+            batch_one_valid = all(
+                sample.value[heap_space_idx] > 0 and sample.value[alloc_space_idx] == 0
+                for sample in batch_one_live_samples
+            )
+            assert batch_one_valid, (
+                "Batch one samples should have heap-space > 0 and alloc-space == 0 (already reported)"
+            )
 
-        del first_batch
-        del second_batch
+            batch_two_valid = all(
+                sample.value[heap_space_idx] > 0 and sample.value[alloc_space_idx] > 0
+                for sample in batch_two_live_samples
+            )
+            assert batch_two_valid, "Batch two samples should have heap-space > 0 and alloc-space > 0 (new allocations)"
+
+            del first_batch
+            del second_batch
 
 
-def test_heap_live_samples_drops_after_free(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_heap_live_samples_drops_after_free() -> None:
     """Verify heap-live-samples disappear from a stack after its objects are freed."""
-    output_filename = _setup_profiling_prelude(tmp_path, "test_heap_live_samples_drops_after_free")
+    import gc
 
-    mc = memalloc.MemoryCollector(heap_sample_size=32)
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import memalloc
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_memalloc import has_function_in_profile_sample
+    from tests.profiling.collector.test_memalloc import one
+    from tests.profiling.collector.test_memalloc import two
+    from tests.profiling.utils import with_profiling_test_agent
 
-    with mc:
-        # Allocate objects via 'one' and 'two', keep them alive
-        batch_one: list[Union[tuple[None, ...], bytearray]] = []
-        for _ in range(30):
-            batch_one.append(one(256))
+    test_name = "test_heap_live_samples_drops_after_free"
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(service=test_name, version="test", env="test")
+        ddup.start()
 
-        batch_two: list[Union[tuple[None, ...], bytearray]] = []
-        for _ in range(30):
-            batch_two.append(two(512))
+        mc = memalloc.MemoryCollector(heap_sample_size=32)
 
-        profile_before = mc.snapshot_and_parse_pprof(output_filename)
+        with mc:
+            # Allocate objects via 'one' and 'two', keep them alive
+            batch_one: list[Union[tuple[None, ...], bytearray]] = []
+            for _ in range(30):
+                batch_one.append(one(256))
 
-        heap_space_idx = pprof_utils.get_sample_type_index(profile_before, "heap-space")
-        heap_live_idx = pprof_utils.get_sample_type_index(profile_before, "heap-live-samples")
-        assert heap_space_idx >= 0
-        assert heap_live_idx >= 0
+            batch_two: list[Union[tuple[None, ...], bytearray]] = []
+            for _ in range(30):
+                batch_two.append(two(512))
 
-        # Both 'one' and 'two' should have live samples
-        live_before = [s for s in profile_before.sample if s.value[heap_space_idx] > 0]
-        one_live_before = [s for s in live_before if has_function_in_profile_sample(profile_before, s, one)]
-        two_live_before = [s for s in live_before if has_function_in_profile_sample(profile_before, s, two)]
+            mc.snapshot()
+            ddup.upload()
+            profile_before = pprof_utils.get_profile_from_agent(agent_client)
+            agent_client.clear()
 
-        assert len(one_live_before) > 0, "Expected live samples from 'one' before free"
-        assert len(two_live_before) > 0, "Expected live samples from 'two' before free"
+            heap_space_idx = pprof_utils.get_sample_type_index(profile_before, "heap-space")
+            heap_live_idx = pprof_utils.get_sample_type_index(profile_before, "heap-live-samples")
+            assert heap_space_idx >= 0
+            assert heap_live_idx >= 0
 
-        # Verify heap-live-samples > 0 for all live entries
-        for s in live_before:
-            assert s.value[heap_live_idx] > 0, "Live sample should have heap-live-samples > 0"
+            # Both 'one' and 'two' should have live samples
+            live_before = [s for s in profile_before.sample if s.value[heap_space_idx] > 0]
+            one_live_before = [s for s in live_before if has_function_in_profile_sample(profile_before, s, one)]
+            two_live_before = [s for s in live_before if has_function_in_profile_sample(profile_before, s, two)]
 
-        # Free batch_one, keep batch_two
-        del batch_one
-        gc.collect()
+            assert len(one_live_before) > 0, "Expected live samples from 'one' before free"
+            assert len(two_live_before) > 0, "Expected live samples from 'two' before free"
 
-        profile_after = mc.snapshot_and_parse_pprof(output_filename)
+            # Verify heap-live-samples > 0 for all live entries
+            for s in live_before:
+                assert s.value[heap_live_idx] > 0, "Live sample should have heap-live-samples > 0"
 
-        heap_space_idx = pprof_utils.get_sample_type_index(profile_after, "heap-space")
-        heap_live_idx = pprof_utils.get_sample_type_index(profile_after, "heap-live-samples")
+            # Free batch_one, keep batch_two
+            del batch_one
+            gc.collect()
 
-        live_after = [s for s in profile_after.sample if s.value[heap_space_idx] > 0]
+            mc.snapshot()
+            ddup.upload()
+            profile_after = pprof_utils.get_profile_from_agent(agent_client)
 
-        # 'one' should have no significant live samples (freed)
-        min_alloc_size = 256
-        one_live_after = [
-            s
-            for s in live_after
-            if has_function_in_profile_sample(profile_after, s, one) and s.value[heap_space_idx] >= min_alloc_size
-        ]
-        assert len(one_live_after) == 0, (
-            f"Expected no significant live samples from 'one' after free, got {len(one_live_after)}"
-        )
+            heap_space_idx = pprof_utils.get_sample_type_index(profile_after, "heap-space")
+            heap_live_idx = pprof_utils.get_sample_type_index(profile_after, "heap-live-samples")
 
-        # 'two' should still have live samples with heap-live-samples > 0
-        two_live_after = [s for s in live_after if has_function_in_profile_sample(profile_after, s, two)]
-        assert len(two_live_after) > 0, "Expected live samples from 'two' to persist after freeing 'one'"
-        for s in two_live_after:
-            assert s.value[heap_live_idx] > 0, "Surviving live sample should have heap-live-samples > 0"
+            live_after = [s for s in profile_after.sample if s.value[heap_space_idx] > 0]
 
-        del batch_two
+            # 'one' should have no significant live samples (freed)
+            min_alloc_size = 256
+            one_live_after = [
+                s
+                for s in live_after
+                if has_function_in_profile_sample(profile_after, s, one) and s.value[heap_space_idx] >= min_alloc_size
+            ]
+            assert len(one_live_after) == 0, (
+                f"Expected no significant live samples from 'one' after free, got {len(one_live_after)}"
+            )
+
+            # 'two' should still have live samples with heap-live-samples > 0
+            two_live_after = [s for s in live_after if has_function_in_profile_sample(profile_after, s, two)]
+            assert len(two_live_after) > 0, "Expected live samples from 'two' to persist after freeing 'one'"
+            for s in two_live_after:
+                assert s.value[heap_live_idx] > 0, "Surviving live sample should have heap-live-samples > 0"
+
+            del batch_two
 
 
-def test_heap_live_samples_aggregate_accuracy(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_heap_live_samples_aggregate_accuracy() -> None:
     """Verify the sum of heap-live-samples is a reasonable estimate of actual live object count.
 
     With a small sampling interval and many allocations, the aggregate heap-live-samples
     should approximate the real number of live objects within a tolerance.
     """
-    output_filename = _setup_profiling_prelude(tmp_path, "test_heap_live_samples_aggregate_accuracy")
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import memalloc
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_memalloc import has_function_in_profile_sample
+    from tests.profiling.collector.test_memalloc import one
+    from tests.profiling.utils import with_profiling_test_agent
 
-    sample_interval = 64
-    num_objects = 500
-    object_size = 256
-    mc = memalloc.MemoryCollector(heap_sample_size=sample_interval)
+    test_name = "test_heap_live_samples_aggregate_accuracy"
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(service=test_name, version="test", env="test")
+        ddup.start()
 
-    with mc:
-        # Allocate a known number of objects, all kept alive
-        live_objects: list[Union[tuple[None, ...], bytearray]] = []
-        for _ in range(num_objects):
-            live_objects.append(one(object_size))
+        sample_interval = 64
+        num_objects = 500
+        object_size = 256
+        mc = memalloc.MemoryCollector(heap_sample_size=sample_interval)
 
-        profile = mc.snapshot_and_parse_pprof(output_filename)
-
-        heap_space_idx = pprof_utils.get_sample_type_index(profile, "heap-space")
-        heap_live_idx = pprof_utils.get_sample_type_index(profile, "heap-live-samples")
-        assert heap_space_idx >= 0
-        assert heap_live_idx >= 0
-
-        # Sum heap-live-samples across all live entries attributed to 'one'
-        live_samples = [s for s in profile.sample if s.value[heap_space_idx] > 0]
-        one_live_samples = [s for s in live_samples if has_function_in_profile_sample(profile, s, one)]
-
-        assert len(one_live_samples) > 0, "Expected live samples from 'one'"
-
-        total_heap_live_count = sum(s.value[heap_live_idx] for s in one_live_samples)
-
-        print(f"Actual live objects: {num_objects}")
-        print(f"Reported heap-live-samples: {total_heap_live_count}")
-        print(f"Count ratio: {total_heap_live_count / num_objects:.2f}")
-
-        # The aggregate should be close to the actual count.
-        # With the Horvitz-Thompson estimator w = 1/(1-exp(-S/R)), the weight
-        # is deterministic for a given allocation size. For our allocations
-        # (size much greater than R), w ~= 1, so the sum should be very close to num_objects.
-        # We allow some slack (not all 500 may be sampled if
-        # an allocation lands exactly on a boundary, and bytearray allocations skew the count higher)
-        assert total_heap_live_count > 0, "heap-live-samples aggregate should be > 0"
-        ratio = total_heap_live_count / num_objects
-        assert 1 <= ratio <= 2, (
-            f"heap-live-samples aggregate ({total_heap_live_count}) should be within 2x of "
-            f"actual count ({num_objects}), got ratio={ratio:.2f}"
-        )
-
-        del live_objects
-
-
-def test_memory_collector_exception_handling(tmp_path: Path) -> None:
-    output_filename = _setup_profiling_prelude(tmp_path, "test_memory_collector_exception_handling")
-
-    mc = memalloc.MemoryCollector(heap_sample_size=256)
-
-    with pytest.raises(ValueError):
         with mc:
-            _allocate_1k()
-            profile = mc.snapshot_and_parse_pprof(output_filename)
-            assert profile is not None
-            raise ValueError("Test exception")
+            # Allocate a known number of objects, all kept alive
+            live_objects: list[Union[tuple[None, ...], bytearray]] = []
+            for _ in range(num_objects):
+                live_objects.append(one(object_size))
 
-    with mc:  # type: ignore[unreachable]
-        _allocate_1k()
-        profile = mc.snapshot_and_parse_pprof(output_filename)
-        assert profile is not None
+            mc.snapshot()
+            ddup.upload()
+            profile = pprof_utils.get_profile_from_agent(agent_client)
+
+            heap_space_idx = pprof_utils.get_sample_type_index(profile, "heap-space")
+            heap_live_idx = pprof_utils.get_sample_type_index(profile, "heap-live-samples")
+            assert heap_space_idx >= 0
+            assert heap_live_idx >= 0
+
+            # Sum heap-live-samples across all live entries attributed to 'one'
+            live_samples = [s for s in profile.sample if s.value[heap_space_idx] > 0]
+            one_live_samples = [s for s in live_samples if has_function_in_profile_sample(profile, s, one)]
+
+            assert len(one_live_samples) > 0, "Expected live samples from 'one'"
+
+            total_heap_live_count = sum(s.value[heap_live_idx] for s in one_live_samples)
+
+            print(f"Actual live objects: {num_objects}")
+            print(f"Reported heap-live-samples: {total_heap_live_count}")
+            print(f"Count ratio: {total_heap_live_count / num_objects:.2f}")
+
+            # The aggregate should be close to the actual count.
+            # With the Horvitz-Thompson estimator w = 1/(1-exp(-S/R)), the weight
+            # is deterministic for a given allocation size. For our allocations
+            # (size much greater than R), w ~= 1, so the sum should be very close to num_objects.
+            # We allow some slack (not all 500 may be sampled if
+            # an allocation lands exactly on a boundary, and bytearray allocations skew the count higher)
+            assert total_heap_live_count > 0, "heap-live-samples aggregate should be > 0"
+            ratio = total_heap_live_count / num_objects
+            assert 1 <= ratio <= 2, (
+                f"heap-live-samples aggregate ({total_heap_live_count}) should be within 2x of "
+                f"actual count ({num_objects}), got ratio={ratio:.2f}"
+            )
+
+            del live_objects
+
+
+@pytest.mark.subprocess(err=None)
+def test_memory_collector_exception_handling() -> None:
+    import pytest
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import memalloc
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_memalloc import _allocate_1k
+    from tests.profiling.utils import with_profiling_test_agent
+
+    test_name = "test_memory_collector_exception_handling"
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(service=test_name, version="test", env="test")
+        ddup.start()
+
+        mc = memalloc.MemoryCollector(heap_sample_size=256)
+
+        with pytest.raises(ValueError):
+            with mc:
+                _allocate_1k()
+                mc.snapshot()
+                ddup.upload()
+                profile = pprof_utils.get_profile_from_agent(agent_client)
+                assert profile is not None
+                agent_client.clear()
+                raise ValueError("Test exception")
+
+        with mc:  # type: ignore[unreachable]
+            _allocate_1k()
+            mc.snapshot()
+            ddup.upload()
+            profile = pprof_utils.get_profile_from_agent(agent_client)
+            assert profile is not None
 
 
 @pytest.mark.subprocess(env=dict(DD_PROFILING_HEAP_SAMPLE_SIZE="1"))
@@ -973,140 +1081,174 @@ def test_memory_collector_allocation_during_shutdown() -> None:
             allocation_thread.join(timeout=1)
 
 
-def test_memory_collector_buffer_pool_exhaustion(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_memory_collector_buffer_pool_exhaustion() -> None:
     """Test that the memory collector handles buffer pool exhaustion.
     This test creates multiple threads that simultaneously allocate with very deep
     stack traces, which could potentially exhaust internal buffer pools.
     """
-    output_filename = _setup_profiling_prelude(tmp_path, "test_memory_collector_buffer_pool_exhaustion")
+    import threading
 
-    mc = memalloc.MemoryCollector(heap_sample_size=64)
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import memalloc
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_memalloc import _create_allocation
+    from tests.profiling.collector.test_memalloc import has_function_in_profile_sample
+    from tests.profiling.utils import with_profiling_test_agent
 
-    # Store reference to nested function for later qualname access
-    deep_alloc_func = None
+    test_name = "test_memory_collector_buffer_pool_exhaustion"
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(service=test_name, version="test", env="test")
+        ddup.start()
 
-    num_threads = 10
-    thread_ids: set[int] = set()
-    thread_ids_lock = threading.Lock()
+        mc = memalloc.MemoryCollector(heap_sample_size=64)
 
-    with mc:
-        threads: list[threading.Thread] = []
-        barrier = threading.Barrier(num_threads)
+        # Store reference to nested function for later qualname access
+        deep_alloc_func = None
 
-        def allocate_with_traceback() -> None:
-            # Record this thread's ID before waiting
-            with thread_ids_lock:
-                thread_ids.add(threading.current_thread().ident)  # type: ignore[arg-type]
-            barrier.wait()
+        num_threads = 10
+        thread_ids: set[int] = set()
+        thread_ids_lock = threading.Lock()
 
-            def deep_alloc(depth: int) -> Union[tuple[None, ...], bytearray]:
-                if depth == 0:
-                    return _create_allocation(100)
-                return deep_alloc(depth - 1)
+        with mc:
+            threads: list[threading.Thread] = []
+            barrier = threading.Barrier(num_threads)
 
-            # Capture reference to deep_alloc for later use
-            nonlocal deep_alloc_func
-            deep_alloc_func = deep_alloc
-            # Multiple allocations per thread to make sampling more reliable
-            for _ in range(5):
-                data = deep_alloc(50)
-                del data
+            def allocate_with_traceback() -> None:
+                # Record this thread's ID before waiting
+                with thread_ids_lock:
+                    thread_ids.add(threading.current_thread().ident)  # type: ignore[arg-type]
+                barrier.wait()
 
-        for _ in range(num_threads):
-            t = threading.Thread(target=allocate_with_traceback)
-            threads.append(t)
-            t.start()
+                def deep_alloc(depth: int) -> Union[tuple[None, ...], bytearray]:
+                    if depth == 0:
+                        return _create_allocation(100)
+                    return deep_alloc(depth - 1)
 
-        for t in threads:
-            t.join()
+                # Capture reference to deep_alloc for later use
+                nonlocal deep_alloc_func
+                deep_alloc_func = deep_alloc
+                # Multiple allocations per thread to make sampling more reliable
+                for _ in range(5):
+                    data = deep_alloc(50)
+                    del data
 
-        profile = mc.snapshot_and_parse_pprof(output_filename)
+            for _ in range(num_threads):
+                t = threading.Thread(target=allocate_with_traceback)
+                threads.append(t)
+                t.start()
 
-        # Get sample type indices
-        alloc_count_idx = pprof_utils.get_sample_type_index(profile, "alloc-samples")
-        assert alloc_count_idx >= 0, "alloc-samples sample type not found in profile"
+            for t in threads:
+                t.join()
 
-        deep_alloc_total_count = 0
-        max_stack_depth = 0
-        sampled_thread_ids: set[int] = set()
+            mc.snapshot()
+            ddup.upload()
+            profile = pprof_utils.get_profile_from_agent(agent_client)
 
-        for sample in profile.sample:
-            # Buffer pool test: All samples should have stack frames
-            assert len(sample.location_id) > 0, "Buffer pool test: All samples should have stack frames"
-            stack_depth = len(sample.location_id)
-            max_stack_depth = max(max_stack_depth, stack_depth)
+            # Get sample type indices
+            alloc_count_idx = pprof_utils.get_sample_type_index(profile, "alloc-samples")
+            assert alloc_count_idx >= 0, "alloc-samples sample type not found in profile"
 
-            if deep_alloc_func and has_function_in_profile_sample(profile, sample, deep_alloc_func):
-                # Samples with identical stack traces are merged in pprof profiles,
-                # so we need to sum the alloc-samples count value
-                deep_alloc_total_count += sample.value[alloc_count_idx]
-                # Track which threads got sampled
-                thread_id_label = pprof_utils.get_label_with_key(profile.string_table, sample, "thread id")
-                if thread_id_label is not None:
-                    sampled_thread_ids.add(thread_id_label.num)
+            deep_alloc_total_count = 0
+            max_stack_depth = 0
+            sampled_thread_ids: set[int] = set()
 
-        assert deep_alloc_total_count >= 10, (
-            f"Buffer pool test: Expected many allocations from concurrent threads, got {deep_alloc_total_count}"
-        )
+            for sample in profile.sample:
+                # Buffer pool test: All samples should have stack frames
+                assert len(sample.location_id) > 0, "Buffer pool test: All samples should have stack frames"
+                stack_depth = len(sample.location_id)
+                max_stack_depth = max(max_stack_depth, stack_depth)
 
-        # Verify we got samples from all threads
-        assert sampled_thread_ids == thread_ids, (
-            f"Buffer pool test: Expected samples from all {num_threads} threads, "
-            f"but only got samples from {len(sampled_thread_ids)} threads. "
-            f"Missing: {thread_ids - sampled_thread_ids}"
-        )
+                if deep_alloc_func and has_function_in_profile_sample(profile, sample, deep_alloc_func):
+                    # Samples with identical stack traces are merged in pprof profiles,
+                    # so we need to sum the alloc-samples count value
+                    deep_alloc_total_count += sample.value[alloc_count_idx]
+                    # Track which threads got sampled
+                    thread_id_label = pprof_utils.get_label_with_key(profile.string_table, sample, "thread id")
+                    if thread_id_label is not None:
+                        sampled_thread_ids.add(thread_id_label.num)
 
-        assert max_stack_depth >= 50, (
-            f"Buffer pool test: Stack traces should be preserved even under stress (expecting at least 50 frames), "
-            f"but max depth was only {max_stack_depth}"
-        )
+            assert deep_alloc_total_count >= 10, (
+                f"Buffer pool test: Expected many allocations from concurrent threads, got {deep_alloc_total_count}"
+            )
+
+            # Verify we got samples from all threads
+            assert sampled_thread_ids == thread_ids, (
+                f"Buffer pool test: Expected samples from all {num_threads} threads, "
+                f"but only got samples from {len(sampled_thread_ids)} threads. "
+                f"Missing: {thread_ids - sampled_thread_ids}"
+            )
+
+            assert max_stack_depth >= 50, (
+                f"Buffer pool test: Stack traces should be preserved even under stress (expecting at least 50 frames), "
+                f"but max depth was only {max_stack_depth}"
+            )
 
 
-def test_memory_collector_thread_lifecycle(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_memory_collector_thread_lifecycle() -> None:
     """Test that continuously creates and destroys threads while they perform allocations,
     verifying that the collector can track allocations across changing thread contexts.
     """
-    output_filename = _setup_profiling_prelude(tmp_path, "test_memory_collector_thread_lifecycle")
+    import sys
+    import threading
 
-    mc = memalloc.MemoryCollector(heap_sample_size=8)
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import memalloc
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_memalloc import has_function_in_profile_sample
+    from tests.profiling.utils import with_profiling_test_agent
 
-    with mc:
-        threads: list[threading.Thread] = []
+    PY_314_OR_ABOVE = sys.version_info[:2] >= (3, 14)
 
-        def worker():
-            for i in range(10):
-                # On Python 3.14+, increase the allocation size to more reliably
-                # trigger sampling. The CPython internal could have optimized
-                # small allocations, and/or allocations that are deallocated too
-                # quickly.
-                if PY_314_OR_ABOVE:
-                    data = [i] * 10000000
-                else:
-                    data = [i] * 100
-                del data
+    test_name = "test_memory_collector_thread_lifecycle"
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(service=test_name, version="test", env="test")
+        ddup.start()
 
-        for i in range(20):
-            t = threading.Thread(target=worker)
-            t.start()
-            threads.append(t)
+        mc = memalloc.MemoryCollector(heap_sample_size=8)
 
-            if i > 5:
-                old_thread = threads.pop(0)
-                old_thread.join()
+        with mc:
+            threads: list[threading.Thread] = []
 
-        for t in threads:
-            t.join()
+            def worker():
+                for i in range(10):
+                    # On Python 3.14+, increase the allocation size to more reliably
+                    # trigger sampling. The CPython internal could have optimized
+                    # small allocations, and/or allocations that are deallocated too
+                    # quickly.
+                    if PY_314_OR_ABOVE:
+                        data = [i] * 10000000
+                    else:
+                        data = [i] * 100
+                    del data
 
-        profile = mc.snapshot_and_parse_pprof(output_filename)
+            for i in range(20):
+                t = threading.Thread(target=worker)
+                t.start()
+                threads.append(t)
 
-        worker_samples = 0
-        for sample in profile.sample:
-            if has_function_in_profile_sample(profile, sample, worker):
-                worker_samples += 1
+                if i > 5:
+                    old_thread = threads.pop(0)
+                    old_thread.join()
 
-        assert worker_samples > 0, (
-            "Thread lifecycle test: Should capture allocations even as threads are created/destroyed"
-        )
+            for t in threads:
+                t.join()
+
+            mc.snapshot()
+            ddup.upload()
+            profile = pprof_utils.get_profile_from_agent(agent_client)
+
+            worker_samples = 0
+            for sample in profile.sample:
+                if has_function_in_profile_sample(profile, sample, worker):
+                    worker_samples += 1
+
+            assert worker_samples > 0, (
+                "Thread lifecycle test: Should capture allocations even as threads are created/destroyed"
+            )
 
 
 def test_start_twice() -> None:
@@ -1211,7 +1353,8 @@ def test_memalloc_sample_size(
         assert predicate(_derive_default_heap_sample_size(config.heap, default))
 
 
-def test_no_duplicate_dropped_frames_indicator(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_no_duplicate_dropped_frames_indicator() -> None:
     """Regression test for duplicate dropped frames indicator bug.
 
     This test verifies that when export_sample() is called multiple times on the same
@@ -1228,41 +1371,54 @@ def test_no_duplicate_dropped_frames_indicator(tmp_path: Path) -> None:
     calls snapshot twice in a row, and checks that no sample has duplicate
     "<N frame(s) omitted>" frames.
     """
+    from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.internal.settings.profiling import config
+    from ddtrace.profiling.collector import memalloc
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
-    output_filename = _setup_profiling_prelude(tmp_path, "test_no_duplicate_dropped_frames_indicator")
+    test_name = "test_no_duplicate_dropped_frames_indicator"
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(service=test_name, version="test", env="test")
+        ddup.start()
 
-    # Stack depth that should exceed max_nframes to trigger frame dropping
-    DEEP_STACK_DEPTH = 100
+        # Stack depth that should exceed max_nframes to trigger frame dropping
+        DEEP_STACK_DEPTH = 100
 
-    # Verify that max_nframes is less than our deep stack depth
-    # config.max_frames corresponds to DD_PROFILING_MAX_FRAMES (default 64)
-    assert config.max_frames < DEEP_STACK_DEPTH, (
-        f"Test requires DD_PROFILING_MAX_FRAMES ({config.max_frames}) < {DEEP_STACK_DEPTH} to trigger frame dropping"
-    )
+        # Verify that max_nframes is less than our deep stack depth
+        # config.max_frames corresponds to DD_PROFILING_MAX_FRAMES (default 64)
+        assert config.max_frames < DEEP_STACK_DEPTH, (
+            f"Test requires DD_PROFILING_MAX_FRAMES ({config.max_frames})"
+            f" < {DEEP_STACK_DEPTH} to trigger frame dropping"
+        )
 
-    # Create a very deep call stack to trigger frame dropping
-    def make_deep_stack(depth: int):
-        """Recursively creates a call stack of given depth."""
-        if depth == 0:
-            # Allocate at the leaf to create a sample
-            return [object() for _ in range(100)]
-        return make_deep_stack(depth - 1)
+        # Create a very deep call stack to trigger frame dropping
+        def make_deep_stack(depth: int):
+            """Recursively creates a call stack of given depth."""
+            if depth == 0:
+                # Allocate at the leaf to create a sample
+                return [object() for _ in range(100)]
+            return make_deep_stack(depth - 1)
 
-    mc = memalloc.MemoryCollector(heap_sample_size=64)
+        mc = memalloc.MemoryCollector(heap_sample_size=64)
 
-    # Keep allocated objects alive throughout both snapshots
-    junk = []
+        # Keep allocated objects alive throughout both snapshots
+        junk = []
 
-    with mc:
-        # Create allocations from a deep stack to trigger frame dropping
-        for _ in range(10):
-            junk.append(make_deep_stack(DEEP_STACK_DEPTH))
+        with mc:
+            # Create allocations from a deep stack to trigger frame dropping
+            for _ in range(10):
+                junk.append(make_deep_stack(DEEP_STACK_DEPTH))
 
-        # Call snapshot twice in a row to potentially export the same sample multiple times
-        # The objects in junk remain alive, so the samples persist across both exports
-        mc.snapshot_and_parse_pprof(output_filename, assert_samples=False)
-        profile = mc.snapshot_and_parse_pprof(output_filename)
+            # Call snapshot twice in a row to potentially export the same sample multiple times
+            # The objects in junk remain alive, so the samples persist across both exports
+            mc.snapshot()
+            ddup.upload()
+            agent_client.clear()
+            mc.snapshot()
+            ddup.upload()
+            profile = pprof_utils.get_profile_from_agent(agent_client)
 
     # Check each sample for duplicate dropped frames indicators
     for sample_idx, sample in enumerate(profile.sample):
@@ -1288,35 +1444,50 @@ def test_no_duplicate_dropped_frames_indicator(tmp_path: Path) -> None:
         )
 
 
-def test_memory_collector_stack_order(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_memory_collector_stack_order() -> None:
     """Test that stack frames are reported in leaf-to-root order (innermost to outermost).
 
     This test verifies the fix for upside-down flamegraphs by ensuring that when we have
     a call chain like outer() -> middle() -> inner() -> allocation, the frames are
     reported in the order: inner, middle, outer (leaf-to-root).
     """
-    output_filename = _setup_profiling_prelude(tmp_path, "test_memory_collector_stack_order")
+    import threading
 
-    # Define nested functions to create a known call stack
-    def outer_frame() -> Union[tuple[None, ...], bytearray]:
-        return middle_frame()
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import memalloc
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_memalloc import _create_allocation
+    from tests.profiling.utils import with_profiling_test_agent
 
-    def middle_frame() -> Union[tuple[None, ...], bytearray]:
-        return inner_frame()
+    test_name = "test_memory_collector_stack_order"
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(service=test_name, version="test", env="test")
+        ddup.start()
 
-    def inner_frame() -> Union[tuple[None, ...], bytearray]:
-        # This is the leaf frame where the actual allocation happens
-        return _create_allocation(256)
+        # Define nested functions to create a known call stack
+        def outer_frame() -> Union[tuple[None, ...], bytearray]:
+            return middle_frame()
 
-    mc = memalloc.MemoryCollector(heap_sample_size=64)
+        def middle_frame() -> Union[tuple[None, ...], bytearray]:
+            return inner_frame()
 
-    with mc:
-        # Create allocations with our known call stack
-        data = []
-        for _ in range(20):
-            data.append(outer_frame())
+        def inner_frame() -> Union[tuple[None, ...], bytearray]:
+            # This is the leaf frame where the actual allocation happens
+            return _create_allocation(256)
 
-        profile = mc.snapshot_and_parse_pprof(output_filename)
+        mc = memalloc.MemoryCollector(heap_sample_size=64)
+
+        with mc:
+            # Create allocations with our known call stack
+            data = []
+            for _ in range(20):
+                data.append(outer_frame())
+
+            mc.snapshot()
+            ddup.upload()
+            profile = pprof_utils.get_profile_from_agent(agent_client)
 
     # Get samples with alloc-space > 0
     alloc_space_idx = pprof_utils.get_sample_type_index(profile, "alloc-space")
@@ -1452,20 +1623,33 @@ def _count_heap_samples_with_function(
 
 
 @pytest.mark.skipif(not PY_312_OR_ABOVE, reason="MEM-domain hooks are only installed on Python 3.12+")
-def test_mem_domain_allocations_appear_in_heap_samples(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_mem_domain_allocations_appear_in_heap_samples() -> None:
     """A large PYMEM_DOMAIN_MEM allocation must produce heap-space samples."""
-    output_filename: str = _setup_profiling_prelude(tmp_path, "test_mem_domain_heap_samples")
+    import sys
 
-    # 512 KB sampling interval; 16 MB allocation → expected ~32 samples.
-    mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=512 * 1024, mem_domain_enabled=True)
-    obj: object
-    with mc:
-        obj = _make_mem_domain_object(16 * 1024 * 1024)
-        mc.snapshot()
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import memalloc
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_memalloc import _make_mem_domain_object
+    from tests.profiling.utils import with_profiling_test_agent
 
-    ddup.upload()
+    test_name = "test_mem_domain_heap_samples"
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(service=test_name, version="test", env="test")
+        ddup.start()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        # 512 KB sampling interval; 16 MB allocation → expected ~32 samples.
+        mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=512 * 1024, mem_domain_enabled=True)
+        obj: object
+        with mc:
+            obj = _make_mem_domain_object(16 * 1024 * 1024)
+            mc.snapshot()
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+
     samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
     assert len(samples) > 0, (
         f"Expected heap-space samples from a 16 MB PYMEM_DOMAIN_MEM allocation on Python {sys.version_info[:2]}"
@@ -1475,24 +1659,34 @@ def test_mem_domain_allocations_appear_in_heap_samples(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(sys.version_info < (3, 13), reason="bytearray uses PYMEM_DOMAIN_MEM only from Python 3.13+")
-def test_bytearray_tracked_on_py313(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_bytearray_tracked_on_py313() -> None:
     """bytearray allocates its internal buffer via PYMEM_DOMAIN_MEM on Python 3.13+.
 
     Before adding MEM domain hooks it was invisible to the profiler (existing
     tests work around this by using ``(None,) * N`` instead).  This test
     confirms it is now captured.
     """
-    output_filename: str = _setup_profiling_prelude(tmp_path, "test_bytearray_tracked_py313")
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import memalloc
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
-    mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=512 * 1024, mem_domain_enabled=True)
-    ba: bytearray
-    with mc:
-        ba = bytearray(8 * 1024 * 1024)  # 8 MB via PyMem_Malloc (MEM domain, 3.13+)
-        mc.snapshot()
+    test_name = "test_bytearray_tracked_py313"
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(service=test_name, version="test", env="test")
+        ddup.start()
 
-    ddup.upload()
+        mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=512 * 1024, mem_domain_enabled=True)
+        ba: bytearray
+        with mc:
+            ba = bytearray(8 * 1024 * 1024)  # 8 MB via PyMem_Malloc (MEM domain, 3.13+)
+            mc.snapshot()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+
     samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
     assert len(samples) > 0, (
         "bytearray(8 MB) should produce heap-space samples on Python 3.13+ now that PYMEM_DOMAIN_MEM is hooked"
@@ -1502,33 +1696,47 @@ def test_bytearray_tracked_on_py313(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(not PY_312_OR_ABOVE, reason="MEM-domain hooks are only installed on Python 3.12+")
-def test_mem_domain_free_untracks(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_mem_domain_free_untracks() -> None:
     """MEM free hook must untrack the allocation so heap-space drops after del.
 
     Filters samples to only those whose stacktrace includes
     ``_make_mem_domain_object`` so unrelated heap-space samples (e.g. from ddup
     upload or pprof serialization paths) cannot influence the result.
     """
-    output_filename: str = _setup_profiling_prelude(tmp_path, "test_mem_domain_free_untracks")
-    mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=512 * 1024, mem_domain_enabled=True)
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import memalloc
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_memalloc import _count_heap_samples_with_function
+    from tests.profiling.collector.test_memalloc import _make_mem_domain_object
+    from tests.profiling.utils import with_profiling_test_agent
 
-    samples_after_alloc: int
-    samples_after_free: int
+    test_name = "test_mem_domain_free_untracks"
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(service=test_name, version="test", env="test")
+        ddup.start()
 
-    with mc:
-        obj: object = _make_mem_domain_object(16 * 1024 * 1024)
-        mc.snapshot()
-        ddup.upload()
-        profile = pprof_utils.parse_newest_profile(output_filename)
-        heap_samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
-        samples_after_alloc = _count_heap_samples_with_function(profile, heap_samples, "_make_mem_domain_object")
+        mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=512 * 1024, mem_domain_enabled=True)
 
-        del obj
-        mc.snapshot()
-        ddup.upload()
-        profile = pprof_utils.parse_newest_profile(output_filename)
-        heap_samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
-        samples_after_free = _count_heap_samples_with_function(profile, heap_samples, "_make_mem_domain_object")
+        samples_after_alloc: int
+        samples_after_free: int
+
+        with mc:
+            obj: object = _make_mem_domain_object(16 * 1024 * 1024)
+            mc.snapshot()
+            ddup.upload()
+            profile = pprof_utils.get_profile_from_agent(agent_client)
+            heap_samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
+            samples_after_alloc = _count_heap_samples_with_function(profile, heap_samples, "_make_mem_domain_object")
+
+            del obj
+            agent_client.clear()
+            mc.snapshot()
+            ddup.upload()
+            profile = pprof_utils.get_profile_from_agent(agent_client)
+            heap_samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
+            samples_after_free = _count_heap_samples_with_function(profile, heap_samples, "_make_mem_domain_object")
 
     assert samples_after_alloc > 0, "Expected heap-space samples attributed to _make_mem_domain_object after alloc"
     assert samples_after_free < samples_after_alloc, (
@@ -1538,36 +1746,60 @@ def test_mem_domain_free_untracks(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(not PY_312_OR_ABOVE, reason="MEM-domain hooks are only installed on Python 3.12+")
-def test_mem_domain_realloc_retracks(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_mem_domain_realloc_retracks() -> None:
     """Growing a list (reallocs ob_item via PyMem_Realloc) must not corrupt the heap tracker."""
-    output_filename: str = _setup_profiling_prelude(tmp_path, "test_mem_domain_realloc")
-    mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=256 * 1024, mem_domain_enabled=True)
-    lst: list[None]
-    with mc:
-        lst = []
-        for _ in range(200_000):  # repeated appends trigger ob_item reallocs
-            lst.append(None)
-        mc.snapshot()
-    ddup.upload()
-    profile = pprof_utils.parse_newest_profile(output_filename)
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import memalloc
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
+
+    test_name = "test_mem_domain_realloc"
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(service=test_name, version="test", env="test")
+        ddup.start()
+
+        mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=256 * 1024, mem_domain_enabled=True)
+        lst: list[None]
+        with mc:
+            lst = []
+            for _ in range(200_000):  # repeated appends trigger ob_item reallocs
+                lst.append(None)
+            mc.snapshot()
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+
     samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
     assert len(samples) > 0, "heap tracker must not be corrupted by repeated MEM reallocs"
     del lst
 
 
 @pytest.mark.skipif(not PY_312_OR_ABOVE, reason="MEM-domain hooks are only installed on Python 3.12+")
-def test_obj_and_mem_domain_coexist(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_obj_and_mem_domain_coexist() -> None:
     """OBJ and MEM allocations in the same session must not corrupt heap tracker state."""
-    output_filename: str = _setup_profiling_prelude(tmp_path, "test_obj_mem_coexist")
-    mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=256 * 1024, mem_domain_enabled=True)
-    d: dict[int, int]
-    lst: list[None]
-    with mc:
-        d = {i: i for i in range(50_000)}  # OBJ domain
-        lst = [None] * 200_000  # MEM domain (ob_item)
-        mc.snapshot()
-    ddup.upload()
-    profile = pprof_utils.parse_newest_profile(output_filename)
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import memalloc
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
+
+    test_name = "test_obj_mem_coexist"
+    assert ddup.is_available
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(service=test_name, version="test", env="test")
+        ddup.start()
+
+        mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=256 * 1024, mem_domain_enabled=True)
+        d: dict[int, int]
+        lst: list[None]
+        with mc:
+            d = {i: i for i in range(50_000)}  # OBJ domain
+            lst = [None] * 200_000  # MEM domain (ob_item)
+            mc.snapshot()
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+
     samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
     assert len(samples) > 0, "OBJ + MEM coexistence test: expected heap-space samples"
     del d, lst

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -46,16 +46,14 @@ def test_heap_samples_collected() -> None:
     from ddtrace.profiling.profiler import Profiler
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_memalloc import _allocate_1k
-    from tests.profiling.utils import with_profiling_test_agent
 
     # Test for https://github.com/DataDog/dd-trace-py/issues/11069
-    with with_profiling_test_agent() as agent_client:
-        p = Profiler()
-        p.start()
-        x = _allocate_1k()  # noqa: F841
-        p.stop()
+    p = Profiler()
+    p.start()
+    x = _allocate_1k()  # noqa: F841
+    p.stop()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
     assert len(samples) > 0
@@ -74,21 +72,19 @@ def test_memory_collector() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_memalloc import _ALLOC_LINE_NUMBER
     from tests.profiling.collector.test_memalloc import _allocate_1k
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_memory_collector"
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(service=test_name, version="test", env="test")
-        ddup.start()
+    ddup.config(service=test_name, version="test", env="test")
+    ddup.start()
 
-        mc = memalloc.MemoryCollector(heap_sample_size=256)
-        with mc:
-            live_objects = _allocate_1k()  # noqa: F841
-            mc.snapshot()
+    mc = memalloc.MemoryCollector(heap_sample_size=256)
+    with mc:
+        live_objects = _allocate_1k()  # noqa: F841
+        mc.snapshot()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     # Gets samples with alloc-space > 0
     samples = pprof_utils.get_samples_with_value_type(profile, "alloc-space")
@@ -133,36 +129,34 @@ def test_memory_collector_ignore_profiler() -> None:
     from ddtrace.profiling.collector import memalloc
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_memalloc import _allocate_1k
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_memory_collector_ignore_profiler"
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(service=test_name, version="test", env="test")
-        ddup.start()
+    ddup.config(service=test_name, version="test", env="test")
+    ddup.start()
 
-        mc = memalloc.MemoryCollector(ignore_profiler=True)
-        quit_thread = threading.Event()
+    mc = memalloc.MemoryCollector(ignore_profiler=True)
+    quit_thread = threading.Event()
 
-        with mc:
+    with mc:
 
-            def alloc() -> None:
-                _allocate_1k()
-                quit_thread.wait()
+        def alloc() -> None:
+            _allocate_1k()
+            quit_thread.wait()
 
-            alloc_thread = threading.Thread(name="allocator", target=alloc)
-            alloc_thread._ddtrace_profiling_ignore = True  # type: ignore[attr-defined]
-            alloc_thread.start()
+        alloc_thread = threading.Thread(name="allocator", target=alloc)
+        alloc_thread._ddtrace_profiling_ignore = True  # type: ignore[attr-defined]
+        alloc_thread.start()
 
-            mc.snapshot()
+        mc.snapshot()
 
-        # We need to wait for the data collection to happen so it gets the
-        # `_ddtrace_profiling_ignore` Thread attribute from the global thread list.
-        quit_thread.set()
-        alloc_thread.join()
+    # We need to wait for the data collection to happen so it gets the
+    # `_ddtrace_profiling_ignore` Thread attribute from the global thread list.
+    quit_thread.set()
+    alloc_thread.join()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent_client, assert_samples=False)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent(assert_samples=False)
     assert len(profile.sample) == 0, "Expected no samples in profile when profiler is ignored"
 
 
@@ -528,87 +522,79 @@ def test_memory_collector_allocation_tracking_across_snapshots() -> None:
     from tests.profiling.collector.test_memalloc import has_function_in_profile_sample
     from tests.profiling.collector.test_memalloc import one
     from tests.profiling.collector.test_memalloc import two
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_memory_collector_allocation_tracking_across_snapshots"
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(service=test_name, version="test", env="test")
-        ddup.start()
+    ddup.config(service=test_name, version="test", env="test")
+    ddup.start()
 
-        mc = memalloc.MemoryCollector(heap_sample_size=64)
+    mc = memalloc.MemoryCollector(heap_sample_size=64)
 
-        with mc:
-            data_to_free = []
-            for _ in range(10):
-                data_to_free.append(one(256))
+    with mc:
+        data_to_free = []
+        for _ in range(10):
+            data_to_free.append(one(256))
 
-            data_to_keep = []
-            for _ in range(10):
-                data_to_keep.append(two(512))
+        data_to_keep = []
+        for _ in range(10):
+            data_to_keep.append(two(512))
 
-            del data_to_free
+        del data_to_free
 
-            mc.snapshot()
-            ddup.upload()
-            profile = pprof_utils.get_profile_from_agent(agent_client)
+        mc.snapshot()
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent()
 
-            # Get sample type indices
-            heap_space_idx = pprof_utils.get_sample_type_index(profile, "heap-space")
-            alloc_space_idx = pprof_utils.get_sample_type_index(profile, "alloc-space")
-            alloc_count_idx = pprof_utils.get_sample_type_index(profile, "alloc-samples")
+        # Get sample type indices
+        heap_space_idx = pprof_utils.get_sample_type_index(profile, "heap-space")
+        alloc_space_idx = pprof_utils.get_sample_type_index(profile, "alloc-space")
+        alloc_count_idx = pprof_utils.get_sample_type_index(profile, "alloc-samples")
 
-            # Assert that required sample types exist
-            assert heap_space_idx >= 0, "heap-space sample type not found in profile"
-            assert alloc_space_idx >= 0, "alloc-space sample type not found in profile"
-            assert alloc_count_idx >= 0, "alloc-samples sample type not found in profile"
+        # Assert that required sample types exist
+        assert heap_space_idx >= 0, "heap-space sample type not found in profile"
+        assert alloc_space_idx >= 0, "alloc-space sample type not found in profile"
+        assert alloc_count_idx >= 0, "alloc-samples sample type not found in profile"
 
-            initial_allocations_valid = all(sample.value[alloc_space_idx] > 0 for sample in profile.sample)
-            assert initial_allocations_valid, "Initial snapshot should have alloc-space>0 (new allocations)"
+        initial_allocations_valid = all(sample.value[alloc_space_idx] > 0 for sample in profile.sample)
+        assert initial_allocations_valid, "Initial snapshot should have alloc-space>0 (new allocations)"
 
-            # Get freed samples (alloc-space > 0, heap-space == 0)
-            freed_samples = [s for s in profile.sample if s.value[alloc_space_idx] > 0 and s.value[heap_space_idx] == 0]
-            # Get live samples (heap-space > 0)
-            live_samples = [s for s in profile.sample if s.value[heap_space_idx] > 0]
+        # Get freed samples (alloc-space > 0, heap-space == 0)
+        freed_samples = [s for s in profile.sample if s.value[alloc_space_idx] > 0 and s.value[heap_space_idx] == 0]
+        # Get live samples (heap-space > 0)
+        live_samples = [s for s in profile.sample if s.value[heap_space_idx] > 0]
 
-            assert len(freed_samples) > 0, "Should have some freed samples after deletion"
+        assert len(freed_samples) > 0, "Should have some freed samples after deletion"
 
-            assert len(live_samples) > 0, "Should have some live samples"
+        assert len(live_samples) > 0, "Should have some live samples"
 
-            # Validate all samples have valid values
-            for sample in profile.sample:
-                has_heap = sample.value[heap_space_idx] > 0
-                has_alloc = sample.value[alloc_space_idx] > 0
-                assert has_heap or has_alloc, "Sample should have either heap-space or alloc-space > 0"
-                assert sample.value[alloc_count_idx] >= 0, (
-                    f"alloc-samples should be non-negative, got {sample.value[alloc_count_idx]}"
-                )
-
-            one_freed_samples = [
-                sample for sample in freed_samples if has_function_in_profile_sample(profile, sample, one)
-            ]
-
-            assert len(one_freed_samples) > 0, "Should have freed samples from function 'one'"
-            one_freed_samples_valid = all(
-                sample.value[heap_space_idx] == 0 and sample.value[alloc_space_idx] > 0 for sample in one_freed_samples
-            )
-            assert one_freed_samples_valid, (
-                "Freed samples from function 'one' should have heap-space == 0 and alloc-space > 0"
+        # Validate all samples have valid values
+        for sample in profile.sample:
+            has_heap = sample.value[heap_space_idx] > 0
+            has_alloc = sample.value[alloc_space_idx] > 0
+            assert has_heap or has_alloc, "Sample should have either heap-space or alloc-space > 0"
+            assert sample.value[alloc_count_idx] >= 0, (
+                f"alloc-samples should be non-negative, got {sample.value[alloc_count_idx]}"
             )
 
-            two_live_samples = [
-                sample for sample in live_samples if has_function_in_profile_sample(profile, sample, two)
-            ]
+        one_freed_samples = [sample for sample in freed_samples if has_function_in_profile_sample(profile, sample, one)]
 
-            assert len(two_live_samples) > 0, "Should have live samples from function 'two'"
-            two_live_samples_valid = all(
-                sample.value[heap_space_idx] > 0 and sample.value[alloc_space_idx] > 0 for sample in two_live_samples
-            )
-            assert two_live_samples_valid, (
-                "Live samples from function 'two' should have heap-space > 0 and alloc-space > 0"
-            )
+        assert len(one_freed_samples) > 0, "Should have freed samples from function 'one'"
+        one_freed_samples_valid = all(
+            sample.value[heap_space_idx] == 0 and sample.value[alloc_space_idx] > 0 for sample in one_freed_samples
+        )
+        assert one_freed_samples_valid, (
+            "Freed samples from function 'one' should have heap-space == 0 and alloc-space > 0"
+        )
 
-            del data_to_keep
+        two_live_samples = [sample for sample in live_samples if has_function_in_profile_sample(profile, sample, two)]
+
+        assert len(two_live_samples) > 0, "Should have live samples from function 'two'"
+        two_live_samples_valid = all(
+            sample.value[heap_space_idx] > 0 and sample.value[alloc_space_idx] > 0 for sample in two_live_samples
+        )
+        assert two_live_samples_valid, "Live samples from function 'two' should have heap-space > 0 and alloc-space > 0"
+
+        del data_to_keep
 
 
 @pytest.mark.subprocess(err=None)
@@ -621,108 +607,107 @@ def test_memory_collector_python_interface_with_allocation_tracking() -> None:
     from tests.profiling.collector.test_memalloc import has_function_in_profile_sample
     from tests.profiling.collector.test_memalloc import one
     from tests.profiling.collector.test_memalloc import two
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_memory_collector_python_interface_with_allocation_tracking"
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(service=test_name, version="test", env="test")
-        ddup.start()
+    ddup.config(service=test_name, version="test", env="test")
+    ddup.start()
 
-        mc = memalloc.MemoryCollector(heap_sample_size=32)
+    mc = memalloc.MemoryCollector(heap_sample_size=32)
 
-        with mc:
-            first_batch: list[Union[tuple[None, ...], bytearray]] = []
-            for _ in range(20):
-                first_batch.append(one(256))
+    with mc:
+        first_batch: list[Union[tuple[None, ...], bytearray]] = []
+        for _ in range(20):
+            first_batch.append(one(256))
 
-            # We're taking a snapshot here to ensure that in the next snapshot, we don't see any "one" allocations
-            mc.snapshot()
-            ddup.upload()
-            agent_client.clear()
+        # We're taking a snapshot here to ensure that in the next snapshot, we don't see any "one" allocations
+        mc.snapshot()
+        ddup.upload()
+        from tests.profiling.utils import clear_agent_session
 
-            second_batch: list[Union[tuple[None, ...], bytearray]] = []
-            for _ in range(15):
-                second_batch.append(two(512))
+        clear_agent_session()
 
-            del first_batch
+        second_batch: list[Union[tuple[None, ...], bytearray]] = []
+        for _ in range(15):
+            second_batch.append(two(512))
 
-            # Force a full GC collection to clear CPython's internal free lists
-            # (tuple, float, list, dict, etc.).  On Python < 3.13, calling
-            # bytearray(256) inside one() goes through _PyObject_MakeTpCall,
-            # which creates a temporary 1-element args tuple (256,).  When that
-            # tuple's refcount drops to zero, tupledealloc caches it in the
-            # tuple free list WITHOUT calling PyObject_Free, so the profiler's
-            # memalloc_free hook is never triggered and the allocation stays
-            # tracked as "live" in allocs_m even though the Python object is
-            # logically dead.  gc.collect(generation=2) calls clear_freelists()
-            # -> _PyTuple_ClearFreeList() -> PyObject_GC_Del() -> PyObject_Free(),
-            # which properly fires memalloc_free -> untrack and removes these
-            # ghost entries.
-            gc.collect()
+        del first_batch
 
-            mc.snapshot()
-            ddup.upload()
-            final_profile = pprof_utils.get_profile_from_agent(agent_client)
+        # Force a full GC collection to clear CPython's internal free lists
+        # (tuple, float, list, dict, etc.).  On Python < 3.13, calling
+        # bytearray(256) inside one() goes through _PyObject_MakeTpCall,
+        # which creates a temporary 1-element args tuple (256,).  When that
+        # tuple's refcount drops to zero, tupledealloc caches it in the
+        # tuple free list WITHOUT calling PyObject_Free, so the profiler's
+        # memalloc_free hook is never triggered and the allocation stays
+        # tracked as "live" in allocs_m even though the Python object is
+        # logically dead.  gc.collect(generation=2) calls clear_freelists()
+        # -> _PyTuple_ClearFreeList() -> PyObject_GC_Del() -> PyObject_Free(),
+        # which properly fires memalloc_free -> untrack and removes these
+        # ghost entries.
+        gc.collect()
 
-        assert len(final_profile.sample) > 0, "Final snapshot should have samples"
+        mc.snapshot()
+        ddup.upload()
+        final_profile = pprof_utils.get_profile_from_agent()
 
-        # Get sample type indices
-        heap_space_idx = pprof_utils.get_sample_type_index(final_profile, "heap-space")
-        alloc_space_idx = pprof_utils.get_sample_type_index(final_profile, "alloc-space")
-        alloc_count_idx = pprof_utils.get_sample_type_index(final_profile, "alloc-samples")
+    assert len(final_profile.sample) > 0, "Final snapshot should have samples"
 
-        # Assert that required sample types exist in the profile
-        assert heap_space_idx >= 0, "heap-space sample type not found in profile"
-        assert alloc_space_idx >= 0, "alloc-space sample type not found in profile"
-        assert alloc_count_idx >= 0, "alloc-samples sample type not found in profile"
+    # Get sample type indices
+    heap_space_idx = pprof_utils.get_sample_type_index(final_profile, "heap-space")
+    alloc_space_idx = pprof_utils.get_sample_type_index(final_profile, "alloc-space")
+    alloc_count_idx = pprof_utils.get_sample_type_index(final_profile, "alloc-samples")
 
-        # Validate all samples have valid values
-        for sample in final_profile.sample:
-            # Check that at least one value type is non-zero
-            has_heap = sample.value[heap_space_idx] > 0
-            has_alloc = sample.value[alloc_space_idx] > 0
-            assert has_heap or has_alloc, "Sample should have either heap-space or alloc-space > 0"
-            assert sample.value[alloc_count_idx] >= 0, (
-                f"alloc-samples should be non-negative, got {sample.value[alloc_count_idx]}"
-            )
+    # Assert that required sample types exist in the profile
+    assert heap_space_idx >= 0, "heap-space sample type not found in profile"
+    assert alloc_space_idx >= 0, "alloc-space sample type not found in profile"
+    assert alloc_count_idx >= 0, "alloc-samples sample type not found in profile"
 
-        # Get live samples (heap-space > 0)
-        live_samples = [s for s in final_profile.sample if s.value[heap_space_idx] > 0]
-
-        # Check that we have no significant live samples with 'one' in traceback (they were freed).
-        # Small residual allocations (< min_alloc_size) may remain due to CPython internal
-        # caching (type caches, inline bytecode caches, descriptor objects, etc.) that are
-        # allocated while one() is on the call stack and not freed by del + gc.collect().
-        # With aggressive sampling (heap_sample_size=32), these are occasionally sampled.
-        # We only assert on allocations large enough to be the actual one() result object
-        # (bytearray(256) on < 3.13 or (None,)*256 ~= 2096 bytes on 3.13+).
-        min_alloc_size = 256
-        one_samples_in_final = [
-            sample
-            for sample in live_samples
-            if has_function_in_profile_sample(final_profile, sample, one)
-            and sample.value[heap_space_idx] >= min_alloc_size
-        ]
-
-        assert len(one_samples_in_final) == 0, (
-            f"Should have no live samples with 'one' in traceback in final_samples, got {len(one_samples_in_final)}"
+    # Validate all samples have valid values
+    for sample in final_profile.sample:
+        # Check that at least one value type is non-zero
+        has_heap = sample.value[heap_space_idx] > 0
+        has_alloc = sample.value[alloc_space_idx] > 0
+        assert has_heap or has_alloc, "Sample should have either heap-space or alloc-space > 0"
+        assert sample.value[alloc_count_idx] >= 0, (
+            f"alloc-samples should be non-negative, got {sample.value[alloc_count_idx]}"
         )
 
-        # Check that we have live samples from function 'two'
-        batch_two_live_samples = [
-            sample for sample in live_samples if has_function_in_profile_sample(final_profile, sample, two)
-        ]
+    # Get live samples (heap-space > 0)
+    live_samples = [s for s in final_profile.sample if s.value[heap_space_idx] > 0]
 
-        assert len(batch_two_live_samples) > 0, (
-            f"Should have live samples from batch two, got {len(batch_two_live_samples)}"
-        )
-        batch_two_valid = all(
-            sample.value[heap_space_idx] > 0 and sample.value[alloc_space_idx] >= 0 for sample in batch_two_live_samples
-        )
-        assert batch_two_valid, "Batch two samples should have heap-space > 0 and alloc-space >= 0"
+    # Check that we have no significant live samples with 'one' in traceback (they were freed).
+    # Small residual allocations (< min_alloc_size) may remain due to CPython internal
+    # caching (type caches, inline bytecode caches, descriptor objects, etc.) that are
+    # allocated while one() is on the call stack and not freed by del + gc.collect().
+    # With aggressive sampling (heap_sample_size=32), these are occasionally sampled.
+    # We only assert on allocations large enough to be the actual one() result object
+    # (bytearray(256) on < 3.13 or (None,)*256 ~= 2096 bytes on 3.13+).
+    min_alloc_size = 256
+    one_samples_in_final = [
+        sample
+        for sample in live_samples
+        if has_function_in_profile_sample(final_profile, sample, one) and sample.value[heap_space_idx] >= min_alloc_size
+    ]
 
-        del second_batch
+    assert len(one_samples_in_final) == 0, (
+        f"Should have no live samples with 'one' in traceback in final_samples, got {len(one_samples_in_final)}"
+    )
+
+    # Check that we have live samples from function 'two'
+    batch_two_live_samples = [
+        sample for sample in live_samples if has_function_in_profile_sample(final_profile, sample, two)
+    ]
+
+    assert len(batch_two_live_samples) > 0, (
+        f"Should have live samples from batch two, got {len(batch_two_live_samples)}"
+    )
+    batch_two_valid = all(
+        sample.value[heap_space_idx] > 0 and sample.value[alloc_space_idx] >= 0 for sample in batch_two_live_samples
+    )
+    assert batch_two_valid, "Batch two samples should have heap-space > 0 and alloc-space >= 0"
+
+    del second_batch
 
 
 @pytest.mark.subprocess(err=None)
@@ -733,114 +718,112 @@ def test_memory_collector_python_interface_with_allocation_tracking_no_deletion(
     from tests.profiling.collector.test_memalloc import has_function_in_profile_sample
     from tests.profiling.collector.test_memalloc import one
     from tests.profiling.collector.test_memalloc import two
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_memory_collector_python_interface_with_allocation_tracking_no_deletion"
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(service=test_name, version="test", env="test")
-        ddup.start()
+    ddup.config(service=test_name, version="test", env="test")
+    ddup.start()
 
-        mc = memalloc.MemoryCollector(heap_sample_size=32)
+    mc = memalloc.MemoryCollector(heap_sample_size=32)
 
-        with mc:
-            # Take initial snapshot to reset allocation tracking (may have no samples)
-            mc.snapshot()
-            ddup.upload()
-            agent_client.clear()
+    with mc:
+        # Take initial snapshot to reset allocation tracking (may have no samples)
+        mc.snapshot()
+        ddup.upload()
+        from tests.profiling.utils import clear_agent_session
 
-            first_batch: list[Union[tuple[None, ...], bytearray]] = []
-            for _ in range(20):
-                first_batch.append(one(256))
+        clear_agent_session()
 
-            mc.snapshot()
-            ddup.upload()
-            after_first_batch_profile = pprof_utils.get_profile_from_agent(agent_client)
-            agent_client.clear()
+        first_batch: list[Union[tuple[None, ...], bytearray]] = []
+        for _ in range(20):
+            first_batch.append(one(256))
 
-            second_batch: list[Union[tuple[None, ...], bytearray]] = []
-            for _ in range(15):
-                second_batch.append(two(512))
+        mc.snapshot()
+        ddup.upload()
+        after_first_batch_profile = pprof_utils.get_profile_from_agent()
+        from tests.profiling.utils import clear_agent_session
 
-            mc.snapshot()
-            ddup.upload()
-            final_profile = pprof_utils.get_profile_from_agent(agent_client)
+        clear_agent_session()
 
-            # After initial snapshot, allocation tracking resets
-            # So after_first_batch should have samples from the 20 allocations since last snapshot
-            after_first_batch_count = len(after_first_batch_profile.sample)
-            final_count = len(final_profile.sample)
+        second_batch: list[Union[tuple[None, ...], bytearray]] = []
+        for _ in range(15):
+            second_batch.append(two(512))
 
-            assert after_first_batch_count > 0, (
-                f"Should have samples from first batch allocations. Got {after_first_batch_count}"
-            )
-            assert final_count > 0, f"Final snapshot should have samples. Got {final_count}"
+        mc.snapshot()
+        ddup.upload()
+        final_profile = pprof_utils.get_profile_from_agent()
 
-            # Get sample type indices
-            heap_space_idx = pprof_utils.get_sample_type_index(final_profile, "heap-space")
-            alloc_space_idx = pprof_utils.get_sample_type_index(final_profile, "alloc-space")
-            alloc_count_idx = pprof_utils.get_sample_type_index(final_profile, "alloc-samples")
+        # After initial snapshot, allocation tracking resets
+        # So after_first_batch should have samples from the 20 allocations since last snapshot
+        after_first_batch_count = len(after_first_batch_profile.sample)
+        final_count = len(final_profile.sample)
 
-            # Assert that required sample types exist
-            assert heap_space_idx >= 0, "heap-space sample type not found in profile"
-            assert alloc_space_idx >= 0, "alloc-space sample type not found in profile"
-            assert alloc_count_idx >= 0, "alloc-samples sample type not found in profile"
+        assert after_first_batch_count > 0, (
+            f"Should have samples from first batch allocations. Got {after_first_batch_count}"
+        )
+        assert final_count > 0, f"Final snapshot should have samples. Got {final_count}"
 
-            # Since no objects were deleted, heap samples should accumulate (first_batch + second_batch)
-            # Count heap samples in both profiles
-            after_first_heap_samples = [s for s in after_first_batch_profile.sample if s.value[heap_space_idx] > 0]
-            final_heap_samples = [s for s in final_profile.sample if s.value[heap_space_idx] > 0]
+        # Get sample type indices
+        heap_space_idx = pprof_utils.get_sample_type_index(final_profile, "heap-space")
+        alloc_space_idx = pprof_utils.get_sample_type_index(final_profile, "alloc-space")
+        alloc_count_idx = pprof_utils.get_sample_type_index(final_profile, "alloc-samples")
 
-            assert len(final_heap_samples) > len(after_first_heap_samples), (
-                f"Final should have more heap samples than after first batch (nothing deleted). "
-                f"Got final={len(final_heap_samples)}, after_first={len(after_first_heap_samples)}"
-            )
+        # Assert that required sample types exist
+        assert heap_space_idx >= 0, "heap-space sample type not found in profile"
+        assert alloc_space_idx >= 0, "alloc-space sample type not found in profile"
+        assert alloc_count_idx >= 0, "alloc-samples sample type not found in profile"
 
-            # Validate all samples in final profile have valid values
-            for sample in final_profile.sample:
-                has_heap = sample.value[heap_space_idx] > 0
-                has_alloc = sample.value[alloc_space_idx] > 0
-                assert has_heap or has_alloc, "Sample should have either heap-space or alloc-space > 0"
-                assert sample.value[alloc_count_idx] >= 0, (
-                    f"alloc-samples should be non-negative, got {sample.value[alloc_count_idx]}"
-                )
+        # Since no objects were deleted, heap samples should accumulate (first_batch + second_batch)
+        # Count heap samples in both profiles
+        after_first_heap_samples = [s for s in after_first_batch_profile.sample if s.value[heap_space_idx] > 0]
+        final_heap_samples = [s for s in final_profile.sample if s.value[heap_space_idx] > 0]
 
-            # Get live samples (heap-space > 0)
-            live_samples = [s for s in final_profile.sample if s.value[heap_space_idx] > 0]
+        assert len(final_heap_samples) > len(after_first_heap_samples), (
+            f"Final should have more heap samples than after first batch (nothing deleted). "
+            f"Got final={len(final_heap_samples)}, after_first={len(after_first_heap_samples)}"
+        )
 
-            batch_one_live_samples = [
-                sample for sample in live_samples if has_function_in_profile_sample(final_profile, sample, one)
-            ]
-
-            batch_two_live_samples = [
-                sample for sample in live_samples if has_function_in_profile_sample(final_profile, sample, two)
-            ]
-
-            assert len(batch_one_live_samples) > 0, (
-                f"Should have live samples from batch one, got {len(batch_one_live_samples)}"
-            )
-            assert len(batch_two_live_samples) > 0, (
-                f"Should have live samples from batch two, got {len(batch_two_live_samples)}"
+        # Validate all samples in final profile have valid values
+        for sample in final_profile.sample:
+            has_heap = sample.value[heap_space_idx] > 0
+            has_alloc = sample.value[alloc_space_idx] > 0
+            assert has_heap or has_alloc, "Sample should have either heap-space or alloc-space > 0"
+            assert sample.value[alloc_count_idx] >= 0, (
+                f"alloc-samples should be non-negative, got {sample.value[alloc_count_idx]}"
             )
 
-            # batch_one samples were reported in first snapshot, so alloc-space should be 0 in later snapshots
-            # batch_two samples are new allocations, so alloc-space should be > 0
-            batch_one_valid = all(
-                sample.value[heap_space_idx] > 0 and sample.value[alloc_space_idx] == 0
-                for sample in batch_one_live_samples
-            )
-            assert batch_one_valid, (
-                "Batch one samples should have heap-space > 0 and alloc-space == 0 (already reported)"
-            )
+        # Get live samples (heap-space > 0)
+        live_samples = [s for s in final_profile.sample if s.value[heap_space_idx] > 0]
 
-            batch_two_valid = all(
-                sample.value[heap_space_idx] > 0 and sample.value[alloc_space_idx] > 0
-                for sample in batch_two_live_samples
-            )
-            assert batch_two_valid, "Batch two samples should have heap-space > 0 and alloc-space > 0 (new allocations)"
+        batch_one_live_samples = [
+            sample for sample in live_samples if has_function_in_profile_sample(final_profile, sample, one)
+        ]
 
-            del first_batch
-            del second_batch
+        batch_two_live_samples = [
+            sample for sample in live_samples if has_function_in_profile_sample(final_profile, sample, two)
+        ]
+
+        assert len(batch_one_live_samples) > 0, (
+            f"Should have live samples from batch one, got {len(batch_one_live_samples)}"
+        )
+        assert len(batch_two_live_samples) > 0, (
+            f"Should have live samples from batch two, got {len(batch_two_live_samples)}"
+        )
+
+        # batch_one samples were reported in first snapshot, so alloc-space should be 0 in later snapshots
+        # batch_two samples are new allocations, so alloc-space should be > 0
+        batch_one_valid = all(
+            sample.value[heap_space_idx] > 0 and sample.value[alloc_space_idx] == 0 for sample in batch_one_live_samples
+        )
+        assert batch_one_valid, "Batch one samples should have heap-space > 0 and alloc-space == 0 (already reported)"
+
+        batch_two_valid = all(
+            sample.value[heap_space_idx] > 0 and sample.value[alloc_space_idx] > 0 for sample in batch_two_live_samples
+        )
+        assert batch_two_valid, "Batch two samples should have heap-space > 0 and alloc-space > 0 (new allocations)"
+
+        del first_batch
+        del second_batch
 
 
 @pytest.mark.subprocess(err=None)
@@ -854,79 +837,79 @@ def test_heap_live_samples_drops_after_free() -> None:
     from tests.profiling.collector.test_memalloc import has_function_in_profile_sample
     from tests.profiling.collector.test_memalloc import one
     from tests.profiling.collector.test_memalloc import two
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_heap_live_samples_drops_after_free"
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(service=test_name, version="test", env="test")
-        ddup.start()
+    ddup.config(service=test_name, version="test", env="test")
+    ddup.start()
 
-        mc = memalloc.MemoryCollector(heap_sample_size=32)
+    mc = memalloc.MemoryCollector(heap_sample_size=32)
 
-        with mc:
-            # Allocate objects via 'one' and 'two', keep them alive
-            batch_one: list[Union[tuple[None, ...], bytearray]] = []
-            for _ in range(30):
-                batch_one.append(one(256))
+    with mc:
+        # Allocate objects via 'one' and 'two', keep them alive
+        batch_one: list[Union[tuple[None, ...], bytearray]] = []
+        for _ in range(30):
+            batch_one.append(one(256))
 
-            batch_two: list[Union[tuple[None, ...], bytearray]] = []
-            for _ in range(30):
-                batch_two.append(two(512))
+        batch_two: list[Union[tuple[None, ...], bytearray]] = []
+        for _ in range(30):
+            batch_two.append(two(512))
 
-            mc.snapshot()
-            ddup.upload()
-            profile_before = pprof_utils.get_profile_from_agent(agent_client)
-            agent_client.clear()
+        mc.snapshot()
+        ddup.upload()
+        profile_before = pprof_utils.get_profile_from_agent()
+        from tests.profiling.utils import clear_agent_session
 
-            heap_space_idx = pprof_utils.get_sample_type_index(profile_before, "heap-space")
-            heap_live_idx = pprof_utils.get_sample_type_index(profile_before, "heap-live-samples")
-            assert heap_space_idx >= 0
-            assert heap_live_idx >= 0
+        clear_agent_session()
 
-            # Both 'one' and 'two' should have live samples
-            live_before = [s for s in profile_before.sample if s.value[heap_space_idx] > 0]
-            one_live_before = [s for s in live_before if has_function_in_profile_sample(profile_before, s, one)]
-            two_live_before = [s for s in live_before if has_function_in_profile_sample(profile_before, s, two)]
+        heap_space_idx = pprof_utils.get_sample_type_index(profile_before, "heap-space")
+        heap_live_idx = pprof_utils.get_sample_type_index(profile_before, "heap-live-samples")
+        assert heap_space_idx >= 0
+        assert heap_live_idx >= 0
 
-            assert len(one_live_before) > 0, "Expected live samples from 'one' before free"
-            assert len(two_live_before) > 0, "Expected live samples from 'two' before free"
+        # Both 'one' and 'two' should have live samples
+        live_before = [s for s in profile_before.sample if s.value[heap_space_idx] > 0]
+        one_live_before = [s for s in live_before if has_function_in_profile_sample(profile_before, s, one)]
+        two_live_before = [s for s in live_before if has_function_in_profile_sample(profile_before, s, two)]
 
-            # Verify heap-live-samples > 0 for all live entries
-            for s in live_before:
-                assert s.value[heap_live_idx] > 0, "Live sample should have heap-live-samples > 0"
+        assert len(one_live_before) > 0, "Expected live samples from 'one' before free"
+        assert len(two_live_before) > 0, "Expected live samples from 'two' before free"
 
-            # Free batch_one, keep batch_two
-            del batch_one
-            gc.collect()
+        # Verify heap-live-samples > 0 for all live entries
+        for s in live_before:
+            assert s.value[heap_live_idx] > 0, "Live sample should have heap-live-samples > 0"
 
-            mc.snapshot()
-            ddup.upload()
-            profile_after = pprof_utils.get_profile_from_agent(agent_client)
+        # Free batch_one, keep batch_two
+        del batch_one
+        gc.collect()
 
-            heap_space_idx = pprof_utils.get_sample_type_index(profile_after, "heap-space")
-            heap_live_idx = pprof_utils.get_sample_type_index(profile_after, "heap-live-samples")
+        mc.snapshot()
+        ddup.upload()
+        profile_after = pprof_utils.get_profile_from_agent()
 
-            live_after = [s for s in profile_after.sample if s.value[heap_space_idx] > 0]
+        heap_space_idx = pprof_utils.get_sample_type_index(profile_after, "heap-space")
+        heap_live_idx = pprof_utils.get_sample_type_index(profile_after, "heap-live-samples")
 
-            # 'one' should have no significant live samples (freed)
-            min_alloc_size = 256
-            one_live_after = [
-                s
-                for s in live_after
-                if has_function_in_profile_sample(profile_after, s, one) and s.value[heap_space_idx] >= min_alloc_size
-            ]
-            assert len(one_live_after) == 0, (
-                f"Expected no significant live samples from 'one' after free, got {len(one_live_after)}"
-            )
+        live_after = [s for s in profile_after.sample if s.value[heap_space_idx] > 0]
 
-            # 'two' should still have live samples with heap-live-samples > 0
-            two_live_after = [s for s in live_after if has_function_in_profile_sample(profile_after, s, two)]
-            assert len(two_live_after) > 0, "Expected live samples from 'two' to persist after freeing 'one'"
-            for s in two_live_after:
-                assert s.value[heap_live_idx] > 0, "Surviving live sample should have heap-live-samples > 0"
+        # 'one' should have no significant live samples (freed)
+        min_alloc_size = 256
+        one_live_after = [
+            s
+            for s in live_after
+            if has_function_in_profile_sample(profile_after, s, one) and s.value[heap_space_idx] >= min_alloc_size
+        ]
+        assert len(one_live_after) == 0, (
+            f"Expected no significant live samples from 'one' after free, got {len(one_live_after)}"
+        )
 
-            del batch_two
+        # 'two' should still have live samples with heap-live-samples > 0
+        two_live_after = [s for s in live_after if has_function_in_profile_sample(profile_after, s, two)]
+        assert len(two_live_after) > 0, "Expected live samples from 'two' to persist after freeing 'one'"
+        for s in two_live_after:
+            assert s.value[heap_live_idx] > 0, "Surviving live sample should have heap-live-samples > 0"
+
+        del batch_two
 
 
 @pytest.mark.subprocess(err=None)
@@ -941,60 +924,58 @@ def test_heap_live_samples_aggregate_accuracy() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_memalloc import has_function_in_profile_sample
     from tests.profiling.collector.test_memalloc import one
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_heap_live_samples_aggregate_accuracy"
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(service=test_name, version="test", env="test")
-        ddup.start()
+    ddup.config(service=test_name, version="test", env="test")
+    ddup.start()
 
-        sample_interval = 64
-        num_objects = 500
-        object_size = 256
-        mc = memalloc.MemoryCollector(heap_sample_size=sample_interval)
+    sample_interval = 64
+    num_objects = 500
+    object_size = 256
+    mc = memalloc.MemoryCollector(heap_sample_size=sample_interval)
 
-        with mc:
-            # Allocate a known number of objects, all kept alive
-            live_objects: list[Union[tuple[None, ...], bytearray]] = []
-            for _ in range(num_objects):
-                live_objects.append(one(object_size))
+    with mc:
+        # Allocate a known number of objects, all kept alive
+        live_objects: list[Union[tuple[None, ...], bytearray]] = []
+        for _ in range(num_objects):
+            live_objects.append(one(object_size))
 
-            mc.snapshot()
-            ddup.upload()
-            profile = pprof_utils.get_profile_from_agent(agent_client)
+        mc.snapshot()
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent()
 
-            heap_space_idx = pprof_utils.get_sample_type_index(profile, "heap-space")
-            heap_live_idx = pprof_utils.get_sample_type_index(profile, "heap-live-samples")
-            assert heap_space_idx >= 0
-            assert heap_live_idx >= 0
+        heap_space_idx = pprof_utils.get_sample_type_index(profile, "heap-space")
+        heap_live_idx = pprof_utils.get_sample_type_index(profile, "heap-live-samples")
+        assert heap_space_idx >= 0
+        assert heap_live_idx >= 0
 
-            # Sum heap-live-samples across all live entries attributed to 'one'
-            live_samples = [s for s in profile.sample if s.value[heap_space_idx] > 0]
-            one_live_samples = [s for s in live_samples if has_function_in_profile_sample(profile, s, one)]
+        # Sum heap-live-samples across all live entries attributed to 'one'
+        live_samples = [s for s in profile.sample if s.value[heap_space_idx] > 0]
+        one_live_samples = [s for s in live_samples if has_function_in_profile_sample(profile, s, one)]
 
-            assert len(one_live_samples) > 0, "Expected live samples from 'one'"
+        assert len(one_live_samples) > 0, "Expected live samples from 'one'"
 
-            total_heap_live_count = sum(s.value[heap_live_idx] for s in one_live_samples)
+        total_heap_live_count = sum(s.value[heap_live_idx] for s in one_live_samples)
 
-            print(f"Actual live objects: {num_objects}")
-            print(f"Reported heap-live-samples: {total_heap_live_count}")
-            print(f"Count ratio: {total_heap_live_count / num_objects:.2f}")
+        print(f"Actual live objects: {num_objects}")
+        print(f"Reported heap-live-samples: {total_heap_live_count}")
+        print(f"Count ratio: {total_heap_live_count / num_objects:.2f}")
 
-            # The aggregate should be close to the actual count.
-            # With the Horvitz-Thompson estimator w = 1/(1-exp(-S/R)), the weight
-            # is deterministic for a given allocation size. For our allocations
-            # (size much greater than R), w ~= 1, so the sum should be very close to num_objects.
-            # We allow some slack (not all 500 may be sampled if
-            # an allocation lands exactly on a boundary, and bytearray allocations skew the count higher)
-            assert total_heap_live_count > 0, "heap-live-samples aggregate should be > 0"
-            ratio = total_heap_live_count / num_objects
-            assert 1 <= ratio <= 2, (
-                f"heap-live-samples aggregate ({total_heap_live_count}) should be within 2x of "
-                f"actual count ({num_objects}), got ratio={ratio:.2f}"
-            )
+        # The aggregate should be close to the actual count.
+        # With the Horvitz-Thompson estimator w = 1/(1-exp(-S/R)), the weight
+        # is deterministic for a given allocation size. For our allocations
+        # (size much greater than R), w ~= 1, so the sum should be very close to num_objects.
+        # We allow some slack (not all 500 may be sampled if
+        # an allocation lands exactly on a boundary, and bytearray allocations skew the count higher)
+        assert total_heap_live_count > 0, "heap-live-samples aggregate should be > 0"
+        ratio = total_heap_live_count / num_objects
+        assert 1 <= ratio <= 2, (
+            f"heap-live-samples aggregate ({total_heap_live_count}) should be within 2x of "
+            f"actual count ({num_objects}), got ratio={ratio:.2f}"
+        )
 
-            del live_objects
+        del live_objects
 
 
 @pytest.mark.subprocess(err=None)
@@ -1005,32 +986,32 @@ def test_memory_collector_exception_handling() -> None:
     from ddtrace.profiling.collector import memalloc
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_memalloc import _allocate_1k
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_memory_collector_exception_handling"
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(service=test_name, version="test", env="test")
-        ddup.start()
+    ddup.config(service=test_name, version="test", env="test")
+    ddup.start()
 
-        mc = memalloc.MemoryCollector(heap_sample_size=256)
+    mc = memalloc.MemoryCollector(heap_sample_size=256)
 
-        with pytest.raises(ValueError):
-            with mc:
-                _allocate_1k()
-                mc.snapshot()
-                ddup.upload()
-                profile = pprof_utils.get_profile_from_agent(agent_client)
-                assert profile is not None
-                agent_client.clear()
-                raise ValueError("Test exception")
-
-        with mc:  # type: ignore[unreachable]
+    with pytest.raises(ValueError):
+        with mc:
             _allocate_1k()
             mc.snapshot()
             ddup.upload()
-            profile = pprof_utils.get_profile_from_agent(agent_client)
+            profile = pprof_utils.get_profile_from_agent()
             assert profile is not None
+            from tests.profiling.utils import clear_agent_session
+
+            clear_agent_session()
+            raise ValueError("Test exception")
+
+    with mc:  # type: ignore[unreachable]
+        _allocate_1k()
+        mc.snapshot()
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent()
+        assert profile is not None
 
 
 @pytest.mark.subprocess(env=dict(DD_PROFILING_HEAP_SAMPLE_SIZE="1"))
@@ -1094,96 +1075,94 @@ def test_memory_collector_buffer_pool_exhaustion() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_memalloc import _create_allocation
     from tests.profiling.collector.test_memalloc import has_function_in_profile_sample
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_memory_collector_buffer_pool_exhaustion"
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(service=test_name, version="test", env="test")
-        ddup.start()
+    ddup.config(service=test_name, version="test", env="test")
+    ddup.start()
 
-        mc = memalloc.MemoryCollector(heap_sample_size=64)
+    mc = memalloc.MemoryCollector(heap_sample_size=64)
 
-        # Store reference to nested function for later qualname access
-        deep_alloc_func = None
+    # Store reference to nested function for later qualname access
+    deep_alloc_func = None
 
-        num_threads = 10
-        thread_ids: set[int] = set()
-        thread_ids_lock = threading.Lock()
+    num_threads = 10
+    thread_ids: set[int] = set()
+    thread_ids_lock = threading.Lock()
 
-        with mc:
-            threads: list[threading.Thread] = []
-            barrier = threading.Barrier(num_threads)
+    with mc:
+        threads: list[threading.Thread] = []
+        barrier = threading.Barrier(num_threads)
 
-            def allocate_with_traceback() -> None:
-                # Record this thread's ID before waiting
-                with thread_ids_lock:
-                    thread_ids.add(threading.current_thread().ident)  # type: ignore[arg-type]
-                barrier.wait()
+        def allocate_with_traceback() -> None:
+            # Record this thread's ID before waiting
+            with thread_ids_lock:
+                thread_ids.add(threading.current_thread().ident)  # type: ignore[arg-type]
+            barrier.wait()
 
-                def deep_alloc(depth: int) -> Union[tuple[None, ...], bytearray]:
-                    if depth == 0:
-                        return _create_allocation(100)
-                    return deep_alloc(depth - 1)
+            def deep_alloc(depth: int) -> Union[tuple[None, ...], bytearray]:
+                if depth == 0:
+                    return _create_allocation(100)
+                return deep_alloc(depth - 1)
 
-                # Capture reference to deep_alloc for later use
-                nonlocal deep_alloc_func
-                deep_alloc_func = deep_alloc
-                # Multiple allocations per thread to make sampling more reliable
-                for _ in range(5):
-                    data = deep_alloc(50)
-                    del data
+            # Capture reference to deep_alloc for later use
+            nonlocal deep_alloc_func
+            deep_alloc_func = deep_alloc
+            # Multiple allocations per thread to make sampling more reliable
+            for _ in range(5):
+                data = deep_alloc(50)
+                del data
 
-            for _ in range(num_threads):
-                t = threading.Thread(target=allocate_with_traceback)
-                threads.append(t)
-                t.start()
+        for _ in range(num_threads):
+            t = threading.Thread(target=allocate_with_traceback)
+            threads.append(t)
+            t.start()
 
-            for t in threads:
-                t.join()
+        for t in threads:
+            t.join()
 
-            mc.snapshot()
-            ddup.upload()
-            profile = pprof_utils.get_profile_from_agent(agent_client)
+        mc.snapshot()
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent()
 
-            # Get sample type indices
-            alloc_count_idx = pprof_utils.get_sample_type_index(profile, "alloc-samples")
-            assert alloc_count_idx >= 0, "alloc-samples sample type not found in profile"
+        # Get sample type indices
+        alloc_count_idx = pprof_utils.get_sample_type_index(profile, "alloc-samples")
+        assert alloc_count_idx >= 0, "alloc-samples sample type not found in profile"
 
-            deep_alloc_total_count = 0
-            max_stack_depth = 0
-            sampled_thread_ids: set[int] = set()
+        deep_alloc_total_count = 0
+        max_stack_depth = 0
+        sampled_thread_ids: set[int] = set()
 
-            for sample in profile.sample:
-                # Buffer pool test: All samples should have stack frames
-                assert len(sample.location_id) > 0, "Buffer pool test: All samples should have stack frames"
-                stack_depth = len(sample.location_id)
-                max_stack_depth = max(max_stack_depth, stack_depth)
+        for sample in profile.sample:
+            # Buffer pool test: All samples should have stack frames
+            assert len(sample.location_id) > 0, "Buffer pool test: All samples should have stack frames"
+            stack_depth = len(sample.location_id)
+            max_stack_depth = max(max_stack_depth, stack_depth)
 
-                if deep_alloc_func and has_function_in_profile_sample(profile, sample, deep_alloc_func):
-                    # Samples with identical stack traces are merged in pprof profiles,
-                    # so we need to sum the alloc-samples count value
-                    deep_alloc_total_count += sample.value[alloc_count_idx]
-                    # Track which threads got sampled
-                    thread_id_label = pprof_utils.get_label_with_key(profile.string_table, sample, "thread id")
-                    if thread_id_label is not None:
-                        sampled_thread_ids.add(thread_id_label.num)
+            if deep_alloc_func and has_function_in_profile_sample(profile, sample, deep_alloc_func):
+                # Samples with identical stack traces are merged in pprof profiles,
+                # so we need to sum the alloc-samples count value
+                deep_alloc_total_count += sample.value[alloc_count_idx]
+                # Track which threads got sampled
+                thread_id_label = pprof_utils.get_label_with_key(profile.string_table, sample, "thread id")
+                if thread_id_label is not None:
+                    sampled_thread_ids.add(thread_id_label.num)
 
-            assert deep_alloc_total_count >= 10, (
-                f"Buffer pool test: Expected many allocations from concurrent threads, got {deep_alloc_total_count}"
-            )
+        assert deep_alloc_total_count >= 10, (
+            f"Buffer pool test: Expected many allocations from concurrent threads, got {deep_alloc_total_count}"
+        )
 
-            # Verify we got samples from all threads
-            assert sampled_thread_ids == thread_ids, (
-                f"Buffer pool test: Expected samples from all {num_threads} threads, "
-                f"but only got samples from {len(sampled_thread_ids)} threads. "
-                f"Missing: {thread_ids - sampled_thread_ids}"
-            )
+        # Verify we got samples from all threads
+        assert sampled_thread_ids == thread_ids, (
+            f"Buffer pool test: Expected samples from all {num_threads} threads, "
+            f"but only got samples from {len(sampled_thread_ids)} threads. "
+            f"Missing: {thread_ids - sampled_thread_ids}"
+        )
 
-            assert max_stack_depth >= 50, (
-                f"Buffer pool test: Stack traces should be preserved even under stress (expecting at least 50 frames), "
-                f"but max depth was only {max_stack_depth}"
-            )
+        assert max_stack_depth >= 50, (
+            f"Buffer pool test: Stack traces should be preserved even under stress (expecting at least 50 frames), "
+            f"but max depth was only {max_stack_depth}"
+        )
 
 
 @pytest.mark.subprocess(err=None)
@@ -1198,57 +1177,55 @@ def test_memory_collector_thread_lifecycle() -> None:
     from ddtrace.profiling.collector import memalloc
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_memalloc import has_function_in_profile_sample
-    from tests.profiling.utils import with_profiling_test_agent
 
     PY_314_OR_ABOVE = sys.version_info[:2] >= (3, 14)
 
     test_name = "test_memory_collector_thread_lifecycle"
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(service=test_name, version="test", env="test")
-        ddup.start()
+    ddup.config(service=test_name, version="test", env="test")
+    ddup.start()
 
-        mc = memalloc.MemoryCollector(heap_sample_size=8)
+    mc = memalloc.MemoryCollector(heap_sample_size=8)
 
-        with mc:
-            threads: list[threading.Thread] = []
+    with mc:
+        threads: list[threading.Thread] = []
 
-            def worker():
-                for i in range(10):
-                    # On Python 3.14+, increase the allocation size to more reliably
-                    # trigger sampling. The CPython internal could have optimized
-                    # small allocations, and/or allocations that are deallocated too
-                    # quickly.
-                    if PY_314_OR_ABOVE:
-                        data = [i] * 10000000
-                    else:
-                        data = [i] * 100
-                    del data
+        def worker():
+            for i in range(10):
+                # On Python 3.14+, increase the allocation size to more reliably
+                # trigger sampling. The CPython internal could have optimized
+                # small allocations, and/or allocations that are deallocated too
+                # quickly.
+                if PY_314_OR_ABOVE:
+                    data = [i] * 10000000
+                else:
+                    data = [i] * 100
+                del data
 
-            for i in range(20):
-                t = threading.Thread(target=worker)
-                t.start()
-                threads.append(t)
+        for i in range(20):
+            t = threading.Thread(target=worker)
+            t.start()
+            threads.append(t)
 
-                if i > 5:
-                    old_thread = threads.pop(0)
-                    old_thread.join()
+            if i > 5:
+                old_thread = threads.pop(0)
+                old_thread.join()
 
-            for t in threads:
-                t.join()
+        for t in threads:
+            t.join()
 
-            mc.snapshot()
-            ddup.upload()
-            profile = pprof_utils.get_profile_from_agent(agent_client)
+        mc.snapshot()
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent()
 
-            worker_samples = 0
-            for sample in profile.sample:
-                if has_function_in_profile_sample(profile, sample, worker):
-                    worker_samples += 1
+        worker_samples = 0
+        for sample in profile.sample:
+            if has_function_in_profile_sample(profile, sample, worker):
+                worker_samples += 1
 
-            assert worker_samples > 0, (
-                "Thread lifecycle test: Should capture allocations even as threads are created/destroyed"
-            )
+        assert worker_samples > 0, (
+            "Thread lifecycle test: Should capture allocations even as threads are created/destroyed"
+        )
 
 
 def test_start_twice() -> None:
@@ -1375,50 +1352,49 @@ def test_no_duplicate_dropped_frames_indicator() -> None:
     from ddtrace.internal.settings.profiling import config
     from ddtrace.profiling.collector import memalloc
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_no_duplicate_dropped_frames_indicator"
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(service=test_name, version="test", env="test")
-        ddup.start()
+    ddup.config(service=test_name, version="test", env="test")
+    ddup.start()
 
-        # Stack depth that should exceed max_nframes to trigger frame dropping
-        DEEP_STACK_DEPTH = 100
+    # Stack depth that should exceed max_nframes to trigger frame dropping
+    DEEP_STACK_DEPTH = 100
 
-        # Verify that max_nframes is less than our deep stack depth
-        # config.max_frames corresponds to DD_PROFILING_MAX_FRAMES (default 64)
-        assert config.max_frames < DEEP_STACK_DEPTH, (
-            f"Test requires DD_PROFILING_MAX_FRAMES ({config.max_frames})"
-            f" < {DEEP_STACK_DEPTH} to trigger frame dropping"
-        )
+    # Verify that max_nframes is less than our deep stack depth
+    # config.max_frames corresponds to DD_PROFILING_MAX_FRAMES (default 64)
+    assert config.max_frames < DEEP_STACK_DEPTH, (
+        f"Test requires DD_PROFILING_MAX_FRAMES ({config.max_frames}) < {DEEP_STACK_DEPTH} to trigger frame dropping"
+    )
 
-        # Create a very deep call stack to trigger frame dropping
-        def make_deep_stack(depth: int):
-            """Recursively creates a call stack of given depth."""
-            if depth == 0:
-                # Allocate at the leaf to create a sample
-                return [object() for _ in range(100)]
-            return make_deep_stack(depth - 1)
+    # Create a very deep call stack to trigger frame dropping
+    def make_deep_stack(depth: int):
+        """Recursively creates a call stack of given depth."""
+        if depth == 0:
+            # Allocate at the leaf to create a sample
+            return [object() for _ in range(100)]
+        return make_deep_stack(depth - 1)
 
-        mc = memalloc.MemoryCollector(heap_sample_size=64)
+    mc = memalloc.MemoryCollector(heap_sample_size=64)
 
-        # Keep allocated objects alive throughout both snapshots
-        junk = []
+    # Keep allocated objects alive throughout both snapshots
+    junk = []
 
-        with mc:
-            # Create allocations from a deep stack to trigger frame dropping
-            for _ in range(10):
-                junk.append(make_deep_stack(DEEP_STACK_DEPTH))
+    with mc:
+        # Create allocations from a deep stack to trigger frame dropping
+        for _ in range(10):
+            junk.append(make_deep_stack(DEEP_STACK_DEPTH))
 
-            # Call snapshot twice in a row to potentially export the same sample multiple times
-            # The objects in junk remain alive, so the samples persist across both exports
-            mc.snapshot()
-            ddup.upload()
-            agent_client.clear()
-            mc.snapshot()
-            ddup.upload()
-            profile = pprof_utils.get_profile_from_agent(agent_client)
+        # Call snapshot twice in a row to potentially export the same sample multiple times
+        # The objects in junk remain alive, so the samples persist across both exports
+        mc.snapshot()
+        ddup.upload()
+        from tests.profiling.utils import clear_agent_session
+
+        clear_agent_session()
+        mc.snapshot()
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent()
 
     # Check each sample for duplicate dropped frames indicators
     for sample_idx, sample in enumerate(profile.sample):
@@ -1458,36 +1434,34 @@ def test_memory_collector_stack_order() -> None:
     from ddtrace.profiling.collector import memalloc
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_memalloc import _create_allocation
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_memory_collector_stack_order"
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(service=test_name, version="test", env="test")
-        ddup.start()
+    ddup.config(service=test_name, version="test", env="test")
+    ddup.start()
 
-        # Define nested functions to create a known call stack
-        def outer_frame() -> Union[tuple[None, ...], bytearray]:
-            return middle_frame()
+    # Define nested functions to create a known call stack
+    def outer_frame() -> Union[tuple[None, ...], bytearray]:
+        return middle_frame()
 
-        def middle_frame() -> Union[tuple[None, ...], bytearray]:
-            return inner_frame()
+    def middle_frame() -> Union[tuple[None, ...], bytearray]:
+        return inner_frame()
 
-        def inner_frame() -> Union[tuple[None, ...], bytearray]:
-            # This is the leaf frame where the actual allocation happens
-            return _create_allocation(256)
+    def inner_frame() -> Union[tuple[None, ...], bytearray]:
+        # This is the leaf frame where the actual allocation happens
+        return _create_allocation(256)
 
-        mc = memalloc.MemoryCollector(heap_sample_size=64)
+    mc = memalloc.MemoryCollector(heap_sample_size=64)
 
-        with mc:
-            # Create allocations with our known call stack
-            data = []
-            for _ in range(20):
-                data.append(outer_frame())
+    with mc:
+        # Create allocations with our known call stack
+        data = []
+        for _ in range(20):
+            data.append(outer_frame())
 
-            mc.snapshot()
-            ddup.upload()
-            profile = pprof_utils.get_profile_from_agent(agent_client)
+        mc.snapshot()
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent()
 
     # Get samples with alloc-space > 0
     alloc_space_idx = pprof_utils.get_sample_type_index(profile, "alloc-space")
@@ -1632,23 +1606,21 @@ def test_mem_domain_allocations_appear_in_heap_samples() -> None:
     from ddtrace.profiling.collector import memalloc
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_memalloc import _make_mem_domain_object
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_mem_domain_heap_samples"
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(service=test_name, version="test", env="test")
-        ddup.start()
+    ddup.config(service=test_name, version="test", env="test")
+    ddup.start()
 
-        # 512 KB sampling interval; 16 MB allocation → expected ~32 samples.
-        mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=512 * 1024, mem_domain_enabled=True)
-        obj: object
-        with mc:
-            obj = _make_mem_domain_object(16 * 1024 * 1024)
-            mc.snapshot()
+    # 512 KB sampling interval; 16 MB allocation → expected ~32 samples.
+    mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=512 * 1024, mem_domain_enabled=True)
+    obj: object
+    with mc:
+        obj = _make_mem_domain_object(16 * 1024 * 1024)
+        mc.snapshot()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
     assert len(samples) > 0, (
@@ -1670,22 +1642,20 @@ def test_bytearray_tracked_on_py313() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import memalloc
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_bytearray_tracked_py313"
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(service=test_name, version="test", env="test")
-        ddup.start()
+    ddup.config(service=test_name, version="test", env="test")
+    ddup.start()
 
-        mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=512 * 1024, mem_domain_enabled=True)
-        ba: bytearray
-        with mc:
-            ba = bytearray(8 * 1024 * 1024)  # 8 MB via PyMem_Malloc (MEM domain, 3.13+)
-            mc.snapshot()
+    mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=512 * 1024, mem_domain_enabled=True)
+    ba: bytearray
+    with mc:
+        ba = bytearray(8 * 1024 * 1024)  # 8 MB via PyMem_Malloc (MEM domain, 3.13+)
+        mc.snapshot()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
     assert len(samples) > 0, (
@@ -1709,34 +1679,34 @@ def test_mem_domain_free_untracks() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_memalloc import _count_heap_samples_with_function
     from tests.profiling.collector.test_memalloc import _make_mem_domain_object
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_mem_domain_free_untracks"
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(service=test_name, version="test", env="test")
-        ddup.start()
+    ddup.config(service=test_name, version="test", env="test")
+    ddup.start()
 
-        mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=512 * 1024, mem_domain_enabled=True)
+    mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=512 * 1024, mem_domain_enabled=True)
 
-        samples_after_alloc: int
-        samples_after_free: int
+    samples_after_alloc: int
+    samples_after_free: int
 
-        with mc:
-            obj: object = _make_mem_domain_object(16 * 1024 * 1024)
-            mc.snapshot()
-            ddup.upload()
-            profile = pprof_utils.get_profile_from_agent(agent_client)
-            heap_samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
-            samples_after_alloc = _count_heap_samples_with_function(profile, heap_samples, "_make_mem_domain_object")
+    with mc:
+        obj: object = _make_mem_domain_object(16 * 1024 * 1024)
+        mc.snapshot()
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent()
+        heap_samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
+        samples_after_alloc = _count_heap_samples_with_function(profile, heap_samples, "_make_mem_domain_object")
 
-            del obj
-            agent_client.clear()
-            mc.snapshot()
-            ddup.upload()
-            profile = pprof_utils.get_profile_from_agent(agent_client)
-            heap_samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
-            samples_after_free = _count_heap_samples_with_function(profile, heap_samples, "_make_mem_domain_object")
+        del obj
+        from tests.profiling.utils import clear_agent_session
+
+        clear_agent_session()
+        mc.snapshot()
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent()
+        heap_samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
+        samples_after_free = _count_heap_samples_with_function(profile, heap_samples, "_make_mem_domain_object")
 
     assert samples_after_alloc > 0, "Expected heap-space samples attributed to _make_mem_domain_object after alloc"
     assert samples_after_free < samples_after_alloc, (
@@ -1752,23 +1722,21 @@ def test_mem_domain_realloc_retracks() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import memalloc
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_mem_domain_realloc"
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(service=test_name, version="test", env="test")
-        ddup.start()
+    ddup.config(service=test_name, version="test", env="test")
+    ddup.start()
 
-        mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=256 * 1024, mem_domain_enabled=True)
-        lst: list[None]
-        with mc:
-            lst = []
-            for _ in range(200_000):  # repeated appends trigger ob_item reallocs
-                lst.append(None)
-            mc.snapshot()
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=256 * 1024, mem_domain_enabled=True)
+    lst: list[None]
+    with mc:
+        lst = []
+        for _ in range(200_000):  # repeated appends trigger ob_item reallocs
+            lst.append(None)
+        mc.snapshot()
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
     assert len(samples) > 0, "heap tracker must not be corrupted by repeated MEM reallocs"
@@ -1782,23 +1750,21 @@ def test_obj_and_mem_domain_coexist() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import memalloc
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_obj_mem_coexist"
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(service=test_name, version="test", env="test")
-        ddup.start()
+    ddup.config(service=test_name, version="test", env="test")
+    ddup.start()
 
-        mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=256 * 1024, mem_domain_enabled=True)
-        d: dict[int, int]
-        lst: list[None]
-        with mc:
-            d = {i: i for i in range(50_000)}  # OBJ domain
-            lst = [None] * 200_000  # MEM domain (ob_item)
-            mc.snapshot()
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=256 * 1024, mem_domain_enabled=True)
+    d: dict[int, int]
+    lst: list[None]
+    with mc:
+        d = {i: i for i in range(50_000)}  # OBJ domain
+        lst = [None] * 200_000  # MEM domain (ob_item)
+        mc.snapshot()
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
     assert len(samples) > 0, "OBJ + MEM coexistence test: expected heap-space samples"

--- a/tests/profiling/collector/test_sample_count.py
+++ b/tests/profiling/collector/test_sample_count.py
@@ -1,24 +1,17 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_sample_count",
-        DD_PROFILING_UPLOAD_INTERVAL="1",  # Upload every second
-    ),
-    err=None,
-)
+@pytest.mark.subprocess(err=None)
 def test_sample_count():
     import asyncio
-    import glob
-    import json
-    import os
     import time
     import uuid
 
     from ddtrace import ext
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
+    from tests.profiling.utils import get_all_metadata_from_agent
+    from tests.profiling.utils import with_profiling_test_agent
 
     sleep_time = 0.2
     loop_run_time = 2
@@ -39,33 +32,30 @@ def test_sample_count():
     resource = str(uuid.uuid4())
     span_type = ext.SpanTypes.WEB
 
-    p = profiler.Profiler(tracer=tracer)
-    p.start()
-    with tracer.trace("test_asyncio", resource=resource, span_type=span_type):
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        maintask = loop.create_task(hello(), name="main")
-        loop.run_until_complete(maintask)
-    p.stop()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler(tracer=tracer)
+        p.start()
+        with tracer.trace("test_asyncio", resource=resource, span_type=span_type):
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            maintask = loop.create_task(hello(), name="main")
+            loop.run_until_complete(maintask)
+        p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
+        files = get_all_metadata_from_agent(agent_client, min_count=1)
 
     found_at_least_one_with_more_samples_than_sampling_events = False
-    for i, f in enumerate(files):
-        with open(f, "r") as fp:
-            internal_metadata = json.load(fp)
+    for i, internal_metadata in enumerate(files):
+        if i < len(files) - 1:
+            assert internal_metadata is not None
+            assert "sample_count" in internal_metadata
+            assert internal_metadata["sample_count"] > 0
 
-            if i < len(files) - 1:
-                assert internal_metadata is not None
-                assert "sample_count" in internal_metadata
-                assert internal_metadata["sample_count"] > 0
+        assert "sampling_event_count" in internal_metadata
+        assert internal_metadata["sampling_event_count"] <= internal_metadata["sample_count"]
 
-            assert "sampling_event_count" in internal_metadata
-            assert internal_metadata["sampling_event_count"] <= internal_metadata["sample_count"]
-
-            if internal_metadata["sample_count"] > internal_metadata["sampling_event_count"]:
-                found_at_least_one_with_more_samples_than_sampling_events = True
+        if internal_metadata["sample_count"] > internal_metadata["sampling_event_count"]:
+            found_at_least_one_with_more_samples_than_sampling_events = True
 
     assert found_at_least_one_with_more_samples_than_sampling_events, (
         "Expected at least one file with more samples than sampling events"

--- a/tests/profiling/collector/test_sample_count.py
+++ b/tests/profiling/collector/test_sample_count.py
@@ -11,7 +11,6 @@ def test_sample_count():
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
     from tests.profiling.utils import get_all_metadata_from_agent
-    from tests.profiling.utils import with_profiling_test_agent
 
     sleep_time = 0.2
     loop_run_time = 2
@@ -32,17 +31,16 @@ def test_sample_count():
     resource = str(uuid.uuid4())
     span_type = ext.SpanTypes.WEB
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler(tracer=tracer)
-        p.start()
-        with tracer.trace("test_asyncio", resource=resource, span_type=span_type):
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            maintask = loop.create_task(hello(), name="main")
-            loop.run_until_complete(maintask)
-        p.stop()
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+    with tracer.trace("test_asyncio", resource=resource, span_type=span_type):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        maintask = loop.create_task(hello(), name="main")
+        loop.run_until_complete(maintask)
+    p.stop()
 
-        files = get_all_metadata_from_agent(agent_client, min_count=1)
+    files = get_all_metadata_from_agent(min_count=1)
 
     found_at_least_one_with_more_samples_than_sampling_events = False
     for i, internal_metadata in enumerate(files):

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -1283,7 +1283,7 @@ def test_stress_trace_collection() -> None:
 # This test intentionally keeps DD_PROFILING_OUTPUT_PPROF (file-based approach).
 # It uses ddtrace_run=True so the profiler auto-starts before the function body runs.
 # After os.fork(), the CHILD process must read its own profile before calling os._exit(0).
-# Since the child can't query a parent-process capture server usin the Python object,
+# Since the child can't query a parent-process capture server using the Python object,
 # file-based output is the only practical approach here.
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="fork test only on linux")
 @pytest.mark.subprocess(

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -65,19 +65,17 @@ def test_collect_truncate() -> None:
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_stack import func1
-    from tests.profiling.utils import with_profiling_test_agent
 
     max_nframes = int(os.environ["DD_PROFILING_MAX_FRAMES"])
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler()
-        p.start()
+    p = profiler.Profiler()
+    p.start()
 
-        func1()
+    func1()
 
-        p.stop()
+    p.stop()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
     assert len(samples) > 0
@@ -95,32 +93,30 @@ def test_stack_locations() -> None:
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_stack import _main_thread_has_native_id
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_stack_locations"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def baz() -> None:
-            time.sleep(0.1)
+    def baz() -> None:
+        time.sleep(0.1)
 
-        def bar() -> None:
-            baz()
+    def bar() -> None:
+        baz()
 
-        def foo() -> None:
-            bar()
+    def foo() -> None:
+        bar()
 
-        with stack.StackCollector():
-            for _ in range(10):
-                foo()
+    with stack.StackCollector():
+        for _ in range(10):
+            foo()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
     assert len(samples) > 0
@@ -162,32 +158,30 @@ def test_push_span() -> None:
     from ddtrace.profiling.collector import stack
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_push_span"
 
     tracer._endpoint_call_counter_span_processor.enable()
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        resource = str(uuid.uuid4())
-        span_type = ext.SpanTypes.WEB
+    resource = str(uuid.uuid4())
+    span_type = ext.SpanTypes.WEB
 
-        with stack.StackCollector(
-            tracer=tracer,
-        ):
-            with tracer.trace("foobar", resource=resource, span_type=span_type) as span:
-                span_id = span.span_id
-                local_root_span_id = span._local_root.span_id
-                for _ in range(10):
-                    time.sleep(0.1)
-        ddup.upload(tracer=tracer)
+    with stack.StackCollector(
+        tracer=tracer,
+    ):
+        with tracer.trace("foobar", resource=resource, span_type=span_type) as span:
+            span_id = span.span_id
+            local_root_span_id = span._local_root.span_id
+            for _ in range(10):
+                time.sleep(0.1)
+    ddup.upload(tracer=tracer)
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     samples_with_span_id = pprof_utils.get_samples_with_label_key(profile, "span id")
 
@@ -224,7 +218,6 @@ def test_push_span_unregister_thread() -> None:
     from ddtrace.profiling.collector import stack
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     with patch("ddtrace.internal.datadog.profiling.stack.unregister_thread") as unregister_thread:
         tracer._endpoint_call_counter_span_processor.enable()
@@ -232,31 +225,30 @@ def test_push_span_unregister_thread() -> None:
         test_name = "test_push_span_unregister_thread"
 
         assert ddup.is_available
-        with with_profiling_test_agent() as agent_client:
-            ddup.config(env="test", service=test_name, version="my_version")
-            ddup.start()
-            ddup.upload()
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-            resource = str(uuid.uuid4())
-            span_type = ext.SpanTypes.WEB
+        resource = str(uuid.uuid4())
+        span_type = ext.SpanTypes.WEB
 
-            def target_fun() -> None:
-                for _ in range(10):
-                    time.sleep(0.1)
+        def target_fun() -> None:
+            for _ in range(10):
+                time.sleep(0.1)
 
-            with stack.StackCollector(
-                tracer=tracer,
-            ):
-                with tracer.trace("foobar", resource=resource, span_type=span_type) as span:
-                    span_id = span.span_id
-                    local_root_span_id = span._local_root.span_id
-                    t = threading.Thread(target=target_fun)
-                    t.start()
-                    t.join()
-                    thread_id = t.ident
-            ddup.upload(tracer=tracer)
+        with stack.StackCollector(
+            tracer=tracer,
+        ):
+            with tracer.trace("foobar", resource=resource, span_type=span_type) as span:
+                span_id = span.span_id
+                local_root_span_id = span._local_root.span_id
+                t = threading.Thread(target=target_fun)
+                t.start()
+                t.join()
+                thread_id = t.ident
+        ddup.upload(tracer=tracer)
 
-            profile = pprof_utils.get_profile_from_agent(agent_client)
+        profile = pprof_utils.get_profile_from_agent()
 
         samples_with_span_id = pprof_utils.get_samples_with_label_key(profile, "span id")
         samples = []
@@ -294,32 +286,30 @@ def test_push_non_web_span() -> None:
     from ddtrace.profiling.collector import stack
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     tracer._endpoint_call_counter_span_processor.enable()
 
     test_name = "test_push_non_web_span"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        resource = str(uuid.uuid4())
-        span_type = ext.SpanTypes.SQL
+    resource = str(uuid.uuid4())
+    span_type = ext.SpanTypes.SQL
 
-        with stack.StackCollector(
-            tracer=tracer,
-        ):
-            with tracer.trace("foobar", resource=resource, span_type=span_type) as span:
-                span_id = span.span_id
-                local_root_span_id = span._local_root.span_id
-                for _ in range(10):
-                    time.sleep(0.1)
-        ddup.upload(tracer=tracer)
+    with stack.StackCollector(
+        tracer=tracer,
+    ):
+        with tracer.trace("foobar", resource=resource, span_type=span_type) as span:
+            span_id = span.span_id
+            local_root_span_id = span._local_root.span_id
+            for _ in range(10):
+                time.sleep(0.1)
+    ddup.upload(tracer=tracer)
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     samples_with_span_id = pprof_utils.get_samples_with_label_key(profile, "span id")
     samples = []
@@ -352,33 +342,31 @@ def test_push_span_none_span_type() -> None:
     from ddtrace.profiling.collector import stack
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_push_span_none_span_type"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        tracer._endpoint_call_counter_span_processor.enable()
+    tracer._endpoint_call_counter_span_processor.enable()
 
-        resource = str(uuid.uuid4())
+    resource = str(uuid.uuid4())
 
-        with stack.StackCollector(
-            tracer=tracer,
-        ):
-            # Explicitly set None span_type as the default could change in the
-            # future.
-            with tracer.trace("foobar", resource=resource, span_type=None) as span:
-                span_id = span.span_id
-                local_root_span_id = span._local_root.span_id
-                for _ in range(10):
-                    time.sleep(0.1)
-        ddup.upload(tracer=tracer)
+    with stack.StackCollector(
+        tracer=tracer,
+    ):
+        # Explicitly set None span_type as the default could change in the
+        # future.
+        with tracer.trace("foobar", resource=resource, span_type=None) as span:
+            span_id = span.span_id
+            local_root_span_id = span._local_root.span_id
+            for _ in range(10):
+                time.sleep(0.1)
+    ddup.upload(tracer=tracer)
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     samples_with_span_id = pprof_utils.get_samples_with_label_key(profile, "span id")
     samples = []
@@ -410,7 +398,6 @@ def test_collect_once_with_class() -> None:
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector import test_stack as _test_stack_module
-    from tests.profiling.utils import with_profiling_test_agent
 
     class SomeClass(object):
         @classmethod
@@ -424,17 +411,16 @@ def test_collect_once_with_class() -> None:
     test_name = "test_collect_once_with_class"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        with stack.StackCollector():
-            SomeClass.sleep_class()
+    with stack.StackCollector():
+        SomeClass.sleep_class()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
     assert len(samples) > 0
@@ -484,7 +470,6 @@ def test_collect_once_with_class_not_right_type() -> None:
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector import test_stack as _test_stack_module
-    from tests.profiling.utils import with_profiling_test_agent
 
     class SomeClass(object):
         @classmethod
@@ -498,17 +483,16 @@ def test_collect_once_with_class_not_right_type() -> None:
     test_name = "test_collect_once_with_class"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        with stack.StackCollector():
-            SomeClass.sleep_class(123)
+    with stack.StackCollector():
+        SomeClass.sleep_class(123)
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
     assert len(samples) > 0
@@ -570,41 +554,39 @@ def test_collect_gevent_thread_task() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_stack import _fib
     from tests.profiling.collector.test_stack import _main_thread_has_native_id
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_collect_gevent_thread_task"
 
     assert ddup.is_available
 
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        # Start some (green)threads
-        def _do_fib() -> None:
-            for _ in range(5):
-                # spend some time in CPU so the profiler can catch something
-                # On a Mac w/ Apple M3 MAX with Python 3.11 it takes about 200ms to calculate _fib(32)
-                # And _fib() is called 5 times so it should take about 1 second
-                # We use 5 threads below so it should take about 5 seconds
-                _fib(32)
-                # Just make sure gevent switches threads/greenlets
-                time.sleep(0)
+    # Start some (green)threads
+    def _do_fib() -> None:
+        for _ in range(5):
+            # spend some time in CPU so the profiler can catch something
+            # On a Mac w/ Apple M3 MAX with Python 3.11 it takes about 200ms to calculate _fib(32)
+            # And _fib() is called 5 times so it should take about 1 second
+            # We use 5 threads below so it should take about 5 seconds
+            _fib(32)
+            # Just make sure gevent switches threads/greenlets
+            time.sleep(0)
 
-        threads = []
+    threads = []
 
-        with stack.StackCollector():
-            for i in range(5):
-                t = threading.Thread(target=_do_fib, name=f"TestThread {i}")
-                t.start()
-                threads.append(t)
-            for t in threads:
-                t.join()
+    with stack.StackCollector():
+        for i in range(5):
+            t = threading.Thread(target=_do_fib, name=f"TestThread {i}")
+            t.start()
+            threads.append(t)
+        for t in threads:
+            t.join()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
     assert len(samples) > 0
 
@@ -676,20 +658,18 @@ def test_collect_gevent_task_started_before_profiler() -> None:
     # Import profiler modules after gevent patching and greenlet creation
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler()
-        p.start()
+    p = profiler.Profiler()
+    p.start()
 
-        try:
-            gevent.sleep(1.0)
-        finally:
-            should_stop.set()
-            pre_started_greenlet.join(timeout=2)
-            p.stop()
+    try:
+        gevent.sleep(1.0)
+    finally:
+        should_stop.set()
+        pre_started_greenlet.join(timeout=2)
+        p.stop()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
     assert len(samples) > 0
@@ -750,7 +730,6 @@ def test_gevent_cpu_time_total_accuracy() -> None:
 
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     DURATION_S = 3.0
     CPU_BURN_S = 0.01
@@ -765,26 +744,25 @@ def test_gevent_cpu_time_total_accuracy() -> None:
                 pass
             gevent.sleep(SLEEP_S)
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler()
-        p.start()
-        try:
-            # Stagger workers by CPU_BURN_S so their CPU bursts interleave with
-            # each other's sleep, which spreads the on-CPU greenlet across the
-            # unordered_map iteration order. Without staggering, the same greenlet
-            # tends to win the on-CPU position each sample, masking the bug.
-            workers = []
-            cpu_start_ns = time.process_time_ns()
-            for i in range(NUM_WORKERS):
-                if i > 0:
-                    gevent.sleep(CPU_BURN_S)
-                workers.append(gevent.spawn(worker))
-            gevent.joinall(workers, timeout=DURATION_S + 10)
-            cpu_end_ns = time.process_time_ns()
-        finally:
-            p.stop()
+    p = profiler.Profiler()
+    p.start()
+    try:
+        # Stagger workers by CPU_BURN_S so their CPU bursts interleave with
+        # each other's sleep, which spreads the on-CPU greenlet across the
+        # unordered_map iteration order. Without staggering, the same greenlet
+        # tends to win the on-CPU position each sample, masking the bug.
+        workers = []
+        cpu_start_ns = time.process_time_ns()
+        for i in range(NUM_WORKERS):
+            if i > 0:
+                gevent.sleep(CPU_BURN_S)
+            workers.append(gevent.spawn(worker))
+        gevent.joinall(workers, timeout=DURATION_S + 10)
+        cpu_end_ns = time.process_time_ns()
+    finally:
+        p.stop()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     assert all(g.dead for g in workers), "gevent workers did not finish within timeout"
 
@@ -852,39 +830,37 @@ def test_stress_threads_run_as_thread() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_stress_threads_run_as_thread"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        quit_thread = threading.Event()
+    quit_thread = threading.Event()
 
-        def wait_for_quit() -> None:
-            quit_thread.wait()
+    def wait_for_quit() -> None:
+        quit_thread.wait()
 
-        with stack.StackCollector():
-            NB_THREADS = 40
+    with stack.StackCollector():
+        NB_THREADS = 40
 
-            threads = []
-            for _ in range(NB_THREADS):
-                t = threading.Thread(target=wait_for_quit)
-                t.start()
-                threads.append(t)
+        threads = []
+        for _ in range(NB_THREADS):
+            t = threading.Thread(target=wait_for_quit)
+            t.start()
+            threads.append(t)
 
-            time.sleep(3)
+        time.sleep(3)
 
-            quit_thread.set()
-            for t in threads:
-                t.join()
+        quit_thread.set()
+        for t in threads:
+            t.join()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
     assert len(samples) > 0
@@ -903,29 +879,27 @@ def test_collect_span_id() -> None:
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector import test_stack as _test_stack_module
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_collect_span_id"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        tracer._endpoint_call_counter_span_processor.enable()
-        with stack.StackCollector(tracer=tracer):
-            resource = str(uuid.uuid4())
-            span_type = ext.SpanTypes.WEB
-            with tracer.start_span("foobar", activate=True, resource=resource, span_type=span_type) as span:
-                for _ in range(10):
-                    time.sleep(0.1)
-                span_id = span.span_id
-                local_root_span_id = span._local_root.span_id
+    tracer._endpoint_call_counter_span_processor.enable()
+    with stack.StackCollector(tracer=tracer):
+        resource = str(uuid.uuid4())
+        span_type = ext.SpanTypes.WEB
+        with tracer.start_span("foobar", activate=True, resource=resource, span_type=span_type) as span:
+            for _ in range(10):
+                time.sleep(0.1)
+            span_id = span.span_id
+            local_root_span_id = span._local_root.span_id
 
-        ddup.upload(tracer=tracer)
+    ddup.upload(tracer=tracer)
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = pprof_utils.get_samples_with_label_key(profile, "trace endpoint")
     pprof_utils.assert_profile_has_sample(
@@ -962,26 +936,24 @@ def test_collect_span_resource_after_finish() -> None:
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector import test_stack as _test_stack_module
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_collect_span_resource_after_finish"
 
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        tracer._endpoint_call_counter_span_processor.enable()
-        with stack.StackCollector(tracer=tracer):
-            resource = str(uuid.uuid4())
-            span_type = ext.SpanTypes.WEB
-            span = tracer.start_span("foobar", activate=True, span_type=span_type, resource=resource)
-            for _ in range(10):
-                time.sleep(0.1)
-        ddup.upload(tracer=tracer)
-        span.finish()
+    tracer._endpoint_call_counter_span_processor.enable()
+    with stack.StackCollector(tracer=tracer):
+        resource = str(uuid.uuid4())
+        span_type = ext.SpanTypes.WEB
+        span = tracer.start_span("foobar", activate=True, span_type=span_type, resource=resource)
+        for _ in range(10):
+            time.sleep(0.1)
+    ddup.upload(tracer=tracer)
+    span.finish()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = profile.sample
     pprof_utils.assert_profile_has_sample(
@@ -1021,28 +993,26 @@ def test_resource_not_collected() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector import test_stack as _test_stack_module
     from tests.profiling.collector.test_stack import _fib
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_resource_not_collected"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        with stack.StackCollector(tracer=tracer):
-            # Give the Profiler some time to start
-            time.sleep(0.1)
+    with stack.StackCollector(tracer=tracer):
+        # Give the Profiler some time to start
+        time.sleep(0.1)
 
-            resource = str(uuid.uuid4())
-            span_type = ext.SpanTypes.WEB
-            with tracer.start_span("foobar", activate=True, resource=resource, span_type=span_type) as span:
-                _fib(35)
+        resource = str(uuid.uuid4())
+        span_type = ext.SpanTypes.WEB
+        with tracer.start_span("foobar", activate=True, resource=resource, span_type=span_type) as span:
+            _fib(35)
 
-        ddup.upload(tracer=tracer)
+    ddup.upload(tracer=tracer)
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     pprof_utils.assert_profile_has_sample(
         profile,
@@ -1076,27 +1046,25 @@ def test_collect_nested_span_id() -> None:
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector import test_stack as _test_stack_module
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_collect_nested_span_id"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        tracer._endpoint_call_counter_span_processor.enable()
-        with stack.StackCollector(tracer=tracer):
-            resource = str(uuid.uuid4())
-            span_type = ext.SpanTypes.WEB
-            with tracer.start_span("foobar", activate=True, resource=resource, span_type=span_type):
-                with tracer.start_span("foobar", activate=True, resource=resource, span_type=span_type) as child_span:
-                    for _ in range(10):
-                        time.sleep(0.1)
-        ddup.upload(tracer=tracer)
+    tracer._endpoint_call_counter_span_processor.enable()
+    with stack.StackCollector(tracer=tracer):
+        resource = str(uuid.uuid4())
+        span_type = ext.SpanTypes.WEB
+        with tracer.start_span("foobar", activate=True, resource=resource, span_type=span_type):
+            with tracer.start_span("foobar", activate=True, resource=resource, span_type=span_type) as child_span:
+                for _ in range(10):
+                    time.sleep(0.1)
+    ddup.upload(tracer=tracer)
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = pprof_utils.get_samples_with_label_key(profile, "span id")
     pprof_utils.assert_profile_has_sample(
@@ -1225,48 +1193,46 @@ def test_greenlet_labels_do_not_depend_on_string_table_cleanup() -> None:
     from ddtrace.internal.datadog.profiling import stack as native_stack
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_greenlet_labels_do_not_depend_on_string_table_cleanup"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        with stack.StackCollector():
-            # Track a long-lived greenlet that should survive many uploads
-            long_lived_id = 0xDEAD0001
-            native_stack.track_greenlet(long_lived_id, "long-lived-greenlet", False)
+    with stack.StackCollector():
+        # Track a long-lived greenlet that should survive many uploads
+        long_lived_id = 0xDEAD0001
+        native_stack.track_greenlet(long_lived_id, "long-lived-greenlet", False)
 
-            # Track and untrack short-lived greenlets to exercise erase()
-            for i in range(50):
-                short_id = 0xBEEF0000 + i
-                native_stack.track_greenlet(short_id, f"short-lived-{i}", False)
-                native_stack.untrack_greenlet(short_id)
+        # Track and untrack short-lived greenlets to exercise erase()
+        for i in range(50):
+            short_id = 0xBEEF0000 + i
+            native_stack.track_greenlet(short_id, f"short-lived-{i}", False)
+            native_stack.untrack_greenlet(short_id)
 
-            # Do 30 uploads to exercise repeated profile serialization.
-            for _ in range(30):
-                ddup.upload()
+        # Do 30 uploads to exercise repeated profile serialization.
+        for _ in range(30):
+            ddup.upload()
 
-            # Track more short-lived greenlets after repeated uploads to make sure
-            # label handling remains functional
-            for i in range(50):
-                short_id = 0xCAFE0000 + i
-                native_stack.track_greenlet(short_id, f"post-clear-{i}", False)
-                native_stack.untrack_greenlet(short_id)
+        # Track more short-lived greenlets after repeated uploads to make sure
+        # label handling remains functional
+        for i in range(50):
+            short_id = 0xCAFE0000 + i
+            native_stack.track_greenlet(short_id, f"post-clear-{i}", False)
+            native_stack.untrack_greenlet(short_id)
 
-            # Give the sampler a moment to collect a sample with the long-lived greenlet
-            time.sleep(0.1)
+        # Give the sampler a moment to collect a sample with the long-lived greenlet
+        time.sleep(0.1)
 
-            native_stack.untrack_greenlet(long_lived_id)
+        native_stack.untrack_greenlet(long_lived_id)
 
-        # Final upload — if label handling is corrupted this would crash
-        ddup.upload()
+    # Final upload — if label handling is corrupted this would crash
+    ddup.upload()
 
-        # Verify we got a valid profile (no crash, no corruption)
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    # Verify we got a valid profile (no crash, no corruption)
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
     assert len(samples) > 0
@@ -1280,40 +1246,38 @@ def test_stress_trace_collection() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from ddtrace.trace import tracer
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_stress_trace_collection"
 
     assert ddup.is_available
-    with with_profiling_test_agent():
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        c = stack.StackCollector(tracer=tracer)
-        c.start()
-        try:
+    c = stack.StackCollector(tracer=tracer)
+    c.start()
+    try:
 
-            def _trace() -> None:
-                for _ in range(5000):
-                    with tracer.trace("hello"):
-                        time.sleep(0.001)
+        def _trace() -> None:
+            for _ in range(5000):
+                with tracer.trace("hello"):
+                    time.sleep(0.001)
 
-            NB_THREADS = 30
+        NB_THREADS = 30
 
-            threads = []
-            for _ in range(NB_THREADS):
-                t = threading.Thread(target=_trace)
-                threads.append(t)
+        threads = []
+        for _ in range(NB_THREADS):
+            t = threading.Thread(target=_trace)
+            threads.append(t)
 
-            for t in threads:
-                t.start()
+        for t in threads:
+            t.start()
 
-            for t in threads:
-                t.join()
-        finally:
-            c.stop()
-            ddup.upload(tracer=tracer)
+        for t in threads:
+            t.join()
+    finally:
+        c.stop()
+        ddup.upload(tracer=tracer)
 
 
 # This test intentionally keeps DD_PROFILING_OUTPUT_PPROF (file-based approach).

--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -1,29 +1,22 @@
-import _thread
+import inspect
 import os
-from pathlib import Path
 import sys
 import threading
 import time
-from typing import TYPE_CHECKING
-from typing import Generator
-from unittest.mock import patch
-import uuid
 
 import pytest
-from pytest import FixtureRequest
-from pytest import MonkeyPatch
 
-from ddtrace import ext
-from ddtrace.internal.datadog.profiling import ddup
 from ddtrace.profiling.collector import stack
-from ddtrace.trace import Tracer
-from tests.conftest import get_original_test_name
-from tests.profiling.collector import pprof_utils
 from tests.profiling.collector import test_collector
 
 
-if TYPE_CHECKING:
-    from tests.profiling.collector.pprof_pb2 import Sample  # pyright: ignore[reportMissingModuleSource]
+def _lineno_of(func, substring):
+    """Return the 1-based line number of the first source line of func containing substring."""
+    source_lines, start_lineno = inspect.getsourcelines(func)
+    for offset, line in enumerate(source_lines):
+        if substring in line:
+            return start_lineno + offset
+    raise AssertionError(f"{substring!r} not found in source of {func.__name__}")
 
 
 # Python 3.11.9 is not compatible with gevent, https://github.com/gevent/gevent/issues/2040
@@ -64,7 +57,6 @@ def func5() -> None:
 @pytest.mark.subprocess(
     env=dict(
         DD_PROFILING_MAX_FRAMES="5",
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_collect_truncate",
     )
 )
 def test_collect_truncate() -> None:
@@ -73,20 +65,20 @@ def test_collect_truncate() -> None:
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_stack import func1
-
-    pprof_prefix = os.environ["DD_PROFILING_OUTPUT_PPROF"]
-    output_filename = pprof_prefix + "." + str(os.getpid())
+    from tests.profiling.utils import with_profiling_test_agent
 
     max_nframes = int(os.environ["DD_PROFILING_MAX_FRAMES"])
 
-    p = profiler.Profiler()
-    p.start()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler()
+        p.start()
 
-    func1()
+        func1()
 
-    p.stop()
+        p.stop()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+
     samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
     assert len(samples) > 0
     for sample in samples:
@@ -94,32 +86,42 @@ def test_collect_truncate() -> None:
         assert len(sample.location_id) <= max_nframes + 1, len(sample.location_id)
 
 
-def test_stack_locations(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_stack_locations() -> None:
+    import _thread
+    import time
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_stack import _main_thread_has_native_id
+    from tests.profiling.utils import with_profiling_test_agent
+
     test_name = "test_stack_locations"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def baz() -> None:
-        time.sleep(0.1)
+        def baz() -> None:
+            time.sleep(0.1)
 
-    def bar() -> None:
-        baz()
+        def bar() -> None:
+            baz()
 
-    def foo() -> None:
-        bar()
+        def foo() -> None:
+            bar()
 
-    with stack.StackCollector():
-        for _ in range(10):
-            foo()
+        with stack.StackCollector():
+            for _ in range(10):
+                foo()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+
     samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
     assert len(samples) > 0
 
@@ -150,35 +152,46 @@ def test_stack_locations(tmp_path: Path) -> None:
     pprof_utils.assert_profile_has_sample(profile, samples=samples, expected_sample=expected_sample)
 
 
-def test_push_span(tmp_path: Path, tracer: Tracer) -> None:
+@pytest.mark.subprocess(err=None)
+def test_push_span() -> None:
+    import time
+    import uuid
+
+    from ddtrace import ext
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from ddtrace.trace import tracer
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
+
     test_name = "test_push_span"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     tracer._endpoint_call_counter_span_processor.enable()
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    resource = str(uuid.uuid4())
-    span_type = ext.SpanTypes.WEB
+        resource = str(uuid.uuid4())
+        span_type = ext.SpanTypes.WEB
 
-    with stack.StackCollector(
-        tracer=tracer,
-    ):
-        with tracer.trace("foobar", resource=resource, span_type=span_type) as span:
-            span_id = span.span_id
-            local_root_span_id = span._local_root.span_id
-            for _ in range(10):
-                time.sleep(0.1)
-    ddup.upload(tracer=tracer)
+        with stack.StackCollector(
+            tracer=tracer,
+        ):
+            with tracer.trace("foobar", resource=resource, span_type=span_type) as span:
+                span_id = span.span_id
+                local_root_span_id = span._local_root.span_id
+                for _ in range(10):
+                    time.sleep(0.1)
+        ddup.upload(tracer=tracer)
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+
     samples_with_span_id = pprof_utils.get_samples_with_label_key(profile, "span id")
 
-    samples: list[Sample] = []
+    samples = []
     for sample in samples_with_span_id:
         locations = [pprof_utils.get_location_from_id(profile, location_id) for location_id in sample.location_id]
         if any(location.filename.endswith("test_stack.py") for location in locations):
@@ -199,41 +212,54 @@ def test_push_span(tmp_path: Path, tracer: Tracer) -> None:
     )
 
 
-def test_push_span_unregister_thread(tmp_path: Path, monkeypatch: MonkeyPatch, tracer: Tracer) -> None:
+@pytest.mark.subprocess(err=None)
+def test_push_span_unregister_thread() -> None:
+    import threading
+    import time
+    from unittest.mock import patch
+    import uuid
+
+    from ddtrace import ext
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from ddtrace.trace import tracer
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
+
     with patch("ddtrace.internal.datadog.profiling.stack.unregister_thread") as unregister_thread:
         tracer._endpoint_call_counter_span_processor.enable()
 
         test_name = "test_push_span_unregister_thread"
-        pprof_prefix = str(tmp_path / test_name)
-        output_filename = pprof_prefix + "." + str(os.getpid())
 
         assert ddup.is_available
-        ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-        ddup.start()
-        ddup.upload()
+        with with_profiling_test_agent() as agent_client:
+            ddup.config(env="test", service=test_name, version="my_version")
+            ddup.start()
+            ddup.upload()
 
-        resource = str(uuid.uuid4())
-        span_type = ext.SpanTypes.WEB
+            resource = str(uuid.uuid4())
+            span_type = ext.SpanTypes.WEB
 
-        def target_fun() -> None:
-            for _ in range(10):
-                time.sleep(0.1)
+            def target_fun() -> None:
+                for _ in range(10):
+                    time.sleep(0.1)
 
-        with stack.StackCollector(
-            tracer=tracer,
-        ):
-            with tracer.trace("foobar", resource=resource, span_type=span_type) as span:
-                span_id = span.span_id
-                local_root_span_id = span._local_root.span_id
-                t = threading.Thread(target=target_fun)
-                t.start()
-                t.join()
-                thread_id = t.ident
-        ddup.upload(tracer=tracer)
+            with stack.StackCollector(
+                tracer=tracer,
+            ):
+                with tracer.trace("foobar", resource=resource, span_type=span_type) as span:
+                    span_id = span.span_id
+                    local_root_span_id = span._local_root.span_id
+                    t = threading.Thread(target=target_fun)
+                    t.start()
+                    t.join()
+                    thread_id = t.ident
+            ddup.upload(tracer=tracer)
 
-        profile = pprof_utils.parse_newest_profile(output_filename)
+            profile = pprof_utils.get_profile_from_agent(agent_client)
+
         samples_with_span_id = pprof_utils.get_samples_with_label_key(profile, "span id")
-        samples: list[Sample] = []
+        samples = []
         for sample in samples_with_span_id:
             locations = [pprof_utils.get_location_from_id(profile, location_id) for location_id in sample.location_id]
             if any(location.filename.endswith("test_stack.py") for location in locations):
@@ -252,37 +278,51 @@ def test_push_span_unregister_thread(tmp_path: Path, monkeypatch: MonkeyPatch, t
             print_samples_on_failure=True,
         )
 
-        unregister_thread.assert_called_with(thread_id)
+        # Use assert_any_call rather than assert_called_with because the
+        # StackCollector may unregister multiple threads on stop, so the last
+        # call to unregister_thread may not be for the thread we created.
+        unregister_thread.assert_any_call(thread_id)
 
 
-def test_push_non_web_span(tmp_path: Path, tracer: Tracer) -> None:
+@pytest.mark.subprocess(err=None)
+def test_push_non_web_span() -> None:
+    import time
+    import uuid
+
+    from ddtrace import ext
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from ddtrace.trace import tracer
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
+
     tracer._endpoint_call_counter_span_processor.enable()
 
     test_name = "test_push_non_web_span"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    resource = str(uuid.uuid4())
-    span_type = ext.SpanTypes.SQL
+        resource = str(uuid.uuid4())
+        span_type = ext.SpanTypes.SQL
 
-    with stack.StackCollector(
-        tracer=tracer,
-    ):
-        with tracer.trace("foobar", resource=resource, span_type=span_type) as span:
-            span_id = span.span_id
-            local_root_span_id = span._local_root.span_id
-            for _ in range(10):
-                time.sleep(0.1)
-    ddup.upload(tracer=tracer)
+        with stack.StackCollector(
+            tracer=tracer,
+        ):
+            with tracer.trace("foobar", resource=resource, span_type=span_type) as span:
+                span_id = span.span_id
+                local_root_span_id = span._local_root.span_id
+                for _ in range(10):
+                    time.sleep(0.1)
+        ddup.upload(tracer=tracer)
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+
     samples_with_span_id = pprof_utils.get_samples_with_label_key(profile, "span id")
-    samples: list[Sample] = []
+    samples = []
     for sample in samples_with_span_id:
         locations = [pprof_utils.get_location_from_id(profile, location_id) for location_id in sample.location_id]
         if any(location.filename.endswith("test_stack.py") for location in locations):
@@ -302,36 +342,46 @@ def test_push_non_web_span(tmp_path: Path, tracer: Tracer) -> None:
     )
 
 
-def test_push_span_none_span_type(tmp_path: Path, tracer: Tracer) -> None:
+@pytest.mark.subprocess(err=None)
+def test_push_span_none_span_type() -> None:
     # Test for https://github.com/DataDog/dd-trace-py/issues/11141
+    import time
+    import uuid
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from ddtrace.trace import tracer
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
+
     test_name = "test_push_span_none_span_type"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    tracer._endpoint_call_counter_span_processor.enable()
+        tracer._endpoint_call_counter_span_processor.enable()
 
-    resource = str(uuid.uuid4())
+        resource = str(uuid.uuid4())
 
-    with stack.StackCollector(
-        tracer=tracer,
-    ):
-        # Explicitly set None span_type as the default could change in the
-        # future.
-        with tracer.trace("foobar", resource=resource, span_type=None) as span:
-            span_id = span.span_id
-            local_root_span_id = span._local_root.span_id
-            for _ in range(10):
-                time.sleep(0.1)
-    ddup.upload(tracer=tracer)
+        with stack.StackCollector(
+            tracer=tracer,
+        ):
+            # Explicitly set None span_type as the default could change in the
+            # future.
+            with tracer.trace("foobar", resource=resource, span_type=None) as span:
+                span_id = span.span_id
+                local_root_span_id = span._local_root.span_id
+                for _ in range(10):
+                    time.sleep(0.1)
+        ddup.upload(tracer=tracer)
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+
     samples_with_span_id = pprof_utils.get_samples_with_label_key(profile, "span id")
-    samples: list[Sample] = []
+    samples = []
     for sample in samples_with_span_id:
         locations = [pprof_utils.get_location_from_id(profile, location_id) for location_id in sample.location_id]
         if any(location.filename.endswith("test_stack.py") for location in locations):
@@ -351,7 +401,17 @@ def test_push_span_none_span_type(tmp_path: Path, tracer: Tracer) -> None:
     )
 
 
-def test_collect_once_with_class(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_collect_once_with_class() -> None:
+    import _thread
+    import time
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector import test_stack as _test_stack_module
+    from tests.profiling.utils import with_profiling_test_agent
+
     class SomeClass(object):
         @classmethod
         def sleep_class(cls) -> None:
@@ -362,20 +422,20 @@ def test_collect_once_with_class(tmp_path: Path) -> None:
                 time.sleep(0.1)
 
     test_name = "test_collect_once_with_class"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    with stack.StackCollector():
-        SomeClass.sleep_class()
+        with stack.StackCollector():
+            SomeClass.sleep_class()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+
     samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
     assert len(samples) > 0
 
@@ -397,9 +457,11 @@ def test_collect_once_with_class(tmp_path: Path) -> None:
                     line_no=SomeClass.sleep_class.__code__.co_firstlineno + 2,
                 ),
                 pprof_utils.StackLocation(
-                    function_name="test_collect_once_with_class",
+                    function_name="<module>",
                     filename="test_stack.py",
-                    line_no=test_collect_once_with_class.__code__.co_firstlineno + 20,
+                    line_no=_test_stack_module._lineno_of(
+                        _test_stack_module.test_collect_once_with_class, "SomeClass.sleep_class()"
+                    ),
                 ),
             ],
         ),
@@ -407,12 +469,22 @@ def test_collect_once_with_class(tmp_path: Path) -> None:
     )
 
 
-def test_collect_once_with_class_not_right_type(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_collect_once_with_class_not_right_type() -> None:
     """Test that the stack collector profiles methods with non-conventional parameter names.
 
     Verifies the profiler handles methods where parameters don't follow standard conventions
     (e.g., using 'foobar' instead of 'self' or 'cls').
     """
+
+    import _thread
+    import time
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector import test_stack as _test_stack_module
+    from tests.profiling.utils import with_profiling_test_agent
 
     class SomeClass(object):
         @classmethod
@@ -424,20 +496,20 @@ def test_collect_once_with_class_not_right_type(tmp_path: Path) -> None:
                 time.sleep(0.1)
 
     test_name = "test_collect_once_with_class"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    with stack.StackCollector():
-        SomeClass.sleep_class(123)
+        with stack.StackCollector():
+            SomeClass.sleep_class(123)
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+
     samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
     assert len(samples) > 0
 
@@ -459,9 +531,11 @@ def test_collect_once_with_class_not_right_type(tmp_path: Path) -> None:
                     line_no=SomeClass.sleep_class.__code__.co_firstlineno + 2,
                 ),
                 pprof_utils.StackLocation(
-                    function_name="test_collect_once_with_class_not_right_type",
+                    function_name="<module>",
                     filename="test_stack.py",
-                    line_no=test_collect_once_with_class_not_right_type.__code__.co_firstlineno + 26,
+                    line_no=_test_stack_module._lineno_of(
+                        _test_stack_module.test_collect_once_with_class_not_right_type, "SomeClass.sleep_class(123)"
+                    ),
                 ),
             ],
         ),
@@ -482,13 +556,12 @@ def _fib(n: int) -> int:
     not GEVENT_COMPATIBLE_WITH_PYTHON_VERSION,
     reason=f"gevent is not compatible with Python {'.'.join(map(str, tuple(sys.version_info)[:3]))}",
 )
-@pytest.mark.subprocess(ddtrace_run=True)
+@pytest.mark.subprocess(ddtrace_run=True, err=None)
 def test_collect_gevent_thread_task() -> None:
     from gevent import monkey
 
     monkey.patch_all()
 
-    import os
     import threading
     import time
 
@@ -497,40 +570,41 @@ def test_collect_gevent_thread_task() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_stack import _fib
     from tests.profiling.collector.test_stack import _main_thread_has_native_id
+    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_collect_gevent_thread_task"
-    pprof_prefix = "/tmp/" + test_name
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
 
-    # Start some (green)threads
-    def _do_fib() -> None:
-        for _ in range(5):
-            # spend some time in CPU so the profiler can catch something
-            # On a Mac w/ Apple M3 MAX with Python 3.11 it takes about 200ms to calculate _fib(32)
-            # And _fib() is called 5 times so it should take about 1 second
-            # We use 5 threads below so it should take about 5 seconds
-            _fib(32)
-            # Just make sure gevent switches threads/greenlets
-            time.sleep(0)
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    threads = []
+        # Start some (green)threads
+        def _do_fib() -> None:
+            for _ in range(5):
+                # spend some time in CPU so the profiler can catch something
+                # On a Mac w/ Apple M3 MAX with Python 3.11 it takes about 200ms to calculate _fib(32)
+                # And _fib() is called 5 times so it should take about 1 second
+                # We use 5 threads below so it should take about 5 seconds
+                _fib(32)
+                # Just make sure gevent switches threads/greenlets
+                time.sleep(0)
 
-    with stack.StackCollector():
-        for i in range(5):
-            t = threading.Thread(target=_do_fib, name=f"TestThread {i}")
-            t.start()
-            threads.append(t)
-        for t in threads:
-            t.join()
+        threads = []
 
-    ddup.upload()
+        with stack.StackCollector():
+            for i in range(5):
+                t = threading.Thread(target=_do_fib, name=f"TestThread {i}")
+                t.start()
+                threads.append(t)
+            for t in threads:
+                t.join()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        ddup.upload()
+
+        profile = pprof_utils.get_profile_from_agent(agent_client)
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
     assert len(samples) > 0
 
@@ -570,18 +644,12 @@ def test_collect_gevent_thread_task() -> None:
     not GEVENT_COMPATIBLE_WITH_PYTHON_VERSION,
     reason=f"gevent is not compatible with Python {'.'.join(map(str, tuple(sys.version_info)[:3]))}",
 )
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_collect_gevent_task_started_before_profiler",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess(err=None)
 def test_collect_gevent_task_started_before_profiler() -> None:
     from gevent import monkey
 
     monkey.patch_all()
 
-    import os
     import threading
     import time
 
@@ -608,19 +676,21 @@ def test_collect_gevent_task_started_before_profiler() -> None:
     # Import profiler modules after gevent patching and greenlet creation
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
-    p = profiler.Profiler()
-    p.start()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler()
+        p.start()
 
-    try:
-        gevent.sleep(1.0)
-    finally:
-        should_stop.set()
-        pre_started_greenlet.join(timeout=2)
-        p.stop()
+        try:
+            gevent.sleep(1.0)
+        finally:
+            should_stop.set()
+            pre_started_greenlet.join(timeout=2)
+            p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
     assert len(samples) > 0
 
@@ -650,7 +720,6 @@ def test_collect_gevent_task_started_before_profiler() -> None:
 )
 @pytest.mark.subprocess(
     env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_gevent_cpu_time_total_accuracy",
         _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED="0",
     ),
     err=None,
@@ -675,13 +744,13 @@ def test_gevent_cpu_time_total_accuracy() -> None:
 
     monkey.patch_all()
 
-    import os
     import time
 
     import gevent
 
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     DURATION_S = 3.0
     CPU_BURN_S = 0.01
@@ -696,31 +765,32 @@ def test_gevent_cpu_time_total_accuracy() -> None:
                 pass
             gevent.sleep(SLEEP_S)
 
-    p = profiler.Profiler()
-    p.start()
-    try:
-        # Stagger workers by CPU_BURN_S so their CPU bursts interleave with
-        # each other's sleep, which spreads the on-CPU greenlet across the
-        # unordered_map iteration order. Without staggering, the same greenlet
-        # tends to win the on-CPU position each sample, masking the bug.
-        workers = []
-        cpu_start_ns = time.process_time_ns()
-        for i in range(NUM_WORKERS):
-            if i > 0:
-                gevent.sleep(CPU_BURN_S)
-            workers.append(gevent.spawn(worker))
-        gevent.joinall(workers, timeout=DURATION_S + 10)
-        cpu_end_ns = time.process_time_ns()
-    finally:
-        p.stop()
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler()
+        p.start()
+        try:
+            # Stagger workers by CPU_BURN_S so their CPU bursts interleave with
+            # each other's sleep, which spreads the on-CPU greenlet across the
+            # unordered_map iteration order. Without staggering, the same greenlet
+            # tends to win the on-CPU position each sample, masking the bug.
+            workers = []
+            cpu_start_ns = time.process_time_ns()
+            for i in range(NUM_WORKERS):
+                if i > 0:
+                    gevent.sleep(CPU_BURN_S)
+                workers.append(gevent.spawn(worker))
+            gevent.joinall(workers, timeout=DURATION_S + 10)
+            cpu_end_ns = time.process_time_ns()
+        finally:
+            p.stop()
+
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
     assert all(g.dead for g in workers), "gevent workers did not finish within timeout"
 
     actual_cpu_ns = cpu_end_ns - cpu_start_ns
     assert actual_cpu_ns > 0, "process_time_ns did not advance"
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    profile = pprof_utils.parse_newest_profile(output_filename)
     cpu_time_index = pprof_utils.get_sample_type_index(profile, "cpu-time")
     profile_cpu_ns = sum(sample.value[cpu_time_index] for sample in profile.sample)
 
@@ -774,88 +844,89 @@ exec(
 )
 
 
-def test_stress_threads_run_as_thread(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_stress_threads_run_as_thread() -> None:
+    import threading
+    import time
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
+
     test_name = "test_stress_threads_run_as_thread"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    quit_thread = threading.Event()
+        quit_thread = threading.Event()
 
-    def wait_for_quit() -> None:
-        quit_thread.wait()
+        def wait_for_quit() -> None:
+            quit_thread.wait()
 
-    with stack.StackCollector():
-        NB_THREADS = 40
+        with stack.StackCollector():
+            NB_THREADS = 40
 
-        threads = []
-        for _ in range(NB_THREADS):
-            t = threading.Thread(target=wait_for_quit)
-            t.start()
-            threads.append(t)
+            threads = []
+            for _ in range(NB_THREADS):
+                t = threading.Thread(target=wait_for_quit)
+                t.start()
+                threads.append(t)
 
-        time.sleep(3)
+            time.sleep(3)
 
-        quit_thread.set()
-        for t in threads:
-            t.join()
+            quit_thread.set()
+            for t in threads:
+                t.join()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+
     samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
     assert len(samples) > 0
 
 
-# if you don't need to check the output profile, you can use this fixture
-@pytest.fixture
-def tracer_and_collector(
-    tracer: Tracer, request: FixtureRequest, tmp_path: Path
-) -> Generator[tuple[Tracer, stack.StackCollector], None, None]:
-    test_name = get_original_test_name(request)
-    pprof_prefix = str(tmp_path / test_name)
+@pytest.mark.subprocess(err=None)
+def test_collect_span_id() -> None:
+    import _thread
+    import os
+    import time
+    import uuid
+
+    from ddtrace import ext
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from ddtrace.trace import tracer
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector import test_stack as _test_stack_module
+    from tests.profiling.utils import with_profiling_test_agent
+
+    test_name = "test_collect_span_id"
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    c = stack.StackCollector(tracer=tracer)
-    c.start()
-    try:
-        yield tracer, c
-    finally:
-        c.stop()
+        tracer._endpoint_call_counter_span_processor.enable()
+        with stack.StackCollector(tracer=tracer):
+            resource = str(uuid.uuid4())
+            span_type = ext.SpanTypes.WEB
+            with tracer.start_span("foobar", activate=True, resource=resource, span_type=span_type) as span:
+                for _ in range(10):
+                    time.sleep(0.1)
+                span_id = span.span_id
+                local_root_span_id = span._local_root.span_id
+
         ddup.upload(tracer=tracer)
 
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-def test_collect_span_id(tracer: Tracer, tmp_path: Path) -> None:
-    test_name = "test_collect_span_id"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
-
-    assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
-
-    tracer._endpoint_call_counter_span_processor.enable()
-    with stack.StackCollector(tracer=tracer):
-        resource = str(uuid.uuid4())
-        span_type = ext.SpanTypes.WEB
-        with tracer.start_span("foobar", activate=True, resource=resource, span_type=span_type) as span:
-            for _ in range(10):
-                time.sleep(0.1)
-            span_id = span.span_id
-            local_root_span_id = span._local_root.span_id
-
-    ddup.upload(tracer=tracer)
-
-    profile = pprof_utils.parse_newest_profile(output_filename)
     samples = pprof_utils.get_samples_with_label_key(profile, "trace endpoint")
     pprof_utils.assert_profile_has_sample(
         profile,
@@ -868,9 +939,9 @@ def test_collect_span_id(tracer: Tracer, tmp_path: Path) -> None:
             trace_endpoint=resource,
             locations=[
                 pprof_utils.StackLocation(
-                    filename=os.path.basename(__file__),
-                    function_name=test_name,
-                    line_no=test_collect_span_id.__code__.co_firstlineno + 16,
+                    filename=os.path.basename(_test_stack_module.__file__),
+                    function_name="<module>",
+                    line_no=_test_stack_module._lineno_of(_test_stack_module.test_collect_span_id, "time.sleep(0.1)"),
                 )
             ],
         ),
@@ -878,26 +949,40 @@ def test_collect_span_id(tracer: Tracer, tmp_path: Path) -> None:
     )
 
 
-def test_collect_span_resource_after_finish(tracer: Tracer, tmp_path: Path, request: FixtureRequest) -> None:
-    test_name = get_original_test_name(request)
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
+@pytest.mark.subprocess(err=None)
+def test_collect_span_resource_after_finish() -> None:
+    import _thread
+    import os
+    import time
+    import uuid
 
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    from ddtrace import ext
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from ddtrace.trace import tracer
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector import test_stack as _test_stack_module
+    from tests.profiling.utils import with_profiling_test_agent
 
-    tracer._endpoint_call_counter_span_processor.enable()
-    with stack.StackCollector(tracer=tracer):
-        resource = str(uuid.uuid4())
-        span_type = ext.SpanTypes.WEB
-        span = tracer.start_span("foobar", activate=True, span_type=span_type, resource=resource)
-        for _ in range(10):
-            time.sleep(0.1)
-    ddup.upload(tracer=tracer)
-    span.finish()
+    test_name = "test_collect_span_resource_after_finish"
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
+
+        tracer._endpoint_call_counter_span_processor.enable()
+        with stack.StackCollector(tracer=tracer):
+            resource = str(uuid.uuid4())
+            span_type = ext.SpanTypes.WEB
+            span = tracer.start_span("foobar", activate=True, span_type=span_type, resource=resource)
+            for _ in range(10):
+                time.sleep(0.1)
+        ddup.upload(tracer=tracer)
+        span.finish()
+
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+
     samples = profile.sample
     pprof_utils.assert_profile_has_sample(
         profile,
@@ -910,9 +995,11 @@ def test_collect_span_resource_after_finish(tracer: Tracer, tmp_path: Path, requ
             # trace_endpoint=resource,
             locations=[
                 pprof_utils.StackLocation(
-                    filename=os.path.basename(__file__),
-                    function_name=test_name,
-                    line_no=test_collect_span_resource_after_finish.__code__.co_firstlineno + 15,
+                    filename=os.path.basename(_test_stack_module.__file__),
+                    function_name="<module>",
+                    line_no=_test_stack_module._lineno_of(
+                        _test_stack_module.test_collect_span_resource_after_finish, "time.sleep(0.1)"
+                    ),
                 )
             ],
         ),
@@ -920,28 +1007,43 @@ def test_collect_span_resource_after_finish(tracer: Tracer, tmp_path: Path, requ
     )
 
 
-def test_resource_not_collected(tmp_path: Path, tracer: Tracer) -> None:
+@pytest.mark.subprocess(err=None)
+def test_resource_not_collected() -> None:
+    import _thread
+    import os
+    import time
+    import uuid
+
+    from ddtrace import ext
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from ddtrace.trace import tracer
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector import test_stack as _test_stack_module
+    from tests.profiling.collector.test_stack import _fib
+    from tests.profiling.utils import with_profiling_test_agent
+
     test_name = "test_resource_not_collected"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    with stack.StackCollector(tracer=tracer):
-        # Give the Profiler some time to start
-        time.sleep(0.1)
+        with stack.StackCollector(tracer=tracer):
+            # Give the Profiler some time to start
+            time.sleep(0.1)
 
-        resource = str(uuid.uuid4())
-        span_type = ext.SpanTypes.WEB
-        with tracer.start_span("foobar", activate=True, resource=resource, span_type=span_type) as span:
-            _fib(35)
+            resource = str(uuid.uuid4())
+            span_type = ext.SpanTypes.WEB
+            with tracer.start_span("foobar", activate=True, resource=resource, span_type=span_type) as span:
+                _fib(35)
 
-    ddup.upload(tracer=tracer)
+        ddup.upload(tracer=tracer)
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+
     pprof_utils.assert_profile_has_sample(
         profile,
         profile.sample,
@@ -951,9 +1053,9 @@ def test_resource_not_collected(tmp_path: Path, tracer: Tracer) -> None:
             trace_type=span_type,
             locations=[
                 pprof_utils.StackLocation(
-                    filename=os.path.basename(__file__),
-                    function_name=test_name,
-                    line_no=test_resource_not_collected.__code__.co_firstlineno + 17,
+                    filename=os.path.basename(_test_stack_module.__file__),
+                    function_name="<module>",
+                    line_no=_test_stack_module._lineno_of(_test_stack_module.test_resource_not_collected, "_fib(35)"),
                 )
             ],
         ),
@@ -961,27 +1063,41 @@ def test_resource_not_collected(tmp_path: Path, tracer: Tracer) -> None:
     )
 
 
-def test_collect_nested_span_id(tmp_path: Path, tracer: Tracer, request: FixtureRequest) -> None:
-    test_name = get_original_test_name(request)
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
+@pytest.mark.subprocess(err=None)
+def test_collect_nested_span_id() -> None:
+    import _thread
+    import os
+    import time
+    import uuid
+
+    from ddtrace import ext
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from ddtrace.trace import tracer
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector import test_stack as _test_stack_module
+    from tests.profiling.utils import with_profiling_test_agent
+
+    test_name = "test_collect_nested_span_id"
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    tracer._endpoint_call_counter_span_processor.enable()
-    with stack.StackCollector(tracer=tracer):
-        resource = str(uuid.uuid4())
-        span_type = ext.SpanTypes.WEB
-        with tracer.start_span("foobar", activate=True, resource=resource, span_type=span_type):
-            with tracer.start_span("foobar", activate=True, resource=resource, span_type=span_type) as child_span:
-                for _ in range(10):
-                    time.sleep(0.1)
-    ddup.upload(tracer=tracer)
+        tracer._endpoint_call_counter_span_processor.enable()
+        with stack.StackCollector(tracer=tracer):
+            resource = str(uuid.uuid4())
+            span_type = ext.SpanTypes.WEB
+            with tracer.start_span("foobar", activate=True, resource=resource, span_type=span_type):
+                with tracer.start_span("foobar", activate=True, resource=resource, span_type=span_type) as child_span:
+                    for _ in range(10):
+                        time.sleep(0.1)
+        ddup.upload(tracer=tracer)
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+
     samples = pprof_utils.get_samples_with_label_key(profile, "span id")
     pprof_utils.assert_profile_has_sample(
         profile,
@@ -994,9 +1110,11 @@ def test_collect_nested_span_id(tmp_path: Path, tracer: Tracer, request: Fixture
             trace_endpoint=resource,
             locations=[
                 pprof_utils.StackLocation(
-                    filename=os.path.basename(__file__),
-                    function_name=test_name,
-                    line_no=test_collect_nested_span_id.__code__.co_firstlineno + 17,
+                    filename=os.path.basename(_test_stack_module.__file__),
+                    function_name="<module>",
+                    line_no=_test_stack_module._lineno_of(
+                        _test_stack_module.test_collect_nested_span_id, "time.sleep(0.1)"
+                    ),
                 )
             ],
         ),
@@ -1009,9 +1127,6 @@ def test_collect_nested_span_id(tmp_path: Path, tracer: Tracer, request: Fixture
     reason=f"gevent is not compatible with Python {'.'.join(map(str, tuple(sys.version_info)[:3]))}",
 )
 @pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_gevent_greenlet_switch_not_blocked_by_profiler",
-    ),
     out=None,
     err=None,
 )
@@ -1099,79 +1214,113 @@ def test_gevent_greenlet_switch_not_blocked_by_profiler() -> None:
     )
 
 
-def test_greenlet_labels_do_not_depend_on_string_table_cleanup(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_greenlet_labels_do_not_depend_on_string_table_cleanup() -> None:
     """Verify that tracking/untracking greenlets across many uploads does not
     crash or lose greenlet names now that greenlet labels are not StringTable entries.
     """
+    import time
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.internal.datadog.profiling import stack as native_stack
+    from ddtrace.profiling.collector import stack
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
+
     test_name = "test_greenlet_labels_do_not_depend_on_string_table_cleanup"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    from ddtrace.internal.datadog.profiling import stack as native_stack
+        with stack.StackCollector():
+            # Track a long-lived greenlet that should survive many uploads
+            long_lived_id = 0xDEAD0001
+            native_stack.track_greenlet(long_lived_id, "long-lived-greenlet", False)
 
-    with stack.StackCollector():
-        # Track a long-lived greenlet that should survive many uploads
-        long_lived_id = 0xDEAD0001
-        native_stack.track_greenlet(long_lived_id, "long-lived-greenlet", False)
+            # Track and untrack short-lived greenlets to exercise erase()
+            for i in range(50):
+                short_id = 0xBEEF0000 + i
+                native_stack.track_greenlet(short_id, f"short-lived-{i}", False)
+                native_stack.untrack_greenlet(short_id)
 
-        # Track and untrack short-lived greenlets to exercise erase()
-        for i in range(50):
-            short_id = 0xBEEF0000 + i
-            native_stack.track_greenlet(short_id, f"short-lived-{i}", False)
-            native_stack.untrack_greenlet(short_id)
+            # Do 30 uploads to exercise repeated profile serialization.
+            for _ in range(30):
+                ddup.upload()
 
-        # Do 30 uploads to exercise repeated profile serialization.
-        for _ in range(30):
-            ddup.upload()
+            # Track more short-lived greenlets after repeated uploads to make sure
+            # label handling remains functional
+            for i in range(50):
+                short_id = 0xCAFE0000 + i
+                native_stack.track_greenlet(short_id, f"post-clear-{i}", False)
+                native_stack.untrack_greenlet(short_id)
 
-        # Track more short-lived greenlets after repeated uploads to make sure
-        # label handling remains functional
-        for i in range(50):
-            short_id = 0xCAFE0000 + i
-            native_stack.track_greenlet(short_id, f"post-clear-{i}", False)
-            native_stack.untrack_greenlet(short_id)
+            # Give the sampler a moment to collect a sample with the long-lived greenlet
+            time.sleep(0.1)
 
-        # Give the sampler a moment to collect a sample with the long-lived greenlet
-        time.sleep(0.1)
+            native_stack.untrack_greenlet(long_lived_id)
 
-        native_stack.untrack_greenlet(long_lived_id)
+        # Final upload — if label handling is corrupted this would crash
+        ddup.upload()
 
-    # Final upload — if label handling is corrupted this would crash
-    ddup.upload()
+        # Verify we got a valid profile (no crash, no corruption)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
-    # Verify we got a valid profile (no crash, no corruption)
-    profile = pprof_utils.parse_newest_profile(output_filename)
     samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
     assert len(samples) > 0
 
 
-def test_stress_trace_collection(tracer_and_collector: tuple[Tracer, stack.StackCollector]) -> None:
-    tracer, _ = tracer_and_collector
+@pytest.mark.subprocess(err=None)
+def test_stress_trace_collection() -> None:
+    import threading
+    import time
 
-    def _trace() -> None:
-        for _ in range(5000):
-            with tracer.trace("hello"):
-                time.sleep(0.001)
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from ddtrace.trace import tracer
+    from tests.profiling.utils import with_profiling_test_agent
 
-    NB_THREADS = 30
+    test_name = "test_stress_trace_collection"
 
-    threads = []
-    for _ in range(NB_THREADS):
-        t = threading.Thread(target=_trace)
-        threads.append(t)
+    assert ddup.is_available
+    with with_profiling_test_agent():
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    for t in threads:
-        t.start()
+        c = stack.StackCollector(tracer=tracer)
+        c.start()
+        try:
 
-    for t in threads:
-        t.join()
+            def _trace() -> None:
+                for _ in range(5000):
+                    with tracer.trace("hello"):
+                        time.sleep(0.001)
+
+            NB_THREADS = 30
+
+            threads = []
+            for _ in range(NB_THREADS):
+                t = threading.Thread(target=_trace)
+                threads.append(t)
+
+            for t in threads:
+                t.start()
+
+            for t in threads:
+                t.join()
+        finally:
+            c.stop()
+            ddup.upload(tracer=tracer)
 
 
+# This test intentionally keeps DD_PROFILING_OUTPUT_PPROF (file-based approach).
+# It uses ddtrace_run=True so the profiler auto-starts before the function body runs.
+# After os.fork(), the CHILD process must read its own profile before calling os._exit(0).
+# Since the child can't query a parent-process capture server usin the Python object,
+# file-based output is the only practical approach here.
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="fork test only on linux")
 @pytest.mark.subprocess(
     ddtrace_run=True,

--- a/tests/profiling/collector/test_stack_asyncio_basic.py
+++ b/tests/profiling/collector/test_stack_asyncio_basic.py
@@ -1,16 +1,10 @@
 import pytest
 
 
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_stack_asyncio_basic",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess(err=None)
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_asyncio_basic() -> None:
     import asyncio
-    import os
     import time
     import uuid
 
@@ -19,6 +13,7 @@ def test_asyncio_basic() -> None:
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -39,28 +34,27 @@ def test_asyncio_basic() -> None:
     resource = str(uuid.uuid4())
     span_type = ext.SpanTypes.WEB
 
-    p = profiler.Profiler(tracer=tracer)
-    p.start()
-    with tracer.trace("test_asyncio_basic", resource=resource, span_type=span_type) as span:
-        span_id = span.span_id
-        local_root_span_id = span._local_root.span_id
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler(tracer=tracer)
+        p.start()
+        with tracer.trace("test_asyncio_basic", resource=resource, span_type=span_type) as span:
+            span_id = span.span_id
+            local_root_span_id = span._local_root.span_id
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        main_task = loop.create_task(hello(), name="main")
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            main_task = loop.create_task(hello(), name="main")
 
-        t1, t2 = loop.run_until_complete(main_task)
-    p.stop()
+            t1, t2 = loop.run_until_complete(main_task)
+        p.stop()
+
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
     t1_name = t1.get_name()
     t2_name = t2.get_name()
 
     assert t1_name == "sleep 1"
     assert t2_name == "sleep 2"
-
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-
-    profile = pprof_utils.parse_newest_profile(output_filename)
 
     samples_with_span_id = pprof_utils.get_samples_with_label_key(profile, "span id")
     assert len(samples_with_span_id) > 0

--- a/tests/profiling/collector/test_stack_asyncio_basic.py
+++ b/tests/profiling/collector/test_stack_asyncio_basic.py
@@ -13,7 +13,6 @@ def test_asyncio_basic() -> None:
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -34,21 +33,20 @@ def test_asyncio_basic() -> None:
     resource = str(uuid.uuid4())
     span_type = ext.SpanTypes.WEB
 
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler(tracer=tracer)
-        p.start()
-        with tracer.trace("test_asyncio_basic", resource=resource, span_type=span_type) as span:
-            span_id = span.span_id
-            local_root_span_id = span._local_root.span_id
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+    with tracer.trace("test_asyncio_basic", resource=resource, span_type=span_type) as span:
+        span_id = span.span_id
+        local_root_span_id = span._local_root.span_id
 
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            main_task = loop.create_task(hello(), name="main")
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        main_task = loop.create_task(hello(), name="main")
 
-            t1, t2 = loop.run_until_complete(main_task)
-        p.stop()
+        t1, t2 = loop.run_until_complete(main_task)
+    p.stop()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     t1_name = t1.get_name()
     t2_name = t2.get_name()

--- a/tests/profiling/collector/test_stack_native.py
+++ b/tests/profiling/collector/test_stack_native.py
@@ -92,26 +92,24 @@ def test_native_frames_detection() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     test_name = "test_native_frames_detection"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def sleep_loop() -> None:
-            for _ in range(10):
-                time.sleep(0.1)
+    def sleep_loop() -> None:
+        for _ in range(10):
+            time.sleep(0.1)
 
-        with stack.StackCollector():
-            sleep_loop()
+    with stack.StackCollector():
+        sleep_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
     samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
     assert len(samples) > 0
 
@@ -159,7 +157,6 @@ def test_native_frames_preserved_after_fork() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -169,65 +166,64 @@ def test_native_frames_preserved_after_fork() -> None:
     test_name = "test_native_frames_preserved_after_fork"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
+
+    def compress_loop() -> None:
+        data = b"x" * 100000
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            zlib.compress(data)
+
+    # Start the profiler and warm up call sites. sys.monitoring returns DISABLE
+    # after the first fire, so the callback won't trigger again for these sites.
+    # Fork while the profiler is still running (like gunicorn workers).
+    collector = stack.StackCollector()
+    collector.start()
+    compress_loop()
+
+    # Fork while profiler is running. The sampler restarts via the atfork
+    # handler, and the NativeCallRegistry data is preserved.
+    pid = os.fork()
+    if pid == 0:
+        # ----- child process -----
+        # The child inherits _DD_PROFILING_TEST_TOKEN / _DD_PROFILING_TEST_PROXY_URL
+        # and uploads through the same proxy session as the parent.
         ddup.config(env="test", service=test_name, version="my_version")
         ddup.start()
         ddup.upload()
 
-        def compress_loop() -> None:
-            data = b"x" * 100000
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                zlib.compress(data)
-
-        # Start the profiler and warm up call sites. sys.monitoring returns DISABLE
-        # after the first fire, so the callback won't trigger again for these sites.
-        # Fork while the profiler is still running (like gunicorn workers).
-        collector = stack.StackCollector()
-        collector.start()
+        # The sampler restarted automatically via atfork. Run the same C
+        # calls — the registry should still have the call site entries from
+        # the parent, so native frames should appear.
         compress_loop()
 
-        # Fork while profiler is running. The sampler restarts via the atfork
-        # handler, and the NativeCallRegistry data is preserved.
-        pid = os.fork()
-        if pid == 0:
-            # ----- child process -----
-            # The child inherits _DD_PROFILING_TEST_AGENT_URL and uploads to the
-            # same capture server as the parent.
-            ddup.config(env="test", service=test_name, version="my_version")
-            ddup.start()
-            ddup.upload()
+        collector.stop()
+        ddup.upload()
 
-            # The sampler restarted automatically via atfork. Run the same C
-            # calls — the registry should still have the call site entries from
-            # the parent, so native frames should appear.
-            compress_loop()
+        os._exit(0)
+    else:
+        # ----- parent process -----
+        collector.stop()
+        _, status = os.waitpid(pid, 0)
+        exit_code = os.waitstatus_to_exitcode(status)
+        assert exit_code == 0, "Child process failed: native frames were not preserved after fork"
 
-            collector.stop()
-            ddup.upload()
+        profile = pprof_utils.get_profile_from_agent()
+        samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
+        assert len(samples) > 0
 
-            os._exit(0)
-        else:
-            # ----- parent process -----
-            collector.stop()
-            _, status = os.waitpid(pid, 0)
-            exit_code = os.waitstatus_to_exitcode(status)
-            assert exit_code == 0, "Child process failed: native frames were not preserved after fork"
-
-            profile = pprof_utils.get_profile_from_agent(agent_client)
-            samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
-            assert len(samples) > 0
-
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples=samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_id=_thread.get_ident(),
-                    thread_name="MainThread",
-                    locations=[loc("compress"), loc("compress_loop", FILE_NAME)],
-                ),
-                print_samples_on_failure=True,
-            )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(),
+                thread_name="MainThread",
+                locations=[loc("compress"), loc("compress_loop", FILE_NAME)],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -241,7 +237,6 @@ def test_native_frames_detection_hashlib() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -251,41 +246,40 @@ def test_native_frames_detection_hashlib() -> None:
     test_name = "test_native_frames_detection_hashlib"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def sha256_loop() -> None:
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                hashlib.sha256(b"Hello, world!")
+    def sha256_loop() -> None:
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            hashlib.sha256(b"Hello, world!")
 
-        with stack.StackCollector():
-            sha256_loop()
+    with stack.StackCollector():
+        sha256_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        expected_stacks = [
-            [loc("sha256"), loc("sha256_loop", FILE_NAME)],
-            [loc("monotonic"), loc("sha256_loop", FILE_NAME)],
-        ]
+    expected_stacks = [
+        [loc("sha256"), loc("sha256_loop", FILE_NAME)],
+        [loc("monotonic"), loc("sha256_loop", FILE_NAME)],
+    ]
 
-        for exp_stack in expected_stacks:
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples=samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_id=_thread.get_ident(),
-                    thread_name="MainThread",
-                    locations=exp_stack,
-                ),
-                print_samples_on_failure=True,
-            )
+    for exp_stack in expected_stacks:
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(),
+                thread_name="MainThread",
+                locations=exp_stack,
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -299,7 +293,6 @@ def test_native_frames_detection_hashlib_kwarg() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -309,39 +302,38 @@ def test_native_frames_detection_hashlib_kwarg() -> None:
     test_name = "test_native_frames_detection_hashlib"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def sha256_loop() -> None:
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                hashlib.sha256(b"Hello, world!")
+    def sha256_loop() -> None:
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            hashlib.sha256(b"Hello, world!")
 
-        with stack.StackCollector():
-            sha256_loop()
+    with stack.StackCollector():
+        sha256_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        expected_stacks = [
-            [loc("sha256"), loc("sha256_loop", FILE_NAME)],
-            [loc("monotonic"), loc("sha256_loop", FILE_NAME)],
-        ]
+    expected_stacks = [
+        [loc("sha256"), loc("sha256_loop", FILE_NAME)],
+        [loc("monotonic"), loc("sha256_loop", FILE_NAME)],
+    ]
 
-        for exp_stack in expected_stacks:
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples=samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
-                ),
-                print_samples_on_failure=True,
-            )
+    for exp_stack in expected_stacks:
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -360,7 +352,6 @@ def test_native_frames_detection_numpy_flat() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -370,36 +361,35 @@ def test_native_frames_detection_numpy_flat() -> None:
     test_name = "test_native_frames_detection_hashlib"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def numpy_loop() -> None:
-            test_start = time.monotonic()
-            while time.monotonic() - test_start < 2:
-                mat = np.random.rand(1000, 1000)
-                np.matmul(mat, mat)
+    def numpy_loop() -> None:
+        test_start = time.monotonic()
+        while time.monotonic() - test_start < 2:
+            mat = np.random.rand(1000, 1000)
+            np.matmul(mat, mat)
 
-        with stack.StackCollector():
-            numpy_loop()
+    with stack.StackCollector():
+        numpy_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(),
-                thread_name="MainThread",
-                locations=[loc("matmul"), loc("numpy_loop", FILE_NAME)],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_id=_thread.get_ident(),
+            thread_name="MainThread",
+            locations=[loc("matmul"), loc("numpy_loop", FILE_NAME)],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -418,7 +408,6 @@ def test_native_frames_detection_numpy_nested() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -428,35 +417,34 @@ def test_native_frames_detection_numpy_nested() -> None:
     test_name = "test_native_frames_detection_hashlib"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def numpy_loop() -> None:
-            test_start = time.monotonic()
-            while time.monotonic() - test_start < 2:
-                np.matmul(np.random.rand(1000, 1000), np.random.rand(1000, 1000))
+    def numpy_loop() -> None:
+        test_start = time.monotonic()
+        while time.monotonic() - test_start < 2:
+            np.matmul(np.random.rand(1000, 1000), np.random.rand(1000, 1000))
 
-        with stack.StackCollector():
-            numpy_loop()
+    with stack.StackCollector():
+        numpy_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(),
-                thread_name="MainThread",
-                locations=[loc("matmul"), loc("numpy_loop", FILE_NAME)],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_id=_thread.get_ident(),
+            thread_name="MainThread",
+            locations=[loc("matmul"), loc("numpy_loop", FILE_NAME)],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -470,7 +458,6 @@ def test_native_frames_detection_zlib() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -480,36 +467,35 @@ def test_native_frames_detection_zlib() -> None:
     test_name = "test_native_frames_detection_zlib"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def zlib_loop() -> None:
-            data = b"x" * 100000
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                zlib.compress(data)
+    def zlib_loop() -> None:
+        data = b"x" * 100000
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            zlib.compress(data)
 
-        with stack.StackCollector():
-            zlib_loop()
+    with stack.StackCollector():
+        zlib_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(),
-                thread_name="MainThread",
-                locations=[loc("compress"), loc("zlib_loop", FILE_NAME)],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_id=_thread.get_ident(),
+            thread_name="MainThread",
+            locations=[loc("compress"), loc("zlib_loop", FILE_NAME)],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -522,7 +508,6 @@ def test_native_frames_detection_sorted_builtin() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -532,36 +517,35 @@ def test_native_frames_detection_sorted_builtin() -> None:
     test_name = "test_native_frames_detection_sorted_builtin"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def sorted_loop() -> None:
-            data = list(range(10000, 0, -1))
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                sorted(data)
+    def sorted_loop() -> None:
+        data = list(range(10000, 0, -1))
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            sorted(data)
 
-        with stack.StackCollector():
-            sorted_loop()
+    with stack.StackCollector():
+        sorted_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(),
-                thread_name="MainThread",
-                locations=[loc("sorted"), loc("sorted_loop", FILE_NAME)],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_id=_thread.get_ident(),
+            thread_name="MainThread",
+            locations=[loc("sorted"), loc("sorted_loop", FILE_NAME)],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -574,7 +558,6 @@ def test_native_frames_detection_list_sort_method() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -584,37 +567,36 @@ def test_native_frames_detection_list_sort_method() -> None:
     test_name = "test_native_frames_detection_list_sort"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def sort_loop() -> None:
-            original = list(range(10000, 0, -1))
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                data = original.copy()
-                data.sort()
+    def sort_loop() -> None:
+        original = list(range(10000, 0, -1))
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            data = original.copy()
+            data.sort()
 
-        with stack.StackCollector():
-            sort_loop()
+    with stack.StackCollector():
+        sort_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(),
-                thread_name="MainThread",
-                locations=[loc("sort"), loc("sort_loop", FILE_NAME)],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_id=_thread.get_ident(),
+            thread_name="MainThread",
+            locations=[loc("sort"), loc("sort_loop", FILE_NAME)],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -628,7 +610,6 @@ def test_native_frames_detection_regex_method() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -638,37 +619,36 @@ def test_native_frames_detection_regex_method() -> None:
     test_name = "test_native_frames_detection_regex"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def regex_loop() -> None:
-            pattern = re.compile(r"[a-z]+")
-            text = "hello world foo bar baz " * 10000
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                pattern.findall(text)
+    def regex_loop() -> None:
+        pattern = re.compile(r"[a-z]+")
+        text = "hello world foo bar baz " * 10000
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            pattern.findall(text)
 
-        with stack.StackCollector():
-            regex_loop()
+    with stack.StackCollector():
+        regex_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(),
-                thread_name="MainThread",
-                locations=[loc("findall"), loc("regex_loop", FILE_NAME)],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_id=_thread.get_ident(),
+            thread_name="MainThread",
+            locations=[loc("findall"), loc("regex_loop", FILE_NAME)],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -682,7 +662,6 @@ def test_native_frames_detection_expression_arg() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -692,37 +671,36 @@ def test_native_frames_detection_expression_arg() -> None:
     test_name = "test_native_frames_detection_expression_arg"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def compress_concat_loop() -> None:
-            chunk_a = b"x" * 50000
-            chunk_b = b"y" * 50000
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                zlib.compress(chunk_a + chunk_b)
+    def compress_concat_loop() -> None:
+        chunk_a = b"x" * 50000
+        chunk_b = b"y" * 50000
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            zlib.compress(chunk_a + chunk_b)
 
-        with stack.StackCollector():
-            compress_concat_loop()
+    with stack.StackCollector():
+        compress_concat_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(),
-                thread_name="MainThread",
-                locations=[loc("compress"), loc("compress_concat_loop", FILE_NAME)],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_id=_thread.get_ident(),
+            thread_name="MainThread",
+            locations=[loc("compress"), loc("compress_concat_loop", FILE_NAME)],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -738,7 +716,6 @@ def test_native_frames_detection_nested_c_calls() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -748,40 +725,39 @@ def test_native_frames_detection_nested_c_calls() -> None:
     test_name = "test_native_frames_detection_nested_c_calls"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def nested_loop() -> None:
-            data = os.urandom(100000)
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                hashlib.sha256(zlib.compress(data))
+    def nested_loop() -> None:
+        data = os.urandom(100000)
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            hashlib.sha256(zlib.compress(data))
 
-        with stack.StackCollector():
-            nested_loop()
+    with stack.StackCollector():
+        nested_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        expected_stacks = [
-            [loc("sha256"), loc("nested_loop", FILE_NAME)],
-            [loc("compress"), loc("nested_loop", FILE_NAME)],
-        ]
+    expected_stacks = [
+        [loc("sha256"), loc("nested_loop", FILE_NAME)],
+        [loc("compress"), loc("nested_loop", FILE_NAME)],
+    ]
 
-        for exp_stack in expected_stacks:
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples=samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
-                ),
-                print_samples_on_failure=True,
-            )
+    for exp_stack in expected_stacks:
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -794,7 +770,6 @@ def test_native_frames_detection_call_kw() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -804,36 +779,35 @@ def test_native_frames_detection_call_kw() -> None:
     test_name = "test_native_frames_detection_call_kw"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def sorted_kw_loop() -> None:
-            data = list(range(10000, 0, -1))
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                sorted(data, reverse=True)
+    def sorted_kw_loop() -> None:
+        data = list(range(10000, 0, -1))
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            sorted(data, reverse=True)
 
-        with stack.StackCollector():
-            sorted_kw_loop()
+    with stack.StackCollector():
+        sorted_kw_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(),
-                thread_name="MainThread",
-                locations=[loc("sorted"), loc("sorted_kw_loop", FILE_NAME)],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_id=_thread.get_ident(),
+            thread_name="MainThread",
+            locations=[loc("sorted"), loc("sorted_kw_loop", FILE_NAME)],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -847,7 +821,6 @@ def test_native_frames_detection_many_args() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -857,35 +830,34 @@ def test_native_frames_detection_many_args() -> None:
     test_name = "test_native_frames_detection_many_args"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def pbkdf2_loop() -> None:
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                hashlib.pbkdf2_hmac("sha256", b"password", b"salt", 50000)
+    def pbkdf2_loop() -> None:
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            hashlib.pbkdf2_hmac("sha256", b"password", b"salt", 50000)
 
-        with stack.StackCollector():
-            pbkdf2_loop()
+    with stack.StackCollector():
+        pbkdf2_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(),
-                thread_name="MainThread",
-                locations=[loc("pbkdf2_hmac"), loc("pbkdf2_loop", FILE_NAME)],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_id=_thread.get_ident(),
+            thread_name="MainThread",
+            locations=[loc("pbkdf2_hmac"), loc("pbkdf2_loop", FILE_NAME)],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -899,7 +871,6 @@ def test_native_frames_detection_method_two_args() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -909,37 +880,36 @@ def test_native_frames_detection_method_two_args() -> None:
     test_name = "test_native_frames_detection_method_two_args"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def regex_sub_loop() -> None:
-            pattern = re.compile(r"[a-z]+")
-            text = "hello world foo bar baz " * 10000
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                pattern.sub("X", text)
+    def regex_sub_loop() -> None:
+        pattern = re.compile(r"[a-z]+")
+        text = "hello world foo bar baz " * 10000
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            pattern.sub("X", text)
 
-        with stack.StackCollector():
-            regex_sub_loop()
+    with stack.StackCollector():
+        regex_sub_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(),
-                thread_name="MainThread",
-                locations=[loc("sub"), loc("regex_sub_loop", FILE_NAME)],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_id=_thread.get_ident(),
+            thread_name="MainThread",
+            locations=[loc("sub"), loc("regex_sub_loop", FILE_NAME)],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -952,7 +922,6 @@ def test_native_frames_detection_method_on_literal() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -962,36 +931,35 @@ def test_native_frames_detection_method_on_literal() -> None:
     test_name = "test_native_frames_detection_method_on_literal"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def join_loop() -> None:
-            chunks = [b"x" * 1000] * 1000
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                b"".join(chunks)
+    def join_loop() -> None:
+        chunks = [b"x" * 1000] * 1000
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            b"".join(chunks)
 
-        with stack.StackCollector():
-            join_loop()
+    with stack.StackCollector():
+        join_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(),
-                thread_name="MainThread",
-                locations=[loc("join"), loc("join_loop", FILE_NAME)],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_id=_thread.get_ident(),
+            thread_name="MainThread",
+            locations=[loc("join"), loc("join_loop", FILE_NAME)],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -1007,7 +975,6 @@ def test_native_frames_detection_sequential_calls() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -1017,41 +984,40 @@ def test_native_frames_detection_sequential_calls() -> None:
     test_name = "test_native_frames_detection_sequential_calls"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def sequential_loop() -> None:
-            data = os.urandom(100000)
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                zlib.compress(data)
-                hashlib.sha256(data)
+    def sequential_loop() -> None:
+        data = os.urandom(100000)
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            zlib.compress(data)
+            hashlib.sha256(data)
 
-        with stack.StackCollector():
-            sequential_loop()
+    with stack.StackCollector():
+        sequential_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        expected_stacks = [
-            [loc("compress"), loc("sequential_loop", FILE_NAME)],
-            [loc("sha256"), loc("sequential_loop", FILE_NAME)],
-        ]
+    expected_stacks = [
+        [loc("compress"), loc("sequential_loop", FILE_NAME)],
+        [loc("sha256"), loc("sequential_loop", FILE_NAME)],
+    ]
 
-        for exp_stack in expected_stacks:
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples=samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
-                ),
-                print_samples_on_failure=True,
-            )
+    for exp_stack in expected_stacks:
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -1065,7 +1031,6 @@ def test_native_frames_detection_math_factorial() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -1075,35 +1040,34 @@ def test_native_frames_detection_math_factorial() -> None:
     test_name = "test_native_frames_detection_math_factorial"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def factorial_loop() -> None:
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                math.factorial(10000)
+    def factorial_loop() -> None:
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            math.factorial(10000)
 
-        with stack.StackCollector():
-            factorial_loop()
+    with stack.StackCollector():
+        factorial_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(),
-                thread_name="MainThread",
-                locations=[loc("factorial"), loc("factorial_loop", FILE_NAME)],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_id=_thread.get_ident(),
+            thread_name="MainThread",
+            locations=[loc("factorial"), loc("factorial_loop", FILE_NAME)],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -1116,7 +1080,6 @@ def test_native_frames_detection_isinstance() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -1126,38 +1089,37 @@ def test_native_frames_detection_isinstance() -> None:
     test_name = "test_native_frames_detection_isinstance"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def isinstance_loop() -> None:
-            classes = (int, float, str, bytes, list, dict, tuple, set, frozenset, bool)
-            obj = "hello"
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                for _ in range(10000):
-                    isinstance(obj, classes)
+    def isinstance_loop() -> None:
+        classes = (int, float, str, bytes, list, dict, tuple, set, frozenset, bool)
+        obj = "hello"
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            for _ in range(10000):
+                isinstance(obj, classes)
 
-        with stack.StackCollector():
-            isinstance_loop()
+    with stack.StackCollector():
+        isinstance_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(),
-                thread_name="MainThread",
-                locations=[loc("isinstance"), loc("isinstance_loop", FILE_NAME)],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_id=_thread.get_ident(),
+            thread_name="MainThread",
+            locations=[loc("isinstance"), loc("isinstance_loop", FILE_NAME)],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -1170,7 +1132,6 @@ def test_native_frames_detection_constructors() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -1180,54 +1141,53 @@ def test_native_frames_detection_constructors() -> None:
     test_name = "test_native_frames_detection_constructors"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        source = [(i, i) for i in range(10000)]
+    source = [(i, i) for i in range(10000)]
 
-        def dict_loop() -> None:
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                dict(source)
+    def dict_loop() -> None:
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            dict(source)
 
-        def list_loop() -> None:
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                list(source)
+    def list_loop() -> None:
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            list(source)
 
-        def set_loop() -> None:
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                set(source)
+    def set_loop() -> None:
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            set(source)
 
-        with stack.StackCollector():
-            dict_loop()
-            list_loop()
-            set_loop()
+    with stack.StackCollector():
+        dict_loop()
+        list_loop()
+        set_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        expected_stacks = [
-            [loc("dict"), loc("dict_loop", FILE_NAME)],
-            [loc("list"), loc("list_loop", FILE_NAME)],
-            [loc("set"), loc("set_loop", FILE_NAME)],
-        ]
+    expected_stacks = [
+        [loc("dict"), loc("dict_loop", FILE_NAME)],
+        [loc("list"), loc("list_loop", FILE_NAME)],
+        [loc("set"), loc("set_loop", FILE_NAME)],
+    ]
 
-        for exp_stack in expected_stacks:
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples=samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
-                ),
-                print_samples_on_failure=True,
-            )
+    for exp_stack in expected_stacks:
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -1240,7 +1200,6 @@ def test_native_frames_detection_eval() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -1250,37 +1209,36 @@ def test_native_frames_detection_eval() -> None:
     test_name = "test_native_frames_detection_eval"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        code = compile("sum(range(10000))", "<string>", "eval")
+    code = compile("sum(range(10000))", "<string>", "eval")
 
-        def eval_loop() -> None:
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                eval(code)
+    def eval_loop() -> None:
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            eval(code)
 
-        with stack.StackCollector():
-            eval_loop()
+    with stack.StackCollector():
+        eval_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(),
-                thread_name="MainThread",
-                locations=[loc("eval"), loc("eval_loop", FILE_NAME)],
-            ),
-            print_samples_on_failure=True,
-        )
+    pprof_utils.assert_profile_has_sample(
+        profile,
+        samples=samples,
+        expected_sample=pprof_utils.StackEvent(
+            thread_id=_thread.get_ident(),
+            thread_name="MainThread",
+            locations=[loc("eval"), loc("eval_loop", FILE_NAME)],
+        ),
+        print_samples_on_failure=True,
+    )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -1293,7 +1251,6 @@ def test_native_frames_detection_str_repr() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -1303,47 +1260,46 @@ def test_native_frames_detection_str_repr() -> None:
     test_name = "test_native_frames_detection_str_repr"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        big_list = list(range(100000))
+    big_list = list(range(100000))
 
-        def str_loop() -> None:
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                str(big_list)
+    def str_loop() -> None:
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            str(big_list)
 
-        def repr_loop() -> None:
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                repr(big_list)
+    def repr_loop() -> None:
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            repr(big_list)
 
-        with stack.StackCollector():
-            str_loop()
-            repr_loop()
+    with stack.StackCollector():
+        str_loop()
+        repr_loop()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        expected_stacks = [
-            [loc("str"), loc("str_loop", FILE_NAME)],
-            [loc("repr"), loc("repr_loop", FILE_NAME)],
-        ]
+    expected_stacks = [
+        [loc("str"), loc("str_loop", FILE_NAME)],
+        [loc("repr"), loc("repr_loop", FILE_NAME)],
+    ]
 
-        for exp_stack in expected_stacks:
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples=samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
-                ),
-                print_samples_on_failure=True,
-            )
+    for exp_stack in expected_stacks:
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -1357,7 +1313,6 @@ def test_top_c_frame_detection_nested_sort_with_key() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
@@ -1367,56 +1322,55 @@ def test_top_c_frame_detection_nested_sort_with_key() -> None:
     test_name = "test_top_c_frame_detection_nested_sort_with_key"
 
     assert ddup.is_available
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()
 
-        def inner_key(x: int) -> int:
-            return math.factorial(x + 2000)
+    def inner_key(x: int) -> int:
+        return math.factorial(x + 2000)
 
-        def outer_key(x: int) -> int:
-            inner_data = list(range(x + 1))
-            inner_data.sort(key=inner_key)
-            return inner_data[-1] if inner_data else 0
+    def outer_key(x: int) -> int:
+        inner_data = list(range(x + 1))
+        inner_data.sort(key=inner_key)
+        return inner_data[-1] if inner_data else 0
 
-        def outer_func() -> None:
-            end = time.monotonic() + 2
-            while time.monotonic() < end:
-                data = list(range(15, 0, -1))
-                data.sort(key=outer_key)
+    def outer_func() -> None:
+        end = time.monotonic() + 2
+        while time.monotonic() < end:
+            data = list(range(15, 0, -1))
+            data.sort(key=outer_key)
 
-        with stack.StackCollector():
-            outer_func()
+    with stack.StackCollector():
+        outer_func()
 
-        ddup.upload()
+    ddup.upload()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+    profile = pprof_utils.get_profile_from_agent()
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
 
-        expected_stacks = [
-            # outer sort called from outer_func
-            [loc("sort"), loc("outer_func", FILE_NAME)],
-            # inner sort called from outer_key, which is the key for the outer sort
-            [loc("sort"), loc("outer_key", FILE_NAME), loc("sort"), loc("outer_func", FILE_NAME)],
-            # factorial called from inner_key, which is the key for the inner sort
-            [
-                loc("factorial"),
-                loc("inner_key", FILE_NAME),
-                loc("sort"),
-                loc("outer_key", FILE_NAME),
-                loc("sort"),
-                loc("outer_func", FILE_NAME),
-            ],
-        ]
+    expected_stacks = [
+        # outer sort called from outer_func
+        [loc("sort"), loc("outer_func", FILE_NAME)],
+        # inner sort called from outer_key, which is the key for the outer sort
+        [loc("sort"), loc("outer_key", FILE_NAME), loc("sort"), loc("outer_func", FILE_NAME)],
+        # factorial called from inner_key, which is the key for the inner sort
+        [
+            loc("factorial"),
+            loc("inner_key", FILE_NAME),
+            loc("sort"),
+            loc("outer_key", FILE_NAME),
+            loc("sort"),
+            loc("outer_func", FILE_NAME),
+        ],
+    ]
 
-        for exp_stack in expected_stacks:
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples=samples,
-                expected_sample=pprof_utils.StackEvent(
-                    thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
-                ),
-                print_samples_on_failure=True,
-            )
+    for exp_stack in expected_stacks:
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
+            ),
+            print_samples_on_failure=True,
+        )

--- a/tests/profiling/collector/test_stack_native.py
+++ b/tests/profiling/collector/test_stack_native.py
@@ -1,15 +1,7 @@
-import _thread
-import os
-from pathlib import Path
 import sys
-import time
 from unittest import mock
 
 import pytest
-
-from ddtrace.internal.datadog.profiling import ddup
-from ddtrace.profiling.collector import stack
-from tests.profiling.collector import pprof_utils
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -91,27 +83,35 @@ def test_native_call_registry_is_bounded_for_dynamic_code() -> None:
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
-def test_native_frames_detection(tmp_path: Path) -> None:
+@pytest.mark.subprocess(err=None)
+def test_native_frames_detection() -> None:
     """Test that the top-most native C frame is tracked and appears as the leaf frame in the profile."""
+    import _thread
+    import time
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
+
     test_name = "test_native_frames_detection"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def sleep_loop() -> None:
-        for _ in range(10):
-            time.sleep(0.1)
+        def sleep_loop() -> None:
+            for _ in range(10):
+                time.sleep(0.1)
 
-    with stack.StackCollector():
-        sleep_loop()
+        with stack.StackCollector():
+            sleep_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
     samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
     assert len(samples) > 0
 
@@ -153,69 +153,71 @@ def test_native_frames_preserved_after_fork() -> None:
     """
     import _thread
     import os
-    import pathlib
-    import tempfile
     import time
     import zlib
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name, filename="", line_no=-1):
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_preserved_after_fork"
-    pprof_prefix = str(tmp_path / test_name)
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
-
-    def compress_loop() -> None:
-        data = b"x" * 100000
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            zlib.compress(data)
-
-    # Start the profiler and warm up call sites. sys.monitoring returns DISABLE
-    # after the first fire, so the callback won't trigger again for these sites.
-    # Fork while the profiler is still running (like gunicorn workers).
-    collector = stack.StackCollector()
-    collector.start()
-    compress_loop()
-
-    # Fork while profiler is running. The sampler restarts via the atfork
-    # handler, and the NativeCallRegistry data is preserved.
-    pid = os.fork()
-    if pid == 0:
-        # ----- child process -----
-        # Reconfigure ddup to write to a child-specific file so we can
-        # read the child's profile independently.
-        child_pprof_prefix = str(tmp_path / (test_name + "_child"))
-        child_output = child_pprof_prefix + "." + str(os.getpid())
-
-        ddup.config(env="test", service=test_name, version="my_version", output_filename=child_pprof_prefix)
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
         ddup.start()
         ddup.upload()
 
-        # The sampler restarted automatically via atfork. Run the same C
-        # calls — the registry should still have the call site entries from
-        # the parent, so native frames should appear.
+        def compress_loop() -> None:
+            data = b"x" * 100000
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                zlib.compress(data)
+
+        # Start the profiler and warm up call sites. sys.monitoring returns DISABLE
+        # after the first fire, so the callback won't trigger again for these sites.
+        # Fork while the profiler is still running (like gunicorn workers).
+        collector = stack.StackCollector()
+        collector.start()
         compress_loop()
 
-        collector.stop()
-        ddup.upload()
+        # Fork while profiler is running. The sampler restarts via the atfork
+        # handler, and the NativeCallRegistry data is preserved.
+        pid = os.fork()
+        if pid == 0:
+            # ----- child process -----
+            # The child inherits _DD_PROFILING_TEST_AGENT_URL and uploads to the
+            # same capture server as the parent.
+            ddup.config(env="test", service=test_name, version="my_version")
+            ddup.start()
+            ddup.upload()
 
-        profile = pprof_utils.parse_newest_profile(child_output)
-        samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
-        assert len(samples) > 0
+            # The sampler restarted automatically via atfork. Run the same C
+            # calls — the registry should still have the call site entries from
+            # the parent, so native frames should appear.
+            compress_loop()
 
-        try:
+            collector.stop()
+            ddup.upload()
+
+            os._exit(0)
+        else:
+            # ----- parent process -----
+            collector.stop()
+            _, status = os.waitpid(pid, 0)
+            exit_code = os.waitstatus_to_exitcode(status)
+            assert exit_code == 0, "Child process failed: native frames were not preserved after fork"
+
+            profile = pprof_utils.get_profile_from_agent(agent_client)
+            samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
+            assert len(samples) > 0
+
             pprof_utils.assert_profile_has_sample(
                 profile,
                 samples=samples,
@@ -226,15 +228,6 @@ def test_native_frames_preserved_after_fork() -> None:
                 ),
                 print_samples_on_failure=True,
             )
-        except AssertionError:
-            os._exit(1)
-        os._exit(0)
-    else:
-        # ----- parent process -----
-        collector.stop()
-        _, status = os.waitpid(pid, 0)
-        exit_code = os.waitstatus_to_exitcode(status)
-        assert exit_code == 0, "Child process failed: native frames were not preserved after fork"
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -243,60 +236,56 @@ def test_native_frames_detection_hashlib() -> None:
     """Test that hashlib.sha256 appears as the top-most native C frame in the profile."""
     import _thread
     import hashlib
-    import os
-    import pathlib
-    import tempfile
     import time
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name, filename="", line_no=-1):
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_hashlib"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def sha256_loop() -> None:
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            hashlib.sha256(b"Hello, world!")
+        def sha256_loop() -> None:
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                hashlib.sha256(b"Hello, world!")
 
-    with stack.StackCollector():
-        sha256_loop()
+        with stack.StackCollector():
+            sha256_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    expected_stacks = [
-        [loc("sha256"), loc("sha256_loop", FILE_NAME)],
-        [loc("monotonic"), loc("sha256_loop", FILE_NAME)],
-    ]
+        expected_stacks = [
+            [loc("sha256"), loc("sha256_loop", FILE_NAME)],
+            [loc("monotonic"), loc("sha256_loop", FILE_NAME)],
+        ]
 
-    for exp_stack in expected_stacks:
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(),
-                thread_name="MainThread",
-                locations=exp_stack,
-            ),
-            print_samples_on_failure=True,
-        )
+        for exp_stack in expected_stacks:
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples=samples,
+                expected_sample=pprof_utils.StackEvent(
+                    thread_id=_thread.get_ident(),
+                    thread_name="MainThread",
+                    locations=exp_stack,
+                ),
+                print_samples_on_failure=True,
+            )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -305,58 +294,54 @@ def test_native_frames_detection_hashlib_kwarg() -> None:
     """Test that hashlib.sha256 appears as the top-most native C frame in the profile."""
     import _thread
     import hashlib
-    import os
-    import pathlib
-    import tempfile
     import time
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name, filename="", line_no=-1):
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_hashlib"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def sha256_loop() -> None:
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            hashlib.sha256(b"Hello, world!")
+        def sha256_loop() -> None:
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                hashlib.sha256(b"Hello, world!")
 
-    with stack.StackCollector():
-        sha256_loop()
+        with stack.StackCollector():
+            sha256_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    expected_stacks = [
-        [loc("sha256"), loc("sha256_loop", FILE_NAME)],
-        [loc("monotonic"), loc("sha256_loop", FILE_NAME)],
-    ]
+        expected_stacks = [
+            [loc("sha256"), loc("sha256_loop", FILE_NAME)],
+            [loc("monotonic"), loc("sha256_loop", FILE_NAME)],
+        ]
 
-    for exp_stack in expected_stacks:
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
-            ),
-            print_samples_on_failure=True,
-        )
+        for exp_stack in expected_stacks:
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples=samples,
+                expected_sample=pprof_utils.StackEvent(
+                    thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
+                ),
+                print_samples_on_failure=True,
+            )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -368,9 +353,6 @@ def test_native_frames_detection_hashlib_kwarg() -> None:
 def test_native_frames_detection_numpy_flat() -> None:
     """Test that hashlib.sha256 appears as the top-most native C frame in the profile."""
     import _thread
-    import os
-    import pathlib
-    import tempfile
     import time
 
     import numpy as np
@@ -378,49 +360,46 @@ def test_native_frames_detection_numpy_flat() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name, filename="", line_no=-1):
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_hashlib"
-    pprof_prefix = str(tmp_path / test_name)
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def numpy_loop() -> None:
-        test_start = time.monotonic()
-        while time.monotonic() - test_start < 2:
-            mat = np.random.rand(1000, 1000)
-            np.matmul(mat, mat)
+        def numpy_loop() -> None:
+            test_start = time.monotonic()
+            while time.monotonic() - test_start < 2:
+                mat = np.random.rand(1000, 1000)
+                np.matmul(mat, mat)
 
-    with stack.StackCollector():
-        numpy_loop()
+        with stack.StackCollector():
+            numpy_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    all_files_for_pid = sorted([x for x in os.listdir(tmp_path) if ".pprof" in x])
-    parent_files = [str(tmp_path / f) for f in all_files_for_pid if f".{str(os.getpid())}." in f]
-    profiles = [pprof_utils.parse_profile(f) for f in parent_files]
-    profile = pprof_utils.merge_profiles(profiles)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_id=_thread.get_ident(),
-            thread_name="MainThread",
-            locations=[loc("matmul"), loc("numpy_loop", FILE_NAME)],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(),
+                thread_name="MainThread",
+                locations=[loc("matmul"), loc("numpy_loop", FILE_NAME)],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -432,9 +411,6 @@ def test_native_frames_detection_numpy_flat() -> None:
 def test_native_frames_detection_numpy_nested() -> None:
     """Test that numpy.matmul appears as the top-most native C frame in the profile."""
     import _thread
-    import os
-    import pathlib
-    import tempfile
     import time
 
     import numpy as np
@@ -442,48 +418,45 @@ def test_native_frames_detection_numpy_nested() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name, filename="", line_no=-1):
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_hashlib"
-    pprof_prefix = str(tmp_path / test_name)
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def numpy_loop() -> None:
-        test_start = time.monotonic()
-        while time.monotonic() - test_start < 2:
-            np.matmul(np.random.rand(1000, 1000), np.random.rand(1000, 1000))
+        def numpy_loop() -> None:
+            test_start = time.monotonic()
+            while time.monotonic() - test_start < 2:
+                np.matmul(np.random.rand(1000, 1000), np.random.rand(1000, 1000))
 
-    with stack.StackCollector():
-        numpy_loop()
+        with stack.StackCollector():
+            numpy_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    all_files_for_pid = sorted([x for x in os.listdir(tmp_path) if ".pprof" in x])
-    parent_files = [str(tmp_path / f) for f in all_files_for_pid if f".{str(os.getpid())}." in f]
-    profiles = [pprof_utils.parse_profile(f) for f in parent_files]
-    profile = pprof_utils.merge_profiles(profiles)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_id=_thread.get_ident(),
-            thread_name="MainThread",
-            locations=[loc("matmul"), loc("numpy_loop", FILE_NAME)],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(),
+                thread_name="MainThread",
+                locations=[loc("matmul"), loc("numpy_loop", FILE_NAME)],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -491,56 +464,52 @@ def test_native_frames_detection_numpy_nested() -> None:
 def test_native_frames_detection_zlib() -> None:
     """Test module-level C function: zlib.compress."""
     import _thread
-    import os
-    import pathlib
-    import tempfile
     import time
     import zlib
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name, filename="", line_no=-1):
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_zlib"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def zlib_loop() -> None:
-        data = b"x" * 100000
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            zlib.compress(data)
+        def zlib_loop() -> None:
+            data = b"x" * 100000
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                zlib.compress(data)
 
-    with stack.StackCollector():
-        zlib_loop()
+        with stack.StackCollector():
+            zlib_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_id=_thread.get_ident(),
-            thread_name="MainThread",
-            locations=[loc("compress"), loc("zlib_loop", FILE_NAME)],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(),
+                thread_name="MainThread",
+                locations=[loc("compress"), loc("zlib_loop", FILE_NAME)],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -548,55 +517,51 @@ def test_native_frames_detection_zlib() -> None:
 def test_native_frames_detection_sorted_builtin() -> None:
     """Test builtin function: sorted()."""
     import _thread
-    import os
-    import pathlib
-    import tempfile
     import time
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name, filename="", line_no=-1):
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_sorted_builtin"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def sorted_loop() -> None:
-        data = list(range(10000, 0, -1))
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            sorted(data)
+        def sorted_loop() -> None:
+            data = list(range(10000, 0, -1))
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                sorted(data)
 
-    with stack.StackCollector():
-        sorted_loop()
+        with stack.StackCollector():
+            sorted_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_id=_thread.get_ident(),
-            thread_name="MainThread",
-            locations=[loc("sorted"), loc("sorted_loop", FILE_NAME)],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(),
+                thread_name="MainThread",
+                locations=[loc("sorted"), loc("sorted_loop", FILE_NAME)],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -604,56 +569,52 @@ def test_native_frames_detection_sorted_builtin() -> None:
 def test_native_frames_detection_list_sort_method() -> None:
     """Test method call: list.sort()."""
     import _thread
-    import os
-    import pathlib
-    import tempfile
     import time
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name, filename="", line_no=-1):
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_list_sort"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def sort_loop() -> None:
-        original = list(range(10000, 0, -1))
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            data = original.copy()
-            data.sort()
+        def sort_loop() -> None:
+            original = list(range(10000, 0, -1))
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                data = original.copy()
+                data.sort()
 
-    with stack.StackCollector():
-        sort_loop()
+        with stack.StackCollector():
+            sort_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_id=_thread.get_ident(),
-            thread_name="MainThread",
-            locations=[loc("sort"), loc("sort_loop", FILE_NAME)],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(),
+                thread_name="MainThread",
+                locations=[loc("sort"), loc("sort_loop", FILE_NAME)],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -661,57 +622,53 @@ def test_native_frames_detection_list_sort_method() -> None:
 def test_native_frames_detection_regex_method() -> None:
     """Test method call on C object: Pattern.findall()."""
     import _thread
-    import os
-    import pathlib
     import re
-    import tempfile
     import time
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name, filename="", line_no=-1):
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_regex"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def regex_loop() -> None:
-        pattern = re.compile(r"[a-z]+")
-        text = "hello world foo bar baz " * 10000
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            pattern.findall(text)
+        def regex_loop() -> None:
+            pattern = re.compile(r"[a-z]+")
+            text = "hello world foo bar baz " * 10000
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                pattern.findall(text)
 
-    with stack.StackCollector():
-        regex_loop()
+        with stack.StackCollector():
+            regex_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_id=_thread.get_ident(),
-            thread_name="MainThread",
-            locations=[loc("findall"), loc("regex_loop", FILE_NAME)],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(),
+                thread_name="MainThread",
+                locations=[loc("findall"), loc("regex_loop", FILE_NAME)],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -719,57 +676,53 @@ def test_native_frames_detection_regex_method() -> None:
 def test_native_frames_detection_expression_arg() -> None:
     """Test C call with expression as argument: zlib.compress(chunk_a + chunk_b)."""
     import _thread
-    import os
-    import pathlib
-    import tempfile
     import time
     import zlib
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name, filename="", line_no=-1):
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_expression_arg"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def compress_concat_loop() -> None:
-        chunk_a = b"x" * 50000
-        chunk_b = b"y" * 50000
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            zlib.compress(chunk_a + chunk_b)
+        def compress_concat_loop() -> None:
+            chunk_a = b"x" * 50000
+            chunk_b = b"y" * 50000
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                zlib.compress(chunk_a + chunk_b)
 
-    with stack.StackCollector():
-        compress_concat_loop()
+        with stack.StackCollector():
+            compress_concat_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_id=_thread.get_ident(),
-            thread_name="MainThread",
-            locations=[loc("compress"), loc("compress_concat_loop", FILE_NAME)],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(),
+                thread_name="MainThread",
+                locations=[loc("compress"), loc("compress_concat_loop", FILE_NAME)],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -779,59 +732,56 @@ def test_native_frames_detection_nested_c_calls() -> None:
     import _thread
     import hashlib
     import os
-    import pathlib
-    import tempfile
     import time
     import zlib
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name, filename="", line_no=-1):
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_nested_c_calls"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def nested_loop() -> None:
-        data = os.urandom(100000)
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            hashlib.sha256(zlib.compress(data))
+        def nested_loop() -> None:
+            data = os.urandom(100000)
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                hashlib.sha256(zlib.compress(data))
 
-    with stack.StackCollector():
-        nested_loop()
+        with stack.StackCollector():
+            nested_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    expected_stacks = [
-        [loc("sha256"), loc("nested_loop", FILE_NAME)],
-        [loc("compress"), loc("nested_loop", FILE_NAME)],
-    ]
+        expected_stacks = [
+            [loc("sha256"), loc("nested_loop", FILE_NAME)],
+            [loc("compress"), loc("nested_loop", FILE_NAME)],
+        ]
 
-    for exp_stack in expected_stacks:
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
-            ),
-            print_samples_on_failure=True,
-        )
+        for exp_stack in expected_stacks:
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples=samples,
+                expected_sample=pprof_utils.StackEvent(
+                    thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
+                ),
+                print_samples_on_failure=True,
+            )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -839,55 +789,51 @@ def test_native_frames_detection_nested_c_calls() -> None:
 def test_native_frames_detection_call_kw() -> None:
     """Test builtin with keyword argument: sorted(data, reverse=True)."""
     import _thread
-    import os
-    import pathlib
-    import tempfile
     import time
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name, filename="", line_no=-1):
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_call_kw"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def sorted_kw_loop() -> None:
-        data = list(range(10000, 0, -1))
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            sorted(data, reverse=True)
+        def sorted_kw_loop() -> None:
+            data = list(range(10000, 0, -1))
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                sorted(data, reverse=True)
 
-    with stack.StackCollector():
-        sorted_kw_loop()
+        with stack.StackCollector():
+            sorted_kw_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_id=_thread.get_ident(),
-            thread_name="MainThread",
-            locations=[loc("sorted"), loc("sorted_kw_loop", FILE_NAME)],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(),
+                thread_name="MainThread",
+                locations=[loc("sorted"), loc("sorted_kw_loop", FILE_NAME)],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -896,54 +842,50 @@ def test_native_frames_detection_many_args() -> None:
     """Test C function with many positional arguments: hashlib.pbkdf2_hmac(algo, pwd, salt, iters)."""
     import _thread
     import hashlib
-    import os
-    import pathlib
-    import tempfile
     import time
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name, filename="", line_no=-1):
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_many_args"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def pbkdf2_loop() -> None:
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            hashlib.pbkdf2_hmac("sha256", b"password", b"salt", 50000)
+        def pbkdf2_loop() -> None:
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                hashlib.pbkdf2_hmac("sha256", b"password", b"salt", 50000)
 
-    with stack.StackCollector():
-        pbkdf2_loop()
+        with stack.StackCollector():
+            pbkdf2_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_id=_thread.get_ident(),
-            thread_name="MainThread",
-            locations=[loc("pbkdf2_hmac"), loc("pbkdf2_loop", FILE_NAME)],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(),
+                thread_name="MainThread",
+                locations=[loc("pbkdf2_hmac"), loc("pbkdf2_loop", FILE_NAME)],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -951,57 +893,53 @@ def test_native_frames_detection_many_args() -> None:
 def test_native_frames_detection_method_two_args() -> None:
     """Test C method call with 2 arguments: Pattern.sub(repl, text)."""
     import _thread
-    import os
-    import pathlib
     import re
-    import tempfile
     import time
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name, filename="", line_no=-1):
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_method_two_args"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def regex_sub_loop() -> None:
-        pattern = re.compile(r"[a-z]+")
-        text = "hello world foo bar baz " * 10000
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            pattern.sub("X", text)
+        def regex_sub_loop() -> None:
+            pattern = re.compile(r"[a-z]+")
+            text = "hello world foo bar baz " * 10000
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                pattern.sub("X", text)
 
-    with stack.StackCollector():
-        regex_sub_loop()
+        with stack.StackCollector():
+            regex_sub_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_id=_thread.get_ident(),
-            thread_name="MainThread",
-            locations=[loc("sub"), loc("regex_sub_loop", FILE_NAME)],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(),
+                thread_name="MainThread",
+                locations=[loc("sub"), loc("regex_sub_loop", FILE_NAME)],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -1009,55 +947,51 @@ def test_native_frames_detection_method_two_args() -> None:
 def test_native_frames_detection_method_on_literal() -> None:
     """Test method call on a literal: b''.join(chunks)."""
     import _thread
-    import os
-    import pathlib
-    import tempfile
     import time
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name, filename="", line_no=-1):
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_method_on_literal"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def join_loop() -> None:
-        chunks = [b"x" * 1000] * 1000
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            b"".join(chunks)
+        def join_loop() -> None:
+            chunks = [b"x" * 1000] * 1000
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                b"".join(chunks)
 
-    with stack.StackCollector():
-        join_loop()
+        with stack.StackCollector():
+            join_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_id=_thread.get_ident(),
-            thread_name="MainThread",
-            locations=[loc("join"), loc("join_loop", FILE_NAME)],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(),
+                thread_name="MainThread",
+                locations=[loc("join"), loc("join_loop", FILE_NAME)],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -1067,60 +1001,57 @@ def test_native_frames_detection_sequential_calls() -> None:
     import _thread
     import hashlib
     import os
-    import pathlib
-    import tempfile
     import time
     import zlib
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name, filename="", line_no=-1):
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_sequential_calls"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def sequential_loop() -> None:
-        data = os.urandom(100000)
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            zlib.compress(data)
-            hashlib.sha256(data)
+        def sequential_loop() -> None:
+            data = os.urandom(100000)
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                zlib.compress(data)
+                hashlib.sha256(data)
 
-    with stack.StackCollector():
-        sequential_loop()
+        with stack.StackCollector():
+            sequential_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    expected_stacks = [
-        [loc("compress"), loc("sequential_loop", FILE_NAME)],
-        [loc("sha256"), loc("sequential_loop", FILE_NAME)],
-    ]
+        expected_stacks = [
+            [loc("compress"), loc("sequential_loop", FILE_NAME)],
+            [loc("sha256"), loc("sequential_loop", FILE_NAME)],
+        ]
 
-    for exp_stack in expected_stacks:
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
-            ),
-            print_samples_on_failure=True,
-        )
+        for exp_stack in expected_stacks:
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples=samples,
+                expected_sample=pprof_utils.StackEvent(
+                    thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
+                ),
+                print_samples_on_failure=True,
+            )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -1129,54 +1060,50 @@ def test_native_frames_detection_math_factorial() -> None:
     """Test module-level C function: math.factorial."""
     import _thread
     import math
-    import os
-    import pathlib
-    import tempfile
     import time
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name: str, filename: str = "", line_no: int = -1) -> pprof_utils.StackLocation:
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_math_factorial"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def factorial_loop() -> None:
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            math.factorial(10000)
+        def factorial_loop() -> None:
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                math.factorial(10000)
 
-    with stack.StackCollector():
-        factorial_loop()
+        with stack.StackCollector():
+            factorial_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_id=_thread.get_ident(),
-            thread_name="MainThread",
-            locations=[loc("factorial"), loc("factorial_loop", FILE_NAME)],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(),
+                thread_name="MainThread",
+                locations=[loc("factorial"), loc("factorial_loop", FILE_NAME)],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -1184,57 +1111,53 @@ def test_native_frames_detection_math_factorial() -> None:
 def test_native_frames_detection_isinstance() -> None:
     """Test builtin function: isinstance()."""
     import _thread
-    import os
-    import pathlib
-    import tempfile
     import time
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name: str, filename: str = "", line_no: int = -1) -> pprof_utils.StackLocation:
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_isinstance"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def isinstance_loop() -> None:
-        classes = (int, float, str, bytes, list, dict, tuple, set, frozenset, bool)
-        obj = "hello"
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            for _ in range(10000):
-                isinstance(obj, classes)
+        def isinstance_loop() -> None:
+            classes = (int, float, str, bytes, list, dict, tuple, set, frozenset, bool)
+            obj = "hello"
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                for _ in range(10000):
+                    isinstance(obj, classes)
 
-    with stack.StackCollector():
-        isinstance_loop()
+        with stack.StackCollector():
+            isinstance_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_id=_thread.get_ident(),
-            thread_name="MainThread",
-            locations=[loc("isinstance"), loc("isinstance_loop", FILE_NAME)],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(),
+                thread_name="MainThread",
+                locations=[loc("isinstance"), loc("isinstance_loop", FILE_NAME)],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -1242,73 +1165,69 @@ def test_native_frames_detection_isinstance() -> None:
 def test_native_frames_detection_constructors() -> None:
     """Test builtin type constructors: dict(), list(), set()."""
     import _thread
-    import os
-    import pathlib
-    import tempfile
     import time
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name: str, filename: str = "", line_no: int = -1) -> pprof_utils.StackLocation:
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_constructors"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    source = [(i, i) for i in range(10000)]
+        source = [(i, i) for i in range(10000)]
 
-    def dict_loop() -> None:
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            dict(source)
+        def dict_loop() -> None:
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                dict(source)
 
-    def list_loop() -> None:
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            list(source)
+        def list_loop() -> None:
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                list(source)
 
-    def set_loop() -> None:
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            set(source)
+        def set_loop() -> None:
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                set(source)
 
-    with stack.StackCollector():
-        dict_loop()
-        list_loop()
-        set_loop()
+        with stack.StackCollector():
+            dict_loop()
+            list_loop()
+            set_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    expected_stacks = [
-        [loc("dict"), loc("dict_loop", FILE_NAME)],
-        [loc("list"), loc("list_loop", FILE_NAME)],
-        [loc("set"), loc("set_loop", FILE_NAME)],
-    ]
+        expected_stacks = [
+            [loc("dict"), loc("dict_loop", FILE_NAME)],
+            [loc("list"), loc("list_loop", FILE_NAME)],
+            [loc("set"), loc("set_loop", FILE_NAME)],
+        ]
 
-    for exp_stack in expected_stacks:
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
-            ),
-            print_samples_on_failure=True,
-        )
+        for exp_stack in expected_stacks:
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples=samples,
+                expected_sample=pprof_utils.StackEvent(
+                    thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
+                ),
+                print_samples_on_failure=True,
+            )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -1316,56 +1235,52 @@ def test_native_frames_detection_constructors() -> None:
 def test_native_frames_detection_eval() -> None:
     """Test builtin function: eval()."""
     import _thread
-    import os
-    import pathlib
-    import tempfile
     import time
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name: str, filename: str = "", line_no: int = -1) -> pprof_utils.StackLocation:
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_eval"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    code = compile("sum(range(10000))", "<string>", "eval")
+        code = compile("sum(range(10000))", "<string>", "eval")
 
-    def eval_loop() -> None:
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            eval(code)
+        def eval_loop() -> None:
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                eval(code)
 
-    with stack.StackCollector():
-        eval_loop()
+        with stack.StackCollector():
+            eval_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=samples,
-        expected_sample=pprof_utils.StackEvent(
-            thread_id=_thread.get_ident(),
-            thread_name="MainThread",
-            locations=[loc("eval"), loc("eval_loop", FILE_NAME)],
-        ),
-        print_samples_on_failure=True,
-    )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=samples,
+            expected_sample=pprof_utils.StackEvent(
+                thread_id=_thread.get_ident(),
+                thread_name="MainThread",
+                locations=[loc("eval"), loc("eval_loop", FILE_NAME)],
+            ),
+            print_samples_on_failure=True,
+        )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -1373,66 +1288,62 @@ def test_native_frames_detection_eval() -> None:
 def test_native_frames_detection_str_repr() -> None:
     """Test dunder methods: str() and repr() on a large container."""
     import _thread
-    import os
-    import pathlib
-    import tempfile
     import time
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name: str, filename: str = "", line_no: int = -1) -> pprof_utils.StackLocation:
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_native_frames_detection_str_repr"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    big_list = list(range(100000))
+        big_list = list(range(100000))
 
-    def str_loop() -> None:
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            str(big_list)
+        def str_loop() -> None:
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                str(big_list)
 
-    def repr_loop() -> None:
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            repr(big_list)
+        def repr_loop() -> None:
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                repr(big_list)
 
-    with stack.StackCollector():
-        str_loop()
-        repr_loop()
+        with stack.StackCollector():
+            str_loop()
+            repr_loop()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    expected_stacks = [
-        [loc("str"), loc("str_loop", FILE_NAME)],
-        [loc("repr"), loc("repr_loop", FILE_NAME)],
-    ]
+        expected_stacks = [
+            [loc("str"), loc("str_loop", FILE_NAME)],
+            [loc("repr"), loc("repr_loop", FILE_NAME)],
+        ]
 
-    for exp_stack in expected_stacks:
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
-            ),
-            print_samples_on_failure=True,
-        )
+        for exp_stack in expected_stacks:
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples=samples,
+                expected_sample=pprof_utils.StackEvent(
+                    thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
+                ),
+                print_samples_on_failure=True,
+            )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Native C frame tracking requires Python 3.12+")
@@ -1441,75 +1352,71 @@ def test_top_c_frame_detection_nested_sort_with_key() -> None:
     """Test nested native frames: sort(key=py) -> sort(key=py) -> factorial."""
     import _thread
     import math
-    import os
-    import pathlib
-    import tempfile
     import time
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
     FILE_NAME = "test_stack_native.py"
 
     def loc(function_name: str, filename: str = "", line_no: int = -1) -> pprof_utils.StackLocation:
         return pprof_utils.StackLocation(function_name=function_name, filename=filename, line_no=line_no)
 
-    tmp_path = pathlib.Path(tempfile.mkdtemp())
     test_name = "test_top_c_frame_detection_nested_sort_with_key"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
 
     assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-    def inner_key(x: int) -> int:
-        return math.factorial(x + 2000)
+        def inner_key(x: int) -> int:
+            return math.factorial(x + 2000)
 
-    def outer_key(x: int) -> int:
-        inner_data = list(range(x + 1))
-        inner_data.sort(key=inner_key)
-        return inner_data[-1] if inner_data else 0
+        def outer_key(x: int) -> int:
+            inner_data = list(range(x + 1))
+            inner_data.sort(key=inner_key)
+            return inner_data[-1] if inner_data else 0
 
-    def outer_func() -> None:
-        end = time.monotonic() + 2
-        while time.monotonic() < end:
-            data = list(range(15, 0, -1))
-            data.sort(key=outer_key)
+        def outer_func() -> None:
+            end = time.monotonic() + 2
+            while time.monotonic() < end:
+                data = list(range(15, 0, -1))
+                data.sort(key=outer_key)
 
-    with stack.StackCollector():
-        outer_func()
+        with stack.StackCollector():
+            outer_func()
 
-    ddup.upload()
+        ddup.upload()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
+        profile = pprof_utils.get_profile_from_agent(agent_client)
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        assert len(samples) > 0
 
-    expected_stacks = [
-        # outer sort called from outer_func
-        [loc("sort"), loc("outer_func", FILE_NAME)],
-        # inner sort called from outer_key, which is the key for the outer sort
-        [loc("sort"), loc("outer_key", FILE_NAME), loc("sort"), loc("outer_func", FILE_NAME)],
-        # factorial called from inner_key, which is the key for the inner sort
-        [
-            loc("factorial"),
-            loc("inner_key", FILE_NAME),
-            loc("sort"),
-            loc("outer_key", FILE_NAME),
-            loc("sort"),
-            loc("outer_func", FILE_NAME),
-        ],
-    ]
+        expected_stacks = [
+            # outer sort called from outer_func
+            [loc("sort"), loc("outer_func", FILE_NAME)],
+            # inner sort called from outer_key, which is the key for the outer sort
+            [loc("sort"), loc("outer_key", FILE_NAME), loc("sort"), loc("outer_func", FILE_NAME)],
+            # factorial called from inner_key, which is the key for the inner sort
+            [
+                loc("factorial"),
+                loc("inner_key", FILE_NAME),
+                loc("sort"),
+                loc("outer_key", FILE_NAME),
+                loc("sort"),
+                loc("outer_func", FILE_NAME),
+            ],
+        ]
 
-    for exp_stack in expected_stacks:
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            expected_sample=pprof_utils.StackEvent(
-                thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
-            ),
-            print_samples_on_failure=True,
-        )
+        for exp_stack in expected_stacks:
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples=samples,
+                expected_sample=pprof_utils.StackEvent(
+                    thread_id=_thread.get_ident(), thread_name="MainThread", locations=exp_stack
+                ),
+                print_samples_on_failure=True,
+            )

--- a/tests/profiling/collector/test_stack_threadpool.py
+++ b/tests/profiling/collector/test_stack_threadpool.py
@@ -4,41 +4,15 @@ Tests for profiler span linkage in thread pool workers.
 
 from __future__ import annotations
 
-import concurrent.futures
-import os
-from pathlib import Path
-import time
-from typing import TYPE_CHECKING
-import uuid
-
 import pytest
 
-from ddtrace import ext
-from ddtrace._trace.context import Context
-from ddtrace.contrib.internal.futures.patch import patch as futures_patch
-from ddtrace.contrib.internal.futures.patch import unpatch as futures_unpatch
-from ddtrace.internal.datadog.profiling import ddup
 from ddtrace.internal.datadog.profiling import stack as stack_module
-from ddtrace.profiling.collector import stack
-from ddtrace.trace import Tracer
-from tests.profiling.collector import pprof_utils
-
-
-if TYPE_CHECKING:
-    from tests.profiling.collector.pprof_pb2 import Sample  # pyright: ignore[reportMissingModuleSource]
-
-
-@pytest.fixture(autouse=True)
-def patch_futures():
-    futures_patch()
-    try:
-        yield
-    finally:
-        futures_unpatch()
 
 
 def test_link_span_plain_context_uses_span_id_as_local_root() -> None:
     """Context activation without profiler _meta must link using span_id as local root."""
+    from ddtrace._trace.context import Context
+
     if not stack_module.is_available:
         pytest.skip("stack profiler not available")
 
@@ -48,6 +22,7 @@ def test_link_span_plain_context_uses_span_id_as_local_root() -> None:
 
 def test_link_span_context_reads_profiler_meta() -> None:
     """Context._meta profiler keys supply full local root and span type linkage."""
+    from ddtrace._trace.context import Context
     from ddtrace.internal.datadog.profiling import context_meta
 
     if not stack_module.is_available:
@@ -58,136 +33,155 @@ def test_link_span_context_reads_profiler_meta() -> None:
     stack_module.link_span(ctx)
 
 
-def _get_threadpool_samples(profile) -> list[Sample]:
-    """
-    Return all samples from ThreadPoolExecutor worker threads.
-    """
-    result = []
-    for sample in profile.sample:
-        label = pprof_utils.get_label_with_key(profile.string_table, sample, "thread name")
-        if label is not None and "ThreadPoolExecutor" in profile.string_table[label.str]:
-            result.append(sample)
-    return result
-
-
-def test_threadpool_worker_with_explicit_child_span(tmp_path: Path, tracer: Tracer) -> None:
-    """
-    A worker that creates an explicit child span should have its profiler
+# The two tests below use ddup.config()/ddup.upload() directly.
+# They run as @pytest.mark.subprocess to avoid libdatadog's tokio runtime
+# thread-affinity constraint, which conflicts with pytest's fixture threading.
+@pytest.mark.subprocess(err=None)
+def test_threadpool_worker_with_explicit_child_span() -> None:
+    """A worker that creates an explicit child span should have its profiler
     samples linked to the child span's IDs.
     """
-    test_name = "test_threadpool_worker_with_explicit_child_span"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
+    import concurrent.futures
+    import time
+    import uuid
 
-    tracer._endpoint_call_counter_span_processor.enable()
+    from ddtrace import ext
+    from ddtrace.contrib.internal.futures.patch import patch as futures_patch
+    from ddtrace.contrib.internal.futures.patch import unpatch as futures_unpatch
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from ddtrace.trace import tracer
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
-    assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    futures_patch()
+    try:
+        test_name = "test_threadpool_worker_with_explicit_child_span"
 
-    resource = str(uuid.uuid4())
-    span_type = ext.SpanTypes.WEB
+        tracer._endpoint_call_counter_span_processor.enable()
 
-    child_span_ids: list[int] = []
+        assert ddup.is_available
+        with with_profiling_test_agent() as agent_client:
+            ddup.config(env="test", service=test_name, version="my_version")
+            ddup.start()
+            ddup.upload()
 
-    def worker_with_span() -> None:
-        with tracer.trace("worker.query", resource=resource, span_type=span_type) as child_span:
-            child_span_ids.append(child_span.span_id)
-            for _ in range(20):
-                time.sleep(0.1)
+            resource = str(uuid.uuid4())
+            span_type = ext.SpanTypes.WEB
 
-    with stack.StackCollector(tracer=tracer):
-        with tracer.trace("executing_queries", resource=resource, span_type=span_type) as parent_span:
-            local_root_span_id = parent_span._local_root.span_id
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                executor.submit(worker_with_span).result()
+            child_span_ids: list[int] = []
 
-    ddup.upload(tracer=tracer)
+            def worker_with_span() -> None:
+                with tracer.trace("worker.query", resource=resource, span_type=span_type) as child_span:
+                    child_span_ids.append(child_span.span_id)
+                    for _ in range(20):
+                        time.sleep(0.1)
 
-    assert child_span_ids, "worker_with_span() did not run"
-    child_span_id = child_span_ids[0]
+            with stack.StackCollector(tracer=tracer):
+                with tracer.trace("executing_queries", resource=resource, span_type=span_type) as parent_span:
+                    local_root_span_id = parent_span._local_root.span_id
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                        executor.submit(worker_with_span).result()
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+            ddup.upload(tracer=tracer)
 
-    # All span-tagged samples in the profile. child_span_id is unique to the
-    # worker thread so any hit here proves the worker is linked correctly.
-    all_span_samples = pprof_utils.get_samples_with_label_key(profile, "span id")
-    assert all_span_samples, (
-        "Profile has no samples with a 'span id' label — is the StackCollector running and the tracer connected?"
-    )
+            assert child_span_ids, "worker_with_span() did not run"
+            child_span_id = child_span_ids[0]
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=all_span_samples,
-        expected_sample=pprof_utils.StackEvent(
-            span_id=child_span_id,
-            local_root_span_id=local_root_span_id,
-            trace_type=span_type,
-        ),
-        print_samples_on_failure=True,
-    )
+            profile = pprof_utils.get_profile_from_agent(agent_client)
+
+            all_span_samples = pprof_utils.get_samples_with_label_key(profile, "span id")
+            assert all_span_samples, "Profile has no samples with a 'span id' label — is the StackCollector running?"
+
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples=all_span_samples,
+                expected_sample=pprof_utils.StackEvent(
+                    span_id=child_span_id,
+                    local_root_span_id=local_root_span_id,
+                    trace_type=span_type,
+                ),
+                print_samples_on_failure=True,
+            )
+    finally:
+        futures_unpatch()
 
 
-def test_threadpool_worker_context_propagated_not_linked_to_profiler(tmp_path: Path, tracer: Tracer) -> None:
-    """
-    Worker thread profiler samples should carry the parent span's span_id when
+@pytest.mark.subprocess(err=None)
+def test_threadpool_worker_context_propagated_not_linked_to_profiler() -> None:
+    """Worker thread profiler samples should carry the parent span's span_id when
     the futures integration propagates the parent Context (no explicit child span).
     """
-    test_name = "test_threadpool_worker_context_propagated_not_linked"
-    pprof_prefix = str(tmp_path / test_name)
-    output_filename = pprof_prefix + "." + str(os.getpid())
+    import concurrent.futures
+    import time
+    import uuid
 
-    tracer._endpoint_call_counter_span_processor.enable()
+    from ddtrace import ext
+    from ddtrace.contrib.internal.futures.patch import patch as futures_patch
+    from ddtrace.contrib.internal.futures.patch import unpatch as futures_unpatch
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector import stack
+    from ddtrace.trace import tracer
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.utils import with_profiling_test_agent
 
-    assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()
+    def _get_threadpool_samples(profile):
+        result = []
+        for sample in profile.sample:
+            label = pprof_utils.get_label_with_key(profile.string_table, sample, "thread name")
+            if label is not None and "ThreadPoolExecutor" in profile.string_table[label.str]:
+                result.append(sample)
+        return result
 
-    resource = str(uuid.uuid4())
-    span_type = ext.SpanTypes.WEB
+    futures_patch()
+    try:
+        test_name = "test_threadpool_worker_context_propagated_not_linked"
 
-    def worker_context_only() -> None:
-        # no tracer.trace() call here; only the propagated Context is active
-        for _ in range(20):
-            time.sleep(0.1)
+        tracer._endpoint_call_counter_span_processor.enable()
 
-    with stack.StackCollector(tracer=tracer):
-        with tracer.trace("executing_queries", resource=resource, span_type=span_type) as parent_span:
-            parent_span_id = parent_span.span_id
-            local_root_span_id = parent_span._local_root.span_id
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                executor.submit(worker_context_only).result()
+        assert ddup.is_available
+        with with_profiling_test_agent() as agent_client:
+            ddup.config(env="test", service=test_name, version="my_version")
+            ddup.start()
+            ddup.upload()
 
-    ddup.upload(tracer=tracer)
+            resource = str(uuid.uuid4())
+            span_type = ext.SpanTypes.WEB
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+            def worker_context_only() -> None:
+                for _ in range(20):
+                    time.sleep(0.1)
 
-    # Check that the worker was actually sampled by looking for ThreadPoolExecutor
-    # thread-name labels
-    all_worker_samples = _get_threadpool_samples(profile)
-    assert all_worker_samples, (
-        "No samples found from ThreadPoolExecutor worker threads "
-        "(looked for 'thread name' label containing 'ThreadPoolExecutor'). "
-        "The worker may not have run long enough or the profiler may not record "
-        "thread names for executor threads. Increase sleep iterations if needed."
-    )
+            with stack.StackCollector(tracer=tracer):
+                with tracer.trace("executing_queries", resource=resource, span_type=span_type) as parent_span:
+                    parent_span_id = parent_span.span_id
+                    local_root_span_id = parent_span._local_root.span_id
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                        executor.submit(worker_context_only).result()
 
-    worker_samples_with_span_id = [
-        s for s in all_worker_samples if pprof_utils.get_label_with_key(profile.string_table, s, "span id") is not None
-    ]
-    assert worker_samples_with_span_id, (
-        "Worker thread samples have no 'span id' label. The profiler did not link the worker thread to the parent."
-    )
+            ddup.upload(tracer=tracer)
 
-    pprof_utils.assert_profile_has_sample(
-        profile,
-        samples=worker_samples_with_span_id,
-        expected_sample=pprof_utils.StackEvent(
-            span_id=parent_span_id,
-            local_root_span_id=local_root_span_id,
-            trace_type=span_type,
-        ),
-        print_samples_on_failure=True,
-    )
+            profile = pprof_utils.get_profile_from_agent(agent_client)
+
+            all_worker_samples = _get_threadpool_samples(profile)
+            assert all_worker_samples, "No samples found from ThreadPoolExecutor worker threads."
+
+            worker_samples_with_span_id = [
+                s
+                for s in all_worker_samples
+                if pprof_utils.get_label_with_key(profile.string_table, s, "span id") is not None
+            ]
+            assert worker_samples_with_span_id, "Worker thread samples have no 'span id' label."
+
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples=worker_samples_with_span_id,
+                expected_sample=pprof_utils.StackEvent(
+                    span_id=parent_span_id,
+                    local_root_span_id=local_root_span_id,
+                    trace_type=span_type,
+                ),
+                print_samples_on_failure=True,
+            )
+    finally:
+        futures_unpatch()

--- a/tests/profiling/collector/test_stack_threadpool.py
+++ b/tests/profiling/collector/test_stack_threadpool.py
@@ -52,7 +52,6 @@ def test_threadpool_worker_with_explicit_child_span() -> None:
     from ddtrace.profiling.collector import stack
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     futures_patch()
     try:
@@ -61,48 +60,47 @@ def test_threadpool_worker_with_explicit_child_span() -> None:
         tracer._endpoint_call_counter_span_processor.enable()
 
         assert ddup.is_available
-        with with_profiling_test_agent() as agent_client:
-            ddup.config(env="test", service=test_name, version="my_version")
-            ddup.start()
-            ddup.upload()
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-            resource = str(uuid.uuid4())
-            span_type = ext.SpanTypes.WEB
+        resource = str(uuid.uuid4())
+        span_type = ext.SpanTypes.WEB
 
-            child_span_ids: list[int] = []
+        child_span_ids: list[int] = []
 
-            def worker_with_span() -> None:
-                with tracer.trace("worker.query", resource=resource, span_type=span_type) as child_span:
-                    child_span_ids.append(child_span.span_id)
-                    for _ in range(20):
-                        time.sleep(0.1)
+        def worker_with_span() -> None:
+            with tracer.trace("worker.query", resource=resource, span_type=span_type) as child_span:
+                child_span_ids.append(child_span.span_id)
+                for _ in range(20):
+                    time.sleep(0.1)
 
-            with stack.StackCollector(tracer=tracer):
-                with tracer.trace("executing_queries", resource=resource, span_type=span_type) as parent_span:
-                    local_root_span_id = parent_span._local_root.span_id
-                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                        executor.submit(worker_with_span).result()
+        with stack.StackCollector(tracer=tracer):
+            with tracer.trace("executing_queries", resource=resource, span_type=span_type) as parent_span:
+                local_root_span_id = parent_span._local_root.span_id
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                    executor.submit(worker_with_span).result()
 
-            ddup.upload(tracer=tracer)
+        ddup.upload(tracer=tracer)
 
-            assert child_span_ids, "worker_with_span() did not run"
-            child_span_id = child_span_ids[0]
+        assert child_span_ids, "worker_with_span() did not run"
+        child_span_id = child_span_ids[0]
 
-            profile = pprof_utils.get_profile_from_agent(agent_client)
+        profile = pprof_utils.get_profile_from_agent()
 
-            all_span_samples = pprof_utils.get_samples_with_label_key(profile, "span id")
-            assert all_span_samples, "Profile has no samples with a 'span id' label — is the StackCollector running?"
+        all_span_samples = pprof_utils.get_samples_with_label_key(profile, "span id")
+        assert all_span_samples, "Profile has no samples with a 'span id' label — is the StackCollector running?"
 
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples=all_span_samples,
-                expected_sample=pprof_utils.StackEvent(
-                    span_id=child_span_id,
-                    local_root_span_id=local_root_span_id,
-                    trace_type=span_type,
-                ),
-                print_samples_on_failure=True,
-            )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=all_span_samples,
+            expected_sample=pprof_utils.StackEvent(
+                span_id=child_span_id,
+                local_root_span_id=local_root_span_id,
+                trace_type=span_type,
+            ),
+            print_samples_on_failure=True,
+        )
     finally:
         futures_unpatch()
 
@@ -123,7 +121,6 @@ def test_threadpool_worker_context_propagated_not_linked_to_profiler() -> None:
     from ddtrace.profiling.collector import stack
     from ddtrace.trace import tracer
     from tests.profiling.collector import pprof_utils
-    from tests.profiling.utils import with_profiling_test_agent
 
     def _get_threadpool_samples(profile):
         result = []
@@ -140,48 +137,47 @@ def test_threadpool_worker_context_propagated_not_linked_to_profiler() -> None:
         tracer._endpoint_call_counter_span_processor.enable()
 
         assert ddup.is_available
-        with with_profiling_test_agent() as agent_client:
-            ddup.config(env="test", service=test_name, version="my_version")
-            ddup.start()
-            ddup.upload()
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()
 
-            resource = str(uuid.uuid4())
-            span_type = ext.SpanTypes.WEB
+        resource = str(uuid.uuid4())
+        span_type = ext.SpanTypes.WEB
 
-            def worker_context_only() -> None:
-                for _ in range(20):
-                    time.sleep(0.1)
+        def worker_context_only() -> None:
+            for _ in range(20):
+                time.sleep(0.1)
 
-            with stack.StackCollector(tracer=tracer):
-                with tracer.trace("executing_queries", resource=resource, span_type=span_type) as parent_span:
-                    parent_span_id = parent_span.span_id
-                    local_root_span_id = parent_span._local_root.span_id
-                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                        executor.submit(worker_context_only).result()
+        with stack.StackCollector(tracer=tracer):
+            with tracer.trace("executing_queries", resource=resource, span_type=span_type) as parent_span:
+                parent_span_id = parent_span.span_id
+                local_root_span_id = parent_span._local_root.span_id
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                    executor.submit(worker_context_only).result()
 
-            ddup.upload(tracer=tracer)
+        ddup.upload(tracer=tracer)
 
-            profile = pprof_utils.get_profile_from_agent(agent_client)
+        profile = pprof_utils.get_profile_from_agent()
 
-            all_worker_samples = _get_threadpool_samples(profile)
-            assert all_worker_samples, "No samples found from ThreadPoolExecutor worker threads."
+        all_worker_samples = _get_threadpool_samples(profile)
+        assert all_worker_samples, "No samples found from ThreadPoolExecutor worker threads."
 
-            worker_samples_with_span_id = [
-                s
-                for s in all_worker_samples
-                if pprof_utils.get_label_with_key(profile.string_table, s, "span id") is not None
-            ]
-            assert worker_samples_with_span_id, "Worker thread samples have no 'span id' label."
+        worker_samples_with_span_id = [
+            s
+            for s in all_worker_samples
+            if pprof_utils.get_label_with_key(profile.string_table, s, "span id") is not None
+        ]
+        assert worker_samples_with_span_id, "Worker thread samples have no 'span id' label."
 
-            pprof_utils.assert_profile_has_sample(
-                profile,
-                samples=worker_samples_with_span_id,
-                expected_sample=pprof_utils.StackEvent(
-                    span_id=parent_span_id,
-                    local_root_span_id=local_root_span_id,
-                    trace_type=span_type,
-                ),
-                print_samples_on_failure=True,
-            )
+        pprof_utils.assert_profile_has_sample(
+            profile,
+            samples=worker_samples_with_span_id,
+            expected_sample=pprof_utils.StackEvent(
+                span_id=parent_span_id,
+                local_root_span_id=local_root_span_id,
+                trace_type=span_type,
+            ),
+            print_samples_on_failure=True,
+        )
     finally:
         futures_unpatch()

--- a/tests/profiling/collector/test_thread_subsampling.py
+++ b/tests/profiling/collector/test_thread_subsampling.py
@@ -11,22 +11,19 @@ import pytest
 
 @pytest.mark.subprocess(
     env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_thread_subsampling_cap",
         _DD_PROFILING_STACK_MAX_THREADS="1",
         _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED="0",
     ),
-    err=None,
 )
 def test_thread_subsampling_cap_respected() -> None:
     """With max_threads=1, at most 1 thread is sampled per cycle, even with many threads alive."""
-    import glob
-    import json
-    import os
     import threading
     import time
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
+    from tests.profiling.utils import get_all_metadata_from_agent
+    from tests.profiling.utils import with_profiling_test_agent
 
     N_THREADS = 10
     max_threads = 1
@@ -38,34 +35,31 @@ def test_thread_subsampling_cap_respected() -> None:
             time.sleep(0.01)
 
     test_name = "test_thread_subsampling_cap"
-    pprof_prefix = os.environ["DD_PROFILING_OUTPUT_PPROF"]
 
-    assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()  # flush initial empty state; resets stats counters
+    with with_profiling_test_agent() as agent_client:
+        assert ddup.is_available
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()  # flush initial empty state; resets stats counters
 
-    threads = [threading.Thread(target=worker, daemon=True) for _ in range(N_THREADS)]
-    for t in threads:
-        t.start()
+        threads = [threading.Thread(target=worker, daemon=True) for _ in range(N_THREADS)]
+        for t in threads:
+            t.start()
 
-    with stack.StackCollector():
-        time.sleep(2)
+        with stack.StackCollector():
+            time.sleep(2)
 
-    stop_event.set()
-    for t in threads:
-        t.join(timeout=2)
+        stop_event.set()
+        for t in threads:
+            t.join(timeout=2)
 
-    ddup.upload()
+        ddup.upload()
 
-    output_filename = pprof_prefix + "." + str(os.getpid())
-    files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
-    assert files, f"No internal metadata files found at {output_filename}.*"
+        files = get_all_metadata_from_agent(agent_client, min_count=1)
 
-    for f in files:
-        with open(f) as fp:
-            metadata = json.load(fp)
+    assert files, "No internal metadata received from test agent"
 
+    for metadata in files:
         sampling_event_count: int = metadata.get("sampling_event_count", 0)
         sample_count: int = metadata.get("sample_count", 0)
 
@@ -81,11 +75,9 @@ def test_thread_subsampling_cap_respected() -> None:
 
 @pytest.mark.subprocess(
     env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_thread_subsampling_nocap",
         _DD_PROFILING_STACK_MAX_THREADS="0",  # 0 = unlimited
         _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED="0",
     ),
-    err=None,
 )
 def test_thread_subsampling_all_threads_sampled_without_cap() -> None:
     """Without a cap (max_threads=0), all threads are sampled each cycle.
@@ -93,14 +85,13 @@ def test_thread_subsampling_all_threads_sampled_without_cap() -> None:
     With N_THREADS additional threads running, sample_count should be
     significantly greater than sampling_event_count.
     """
-    import glob
-    import json
-    import os
     import threading
     import time
 
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
+    from tests.profiling.utils import get_all_metadata_from_agent
+    from tests.profiling.utils import with_profiling_test_agent
 
     N_THREADS = 10
 
@@ -111,35 +102,31 @@ def test_thread_subsampling_all_threads_sampled_without_cap() -> None:
             time.sleep(0.01)
 
     test_name = "test_thread_subsampling_nocap"
-    pprof_prefix = os.environ["DD_PROFILING_OUTPUT_PPROF"]
 
-    assert ddup.is_available
-    ddup.config(env="test", service=test_name, version="my_version", output_filename=pprof_prefix)
-    ddup.start()
-    ddup.upload()  # flush initial empty state; resets stats counters
+    with with_profiling_test_agent() as agent_client:
+        assert ddup.is_available
+        ddup.config(env="test", service=test_name, version="my_version")
+        ddup.start()
+        ddup.upload()  # flush initial empty state; resets stats counters
 
-    threads = [threading.Thread(target=worker, daemon=True) for _ in range(N_THREADS)]
-    for t in threads:
-        t.start()
+        threads = [threading.Thread(target=worker, daemon=True) for _ in range(N_THREADS)]
+        for t in threads:
+            t.start()
 
-    with stack.StackCollector():
-        time.sleep(2)
+        with stack.StackCollector():
+            time.sleep(2)
 
-    stop_event.set()
-    for t in threads:
-        t.join(timeout=2)
+        stop_event.set()
+        for t in threads:
+            t.join(timeout=2)
 
-    ddup.upload()
+        ddup.upload()
 
-    output_filename = pprof_prefix + "." + str(os.getpid())
-    files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
-    assert files, f"No internal metadata files found at {output_filename}.*"
+        files = get_all_metadata_from_agent(agent_client, min_count=1)
 
     total_events: int = 0
     total_samples: int = 0
-    for f in files:
-        with open(f) as fp:
-            metadata = json.load(fp)
+    for metadata in files:
         total_events += metadata.get("sampling_event_count", 0)
         total_samples += metadata.get("sample_count", 0)
 

--- a/tests/profiling/collector/test_thread_subsampling.py
+++ b/tests/profiling/collector/test_thread_subsampling.py
@@ -23,7 +23,6 @@ def test_thread_subsampling_cap_respected() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.utils import get_all_metadata_from_agent
-    from tests.profiling.utils import with_profiling_test_agent
 
     N_THREADS = 10
     max_threads = 1
@@ -36,26 +35,25 @@ def test_thread_subsampling_cap_respected() -> None:
 
     test_name = "test_thread_subsampling_cap"
 
-    with with_profiling_test_agent() as agent_client:
-        assert ddup.is_available
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()  # flush initial empty state; resets stats counters
+    assert ddup.is_available
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()  # flush initial empty state; resets stats counters
 
-        threads = [threading.Thread(target=worker, daemon=True) for _ in range(N_THREADS)]
-        for t in threads:
-            t.start()
+    threads = [threading.Thread(target=worker, daemon=True) for _ in range(N_THREADS)]
+    for t in threads:
+        t.start()
 
-        with stack.StackCollector():
-            time.sleep(2)
+    with stack.StackCollector():
+        time.sleep(2)
 
-        stop_event.set()
-        for t in threads:
-            t.join(timeout=2)
+    stop_event.set()
+    for t in threads:
+        t.join(timeout=2)
 
-        ddup.upload()
+    ddup.upload()
 
-        files = get_all_metadata_from_agent(agent_client, min_count=1)
+    files = get_all_metadata_from_agent(min_count=1)
 
     assert files, "No internal metadata received from test agent"
 
@@ -91,7 +89,6 @@ def test_thread_subsampling_all_threads_sampled_without_cap() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector import stack
     from tests.profiling.utils import get_all_metadata_from_agent
-    from tests.profiling.utils import with_profiling_test_agent
 
     N_THREADS = 10
 
@@ -103,26 +100,25 @@ def test_thread_subsampling_all_threads_sampled_without_cap() -> None:
 
     test_name = "test_thread_subsampling_nocap"
 
-    with with_profiling_test_agent() as agent_client:
-        assert ddup.is_available
-        ddup.config(env="test", service=test_name, version="my_version")
-        ddup.start()
-        ddup.upload()  # flush initial empty state; resets stats counters
+    assert ddup.is_available
+    ddup.config(env="test", service=test_name, version="my_version")
+    ddup.start()
+    ddup.upload()  # flush initial empty state; resets stats counters
 
-        threads = [threading.Thread(target=worker, daemon=True) for _ in range(N_THREADS)]
-        for t in threads:
-            t.start()
+    threads = [threading.Thread(target=worker, daemon=True) for _ in range(N_THREADS)]
+    for t in threads:
+        t.start()
 
-        with stack.StackCollector():
-            time.sleep(2)
+    with stack.StackCollector():
+        time.sleep(2)
 
-        stop_event.set()
-        for t in threads:
-            t.join(timeout=2)
+    stop_event.set()
+    for t in threads:
+        t.join(timeout=2)
 
-        ddup.upload()
+    ddup.upload()
 
-        files = get_all_metadata_from_agent(agent_client, min_count=1)
+    files = get_all_metadata_from_agent(min_count=1)
 
     total_events: int = 0
     total_samples: int = 0

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -1,25 +1,17 @@
 from __future__ import annotations
 
 import _thread
-import glob
 import os
 import pickle
 import sys
 import threading
 import time
-from typing import Callable
 from typing import Optional
 from typing import Union
-from typing import cast
 from unittest import mock
-import uuid
 
 import pytest
 
-from ddtrace import ext
-from ddtrace._trace.span import Span
-from ddtrace._trace.tracer import Tracer
-from ddtrace.internal.datadog.profiling import ddup
 from ddtrace.profiling.collector._lock import _LockAllocatorWrapper as LockAllocatorWrapper
 from ddtrace.profiling.collector._lock import _ProfiledLock
 from ddtrace.profiling.collector.threading import ThreadingBoundedSemaphoreCollector
@@ -27,13 +19,11 @@ from ddtrace.profiling.collector.threading import ThreadingConditionCollector
 from ddtrace.profiling.collector.threading import ThreadingLockCollector
 from ddtrace.profiling.collector.threading import ThreadingRLockCollector
 from ddtrace.profiling.collector.threading import ThreadingSemaphoreCollector
-from tests.profiling.collector import pprof_utils
 from tests.profiling.collector import test_collector
 from tests.profiling.collector.lock_test_common import assert_pep604_type_union_syntax
 from tests.profiling.collector.lock_utils import LineNo
 from tests.profiling.collector.lock_utils import get_lock_linenos
 from tests.profiling.collector.lock_utils import init_linenos
-from tests.profiling.collector.pprof_utils import pprof_pb2  # type: ignore[attr-defined]
 from tests.profiling.collector.test_utils import init_ddup
 
 
@@ -58,35 +48,7 @@ CollectorTypeInst = Union[
 CollectorTypeClass = type[CollectorTypeInst]
 
 
-# Module-level globals for testing global lock profiling
-_test_global_lock: LockTypeInst
-
-
-class TestBar:
-    pass
-
-
-_test_global_bar_instance: TestBar
-
 init_linenos(__file__)
-
-
-# Helper classes for testing lock collector
-class Foo:
-    def __init__(self, lock_class: LockTypeClass) -> None:
-        self.foo_lock: LockTypeInst = lock_class()  # !CREATE! foolock
-
-    def foo(self) -> None:
-        with self.foo_lock:  # !RELEASE! !ACQUIRE! foolock
-            pass
-
-
-class Bar:
-    def __init__(self, lock_class: LockTypeClass) -> None:
-        self.foo: Foo = Foo(lock_class)
-
-    def bar(self) -> None:
-        self.foo.foo()
 
 
 @pytest.mark.parametrize(
@@ -569,13 +531,13 @@ def test_user_threads_have_native_id():
 @pytest.mark.skipif(not os.getenv("DD_PROFILE_TEST_GEVENT"), reason="gevent is not available")
 @pytest.mark.subprocess(
     env=dict(DD_PROFILING_FILE_PATH=__file__),
+    err=None,
 )
 def test_lock_gevent_tasks() -> None:
     from gevent import monkey
 
     monkey.patch_all()
 
-    import glob
     import os
     import threading
 
@@ -584,20 +546,12 @@ def test_lock_gevent_tasks() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert ddup.is_available, "ddup is not available"
 
     # Set up the ddup exporter
     test_name: str = "test_lock_gevent_tasks"
-    pprof_prefix: str = "/tmp" + os.sep + test_name
-    output_filename: str = pprof_prefix + "." + str(os.getpid())
-    ddup.config(
-        env="test",
-        service=test_name,
-        version="my_version",
-        output_filename=pprof_prefix,
-    )  # pyright: ignore[reportCallIssue]
-    ddup.start()
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -606,15 +560,25 @@ def test_lock_gevent_tasks() -> None:
         lock.acquire()  # !ACQUIRE! test_lock_gevent_tasks
         lock.release()  # !RELEASE! test_lock_gevent_tasks
 
-    def validate_and_cleanup() -> None:
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(
+            env="test",
+            service=test_name,
+            version="my_version",
+        )  # pyright: ignore[reportCallIssue]
+        ddup.start()
+
+        with ThreadingLockCollector(capture_pct=100):
+            t: threading.Thread = threading.Thread(name="foobar", target=play_with_lock)
+            t.start()
+            t.join()
+
         ddup.upload()  # pyright: ignore[reportCallIssue]
 
         expected_filename: str = "test_threading.py"
         linenos: LineNo = get_lock_linenos(test_name)
 
-        profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(  # pyright: ignore[reportInvalidTypeForm]
-            output_filename
-        )
+        profile = pprof_utils.get_profile_from_agent(agent_client)
         pprof_utils.assert_lock_events(
             profile,
             expected_acquire_events=[
@@ -639,32 +603,19 @@ def test_lock_gevent_tasks() -> None:
             ],
         )
 
-        for f in glob.glob(pprof_prefix + ".*"):
-            try:
-                os.remove(f)
-            except Exception as e:
-                print("Error removing file: {}".format(e))
-
-    with ThreadingLockCollector(capture_pct=100):
-        t: threading.Thread = threading.Thread(name="foobar", target=play_with_lock)
-        t.start()
-        t.join()
-
-    validate_and_cleanup()
-
 
 # This test has to be run in a subprocess because it calls gevent.monkey.patch_all()
 # which affects the whole process.
 @pytest.mark.skipif(not os.getenv("DD_PROFILE_TEST_GEVENT"), reason="gevent is not available")
 @pytest.mark.subprocess(
     env=dict(DD_PROFILING_FILE_PATH=__file__),
+    err=None,
 )
 def test_rlock_gevent_tasks() -> None:
     from gevent import monkey
 
     monkey.patch_all()
 
-    import glob
     import os
     import threading
 
@@ -673,20 +624,12 @@ def test_rlock_gevent_tasks() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert ddup.is_available, "ddup is not available"
 
     # Set up the ddup exporter
     test_name: str = "test_rlock_gevent_tasks"
-    pprof_prefix: str = "/tmp" + os.sep + test_name
-    output_filename: str = pprof_prefix + "." + str(os.getpid())
-    ddup.config(
-        env="test",
-        service=test_name,
-        version="my_version",
-        output_filename=pprof_prefix,
-    )  # pyright: ignore[reportCallIssue]
-    ddup.start()
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -695,13 +638,25 @@ def test_rlock_gevent_tasks() -> None:
         lock.acquire()  # !ACQUIRE! test_rlock_gevent_tasks
         lock.release()  # !RELEASE! test_rlock_gevent_tasks
 
-    def validate_and_cleanup() -> None:
+    with with_profiling_test_agent() as agent_client:
+        ddup.config(
+            env="test",
+            service=test_name,
+            version="my_version",
+        )  # pyright: ignore[reportCallIssue]
+        ddup.start()
+
+        with ThreadingRLockCollector(capture_pct=100):
+            t: threading.Thread = threading.Thread(name="foobar", target=play_with_lock)
+            t.start()
+            t.join()
+
         ddup.upload()  # pyright: ignore[reportCallIssue]
 
         expected_filename: str = "test_threading.py"
         linenos: LineNo = get_lock_linenos(test_name)
 
-        profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
         pprof_utils.assert_lock_events(
             profile,
             expected_acquire_events=[
@@ -725,19 +680,6 @@ def test_rlock_gevent_tasks() -> None:
                 ),
             ],
         )
-
-        for f in glob.glob(pprof_prefix + ".*"):
-            try:
-                os.remove(f)
-            except Exception as e:
-                print("Error removing file: {}".format(e))
-
-    with ThreadingRLockCollector(capture_pct=100):
-        t: threading.Thread = threading.Thread(name="foobar", target=play_with_lock)
-        t.start()
-        t.join()
-
-    validate_and_cleanup()
 
 
 @pytest.mark.subprocess(env=dict(DD_PROFILING_ENABLE_ASSERTS="true"))
@@ -1049,72 +991,42 @@ def test_semaphore_and_bounded_semaphore_collectors_coexist() -> None:
             bsem2.release()
 
 
-class LockCollectorTestBase:
-    """Minimal base class providing ddup setup/teardown for lock collector tests.
+# ---------------------------------------------------------------------------
+# Standalone parametrized PEP 604 test (replaces LockCollectorTestBase.test_pep604_type_union_syntax)
+# ---------------------------------------------------------------------------
 
-    Subclasses must define:
-    - collector_class: The collector class to use (e.g., ThreadingLockCollector)
-    - lock_class: The lock class to use (e.g., threading.Lock)
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="PEP 604 type union syntax requires Python 3.10+")
+@pytest.mark.parametrize(
+    "collector_class,lock_class",
+    [
+        (ThreadingLockCollector, threading.Lock),
+        (ThreadingRLockCollector, threading.RLock),
+        (ThreadingSemaphoreCollector, threading.Semaphore),
+        (ThreadingBoundedSemaphoreCollector, threading.BoundedSemaphore),
+        (ThreadingConditionCollector, threading.Condition),
+    ],
+)
+def test_pep604_type_union_syntax(collector_class: CollectorTypeClass, lock_class: LockTypeClass) -> None:
+    """Test that PEP 604 type union syntax works with wrapped lock classes.
+
+    Reproduces https://github.com/DataDog/dd-trace-py/issues/16375
+    Skips when the lock is a factory function (e.g., threading.Lock) rather than a type.
     """
-
-    @property
-    def collector_class(self) -> CollectorTypeClass:
-        raise NotImplementedError("Child classes must implement collector_class")
-
-    @property
-    def lock_class(self) -> LockTypeClass:
-        raise NotImplementedError("Child classes must implement lock_class")
-
-    # setup_method and teardown_method which will be called before and after
-    # each test method, respectively, part of pytest api.
-    def setup_method(self, method: Callable[..., None]) -> None:
-        self.test_name: str = method.__qualname__ if PY_311_OR_ABOVE else method.__name__
-        self.pprof_prefix: str = "/tmp" + os.sep + self.test_name
-        # The output filename will be /tmp/method_name.<pid>.<counter>.
-        # The counter number is incremented for each test case, as the tests are
-        # all run in a single process and share the same exporter.
-        self.output_filename: str = self.pprof_prefix + "." + str(os.getpid())
-
-        # ddup is available when the native module is compiled
-        assert ddup.is_available, "ddup is not available"
-        ddup.config(
-            env="test",
-            service=self.test_name,
-            version="my_version",
-            output_filename=self.pprof_prefix,
-        )  # pyright: ignore[reportCallIssue]
-        ddup.start()
-
-        # Clear any accumulated samples that have been created by other unrelated tests
-        # and that may interfere with our tests.
-        ddup.upload()
-
-    def teardown_method(self) -> None:
-        # Clear any accumulated samples that have not been uploaded and may interfere
-        # with subsequent tests.
-        ddup.upload()
-
-        # might be unnecessary but this will ensure that the file is removed
-        # after each successful test, and when a test fails it's easier to
-        # pinpoint and debug.
-        for f in glob.glob(self.output_filename + ".*"):
-            try:
-                os.remove(f)
-            except Exception as e:
-                print("Error removing file: {}".format(e))
-
-    @pytest.mark.skipif(sys.version_info < (3, 10), reason="PEP 604 type union syntax requires Python 3.10+")
-    def test_pep604_type_union_syntax(self) -> None:
-        """Test that PEP 604 type union syntax works with wrapped lock classes.
-
-        Reproduces https://github.com/DataDog/dd-trace-py/issues/16375
-        Skips when the lock is a factory function (e.g., threading.Lock) rather than a type.
-        """
-        with self.collector_class(capture_pct=100):
-            assert_pep604_type_union_syntax(self.lock_class)  # type: ignore[arg-type]
+    with collector_class(capture_pct=100):
+        # After the collector starts, the module attribute is a _LockAllocatorWrapper.
+        # The parametrized lock_class is the original (pre-patch) reference, so we
+        # look up the live wrapped value by PATCHED_LOCK_NAME instead.
+        wrapped_lock_class = getattr(threading, collector_class.PATCHED_LOCK_NAME)
+        assert_pep604_type_union_syntax(wrapped_lock_class)  # type: ignore[arg-type]
 
 
-class TestGenericLockProfiling(LockCollectorTestBase):
+# ---------------------------------------------------------------------------
+# TestGenericLockProfiling — non-ddup-upload tests kept as a class
+# ---------------------------------------------------------------------------
+
+
+class TestGenericLockProfiling:
     """Generic lock profiling tests that run once with threading.Lock.
 
     These tests verify the core profiling infrastructure which is shared across
@@ -1122,6 +1034,9 @@ class TestGenericLockProfiling(LockCollectorTestBase):
     - All lock types use the same _ProfiledLock wrapper
     - The profiling logic (sampling, stack traces, ddup integration) is identical
     - Lock-type-specific behavior is tested in dedicated test classes
+
+    Only tests that do NOT call ddup.upload() remain here.
+    Tests that call ddup.upload() are converted to @pytest.mark.subprocess functions below.
     """
 
     @property
@@ -1164,739 +1079,6 @@ class TestGenericLockProfiling(LockCollectorTestBase):
         """Test that profiled lock instances can be pickled (Python 3.14+ forkserver compat)."""
         with self.collector_class(capture_pct=100):
             self._assert_pickle_roundtrip(self.lock_class(), _ProfiledLock)
-
-    def test_lock_events(self) -> None:
-        # The first argument is the recorder.Recorder which is used for the
-        # v1 exporter. We don't need it for the v2 exporter.
-        with self.collector_class(capture_pct=100):
-            lock: LockTypeInst = self.lock_class()  # !CREATE! test_lock_events
-            lock.acquire()  # !ACQUIRE! test_lock_events
-            lock.release()  # !RELEASE! test_lock_events
-        # Calling upload will trigger the exporter to write to a file
-        ddup.upload()
-
-        profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(self.output_filename)
-        linenos: LineNo = get_lock_linenos("test_lock_events")
-        pprof_utils.assert_lock_events(
-            profile,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos,
-                    lock_name="lock",
-                ),
-            ],
-            expected_release_events=[
-                pprof_utils.LockReleaseEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos,
-                    lock_name="lock",
-                ),
-            ],
-        )
-
-    def test_lock_events_truncate_frames(self) -> None:
-        """Ensure lock samples keep leaf callsite and use an omitted-frames root when truncated.
-
-        This builds a call stack deeper than max frames, then verifies that for both
-        lock-acquire and lock-release samples we can still find the expected callsite
-        as the leaf frame, while the root frame is the synthetic
-        "<N frame(s) omitted>" marker.
-        """
-        from ddtrace.internal.settings.profiling import config
-
-        # Force a deeper stack than configured max frames so truncation always happens.
-        recursion_depth = config.max_frames + 50
-
-        def deep_lock_ops(depth: int, lock: LockTypeInst) -> None:
-            if depth == 0:
-                lock.acquire()  # !ACQUIRE! test_lock_events_truncate_frames
-                lock.release()  # !RELEASE! test_lock_events_truncate_frames
-                return
-            deep_lock_ops(depth - 1, lock)
-
-        with self.collector_class(capture_pct=100):
-            lock: LockTypeInst = self.lock_class()  # !CREATE! test_lock_events_truncate_frames
-            deep_lock_ops(recursion_depth, lock)
-
-        ddup.upload()
-
-        profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(self.output_filename)
-        linenos: LineNo = get_lock_linenos("test_lock_events_truncate_frames")
-        caller_name = deep_lock_ops.__qualname__ if PY_311_OR_ABOVE else deep_lock_ops.__name__
-
-        def _assert_callsite_sample_is_truncated(sample_type: str, expected_line: int) -> None:
-            samples = pprof_utils.get_samples_with_value_type(profile, sample_type)
-            assert len(samples) > 0
-
-            found_callsite_sample = False
-            for sample_idx, sample in enumerate(samples):
-                # Stack export allows one extra frame for the omitted-frames marker.
-                assert len(sample.location_id) <= config.max_frames + 1, (
-                    f"sample index={sample_idx} has too many locations: {len(sample.location_id)}"
-                )
-
-                leaf_location = pprof_utils.get_location_with_id(profile, sample.location_id[0])
-                leaf_line = leaf_location.line[0]
-                leaf_function = pprof_utils.get_function_with_id(profile, leaf_line.function_id)
-                leaf_function_name = profile.string_table[leaf_function.name]
-                if leaf_function_name == caller_name and leaf_line.line == expected_line:
-                    found_callsite_sample = True
-
-                    root_location = pprof_utils.get_location_with_id(profile, sample.location_id[-1])
-                    root_line = root_location.line[0]
-                    root_function = pprof_utils.get_function_with_id(profile, root_line.function_id)
-                    root_function_name = profile.string_table[root_function.name]
-                    assert root_function_name.startswith("<") and "omitted>" in root_function_name, (
-                        f"expected {sample_type} callsite sample root frame to be omitted marker, got"
-                        f" {root_function_name!r}"
-                    )
-                    break
-
-            assert found_callsite_sample, f"expected to find {sample_type} callsite sample"
-
-        _assert_callsite_sample_is_truncated("lock-acquire", linenos.acquire)
-        _assert_callsite_sample_is_truncated("lock-release", linenos.release)
-
-    def test_lock_acquire_events_class(self) -> None:
-        # Store reference to class for later qualname access
-        foobar_class: Optional[type] = None
-
-        with self.collector_class(capture_pct=100):
-            lock_class: LockTypeClass = self.lock_class  # Capture for inner class
-
-            class Foobar(object):
-                def lockfunc(self) -> None:
-                    lock: LockTypeInst = lock_class()  # !CREATE! test_lock_acquire_events_class
-                    lock.acquire()  # !ACQUIRE! test_lock_acquire_events_class
-
-            # Capture reference before context manager exits
-            foobar_class = Foobar
-            Foobar().lockfunc()
-
-        ddup.upload()  # pyright: ignore[reportCallIssue]
-
-        linenos: LineNo = get_lock_linenos("test_lock_acquire_events_class")
-
-        profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(self.output_filename)
-        assert foobar_class is not None
-        caller_name = foobar_class.lockfunc.__qualname__ if PY_311_OR_ABOVE else foobar_class.lockfunc.__name__
-        pprof_utils.assert_lock_events(
-            profile,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name=caller_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos,
-                    lock_name="lock",
-                ),
-            ],
-        )
-
-    def test_lock_events_tracer(self, tracer: Tracer) -> None:
-        tracer._endpoint_call_counter_span_processor.enable()
-        resource: str = str(uuid.uuid4())
-        span_type: str = ext.SpanTypes.WEB
-        with self.collector_class(
-            tracer=tracer,
-            capture_pct=100,
-        ):
-            lock1: LockTypeInst = self.lock_class()  # !CREATE! test_lock_events_tracer_1
-            lock1.acquire()  # !ACQUIRE! test_lock_events_tracer_1
-            with tracer.trace("test", resource=resource, span_type=span_type) as t:
-                lock2: LockTypeInst = self.lock_class()  # !CREATE! test_lock_events_tracer_2
-                lock2.acquire()  # !ACQUIRE! test_lock_events_tracer_2
-                lock1.release()  # !RELEASE! test_lock_events_tracer_1
-                span_id: int = t.span_id
-
-            lock2.release()  # !RELEASE! test_lock_events_tracer_2
-        ddup.upload(tracer=tracer)
-
-        linenos1: LineNo = get_lock_linenos("test_lock_events_tracer_1")
-        linenos2: LineNo = get_lock_linenos("test_lock_events_tracer_2")
-
-        profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(self.output_filename)
-        pprof_utils.assert_lock_events(
-            profile,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos1,
-                    lock_name="lock1",
-                ),
-                pprof_utils.LockAcquireEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos2,
-                    lock_name="lock2",
-                    span_id=span_id,
-                    trace_endpoint=resource,
-                    trace_type=span_type,
-                ),
-            ],
-            expected_release_events=[
-                pprof_utils.LockReleaseEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos1,
-                    lock_name="lock1",
-                    span_id=span_id,
-                    trace_endpoint=resource,
-                    trace_type=span_type,
-                ),
-                pprof_utils.LockReleaseEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos2,
-                    lock_name="lock2",
-                ),
-            ],
-        )
-
-    def test_lock_events_tracer_non_web(self, tracer: Tracer) -> None:
-        tracer._endpoint_call_counter_span_processor.enable()
-        resource: str = str(uuid.uuid4())
-        span_type: str = ext.SpanTypes.SQL
-        with self.collector_class(
-            tracer=tracer,
-            capture_pct=100,
-        ):
-            with tracer.trace("test", resource=resource, span_type=span_type) as t:
-                lock2: LockTypeInst = self.lock_class()  # !CREATE! test_lock_events_tracer_non_web
-                lock2.acquire()  # !ACQUIRE! test_lock_events_tracer_non_web
-                span_id: int = t.span_id
-
-            lock2.release()  # !RELEASE! test_lock_events_tracer_non_web
-        ddup.upload(tracer=tracer)
-
-        linenos2: LineNo = get_lock_linenos("test_lock_events_tracer_non_web")
-
-        profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(self.output_filename)
-        pprof_utils.assert_lock_events(
-            profile,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos2,
-                    lock_name="lock2",
-                    span_id=span_id,
-                    # no trace endpoint for non-web spans
-                    trace_type=span_type,
-                ),
-            ],
-            expected_release_events=[
-                pprof_utils.LockReleaseEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos2,
-                    lock_name="lock2",
-                ),
-            ],
-        )
-
-    def test_lock_events_tracer_late_finish(self, tracer: Tracer) -> None:
-        tracer._endpoint_call_counter_span_processor.enable()
-        resource: str = str(uuid.uuid4())
-        span_type: str = ext.SpanTypes.WEB
-        with self.collector_class(
-            tracer=tracer,
-            capture_pct=100,
-        ):
-            lock1: LockTypeInst = self.lock_class()  # !CREATE! test_lock_events_tracer_late_finish_1
-            lock1.acquire()  # !ACQUIRE! test_lock_events_tracer_late_finish_1
-            span: Span = tracer.start_span(name="test", span_type=span_type)  # pyright: ignore[reportCallIssue]
-            lock2: LockTypeInst = self.lock_class()  # !CREATE! test_lock_events_tracer_late_finish_2
-            lock2.acquire()  # !ACQUIRE! test_lock_events_tracer_late_finish_2
-            lock1.release()  # !RELEASE! test_lock_events_tracer_late_finish_1
-            lock2.release()  # !RELEASE! test_lock_events_tracer_late_finish_2
-        span.resource = resource
-        span.finish()
-        ddup.upload(tracer=tracer)
-
-        linenos1: LineNo = get_lock_linenos("test_lock_events_tracer_late_finish_1")
-        linenos2: LineNo = get_lock_linenos("test_lock_events_tracer_late_finish_2")
-
-        profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(self.output_filename)
-        pprof_utils.assert_lock_events(
-            profile,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos1,
-                    lock_name="lock1",
-                ),
-                pprof_utils.LockAcquireEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos2,
-                    lock_name="lock2",
-                ),
-            ],
-            expected_release_events=[
-                pprof_utils.LockReleaseEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos1,
-                    lock_name="lock1",
-                ),
-                pprof_utils.LockReleaseEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos2,
-                    lock_name="lock2",
-                ),
-            ],
-        )
-
-    def test_resource_not_collected(self, tracer: Tracer) -> None:
-        tracer._endpoint_call_counter_span_processor.enable()
-        resource: str = str(uuid.uuid4())
-        span_type: str = ext.SpanTypes.WEB
-        with self.collector_class(
-            tracer=tracer,
-            capture_pct=100,
-        ):
-            lock1: LockTypeInst = self.lock_class()  # !CREATE! test_resource_not_collected_1
-            lock1.acquire()  # !ACQUIRE! test_resource_not_collected_1
-            with tracer.trace("test", resource=resource, span_type=span_type) as t:
-                lock2: LockTypeInst = self.lock_class()  # !CREATE! test_resource_not_collected_2
-                lock2.acquire()  # !ACQUIRE! test_resource_not_collected_2
-                lock1.release()  # !RELEASE! test_resource_not_collected_1
-                span_id: int = t.span_id
-            lock2.release()  # !RELEASE! test_resource_not_collected_2
-        ddup.upload(tracer=tracer)
-
-        linenos1: LineNo = get_lock_linenos("test_resource_not_collected_1")
-        linenos2: LineNo = get_lock_linenos("test_resource_not_collected_2")
-
-        profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(self.output_filename)
-        pprof_utils.assert_lock_events(
-            profile,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos1,
-                    lock_name="lock1",
-                ),
-                pprof_utils.LockAcquireEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos2,
-                    lock_name="lock2",
-                    span_id=span_id,
-                    trace_endpoint=None,
-                    trace_type=span_type,
-                ),
-            ],
-            expected_release_events=[
-                pprof_utils.LockReleaseEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos1,
-                    lock_name="lock1",
-                    span_id=span_id,
-                    trace_endpoint=None,
-                    trace_type=span_type,
-                ),
-                pprof_utils.LockReleaseEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos2,
-                    lock_name="lock2",
-                ),
-            ],
-        )
-
-    def test_lock_enter_exit_events(self) -> None:
-        with self.collector_class(capture_pct=100):
-            th_lock: LockTypeInst = self.lock_class()  # !CREATE! test_lock_enter_exit_events
-            with th_lock:  # !ACQUIRE! !RELEASE! test_lock_enter_exit_events
-                pass
-
-        ddup.upload()  # pyright: ignore[reportCallIssue]
-
-        # for enter/exits, we need to update the lock_linenos for versions >= 3.10
-        linenos: LineNo = get_lock_linenos("test_lock_enter_exit_events", with_stmt=True)
-
-        profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(self.output_filename)
-        pprof_utils.assert_lock_events(
-            profile,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos,
-                    lock_name="th_lock",
-                ),
-            ],
-            expected_release_events=[
-                pprof_utils.LockReleaseEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos,
-                    lock_name="th_lock",
-                ),
-            ],
-        )
-
-    @pytest.mark.parametrize(
-        "inspect_dir_enabled",
-        [True, False],
-    )
-    def test_class_member_lock(self, inspect_dir_enabled: bool) -> None:
-        with mock.patch(
-            "ddtrace.internal.settings.profiling.config.lock.name_inspect_dir",
-            inspect_dir_enabled,
-        ):
-            expected_lock_name: Optional[str] = "foo_lock" if inspect_dir_enabled else None
-
-            with self.collector_class(capture_pct=100):
-                foobar: Foo = Foo(self.lock_class)
-                foobar.foo()
-                bar: Bar = Bar(self.lock_class)
-                bar.bar()
-
-            ddup.upload()  # pyright: ignore[reportCallIssue]
-
-            linenos: LineNo = get_lock_linenos("foolock", with_stmt=True)
-            profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(self.output_filename)
-            acquire_samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "lock-acquire")
-            assert len(acquire_samples) >= 2, "Expected at least 2 lock-acquire samples"
-            release_samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "lock-release")
-            assert len(release_samples) >= 2, "Expected at least 2 lock-release samples"
-
-            caller_name = Foo.foo.__qualname__ if PY_311_OR_ABOVE else Foo.foo.__name__
-
-            pprof_utils.assert_lock_events(
-                profile,
-                expected_acquire_events=[
-                    pprof_utils.LockAcquireEvent(
-                        caller_name=caller_name,
-                        filename=os.path.basename(__file__),
-                        linenos=linenos,
-                        lock_name=expected_lock_name,
-                    ),
-                ],
-                expected_release_events=[
-                    pprof_utils.LockReleaseEvent(
-                        caller_name=caller_name,
-                        filename=os.path.basename(__file__),
-                        linenos=linenos,
-                        lock_name=expected_lock_name,
-                    ),
-                ],
-            )
-
-    def test_find_name_slots_object(self) -> None:
-        """Regression: _find_name resolves lock names on __slots__-based objects.
-
-        Objects with __slots__ have no __dict__, so the slots inspection path
-        in _find_name must be used. Previously, the TypeError from vars() was
-        caught and the name resolution was skipped entirely.
-        """
-
-        class SlottedHolder:
-            __slots__ = ("my_lock",)
-
-            def __init__(self, lock_class: LockTypeClass) -> None:
-                self.my_lock: LockTypeInst = lock_class()
-
-        with mock.patch(
-            "ddtrace.internal.settings.profiling.config.lock.name_inspect_dir",
-            True,
-        ):
-            with self.collector_class(capture_pct=100):
-                holder = SlottedHolder(self.lock_class)
-                assert isinstance(holder.my_lock, _ProfiledLock)
-                found_name: Optional[str] = holder.my_lock._find_name({"holder": holder})
-                assert found_name == "my_lock", (
-                    f"Expected 'my_lock' but got {found_name!r}. Lock name resolution through __slots__ is broken."
-                )
-
-    def test_crashing_descriptor_does_not_crash(self) -> None:
-        """Regression: _find_name must not crash when an object has a descriptor that raises.
-
-        Ray's get_actor_name descriptor crashes when accessed from a non-actor
-        worker context. The old dir()+getattr() approach would invoke it and
-        crash. The fix uses __dict__ to avoid invoking class-level descriptors.
-        """
-
-        class CrashingDescriptor:
-            def __get__(self, obj: object, objtype: Optional[type] = None) -> object:
-                raise RuntimeError("Simulated Ray descriptor crash")
-
-        class HolderWithCrashingDescriptor:
-            dangerous_attr = CrashingDescriptor()
-
-            def __init__(self, lock_class: LockTypeClass) -> None:
-                self.my_lock: LockTypeInst = lock_class()
-
-        with mock.patch(
-            "ddtrace.internal.settings.profiling.config.lock.name_inspect_dir",
-            True,
-        ):
-            with self.collector_class(capture_pct=100):
-                holder = HolderWithCrashingDescriptor(self.lock_class)
-                assert isinstance(holder.my_lock, _ProfiledLock)
-                # Must not raise, even though accessing dangerous_attr crashes
-                found_name = holder.my_lock._find_name({"holder": holder})
-                assert found_name == "my_lock", f"Expected 'my_lock' but got {found_name!r}."
-
-    def test_private_lock(self) -> None:
-        # Store reference to class for later qualname access
-        foo_class: Optional[type] = None
-
-        class Foo:
-            def __init__(self, lock_class: LockTypeClass) -> None:
-                self.__lock: LockTypeInst = lock_class()  # !CREATE! test_private_lock
-
-            def foo(self) -> None:
-                with self.__lock:  # !RELEASE! !ACQUIRE! test_private_lock
-                    pass
-
-        # Capture reference before context manager
-        foo_class = Foo
-
-        with self.collector_class(capture_pct=100):
-            foo: Foo = Foo(self.lock_class)
-            foo.foo()
-
-        ddup.upload()  # pyright: ignore[reportCallIssue]
-
-        linenos: LineNo = get_lock_linenos("test_private_lock", with_stmt=True)
-
-        profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(self.output_filename)
-
-        assert foo_class is not None
-        caller_name = foo_class.foo.__qualname__ if PY_311_OR_ABOVE else foo_class.foo.__name__
-        pprof_utils.assert_lock_events(
-            profile,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name=caller_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos,
-                    lock_name="_Foo__lock",
-                ),
-            ],
-            expected_release_events=[
-                pprof_utils.LockReleaseEvent(
-                    caller_name=caller_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos,
-                    lock_name="_Foo__lock",
-                ),
-            ],
-        )
-
-    def test_inner_lock(self) -> None:
-        # Store reference to class for later qualname access
-        bar_class: Optional[type] = None
-
-        class Bar:
-            def __init__(self, lock_class: LockTypeClass) -> None:
-                self.foo: Foo = Foo(lock_class)
-
-            def bar(self) -> None:
-                with self.foo.foo_lock:  # !RELEASE! !ACQUIRE! test_inner_lock
-                    pass
-
-        # Capture reference before context manager
-        bar_class = Bar
-
-        with self.collector_class(capture_pct=100):
-            bar: Bar = Bar(self.lock_class)
-            bar.bar()
-
-        ddup.upload()  # pyright: ignore[reportCallIssue]
-
-        linenos_foo: LineNo = get_lock_linenos("foolock")
-        linenos_bar: LineNo = get_lock_linenos("test_inner_lock", with_stmt=True)
-        linenos_bar = linenos_bar._replace(
-            create=linenos_foo.create,
-        )
-
-        profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(self.output_filename)
-        assert bar_class is not None
-        caller_name = bar_class.bar.__qualname__ if PY_311_OR_ABOVE else bar_class.bar.__name__
-        pprof_utils.assert_lock_events(
-            profile,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name=caller_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos_bar,
-                ),
-            ],
-            expected_release_events=[
-                pprof_utils.LockReleaseEvent(
-                    caller_name=caller_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos_bar,
-                ),
-            ],
-        )
-
-    def test_anonymous_lock(self) -> None:
-        with self.collector_class(capture_pct=100):
-            with self.lock_class():  # !CREATE! !ACQUIRE! !RELEASE! test_anonymous_lock
-                pass
-        ddup.upload()  # pyright: ignore[reportCallIssue]
-
-        linenos: LineNo = get_lock_linenos("test_anonymous_lock", with_stmt=True)
-
-        profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(self.output_filename)
-        pprof_utils.assert_lock_events(
-            profile,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos,
-                ),
-            ],
-            expected_release_events=[
-                pprof_utils.LockReleaseEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos,
-                ),
-            ],
-        )
-
-    def test_global_locks(self) -> None:
-        global _test_global_lock, _test_global_bar_instance
-
-        # Store references to functions/classes for later qualname access
-        foo_func: Optional[Callable[[], None]] = None
-        test_bar_class: Optional[type] = None
-
-        with self.collector_class(capture_pct=100):
-            # Create true module-level globals
-            _test_global_lock = self.lock_class()  # !CREATE! _test_global_lock
-
-            class TestBar:
-                def __init__(self, lock_class: LockTypeClass) -> None:
-                    self.bar_lock: LockTypeInst = lock_class()  # !CREATE! bar_lock
-
-                def bar(self) -> None:
-                    with self.bar_lock:  # !ACQUIRE! !RELEASE! bar_lock
-                        pass
-
-            def foo() -> None:
-                global _test_global_lock
-                assert _test_global_lock is not None
-                with _test_global_lock:  # !ACQUIRE! !RELEASE! _test_global_lock
-                    pass
-
-            # Capture references before context manager exits
-            foo_func = foo
-            test_bar_class = TestBar
-
-            _test_global_bar_instance = TestBar(self.lock_class)  # type: ignore[assignment]
-
-            # Use the locks
-            foo()
-            _test_global_bar_instance.bar()  # type: ignore[attr-defined]
-
-        ddup.upload()  # pyright: ignore[reportCallIssue]
-
-        # Process this file to get the correct line numbers for our !CREATE! comments
-        init_linenos(__file__)
-
-        profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(self.output_filename)
-        linenos_global: LineNo = get_lock_linenos("_test_global_lock", with_stmt=True)
-        linenos_bar: LineNo = get_lock_linenos("bar_lock", with_stmt=True)
-
-        assert foo_func is not None
-        assert test_bar_class is not None
-        caller_name_foo = foo_func.__qualname__ if PY_311_OR_ABOVE else foo_func.__name__
-        caller_name_bar = test_bar_class.bar.__qualname__ if PY_311_OR_ABOVE else test_bar_class.bar.__name__
-
-        pprof_utils.assert_lock_events(
-            profile,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name=caller_name_foo,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos_global,
-                    lock_name="_test_global_lock",
-                ),
-                pprof_utils.LockAcquireEvent(
-                    caller_name=caller_name_bar,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos_bar,
-                    lock_name="bar_lock",
-                ),
-            ],
-            expected_release_events=[
-                pprof_utils.LockReleaseEvent(
-                    caller_name=caller_name_foo,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos_global,
-                    lock_name="_test_global_lock",
-                ),
-                pprof_utils.LockReleaseEvent(
-                    caller_name=caller_name_bar,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos_bar,
-                    lock_name="bar_lock",
-                ),
-            ],
-        )
-
-    def test_upload_resets_profile(self) -> None:
-        # This test checks that the profile is cleared after each upload() call
-        # It is added in test_threading.py as LockCollector can easily be
-        # configured to be deterministic with capture_pct=100.
-        with self.collector_class(capture_pct=100):
-            with self.lock_class():  # !CREATE! !ACQUIRE! !RELEASE! test_upload_resets_profile
-                pass
-
-        ddup.upload()  # pyright: ignore[reportCallIssue]
-
-        linenos: LineNo = get_lock_linenos("test_upload_resets_profile", with_stmt=True)
-
-        pprof: pprof_pb2.Profile = pprof_utils.parse_newest_profile(self.output_filename)
-        pprof_utils.assert_lock_events(
-            pprof,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos,
-                ),
-            ],
-            expected_release_events=[
-                pprof_utils.LockReleaseEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos,
-                ),
-            ],
-        )
-
-        # Now we call upload() again, and we expect the profile to be empty
-        num_files_before_second_upload: int = len(glob.glob(self.output_filename + ".*.pprof"))
-
-        ddup.upload()  # pyright: ignore[reportCallIssue]
-
-        num_files_after_second_upload: int = len(glob.glob(self.output_filename + ".*.pprof"))
-
-        # A new profile file should always be created (upload_seq increments)
-        assert num_files_after_second_upload - num_files_before_second_upload == 1, (
-            f"Expected 1 new file, got {num_files_after_second_upload - num_files_before_second_upload}."
-        )
-
-        # The newest profile file should be empty (no samples), which causes an AssertionError
-        with pytest.raises(AssertionError, match="No samples found in profile"):
-            pprof_utils.parse_newest_profile(self.output_filename)
 
     def test_lock_hash(self) -> None:
         """Test that __hash__ allows profiled locks to be used in sets and dicts."""
@@ -2000,12 +1182,1100 @@ class TestGenericLockProfiling(LockCollectorTestBase):
             f"profiled: {profiled_time_zero:.6f}s)"
         )
 
-    def test_release_not_sampled_when_acquire_not_sampled(self) -> None:
-        """Test that lock release events are NOT sampled if their corresponding acquire was not sampled."""
-        # Use capture_pct=0 to ensure acquire is NEVER sampled
-        with self.collector_class(capture_pct=0):
-            lock: LockTypeInst = self.lock_class()
-            # Do multiple acquire/release cycles
+
+# ---------------------------------------------------------------------------
+# Subprocess versions of TestGenericLockProfiling ddup-upload tests
+# Each subprocess function imports everything it needs inside its body.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_generic_lock_lock_events() -> None:
+    import os
+    import threading
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    def test_lock_events():
+        lock = threading.Lock()  # !CREATE! test_lock_events
+        lock.acquire()  # !ACQUIRE! test_lock_events
+        lock.release()  # !RELEASE! test_lock_events
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_generic_lock_lock_events", version="my_version")
+        ddup.start()
+
+        with ThreadingLockCollector(capture_pct=100):
+            test_lock_events()
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos = get_lock_linenos("test_lock_events")
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events",
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name="lock",
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events",
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name="lock",
+            ),
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_generic_lock_lock_events_truncate_frames() -> None:
+    """Ensure lock samples keep leaf callsite and use an omitted-frames root when truncated."""
+    import os
+    import sys
+    import threading
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.internal.settings.profiling import config
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    PY_311_OR_ABOVE = sys.version_info[:2] >= (3, 11)
+    recursion_depth = config.max_frames + 50
+
+    def deep_lock_ops(depth, lock):
+        if depth == 0:
+            lock.acquire()  # !ACQUIRE! test_lock_events_truncate_frames
+            lock.release()  # !RELEASE! test_lock_events_truncate_frames
+            return
+        deep_lock_ops(depth - 1, lock)
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_generic_lock_lock_events_truncate_frames", version="my_version")
+        ddup.start()
+
+        with ThreadingLockCollector(capture_pct=100):
+            lock = threading.Lock()  # !CREATE! test_lock_events_truncate_frames
+            deep_lock_ops(recursion_depth, lock)
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos = get_lock_linenos("test_lock_events_truncate_frames")
+    caller_name = deep_lock_ops.__qualname__ if PY_311_OR_ABOVE else deep_lock_ops.__name__
+
+    def _assert_callsite_sample_is_truncated(sample_type, expected_line):
+        samples = pprof_utils.get_samples_with_value_type(profile, sample_type)
+        assert len(samples) > 0
+
+        found_callsite_sample = False
+        for sample_idx, sample in enumerate(samples):
+            assert len(sample.location_id) <= config.max_frames + 1, (
+                f"sample index={sample_idx} has too many locations: {len(sample.location_id)}"
+            )
+
+            leaf_location = pprof_utils.get_location_with_id(profile, sample.location_id[0])
+            leaf_line = leaf_location.line[0]
+            leaf_function = pprof_utils.get_function_with_id(profile, leaf_line.function_id)
+            leaf_function_name = profile.string_table[leaf_function.name]
+            if leaf_function_name == caller_name and leaf_line.line == expected_line:
+                found_callsite_sample = True
+
+                root_location = pprof_utils.get_location_with_id(profile, sample.location_id[-1])
+                root_line = root_location.line[0]
+                root_function = pprof_utils.get_function_with_id(profile, root_line.function_id)
+                root_function_name = profile.string_table[root_function.name]
+                assert root_function_name.startswith("<") and "omitted>" in root_function_name, (
+                    f"expected {sample_type} callsite sample root frame to be omitted marker, got"
+                    f" {root_function_name!r}"
+                )
+                break
+
+        assert found_callsite_sample, f"expected to find {sample_type} callsite sample"
+
+    _assert_callsite_sample_is_truncated("lock-acquire", linenos.acquire)
+    _assert_callsite_sample_is_truncated("lock-release", linenos.release)
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_generic_lock_lock_acquire_events_class() -> None:
+    import os
+    import sys
+    import threading
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+    PY_311_OR_ABOVE = sys.version_info[:2] >= (3, 11)
+
+    class Foobar(object):
+        def lockfunc(self):
+            lock = threading.Lock()  # !CREATE! test_lock_acquire_events_class
+            lock.acquire()  # !ACQUIRE! test_lock_acquire_events_class
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_generic_lock_lock_acquire_events_class", version="my_version")
+        ddup.start()
+
+        with ThreadingLockCollector(capture_pct=100):
+            Foobar().lockfunc()
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos = get_lock_linenos("test_lock_acquire_events_class")
+    caller_name = Foobar.lockfunc.__qualname__ if PY_311_OR_ABOVE else Foobar.lockfunc.__name__
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name=caller_name,
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name="lock",
+            ),
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_generic_lock_lock_events_tracer() -> None:
+    import os
+    import threading
+    import uuid
+
+    import ddtrace
+    from ddtrace import ext
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    def test_lock_events_tracer():
+        tracer = ddtrace.trace.tracer
+        tracer._endpoint_call_counter_span_processor.enable()
+        resource = str(uuid.uuid4())
+        span_type = ext.SpanTypes.WEB
+
+        with ThreadingLockCollector(tracer=tracer, capture_pct=100):
+            lock1 = threading.Lock()  # !CREATE! test_lock_events_tracer_1
+            lock1.acquire()  # !ACQUIRE! test_lock_events_tracer_1
+            with tracer.trace("test", resource=resource, span_type=span_type) as t:
+                lock2 = threading.Lock()  # !CREATE! test_lock_events_tracer_2
+                lock2.acquire()  # !ACQUIRE! test_lock_events_tracer_2
+                lock1.release()  # !RELEASE! test_lock_events_tracer_1
+                span_id = t.span_id
+
+            lock2.release()  # !RELEASE! test_lock_events_tracer_2
+        return resource, span_type, span_id
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_generic_lock_lock_events_tracer", version="my_version")
+        ddup.start()
+        resource, span_type, span_id = test_lock_events_tracer()
+        ddup.upload(tracer=ddtrace.trace.tracer)
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos1 = get_lock_linenos("test_lock_events_tracer_1")
+    linenos2 = get_lock_linenos("test_lock_events_tracer_2")
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_threading.py",
+                linenos=linenos1,
+                lock_name="lock1",
+            ),
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_threading.py",
+                linenos=linenos2,
+                lock_name="lock2",
+                span_id=span_id,
+                trace_endpoint=resource,
+                trace_type=span_type,
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_threading.py",
+                linenos=linenos1,
+                lock_name="lock1",
+                span_id=span_id,
+                trace_endpoint=resource,
+                trace_type=span_type,
+            ),
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events_tracer",
+                filename="test_threading.py",
+                linenos=linenos2,
+                lock_name="lock2",
+            ),
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_generic_lock_lock_events_tracer_non_web() -> None:
+    import os
+    import threading
+    import uuid
+
+    import ddtrace
+    from ddtrace import ext
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    def test_lock_events_tracer_non_web():
+        tracer = ddtrace.trace.tracer
+        tracer._endpoint_call_counter_span_processor.enable()
+        resource = str(uuid.uuid4())
+        span_type = ext.SpanTypes.SQL
+
+        with ThreadingLockCollector(tracer=tracer, capture_pct=100):
+            with tracer.trace("test", resource=resource, span_type=span_type) as t:
+                lock2 = threading.Lock()  # !CREATE! test_lock_events_tracer_non_web
+                lock2.acquire()  # !ACQUIRE! test_lock_events_tracer_non_web
+                span_id = t.span_id
+
+            lock2.release()  # !RELEASE! test_lock_events_tracer_non_web
+        return resource, span_type, span_id
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_generic_lock_lock_events_tracer_non_web", version="my_version")
+        ddup.start()
+        resource, span_type, span_id = test_lock_events_tracer_non_web()
+        ddup.upload(tracer=ddtrace.trace.tracer)
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos2 = get_lock_linenos("test_lock_events_tracer_non_web")
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events_tracer_non_web",
+                filename="test_threading.py",
+                linenos=linenos2,
+                lock_name="lock2",
+                span_id=span_id,
+                trace_type=span_type,
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events_tracer_non_web",
+                filename="test_threading.py",
+                linenos=linenos2,
+                lock_name="lock2",
+            ),
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_generic_lock_lock_events_tracer_late_finish() -> None:
+    import os
+    import threading
+    import uuid
+
+    import ddtrace
+    from ddtrace import ext
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    def test_lock_events_tracer_late_finish():
+        tracer = ddtrace.trace.tracer
+        tracer._endpoint_call_counter_span_processor.enable()
+        resource = str(uuid.uuid4())
+        span_type = ext.SpanTypes.WEB
+
+        with ThreadingLockCollector(tracer=tracer, capture_pct=100):
+            lock1 = threading.Lock()  # !CREATE! test_lock_events_tracer_late_finish_1
+            lock1.acquire()  # !ACQUIRE! test_lock_events_tracer_late_finish_1
+            span = tracer.start_span(name="test", span_type=span_type)  # pyright: ignore[reportCallIssue]
+            lock2 = threading.Lock()  # !CREATE! test_lock_events_tracer_late_finish_2
+            lock2.acquire()  # !ACQUIRE! test_lock_events_tracer_late_finish_2
+            lock1.release()  # !RELEASE! test_lock_events_tracer_late_finish_1
+            lock2.release()  # !RELEASE! test_lock_events_tracer_late_finish_2
+        span.resource = resource
+        span.finish()
+        return resource, span_type
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_generic_lock_lock_events_tracer_late_finish", version="my_version")
+        ddup.start()
+        resource, span_type = test_lock_events_tracer_late_finish()
+        ddup.upload(tracer=ddtrace.trace.tracer)
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos1 = get_lock_linenos("test_lock_events_tracer_late_finish_1")
+    linenos2 = get_lock_linenos("test_lock_events_tracer_late_finish_2")
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events_tracer_late_finish",
+                filename="test_threading.py",
+                linenos=linenos1,
+                lock_name="lock1",
+            ),
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_events_tracer_late_finish",
+                filename="test_threading.py",
+                linenos=linenos2,
+                lock_name="lock2",
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events_tracer_late_finish",
+                filename="test_threading.py",
+                linenos=linenos1,
+                lock_name="lock1",
+            ),
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_events_tracer_late_finish",
+                filename="test_threading.py",
+                linenos=linenos2,
+                lock_name="lock2",
+            ),
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_generic_lock_resource_not_collected() -> None:
+    import os
+    import threading
+    import uuid
+
+    import ddtrace
+    from ddtrace import ext
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    def test_resource_not_collected():
+        tracer = ddtrace.trace.tracer
+        tracer._endpoint_call_counter_span_processor.enable()
+        resource = str(uuid.uuid4())
+        span_type = ext.SpanTypes.WEB
+
+        with ThreadingLockCollector(tracer=tracer, capture_pct=100):
+            lock1 = threading.Lock()  # !CREATE! test_resource_not_collected_1
+            lock1.acquire()  # !ACQUIRE! test_resource_not_collected_1
+            with tracer.trace("test", resource=resource, span_type=span_type) as t:
+                lock2 = threading.Lock()  # !CREATE! test_resource_not_collected_2
+                lock2.acquire()  # !ACQUIRE! test_resource_not_collected_2
+                lock1.release()  # !RELEASE! test_resource_not_collected_1
+                span_id = t.span_id
+            lock2.release()  # !RELEASE! test_resource_not_collected_2
+        return resource, span_type, span_id
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_generic_lock_resource_not_collected", version="my_version")
+        ddup.start()
+        resource, span_type, span_id = test_resource_not_collected()
+        ddup.upload(tracer=ddtrace.trace.tracer)
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos1 = get_lock_linenos("test_resource_not_collected_1")
+    linenos2 = get_lock_linenos("test_resource_not_collected_2")
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_resource_not_collected",
+                filename="test_threading.py",
+                linenos=linenos1,
+                lock_name="lock1",
+            ),
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_resource_not_collected",
+                filename="test_threading.py",
+                linenos=linenos2,
+                lock_name="lock2",
+                span_id=span_id,
+                trace_endpoint=None,
+                trace_type=span_type,
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_resource_not_collected",
+                filename="test_threading.py",
+                linenos=linenos1,
+                lock_name="lock1",
+                span_id=span_id,
+                trace_endpoint=None,
+                trace_type=span_type,
+            ),
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_resource_not_collected",
+                filename="test_threading.py",
+                linenos=linenos2,
+                lock_name="lock2",
+            ),
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_generic_lock_lock_enter_exit_events() -> None:
+    import os
+    import threading
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    def test_lock_enter_exit_events():
+        th_lock = threading.Lock()  # !CREATE! test_lock_enter_exit_events
+        with th_lock:  # !ACQUIRE! !RELEASE! test_lock_enter_exit_events
+            pass
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_generic_lock_lock_enter_exit_events", version="my_version")
+        ddup.start()
+
+        with ThreadingLockCollector(capture_pct=100):
+            test_lock_enter_exit_events()
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos = get_lock_linenos("test_lock_enter_exit_events", with_stmt=True)
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_lock_enter_exit_events",
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name="th_lock",
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_lock_enter_exit_events",
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name="th_lock",
+            ),
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_generic_lock_class_member_lock_inspect_dir_enabled() -> None:
+    """test_class_member_lock with inspect_dir_enabled=True."""
+    import os
+    import sys
+    import threading
+    from unittest import mock
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+    PY_311_OR_ABOVE = sys.version_info[:2] >= (3, 11)
+
+    class Foo:
+        def __init__(self):
+            self.foo_lock = threading.Lock()  # !CREATE! foolock
+
+        def foo(self):
+            with self.foo_lock:  # !RELEASE! !ACQUIRE! foolock
+                pass
+
+    class Bar:
+        def __init__(self):
+            self.foo = Foo()
+
+        def bar(self):
+            self.foo.foo()
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_generic_lock_class_member_lock_inspect_dir_enabled", version="my_version")
+        ddup.start()
+
+        with mock.patch("ddtrace.internal.settings.profiling.config.lock.name_inspect_dir", True):
+            with ThreadingLockCollector(capture_pct=100):
+                foobar = Foo()
+                foobar.foo()
+                bar = Bar()
+                bar.bar()
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos = get_lock_linenos("foolock", with_stmt=True)
+    acquire_samples = pprof_utils.get_samples_with_value_type(profile, "lock-acquire")
+    assert len(acquire_samples) >= 2, "Expected at least 2 lock-acquire samples"
+    release_samples = pprof_utils.get_samples_with_value_type(profile, "lock-release")
+    assert len(release_samples) >= 2, "Expected at least 2 lock-release samples"
+
+    caller_name = Foo.foo.__qualname__ if PY_311_OR_ABOVE else Foo.foo.__name__
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name=caller_name,
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name="foo_lock",
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name=caller_name,
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name="foo_lock",
+            ),
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_generic_lock_class_member_lock_inspect_dir_disabled() -> None:
+    """test_class_member_lock with inspect_dir_enabled=False."""
+    import os
+    import sys
+    import threading
+    from unittest import mock
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+    PY_311_OR_ABOVE = sys.version_info[:2] >= (3, 11)
+
+    class Foo:
+        def __init__(self):
+            self.foo_lock = threading.Lock()  # !CREATE! foolock_disabled
+
+        def foo(self):
+            with self.foo_lock:  # !RELEASE! !ACQUIRE! foolock_disabled
+                pass
+
+    class Bar:
+        def __init__(self):
+            self.foo = Foo()
+
+        def bar(self):
+            self.foo.foo()
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(
+            env="test", service="test_generic_lock_class_member_lock_inspect_dir_disabled", version="my_version"
+        )
+        ddup.start()
+
+        with mock.patch("ddtrace.internal.settings.profiling.config.lock.name_inspect_dir", False):
+            with ThreadingLockCollector(capture_pct=100):
+                foobar = Foo()
+                foobar.foo()
+                bar = Bar()
+                bar.bar()
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos = get_lock_linenos("foolock_disabled", with_stmt=True)
+    acquire_samples = pprof_utils.get_samples_with_value_type(profile, "lock-acquire")
+    assert len(acquire_samples) >= 2, "Expected at least 2 lock-acquire samples"
+    release_samples = pprof_utils.get_samples_with_value_type(profile, "lock-release")
+    assert len(release_samples) >= 2, "Expected at least 2 lock-release samples"
+
+    caller_name = Foo.foo.__qualname__ if PY_311_OR_ABOVE else Foo.foo.__name__
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name=caller_name,
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name=None,
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name=caller_name,
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name=None,
+            ),
+        ],
+    )
+
+
+def test_find_name_slots_object() -> None:
+    """Regression: _find_name resolves lock names on __slots__-based objects.
+
+    Objects with __slots__ have no __dict__, so the slots inspection path
+    in _find_name must be used. Previously, the TypeError from vars() was
+    caught and the name resolution was skipped entirely.
+    """
+
+    class SlottedHolder:
+        __slots__ = ("my_lock",)
+
+        def __init__(self) -> None:
+            self.my_lock = threading.Lock()
+
+    with mock.patch(
+        "ddtrace.internal.settings.profiling.config.lock.name_inspect_dir",
+        True,
+    ):
+        with ThreadingLockCollector(capture_pct=100):
+            holder = SlottedHolder()
+            assert isinstance(holder.my_lock, _ProfiledLock)
+            found_name: Optional[str] = holder.my_lock._find_name({"holder": holder})
+            assert found_name == "my_lock", (
+                f"Expected 'my_lock' but got {found_name!r}. Lock name resolution through __slots__ is broken."
+            )
+
+
+def test_crashing_descriptor_does_not_crash() -> None:
+    """Regression: _find_name must not crash when an object has a descriptor that raises.
+
+    Ray's get_actor_name descriptor crashes when accessed from a non-actor
+    worker context. The old dir()+getattr() approach would invoke it and
+    crash. The fix uses __dict__ to avoid invoking class-level descriptors.
+    """
+
+    class CrashingDescriptor:
+        def __get__(self, obj: object, objtype: Optional[type] = None) -> object:
+            raise RuntimeError("Simulated Ray descriptor crash")
+
+    class HolderWithCrashingDescriptor:
+        dangerous_attr = CrashingDescriptor()
+
+        def __init__(self) -> None:
+            self.my_lock = threading.Lock()
+
+    with mock.patch(
+        "ddtrace.internal.settings.profiling.config.lock.name_inspect_dir",
+        True,
+    ):
+        with ThreadingLockCollector(capture_pct=100):
+            holder = HolderWithCrashingDescriptor()
+            assert isinstance(holder.my_lock, _ProfiledLock)
+            # Must not raise, even though accessing dangerous_attr crashes
+            found_name = holder.my_lock._find_name({"holder": holder})
+            assert found_name == "my_lock", f"Expected 'my_lock' but got {found_name!r}."
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_generic_lock_private_lock() -> None:
+    import os
+    import sys
+    import threading
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+    PY_311_OR_ABOVE = sys.version_info[:2] >= (3, 11)
+
+    class Foo:
+        def __init__(self):
+            self.__lock = threading.Lock()  # !CREATE! test_private_lock
+
+        def foo(self):
+            with self.__lock:  # !RELEASE! !ACQUIRE! test_private_lock
+                pass
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_generic_lock_private_lock", version="my_version")
+        ddup.start()
+
+        with ThreadingLockCollector(capture_pct=100):
+            foo = Foo()
+            foo.foo()
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos = get_lock_linenos("test_private_lock", with_stmt=True)
+    caller_name = Foo.foo.__qualname__ if PY_311_OR_ABOVE else Foo.foo.__name__
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name=caller_name,
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name="_Foo__lock",
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name=caller_name,
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name="_Foo__lock",
+            ),
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_generic_lock_inner_lock() -> None:
+    import os
+    import sys
+    import threading
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+    PY_311_OR_ABOVE = sys.version_info[:2] >= (3, 11)
+
+    class Foo:
+        def __init__(self):
+            self.foo_lock = threading.Lock()  # !CREATE! inner_lock_foolock
+
+        def foo(self):
+            with self.foo_lock:  # !RELEASE! !ACQUIRE! inner_lock_foolock
+                pass
+
+    class Bar:
+        def __init__(self):
+            self.foo = Foo()
+
+        def bar(self):
+            with self.foo.foo_lock:  # !RELEASE! !ACQUIRE! test_inner_lock
+                pass
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_generic_lock_inner_lock", version="my_version")
+        ddup.start()
+
+        with ThreadingLockCollector(capture_pct=100):
+            bar = Bar()
+            bar.bar()
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos_foo = get_lock_linenos("inner_lock_foolock")
+    linenos_bar = get_lock_linenos("test_inner_lock", with_stmt=True)
+    linenos_bar = linenos_bar._replace(create=linenos_foo.create)
+    caller_name = Bar.bar.__qualname__ if PY_311_OR_ABOVE else Bar.bar.__name__
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name=caller_name,
+                filename="test_threading.py",
+                linenos=linenos_bar,
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name=caller_name,
+                filename="test_threading.py",
+                linenos=linenos_bar,
+            ),
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_generic_lock_anonymous_lock() -> None:
+    import os
+    import threading
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    def test_anonymous_lock():
+        with threading.Lock():  # !CREATE! !ACQUIRE! !RELEASE! test_anonymous_lock
+            pass
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_generic_lock_anonymous_lock", version="my_version")
+        ddup.start()
+
+        with ThreadingLockCollector(capture_pct=100):
+            test_anonymous_lock()
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos = get_lock_linenos("test_anonymous_lock", with_stmt=True)
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_anonymous_lock",
+                filename="test_threading.py",
+                linenos=linenos,
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_anonymous_lock",
+                filename="test_threading.py",
+                linenos=linenos,
+            ),
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_generic_lock_global_locks() -> None:
+    import os
+    import sys
+    import threading
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+    PY_311_OR_ABOVE = sys.version_info[:2] >= (3, 11)
+
+    _test_global_lock = None
+
+    class TestBar:
+        def __init__(self):
+            self.bar_lock = threading.Lock()  # !CREATE! bar_lock
+
+        def bar(self):
+            with self.bar_lock:  # !ACQUIRE! !RELEASE! bar_lock
+                pass
+
+    def foo():
+        global _test_global_lock
+        assert _test_global_lock is not None
+        with _test_global_lock:  # !ACQUIRE! !RELEASE! _test_global_lock
+            pass
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_generic_lock_global_locks", version="my_version")
+        ddup.start()
+
+        with ThreadingLockCollector(capture_pct=100):
+            _test_global_lock = threading.Lock()  # !CREATE! _test_global_lock
+            test_bar_instance = TestBar()
+            foo()
+            test_bar_instance.bar()
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos_global = get_lock_linenos("_test_global_lock", with_stmt=True)
+    linenos_bar = get_lock_linenos("bar_lock", with_stmt=True)
+    caller_name_foo = foo.__qualname__ if PY_311_OR_ABOVE else foo.__name__
+    caller_name_bar = TestBar.bar.__qualname__ if PY_311_OR_ABOVE else TestBar.bar.__name__
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name=caller_name_foo,
+                filename="test_threading.py",
+                linenos=linenos_global,
+                lock_name="_test_global_lock",
+            ),
+            pprof_utils.LockAcquireEvent(
+                caller_name=caller_name_bar,
+                filename="test_threading.py",
+                linenos=linenos_bar,
+                lock_name="bar_lock",
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name=caller_name_foo,
+                filename="test_threading.py",
+                linenos=linenos_global,
+                lock_name="_test_global_lock",
+            ),
+            pprof_utils.LockReleaseEvent(
+                caller_name=caller_name_bar,
+                filename="test_threading.py",
+                linenos=linenos_bar,
+                lock_name="bar_lock",
+            ),
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_generic_lock_upload_resets_profile() -> None:
+    import os
+    import threading
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    def test_upload_resets_profile():
+        with threading.Lock():  # !CREATE! !ACQUIRE! !RELEASE! test_upload_resets_profile
+            pass
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_generic_lock_upload_resets_profile", version="my_version")
+        ddup.start()
+
+        with ThreadingLockCollector(capture_pct=100):
+            test_upload_resets_profile()
+
+        ddup.upload()
+        linenos = get_lock_linenos("test_upload_resets_profile", with_stmt=True)
+        pprof = pprof_utils.get_profile_from_agent(agent)
+        pprof_utils.assert_lock_events(
+            pprof,
+            expected_acquire_events=[
+                pprof_utils.LockAcquireEvent(
+                    caller_name="test_upload_resets_profile",
+                    filename="test_threading.py",
+                    linenos=linenos,
+                ),
+            ],
+            expected_release_events=[
+                pprof_utils.LockReleaseEvent(
+                    caller_name="test_upload_resets_profile",
+                    filename="test_threading.py",
+                    linenos=linenos,
+                ),
+            ],
+        )
+
+        # Second upload should produce empty profile (no samples)
+        agent.clear()
+        ddup.upload()
+        empty_pprof = pprof_utils.get_profile_from_agent(agent, assert_samples=False)
+        assert len(empty_pprof.sample) == 0, (
+            f"Expected empty profile after second upload, got {len(empty_pprof.sample)} samples"
+        )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_generic_lock_release_not_sampled_when_acquire_not_sampled() -> None:
+    import os
+    import threading
+    import time
+    from typing import cast
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector._lock import _ProfiledLock
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(
+            env="test",
+            service="test_generic_lock_release_not_sampled_when_acquire_not_sampled",
+            version="my_version",
+        )
+        ddup.start()
+
+        with ThreadingLockCollector(capture_pct=0):
+            lock = threading.Lock()
             for _ in range(10):
                 lock.acquire()
                 assert cast(_ProfiledLock, lock).acquired_time is None
@@ -2013,24 +2283,36 @@ class TestGenericLockProfiling(LockCollectorTestBase):
                 lock.release()
 
         ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent, assert_samples=False)
 
-        profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(self.output_filename, assert_samples=False)
-        release_samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "lock-release")
+    release_samples = pprof_utils.get_samples_with_value_type(profile, "lock-release")
+    assert len(release_samples) == 0, (
+        f"Expected no release samples when acquire wasn't sampled, got {len(release_samples)}"
+    )
 
-        # release samples should NOT be generated when acquire wasn't sampled
-        assert len(release_samples) == 0, (
-            f"Expected no release samples when acquire wasn't sampled, got {len(release_samples)}"
-        )
 
-    def test_failed_acquire_produces_no_sample(self) -> None:
-        """Test that a failed non-blocking acquire produces no acquire/release samples.
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_generic_lock_failed_acquire_produces_no_sample() -> None:
+    import os
+    import threading
+    from typing import cast
 
-        When acquire(blocking=False) returns False (lock unavailable), acquired_time
-        must NOT be set. Setting it would produce a spurious acquire sample and corrupt
-        the hold-time of the thread that actually holds the lock.
-        """
-        with self.collector_class(capture_pct=100):
-            lock: LockTypeInst = self.lock_class()
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector._lock import _ProfiledLock
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_generic_lock_failed_acquire_produces_no_sample", version="my_version")
+        ddup.start()
+
+        with ThreadingLockCollector(capture_pct=100):
+            lock = threading.Lock()
             lock.acquire()
             profiled = cast(_ProfiledLock, lock)
             acquired_time_after_success = profiled.acquired_time
@@ -2041,22 +2323,25 @@ class TestGenericLockProfiling(LockCollectorTestBase):
             assert profiled.acquired_time == acquired_time_after_success, (
                 "acquired_time must not change after a failed acquire"
             )
-
             lock.release()
 
         ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
 
-        profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(self.output_filename)
-        acquire_samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "lock-acquire")
-        release_samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "lock-release")
-
-        assert len(acquire_samples) == 1, (
-            f"Expected exactly 1 acquire sample (the successful one), got {len(acquire_samples)}"
-        )
-        assert len(release_samples) == 1, f"Expected exactly 1 release sample, got {len(release_samples)}"
+    acquire_samples = pprof_utils.get_samples_with_value_type(profile, "lock-acquire")
+    release_samples = pprof_utils.get_samples_with_value_type(profile, "lock-release")
+    assert len(acquire_samples) == 1, (
+        f"Expected exactly 1 acquire sample (the successful one), got {len(acquire_samples)}"
+    )
+    assert len(release_samples) == 1, f"Expected exactly 1 release sample, got {len(release_samples)}"
 
 
-class TestThreadingLockCollector(LockCollectorTestBase):
+# ---------------------------------------------------------------------------
+# TestThreadingLockCollector — Lock-specific non-ddup tests
+# ---------------------------------------------------------------------------
+
+
+class TestThreadingLockCollector:
     """Test Lock-specific profiling behavior.
 
     Generic profiling tests are in TestGenericLockProfiling.
@@ -2084,8 +2369,6 @@ class TestThreadingLockCollector(LockCollectorTestBase):
         """Test that __getattr__ delegates Lock-specific attributes."""
         with self.collector_class(capture_pct=100):
             lock: LockTypeInst = self.lock_class()
-            from ddtrace.profiling.collector._lock import _ProfiledLock
-
             assert isinstance(lock, _ProfiledLock)
 
             # acquire_lock and release_lock are aliases that exist on _thread.lock
@@ -2099,7 +2382,12 @@ class TestThreadingLockCollector(LockCollectorTestBase):
             lock.release_lock()
 
 
-class TestThreadingRLockCollector(LockCollectorTestBase):
+# ---------------------------------------------------------------------------
+# TestThreadingRLockCollector — RLock-specific non-ddup tests
+# ---------------------------------------------------------------------------
+
+
+class TestThreadingRLockCollector:
     """Test RLock-specific profiling behavior.
 
     Generic profiling tests are in TestGenericLockProfiling.
@@ -2127,8 +2415,6 @@ class TestThreadingRLockCollector(LockCollectorTestBase):
         """Test that __getattr__ delegates RLock-specific attributes."""
         with self.collector_class(capture_pct=100):
             lock: LockTypeInst = self.lock_class()
-            from ddtrace.profiling.collector._lock import _ProfiledLock
-
             assert isinstance(lock, _ProfiledLock)
 
             # _is_owned() is an RLock-specific method that should be delegated via __getattr__
@@ -2148,123 +2434,41 @@ class TestThreadingRLockCollector(LockCollectorTestBase):
             assert not lock._is_owned()
 
 
-class BaseSemaphoreTest(LockCollectorTestBase):
+# ---------------------------------------------------------------------------
+# BaseSemaphoreTest — shared non-ddup Semaphore tests
+# ---------------------------------------------------------------------------
+
+
+class BaseSemaphoreTest:
     """Base test class for Semaphore-like locks (Semaphore and BoundedSemaphore).
 
-    Contains tests that apply to both regular Semaphore and BoundedSemaphore,
-    particularly those related to internal lock detection and Condition-based implementation.
-    Generic profiling tests are in TestGenericLockProfiling.
+    Contains non-ddup-upload tests that apply to both Semaphore and BoundedSemaphore.
+    Tests that call ddup.upload() are converted to standalone subprocess functions.
     """
 
-    def test_subclassing_wrapped_lock(self) -> None:
-        """Test that subclassing of a wrapped lock type works when profiling is active.
+    @property
+    def collector_class(self) -> CollectorTypeClass:
+        raise NotImplementedError("Child classes must implement collector_class")
 
-        This test is only valid for Semaphore-like types (pure Python classes).
-        threading.Lock and threading.RLock are C types that don't support subclassing
-        through __mro_entries__.
-        """
+    @property
+    def lock_class(self) -> LockTypeClass:
+        raise NotImplementedError("Child classes must implement lock_class")
+
+    def test_subclassing_wrapped_lock(self) -> None:
+        """Test that subclassing of a wrapped lock type works when profiling is active."""
         with self.collector_class():
             assert isinstance(self.lock_class, LockAllocatorWrapper)
 
-            # This should NOT raise TypeError
             class CustomLock(self.lock_class):  # type: ignore[unreachable, name-defined]
                 def __init__(self) -> None:
                     super().__init__()
 
-            # Verify subclassing and functionality
             custom_lock: CustomLock = CustomLock()
             assert custom_lock.acquire()
             custom_lock.release()
 
-    def _verify_no_double_counting(self, marker_name: str, lock_var_name: str) -> None:
-        """Helper method to verify no double-counting in profile output.
-
-        Args:
-            marker_name: The marker name used in !CREATE! comments (e.g., "test_no_double_counting")
-            lock_var_name: The lock variable name to check in profile (e.g., "sem")
-        """
-        ddup.upload()
-
-        profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(self.output_filename)
-
-        # Count lock events (we expect 1 and only 1 acquire / release pair of samples.)
-        acquire_samples_count: int = len(pprof_utils.get_samples_with_value_type(profile, "lock-acquire"))
-        release_samples_count: int = len(pprof_utils.get_samples_with_value_type(profile, "lock-release"))
-
-        # Should have exactly 1 event!
-        # 1 event = Semaphore-like lock profiled, internal Lock skipped (correct)
-        # 2+ events = Both Semaphore-like AND internal Lock profiled (double-counting bug)
-        lock_type_name: str = self.lock_class.__name__
-        assert acquire_samples_count == 1, (
-            f"Expected 1 acquire event ({lock_type_name} only), got {acquire_samples_count}."
-        )
-        assert release_samples_count == 1, (
-            f"Expected 1 release event ({lock_type_name} only), got {release_samples_count}."
-        )
-
-        # Verify the single event is the Semaphore-like lock (not the internal Lock)
-        linenos: LineNo = get_lock_linenos(marker_name)
-        pprof_utils.assert_lock_events(
-            profile,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos,
-                    lock_name=lock_var_name,
-                ),
-            ],
-            expected_release_events=[
-                pprof_utils.LockReleaseEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos,
-                    lock_name=lock_var_name,
-                ),
-            ],
-        )
-
-    def _verify_stack_trace_to_user_code(self, marker_name: str, lock_var_name: str) -> None:
-        """Helper method to verify stack traces point to user code, not threading.py internals.
-
-        Args:
-            marker_name: The marker name used in !CREATE! comments
-            lock_var_name: The lock variable name to check in profile
-        """
-        ddup.upload()
-
-        linenos: LineNo = get_lock_linenos(marker_name)
-        profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(self.output_filename)
-
-        # stack traces should show test_threading.py (this file),
-        # not threading.py (where Condition/Semaphore internals live)
-        pprof_utils.assert_lock_events(
-            profile,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos,
-                    lock_name=lock_var_name,
-                ),
-            ],
-            expected_release_events=[
-                pprof_utils.LockReleaseEvent(
-                    caller_name=self.test_name,
-                    filename=os.path.basename(__file__),
-                    linenos=linenos,
-                    lock_name=lock_var_name,
-                ),
-            ],
-        )
-
     def test_stdlib_internal_lock_is_native(self) -> None:
-        """Locks created internally by threading.py (e.g., inside Condition/Semaphore) must be
-        native (not _ProfiledLock), because threading/asyncio are always excluded from profiling.
-        """
-        from ddtrace.profiling.collector._lock import _ProfiledLock
-        from ddtrace.profiling.collector.threading import ThreadingLockCollector
-
+        """Locks created internally by threading.py must be native (not _ProfiledLock)."""
         with ThreadingLockCollector(capture_pct=100), self.collector_class(capture_pct=100):
             regular_lock: LockTypeInst = threading.Lock()
             assert isinstance(regular_lock, _ProfiledLock), "User lock should be profiled"
@@ -2272,39 +2476,33 @@ class BaseSemaphoreTest(LockCollectorTestBase):
             sem: LockTypeInst = self.lock_class(1)  # type: ignore[call-arg, arg-type]
             assert isinstance(sem, _ProfiledLock), "User semaphore should be profiled"
 
-            # Internal lock (Semaphore -> Condition -> Lock, allocated inside threading.py)
-            # must be a native lock, NOT a _ProfiledLock
             internal_lock = sem._cond._lock
             assert not isinstance(internal_lock, _ProfiledLock), (
                 f"Lock created by threading.py (inside Condition) should be native, got {type(internal_lock).__name__}"
             )
 
     def test_acquire_return_values_preserved(self) -> None:
-        """Test that profiling wrapper preserves acquire() return values (transparency test).
-
-        This verifies the wrapper doesn't break different acquire() modes.
-        Both Semaphore and BoundedSemaphore have identical acquire() behavior.
-
-        Note: We use capture_pct=0 because we only care about behavior, not profile output.
-        """
+        """Test that profiling wrapper preserves acquire() return values."""
         with self.collector_class(capture_pct=0):
             sem: LockTypeInst = self.lock_class(1)  # type: ignore[call-arg, arg-type]
 
-            # Test that blocking acquire succeeds
             result1 = sem.acquire(blocking=True)
             assert result1 in (True, None), "Wrapper must preserve blocking acquire return value"
 
-            # Test that non-blocking acquire on unavailable semaphore returns False
             result2 = sem.acquire(blocking=False)
             assert result2 is False, "Wrapper must preserve non-blocking acquire return value (False when unavailable)"
 
             sem.release()
 
-            # Test that non-blocking acquire on available semaphore returns True
             result3 = sem.acquire(blocking=False)
             assert result3 is True, "Wrapper must preserve non-blocking acquire return value (True when available)"
 
             sem.release()
+
+
+# ---------------------------------------------------------------------------
+# TestThreadingSemaphoreCollector — Semaphore non-ddup tests
+# ---------------------------------------------------------------------------
 
 
 class TestThreadingSemaphoreCollector(BaseSemaphoreTest):
@@ -2318,48 +2516,132 @@ class TestThreadingSemaphoreCollector(BaseSemaphoreTest):
     def lock_class(self) -> type[threading.Semaphore]:
         return threading.Semaphore
 
-    def test_stack_trace_points_to_user_code(self) -> None:
-        """Verify Semaphore stack traces point to user code (uses Semaphore-specific markers)."""
-        with self.collector_class(capture_pct=100):
-            sem: LockTypeInst = self.lock_class(2)  # !CREATE! test_stack_trace_sem
-            sem.acquire()  # !ACQUIRE! test_stack_trace_sem
-            sem.release()  # !RELEASE! test_stack_trace_sem
-
-        self._verify_stack_trace_to_user_code("test_stack_trace_sem", "sem")
-
-    def test_no_double_counting_with_lock_collector(self) -> None:
-        """Verify no double-counting with Semaphore (uses Semaphore-specific markers)."""
-        from ddtrace.profiling.collector.threading import ThreadingLockCollector
-
-        with ThreadingLockCollector(capture_pct=100), self.collector_class(capture_pct=100):
-            sem: LockTypeInst = self.lock_class(1)  # !CREATE! test_no_double_counting
-            sem.acquire()  # !ACQUIRE! test_no_double_counting
-            sem.release()  # !RELEASE! test_no_double_counting
-
-        self._verify_no_double_counting("test_no_double_counting", "sem")
-
     def test_unbounded_behavior_preserved(self) -> None:
-        """Test that profiling wrapper preserves Semaphore's unbounded behavior (transparency test).
-
-        Unlike BoundedSemaphore, regular Semaphore allows unlimited releases (no ValueError).
-        This verifies our profiling wrapper preserves this behavior.
-
-        Note: We use capture_pct=0 because we only care about behavior, not profile output.
-        """
+        """Test that profiling wrapper preserves Semaphore's unbounded behavior."""
         with self.collector_class(capture_pct=0):
             sem: LockTypeInst = self.lock_class(1)
-
-            # Acquire and release normally
             sem.acquire()
             sem.release()
-
-            # Regular Semaphore allows releasing beyond initial value (no exception)
-            # This is the key difference from BoundedSemaphore
             sem.release()  # Should NOT raise ValueError
-            sem.release()  # Can keep releasing
-
-            # Verify we can still acquire (value has increased)
+            sem.release()
             assert sem.acquire(blocking=False) is True, "Semaphore should allow acquire after extra releases"
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_semaphore_stack_trace_points_to_user_code() -> None:
+    """Verify Semaphore stack traces point to user code."""
+    import os
+    import threading
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.threading import ThreadingSemaphoreCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    def test_stack_trace():
+        sem = threading.Semaphore(2)  # !CREATE! test_stack_trace_sem
+        sem.acquire()  # !ACQUIRE! test_stack_trace_sem
+        sem.release()  # !RELEASE! test_stack_trace_sem
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_semaphore_stack_trace_points_to_user_code", version="my_version")
+        ddup.start()
+
+        with ThreadingSemaphoreCollector(capture_pct=100):
+            test_stack_trace()
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos = get_lock_linenos("test_stack_trace_sem")
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_stack_trace",
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name="sem",
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_stack_trace",
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name="sem",
+            ),
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_semaphore_no_double_counting_with_lock_collector() -> None:
+    """Verify no double-counting with Semaphore."""
+    import os
+    import threading
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from ddtrace.profiling.collector.threading import ThreadingSemaphoreCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    def test_no_double_counting():
+        sem = threading.Semaphore(1)  # !CREATE! test_no_double_counting
+        sem.acquire()  # !ACQUIRE! test_no_double_counting
+        sem.release()  # !RELEASE! test_no_double_counting
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_semaphore_no_double_counting_with_lock_collector", version="my_version")
+        ddup.start()
+
+        with ThreadingLockCollector(capture_pct=100), ThreadingSemaphoreCollector(capture_pct=100):
+            test_no_double_counting()
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    acquire_samples_count = len(pprof_utils.get_samples_with_value_type(profile, "lock-acquire"))
+    release_samples_count = len(pprof_utils.get_samples_with_value_type(profile, "lock-release"))
+    assert acquire_samples_count == 1, f"Expected 1 acquire event (Semaphore only), got {acquire_samples_count}."
+    assert release_samples_count == 1, f"Expected 1 release event (Semaphore only), got {release_samples_count}."
+
+    linenos = get_lock_linenos("test_no_double_counting")
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_no_double_counting",
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name="sem",
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_no_double_counting",
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name="sem",
+            ),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestThreadingBoundedSemaphoreCollector — BoundedSemaphore non-ddup tests
+# ---------------------------------------------------------------------------
 
 
 class TestThreadingBoundedSemaphoreCollector(BaseSemaphoreTest):
@@ -2373,58 +2655,130 @@ class TestThreadingBoundedSemaphoreCollector(BaseSemaphoreTest):
     def lock_class(self) -> type[threading.BoundedSemaphore]:
         return threading.BoundedSemaphore
 
-    def test_stack_trace_points_to_user_code(self) -> None:
-        """Verify BoundedSemaphore stack traces point to user code (uses BoundedSemaphore-specific markers)."""
-        with self.collector_class(capture_pct=100):
-            bsem: LockTypeInst = self.lock_class(2)  # !CREATE! test_stack_trace_bsem
-            bsem.acquire()  # !ACQUIRE! test_stack_trace_bsem
-            bsem.release()  # !RELEASE! test_stack_trace_bsem
-
-        self._verify_stack_trace_to_user_code("test_stack_trace_bsem", "bsem")
-
-    def test_no_double_counting_with_lock_collector(self) -> None:
-        """Verify no double-counting with BoundedSemaphore (uses BoundedSemaphore-specific markers)."""
-        from ddtrace.profiling.collector.threading import ThreadingLockCollector
-
-        with ThreadingLockCollector(capture_pct=100), self.collector_class(capture_pct=100):
-            bsem: LockTypeInst = self.lock_class(1)  # !CREATE! test_no_double_counting_bounded
-            bsem.acquire()  # !ACQUIRE! test_no_double_counting_bounded
-            bsem.release()  # !RELEASE! test_no_double_counting_bounded
-
-        self._verify_no_double_counting("test_no_double_counting_bounded", "bsem")
-
     def test_bounded_behavior_preserved(self) -> None:
-        """Test that profiling wrapper preserves BoundedSemaphore's bounded behavior (transparency test).
-
-        This verifies the wrapper doesn't interfere with BoundedSemaphore's unique characteristic:
-        raising ValueError when releasing beyond the initial value.
-
-        Note: We use capture_pct=0 because we only care about behavior, not profile output.
-        """
+        """Test that profiling wrapper preserves BoundedSemaphore's bounded behavior."""
         with self.collector_class(capture_pct=0):
             sem: LockTypeInst = self.lock_class(1)
             sem.acquire()
             sem.release()
-            # BoundedSemaphore should raise ValueError when releasing more than initial value
-            # This proves our profiling wrapper doesn't break BoundedSemaphore's behavior
             with pytest.raises(ValueError, match="Semaphore released too many times"):
                 sem.release()
 
 
-class TestThreadingConditionCollector(LockCollectorTestBase):
-    """Test threading.Condition-specific profiling behavior.
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_bounded_semaphore_stack_trace_points_to_user_code() -> None:
+    """Verify BoundedSemaphore stack traces point to user code."""
+    import os
+    import threading
 
-    Generic profiling tests are in TestGenericLockProfiling.
-    This class can be extended with Condition-specific tests (e.g., wait/notify behavior).
-    """
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.threading import ThreadingBoundedSemaphoreCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
 
-    @property
-    def collector_class(self) -> type[ThreadingConditionCollector]:
-        return ThreadingConditionCollector
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
-    @property
-    def lock_class(self) -> type[threading.Condition]:
-        return threading.Condition
+    def test_stack_trace_bsem():
+        bsem = threading.BoundedSemaphore(2)  # !CREATE! test_stack_trace_bsem
+        bsem.acquire()  # !ACQUIRE! test_stack_trace_bsem
+        bsem.release()  # !RELEASE! test_stack_trace_bsem
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(env="test", service="test_bounded_semaphore_stack_trace_points_to_user_code", version="my_version")
+        ddup.start()
+
+        with ThreadingBoundedSemaphoreCollector(capture_pct=100):
+            test_stack_trace_bsem()
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    linenos = get_lock_linenos("test_stack_trace_bsem")
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_stack_trace_bsem",
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name="bsem",
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_stack_trace_bsem",
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name="bsem",
+            ),
+        ],
+    )
+
+
+@pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
+def test_bounded_semaphore_no_double_counting_with_lock_collector() -> None:
+    """Verify no double-counting with BoundedSemaphore."""
+    import os
+    import threading
+
+    from ddtrace.internal.datadog.profiling import ddup
+    from ddtrace.profiling.collector.threading import ThreadingBoundedSemaphoreCollector
+    from ddtrace.profiling.collector.threading import ThreadingLockCollector
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import get_lock_linenos
+    from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
+
+    init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
+
+    def test_no_double_counting_bounded():
+        bsem = threading.BoundedSemaphore(1)  # !CREATE! test_no_double_counting_bounded
+        bsem.acquire()  # !ACQUIRE! test_no_double_counting_bounded
+        bsem.release()  # !RELEASE! test_no_double_counting_bounded
+
+    assert ddup.is_available, "ddup is not available"
+    with with_profiling_test_agent() as agent:
+        ddup.config(
+            env="test",
+            service="test_bounded_semaphore_no_double_counting_with_lock_collector",
+            version="my_version",
+        )
+        ddup.start()
+
+        with ThreadingLockCollector(capture_pct=100), ThreadingBoundedSemaphoreCollector(capture_pct=100):
+            test_no_double_counting_bounded()
+
+        ddup.upload()
+        profile = pprof_utils.get_profile_from_agent(agent)
+
+    acquire_samples_count = len(pprof_utils.get_samples_with_value_type(profile, "lock-acquire"))
+    release_samples_count = len(pprof_utils.get_samples_with_value_type(profile, "lock-release"))
+    assert acquire_samples_count == 1, f"Expected 1 acquire event (BoundedSemaphore only), got {acquire_samples_count}."
+    assert release_samples_count == 1, f"Expected 1 release event (BoundedSemaphore only), got {release_samples_count}."
+
+    linenos = get_lock_linenos("test_no_double_counting_bounded")
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_no_double_counting_bounded",
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name="bsem",
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_no_double_counting_bounded",
+                filename="test_threading.py",
+                linenos=linenos,
+                lock_name="bsem",
+            ),
+        ],
+    )
 
 
 @pytest.mark.subprocess(env=dict(DD_PROFILING_ENABLE_ASSERTS="true"))

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -546,7 +546,6 @@ def test_lock_gevent_tasks() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert ddup.is_available, "ddup is not available"
 
@@ -560,48 +559,47 @@ def test_lock_gevent_tasks() -> None:
         lock.acquire()  # !ACQUIRE! test_lock_gevent_tasks
         lock.release()  # !RELEASE! test_lock_gevent_tasks
 
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(
-            env="test",
-            service=test_name,
-            version="my_version",
-        )  # pyright: ignore[reportCallIssue]
-        ddup.start()
+    ddup.config(
+        env="test",
+        service=test_name,
+        version="my_version",
+    )  # pyright: ignore[reportCallIssue]
+    ddup.start()
 
-        with ThreadingLockCollector(capture_pct=100):
-            t: threading.Thread = threading.Thread(name="foobar", target=play_with_lock)
-            t.start()
-            t.join()
+    with ThreadingLockCollector(capture_pct=100):
+        t: threading.Thread = threading.Thread(name="foobar", target=play_with_lock)
+        t.start()
+        t.join()
 
-        ddup.upload()  # pyright: ignore[reportCallIssue]
+    ddup.upload()  # pyright: ignore[reportCallIssue]
 
-        expected_filename: str = "test_threading.py"
-        linenos: LineNo = get_lock_linenos(test_name)
+    expected_filename: str = "test_threading.py"
+    linenos: LineNo = get_lock_linenos(test_name)
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        pprof_utils.assert_lock_events(
-            profile,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name="play_with_lock",
-                    filename=expected_filename,
-                    linenos=linenos,
-                    lock_name="lock",
-                    task_id=t.ident,
-                    task_name="foobar",
-                ),
-            ],
-            expected_release_events=[
-                pprof_utils.LockReleaseEvent(
-                    caller_name="play_with_lock",
-                    filename=expected_filename,
-                    linenos=linenos,
-                    lock_name="lock",
-                    task_id=t.ident,
-                    task_name="foobar",
-                ),
-            ],
-        )
+    profile = pprof_utils.get_profile_from_agent()
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="play_with_lock",
+                filename=expected_filename,
+                linenos=linenos,
+                lock_name="lock",
+                task_id=t.ident,
+                task_name="foobar",
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="play_with_lock",
+                filename=expected_filename,
+                linenos=linenos,
+                lock_name="lock",
+                task_id=t.ident,
+                task_name="foobar",
+            ),
+        ],
+    )
 
 
 # This test has to be run in a subprocess because it calls gevent.monkey.patch_all()
@@ -624,7 +622,6 @@ def test_rlock_gevent_tasks() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert ddup.is_available, "ddup is not available"
 
@@ -638,48 +635,47 @@ def test_rlock_gevent_tasks() -> None:
         lock.acquire()  # !ACQUIRE! test_rlock_gevent_tasks
         lock.release()  # !RELEASE! test_rlock_gevent_tasks
 
-    with with_profiling_test_agent() as agent_client:
-        ddup.config(
-            env="test",
-            service=test_name,
-            version="my_version",
-        )  # pyright: ignore[reportCallIssue]
-        ddup.start()
+    ddup.config(
+        env="test",
+        service=test_name,
+        version="my_version",
+    )  # pyright: ignore[reportCallIssue]
+    ddup.start()
 
-        with ThreadingRLockCollector(capture_pct=100):
-            t: threading.Thread = threading.Thread(name="foobar", target=play_with_lock)
-            t.start()
-            t.join()
+    with ThreadingRLockCollector(capture_pct=100):
+        t: threading.Thread = threading.Thread(name="foobar", target=play_with_lock)
+        t.start()
+        t.join()
 
-        ddup.upload()  # pyright: ignore[reportCallIssue]
+    ddup.upload()  # pyright: ignore[reportCallIssue]
 
-        expected_filename: str = "test_threading.py"
-        linenos: LineNo = get_lock_linenos(test_name)
+    expected_filename: str = "test_threading.py"
+    linenos: LineNo = get_lock_linenos(test_name)
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
-        pprof_utils.assert_lock_events(
-            profile,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name="play_with_lock",
-                    filename=expected_filename,
-                    linenos=linenos,
-                    lock_name="lock",
-                    task_id=t.ident,
-                    task_name="foobar",
-                ),
-            ],
-            expected_release_events=[
-                pprof_utils.LockReleaseEvent(
-                    caller_name="play_with_lock",
-                    filename=expected_filename,
-                    linenos=linenos,
-                    lock_name="lock",
-                    task_id=t.ident,
-                    task_name="foobar",
-                ),
-            ],
-        )
+    profile = pprof_utils.get_profile_from_agent()
+    pprof_utils.assert_lock_events(
+        profile,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="play_with_lock",
+                filename=expected_filename,
+                linenos=linenos,
+                lock_name="lock",
+                task_id=t.ident,
+                task_name="foobar",
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="play_with_lock",
+                filename=expected_filename,
+                linenos=linenos,
+                lock_name="lock",
+                task_id=t.ident,
+                task_name="foobar",
+            ),
+        ],
+    )
 
 
 @pytest.mark.subprocess(env=dict(DD_PROFILING_ENABLE_ASSERTS="true"))
@@ -1199,7 +1195,6 @@ def test_generic_lock_lock_events() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -1209,15 +1204,14 @@ def test_generic_lock_lock_events() -> None:
         lock.release()  # !RELEASE! test_lock_events
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_generic_lock_lock_events", version="my_version")
-        ddup.start()
+    ddup.config(env="test", service="test_generic_lock_lock_events", version="my_version")
+    ddup.start()
 
-        with ThreadingLockCollector(capture_pct=100):
-            test_lock_events()
+    with ThreadingLockCollector(capture_pct=100):
+        test_lock_events()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos = get_lock_linenos("test_lock_events")
     pprof_utils.assert_lock_events(
@@ -1254,7 +1248,6 @@ def test_generic_lock_lock_events_truncate_frames() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -1269,16 +1262,15 @@ def test_generic_lock_lock_events_truncate_frames() -> None:
         deep_lock_ops(depth - 1, lock)
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_generic_lock_lock_events_truncate_frames", version="my_version")
-        ddup.start()
+    ddup.config(env="test", service="test_generic_lock_lock_events_truncate_frames", version="my_version")
+    ddup.start()
 
-        with ThreadingLockCollector(capture_pct=100):
-            lock = threading.Lock()  # !CREATE! test_lock_events_truncate_frames
-            deep_lock_ops(recursion_depth, lock)
+    with ThreadingLockCollector(capture_pct=100):
+        lock = threading.Lock()  # !CREATE! test_lock_events_truncate_frames
+        deep_lock_ops(recursion_depth, lock)
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos = get_lock_linenos("test_lock_events_truncate_frames")
     caller_name = deep_lock_ops.__qualname__ if PY_311_OR_ABOVE else deep_lock_ops.__name__
@@ -1327,7 +1319,6 @@ def test_generic_lock_lock_acquire_events_class() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
     PY_311_OR_ABOVE = sys.version_info[:2] >= (3, 11)
@@ -1338,15 +1329,14 @@ def test_generic_lock_lock_acquire_events_class() -> None:
             lock.acquire()  # !ACQUIRE! test_lock_acquire_events_class
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_generic_lock_lock_acquire_events_class", version="my_version")
-        ddup.start()
+    ddup.config(env="test", service="test_generic_lock_lock_acquire_events_class", version="my_version")
+    ddup.start()
 
-        with ThreadingLockCollector(capture_pct=100):
-            Foobar().lockfunc()
+    with ThreadingLockCollector(capture_pct=100):
+        Foobar().lockfunc()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos = get_lock_linenos("test_lock_acquire_events_class")
     caller_name = Foobar.lockfunc.__qualname__ if PY_311_OR_ABOVE else Foobar.lockfunc.__name__
@@ -1376,7 +1366,6 @@ def test_generic_lock_lock_events_tracer() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -1399,12 +1388,11 @@ def test_generic_lock_lock_events_tracer() -> None:
         return resource, span_type, span_id
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_generic_lock_lock_events_tracer", version="my_version")
-        ddup.start()
-        resource, span_type, span_id = test_lock_events_tracer()
-        ddup.upload(tracer=ddtrace.trace.tracer)
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.config(env="test", service="test_generic_lock_lock_events_tracer", version="my_version")
+    ddup.start()
+    resource, span_type, span_id = test_lock_events_tracer()
+    ddup.upload(tracer=ddtrace.trace.tracer)
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos1 = get_lock_linenos("test_lock_events_tracer_1")
     linenos2 = get_lock_linenos("test_lock_events_tracer_2")
@@ -1460,7 +1448,6 @@ def test_generic_lock_lock_events_tracer_non_web() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -1480,12 +1467,11 @@ def test_generic_lock_lock_events_tracer_non_web() -> None:
         return resource, span_type, span_id
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_generic_lock_lock_events_tracer_non_web", version="my_version")
-        ddup.start()
-        resource, span_type, span_id = test_lock_events_tracer_non_web()
-        ddup.upload(tracer=ddtrace.trace.tracer)
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.config(env="test", service="test_generic_lock_lock_events_tracer_non_web", version="my_version")
+    ddup.start()
+    resource, span_type, span_id = test_lock_events_tracer_non_web()
+    ddup.upload(tracer=ddtrace.trace.tracer)
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos2 = get_lock_linenos("test_lock_events_tracer_non_web")
     pprof_utils.assert_lock_events(
@@ -1524,7 +1510,6 @@ def test_generic_lock_lock_events_tracer_late_finish() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -1547,12 +1532,11 @@ def test_generic_lock_lock_events_tracer_late_finish() -> None:
         return resource, span_type
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_generic_lock_lock_events_tracer_late_finish", version="my_version")
-        ddup.start()
-        resource, span_type = test_lock_events_tracer_late_finish()
-        ddup.upload(tracer=ddtrace.trace.tracer)
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.config(env="test", service="test_generic_lock_lock_events_tracer_late_finish", version="my_version")
+    ddup.start()
+    resource, span_type = test_lock_events_tracer_late_finish()
+    ddup.upload(tracer=ddtrace.trace.tracer)
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos1 = get_lock_linenos("test_lock_events_tracer_late_finish_1")
     linenos2 = get_lock_linenos("test_lock_events_tracer_late_finish_2")
@@ -1602,7 +1586,6 @@ def test_generic_lock_resource_not_collected() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -1624,12 +1607,11 @@ def test_generic_lock_resource_not_collected() -> None:
         return resource, span_type, span_id
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_generic_lock_resource_not_collected", version="my_version")
-        ddup.start()
-        resource, span_type, span_id = test_resource_not_collected()
-        ddup.upload(tracer=ddtrace.trace.tracer)
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.config(env="test", service="test_generic_lock_resource_not_collected", version="my_version")
+    ddup.start()
+    resource, span_type, span_id = test_resource_not_collected()
+    ddup.upload(tracer=ddtrace.trace.tracer)
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos1 = get_lock_linenos("test_resource_not_collected_1")
     linenos2 = get_lock_linenos("test_resource_not_collected_2")
@@ -1682,7 +1664,6 @@ def test_generic_lock_lock_enter_exit_events() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -1692,15 +1673,14 @@ def test_generic_lock_lock_enter_exit_events() -> None:
             pass
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_generic_lock_lock_enter_exit_events", version="my_version")
-        ddup.start()
+    ddup.config(env="test", service="test_generic_lock_lock_enter_exit_events", version="my_version")
+    ddup.start()
 
-        with ThreadingLockCollector(capture_pct=100):
-            test_lock_enter_exit_events()
+    with ThreadingLockCollector(capture_pct=100):
+        test_lock_enter_exit_events()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos = get_lock_linenos("test_lock_enter_exit_events", with_stmt=True)
     pprof_utils.assert_lock_events(
@@ -1737,7 +1717,6 @@ def test_generic_lock_class_member_lock_inspect_dir_enabled() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
     PY_311_OR_ABOVE = sys.version_info[:2] >= (3, 11)
@@ -1758,19 +1737,18 @@ def test_generic_lock_class_member_lock_inspect_dir_enabled() -> None:
             self.foo.foo()
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_generic_lock_class_member_lock_inspect_dir_enabled", version="my_version")
-        ddup.start()
+    ddup.config(env="test", service="test_generic_lock_class_member_lock_inspect_dir_enabled", version="my_version")
+    ddup.start()
 
-        with mock.patch("ddtrace.internal.settings.profiling.config.lock.name_inspect_dir", True):
-            with ThreadingLockCollector(capture_pct=100):
-                foobar = Foo()
-                foobar.foo()
-                bar = Bar()
-                bar.bar()
+    with mock.patch("ddtrace.internal.settings.profiling.config.lock.name_inspect_dir", True):
+        with ThreadingLockCollector(capture_pct=100):
+            foobar = Foo()
+            foobar.foo()
+            bar = Bar()
+            bar.bar()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos = get_lock_linenos("foolock", with_stmt=True)
     acquire_samples = pprof_utils.get_samples_with_value_type(profile, "lock-acquire")
@@ -1813,7 +1791,6 @@ def test_generic_lock_class_member_lock_inspect_dir_disabled() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
     PY_311_OR_ABOVE = sys.version_info[:2] >= (3, 11)
@@ -1834,21 +1811,18 @@ def test_generic_lock_class_member_lock_inspect_dir_disabled() -> None:
             self.foo.foo()
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(
-            env="test", service="test_generic_lock_class_member_lock_inspect_dir_disabled", version="my_version"
-        )
-        ddup.start()
+    ddup.config(env="test", service="test_generic_lock_class_member_lock_inspect_dir_disabled", version="my_version")
+    ddup.start()
 
-        with mock.patch("ddtrace.internal.settings.profiling.config.lock.name_inspect_dir", False):
-            with ThreadingLockCollector(capture_pct=100):
-                foobar = Foo()
-                foobar.foo()
-                bar = Bar()
-                bar.bar()
+    with mock.patch("ddtrace.internal.settings.profiling.config.lock.name_inspect_dir", False):
+        with ThreadingLockCollector(capture_pct=100):
+            foobar = Foo()
+            foobar.foo()
+            bar = Bar()
+            bar.bar()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos = get_lock_linenos("foolock_disabled", with_stmt=True)
     acquire_samples = pprof_utils.get_samples_with_value_type(profile, "lock-acquire")
@@ -1946,7 +1920,6 @@ def test_generic_lock_private_lock() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
     PY_311_OR_ABOVE = sys.version_info[:2] >= (3, 11)
@@ -1960,16 +1933,15 @@ def test_generic_lock_private_lock() -> None:
                 pass
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_generic_lock_private_lock", version="my_version")
-        ddup.start()
+    ddup.config(env="test", service="test_generic_lock_private_lock", version="my_version")
+    ddup.start()
 
-        with ThreadingLockCollector(capture_pct=100):
-            foo = Foo()
-            foo.foo()
+    with ThreadingLockCollector(capture_pct=100):
+        foo = Foo()
+        foo.foo()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos = get_lock_linenos("test_private_lock", with_stmt=True)
     caller_name = Foo.foo.__qualname__ if PY_311_OR_ABOVE else Foo.foo.__name__
@@ -2005,7 +1977,6 @@ def test_generic_lock_inner_lock() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
     PY_311_OR_ABOVE = sys.version_info[:2] >= (3, 11)
@@ -2027,16 +1998,15 @@ def test_generic_lock_inner_lock() -> None:
                 pass
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_generic_lock_inner_lock", version="my_version")
-        ddup.start()
+    ddup.config(env="test", service="test_generic_lock_inner_lock", version="my_version")
+    ddup.start()
 
-        with ThreadingLockCollector(capture_pct=100):
-            bar = Bar()
-            bar.bar()
+    with ThreadingLockCollector(capture_pct=100):
+        bar = Bar()
+        bar.bar()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos_foo = get_lock_linenos("inner_lock_foolock")
     linenos_bar = get_lock_linenos("test_inner_lock", with_stmt=True)
@@ -2071,7 +2041,6 @@ def test_generic_lock_anonymous_lock() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -2080,15 +2049,14 @@ def test_generic_lock_anonymous_lock() -> None:
             pass
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_generic_lock_anonymous_lock", version="my_version")
-        ddup.start()
+    ddup.config(env="test", service="test_generic_lock_anonymous_lock", version="my_version")
+    ddup.start()
 
-        with ThreadingLockCollector(capture_pct=100):
-            test_anonymous_lock()
+    with ThreadingLockCollector(capture_pct=100):
+        test_anonymous_lock()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos = get_lock_linenos("test_anonymous_lock", with_stmt=True)
     pprof_utils.assert_lock_events(
@@ -2121,7 +2089,6 @@ def test_generic_lock_global_locks() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
     PY_311_OR_ABOVE = sys.version_info[:2] >= (3, 11)
@@ -2143,18 +2110,17 @@ def test_generic_lock_global_locks() -> None:
             pass
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_generic_lock_global_locks", version="my_version")
-        ddup.start()
+    ddup.config(env="test", service="test_generic_lock_global_locks", version="my_version")
+    ddup.start()
 
-        with ThreadingLockCollector(capture_pct=100):
-            _test_global_lock = threading.Lock()  # !CREATE! _test_global_lock
-            test_bar_instance = TestBar()
-            foo()
-            test_bar_instance.bar()
+    with ThreadingLockCollector(capture_pct=100):
+        _test_global_lock = threading.Lock()  # !CREATE! _test_global_lock
+        test_bar_instance = TestBar()
+        foo()
+        test_bar_instance.bar()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos_global = get_lock_linenos("_test_global_lock", with_stmt=True)
     linenos_bar = get_lock_linenos("bar_lock", with_stmt=True)
@@ -2203,7 +2169,6 @@ def test_generic_lock_upload_resets_profile() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -2212,41 +2177,42 @@ def test_generic_lock_upload_resets_profile() -> None:
             pass
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_generic_lock_upload_resets_profile", version="my_version")
-        ddup.start()
+    ddup.config(env="test", service="test_generic_lock_upload_resets_profile", version="my_version")
+    ddup.start()
 
-        with ThreadingLockCollector(capture_pct=100):
-            test_upload_resets_profile()
+    with ThreadingLockCollector(capture_pct=100):
+        test_upload_resets_profile()
 
-        ddup.upload()
-        linenos = get_lock_linenos("test_upload_resets_profile", with_stmt=True)
-        pprof = pprof_utils.get_profile_from_agent(agent)
-        pprof_utils.assert_lock_events(
-            pprof,
-            expected_acquire_events=[
-                pprof_utils.LockAcquireEvent(
-                    caller_name="test_upload_resets_profile",
-                    filename="test_threading.py",
-                    linenos=linenos,
-                ),
-            ],
-            expected_release_events=[
-                pprof_utils.LockReleaseEvent(
-                    caller_name="test_upload_resets_profile",
-                    filename="test_threading.py",
-                    linenos=linenos,
-                ),
-            ],
-        )
+    ddup.upload()
+    linenos = get_lock_linenos("test_upload_resets_profile", with_stmt=True)
+    pprof = pprof_utils.get_profile_from_agent()
+    pprof_utils.assert_lock_events(
+        pprof,
+        expected_acquire_events=[
+            pprof_utils.LockAcquireEvent(
+                caller_name="test_upload_resets_profile",
+                filename="test_threading.py",
+                linenos=linenos,
+            ),
+        ],
+        expected_release_events=[
+            pprof_utils.LockReleaseEvent(
+                caller_name="test_upload_resets_profile",
+                filename="test_threading.py",
+                linenos=linenos,
+            ),
+        ],
+    )
 
-        # Second upload should produce empty profile (no samples)
-        agent.clear()
-        ddup.upload()
-        empty_pprof = pprof_utils.get_profile_from_agent(agent, assert_samples=False)
-        assert len(empty_pprof.sample) == 0, (
-            f"Expected empty profile after second upload, got {len(empty_pprof.sample)} samples"
-        )
+    # Second upload should produce empty profile (no samples)
+    from tests.profiling.utils import clear_agent_session
+
+    clear_agent_session()
+    ddup.upload()
+    empty_pprof = pprof_utils.get_profile_from_agent(assert_samples=False)
+    assert len(empty_pprof.sample) == 0, (
+        f"Expected empty profile after second upload, got {len(empty_pprof.sample)} samples"
+    )
 
 
 @pytest.mark.subprocess(err=None, env=dict(DD_PROFILING_FILE_PATH=__file__))
@@ -2261,29 +2227,27 @@ def test_generic_lock_release_not_sampled_when_acquire_not_sampled() -> None:
     from ddtrace.profiling.collector.threading import ThreadingLockCollector
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(
-            env="test",
-            service="test_generic_lock_release_not_sampled_when_acquire_not_sampled",
-            version="my_version",
-        )
-        ddup.start()
+    ddup.config(
+        env="test",
+        service="test_generic_lock_release_not_sampled_when_acquire_not_sampled",
+        version="my_version",
+    )
+    ddup.start()
 
-        with ThreadingLockCollector(capture_pct=0):
-            lock = threading.Lock()
-            for _ in range(10):
-                lock.acquire()
-                assert cast(_ProfiledLock, lock).acquired_time is None
-                time.sleep(0.001)
-                lock.release()
+    with ThreadingLockCollector(capture_pct=0):
+        lock = threading.Lock()
+        for _ in range(10):
+            lock.acquire()
+            assert cast(_ProfiledLock, lock).acquired_time is None
+            time.sleep(0.001)
+            lock.release()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent, assert_samples=False)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent(assert_samples=False)
 
     release_samples = pprof_utils.get_samples_with_value_type(profile, "lock-release")
     assert len(release_samples) == 0, (
@@ -2302,31 +2266,29 @@ def test_generic_lock_failed_acquire_produces_no_sample() -> None:
     from ddtrace.profiling.collector.threading import ThreadingLockCollector
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_generic_lock_failed_acquire_produces_no_sample", version="my_version")
-        ddup.start()
+    ddup.config(env="test", service="test_generic_lock_failed_acquire_produces_no_sample", version="my_version")
+    ddup.start()
 
-        with ThreadingLockCollector(capture_pct=100):
-            lock = threading.Lock()
-            lock.acquire()
-            profiled = cast(_ProfiledLock, lock)
-            acquired_time_after_success = profiled.acquired_time
-            assert acquired_time_after_success is not None, "acquired_time must be set after successful acquire"
+    with ThreadingLockCollector(capture_pct=100):
+        lock = threading.Lock()
+        lock.acquire()
+        profiled = cast(_ProfiledLock, lock)
+        acquired_time_after_success = profiled.acquired_time
+        assert acquired_time_after_success is not None, "acquired_time must be set after successful acquire"
 
-            result = lock.acquire(blocking=False)
-            assert result is False, "Non-blocking acquire on held lock must return False"
-            assert profiled.acquired_time == acquired_time_after_success, (
-                "acquired_time must not change after a failed acquire"
-            )
-            lock.release()
+        result = lock.acquire(blocking=False)
+        assert result is False, "Non-blocking acquire on held lock must return False"
+        assert profiled.acquired_time == acquired_time_after_success, (
+            "acquired_time must not change after a failed acquire"
+        )
+        lock.release()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     acquire_samples = pprof_utils.get_samples_with_value_type(profile, "lock-acquire")
     release_samples = pprof_utils.get_samples_with_value_type(profile, "lock-release")
@@ -2538,7 +2500,6 @@ def test_semaphore_stack_trace_points_to_user_code() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -2548,15 +2509,14 @@ def test_semaphore_stack_trace_points_to_user_code() -> None:
         sem.release()  # !RELEASE! test_stack_trace_sem
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_semaphore_stack_trace_points_to_user_code", version="my_version")
-        ddup.start()
+    ddup.config(env="test", service="test_semaphore_stack_trace_points_to_user_code", version="my_version")
+    ddup.start()
 
-        with ThreadingSemaphoreCollector(capture_pct=100):
-            test_stack_trace()
+    with ThreadingSemaphoreCollector(capture_pct=100):
+        test_stack_trace()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos = get_lock_linenos("test_stack_trace_sem")
     pprof_utils.assert_lock_events(
@@ -2592,7 +2552,6 @@ def test_semaphore_no_double_counting_with_lock_collector() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -2602,15 +2561,14 @@ def test_semaphore_no_double_counting_with_lock_collector() -> None:
         sem.release()  # !RELEASE! test_no_double_counting
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_semaphore_no_double_counting_with_lock_collector", version="my_version")
-        ddup.start()
+    ddup.config(env="test", service="test_semaphore_no_double_counting_with_lock_collector", version="my_version")
+    ddup.start()
 
-        with ThreadingLockCollector(capture_pct=100), ThreadingSemaphoreCollector(capture_pct=100):
-            test_no_double_counting()
+    with ThreadingLockCollector(capture_pct=100), ThreadingSemaphoreCollector(capture_pct=100):
+        test_no_double_counting()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     acquire_samples_count = len(pprof_utils.get_samples_with_value_type(profile, "lock-acquire"))
     release_samples_count = len(pprof_utils.get_samples_with_value_type(profile, "lock-release"))
@@ -2676,7 +2634,6 @@ def test_bounded_semaphore_stack_trace_points_to_user_code() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -2686,15 +2643,14 @@ def test_bounded_semaphore_stack_trace_points_to_user_code() -> None:
         bsem.release()  # !RELEASE! test_stack_trace_bsem
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(env="test", service="test_bounded_semaphore_stack_trace_points_to_user_code", version="my_version")
-        ddup.start()
+    ddup.config(env="test", service="test_bounded_semaphore_stack_trace_points_to_user_code", version="my_version")
+    ddup.start()
 
-        with ThreadingBoundedSemaphoreCollector(capture_pct=100):
-            test_stack_trace_bsem()
+    with ThreadingBoundedSemaphoreCollector(capture_pct=100):
+        test_stack_trace_bsem()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     linenos = get_lock_linenos("test_stack_trace_bsem")
     pprof_utils.assert_lock_events(
@@ -2730,7 +2686,6 @@ def test_bounded_semaphore_no_double_counting_with_lock_collector() -> None:
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -2740,19 +2695,18 @@ def test_bounded_semaphore_no_double_counting_with_lock_collector() -> None:
         bsem.release()  # !RELEASE! test_no_double_counting_bounded
 
     assert ddup.is_available, "ddup is not available"
-    with with_profiling_test_agent() as agent:
-        ddup.config(
-            env="test",
-            service="test_bounded_semaphore_no_double_counting_with_lock_collector",
-            version="my_version",
-        )
-        ddup.start()
+    ddup.config(
+        env="test",
+        service="test_bounded_semaphore_no_double_counting_with_lock_collector",
+        version="my_version",
+    )
+    ddup.start()
 
-        with ThreadingLockCollector(capture_pct=100), ThreadingBoundedSemaphoreCollector(capture_pct=100):
-            test_no_double_counting_bounded()
+    with ThreadingLockCollector(capture_pct=100), ThreadingBoundedSemaphoreCollector(capture_pct=100):
+        test_no_double_counting_bounded()
 
-        ddup.upload()
-        profile = pprof_utils.get_profile_from_agent(agent)
+    ddup.upload()
+    profile = pprof_utils.get_profile_from_agent()
 
     acquire_samples_count = len(pprof_utils.get_samples_with_value_type(profile, "lock-acquire"))
     release_samples_count = len(pprof_utils.get_samples_with_value_type(profile, "lock-release"))

--- a/tests/profiling/collector/test_threading.py
+++ b/tests/profiling/collector/test_threading.py
@@ -544,6 +544,7 @@ def test_lock_gevent_tasks() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector.threading import ThreadingLockCollector
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import LineNo  # noqa: F401
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
 
@@ -620,6 +621,7 @@ def test_rlock_gevent_tasks() -> None:
     from ddtrace.internal.datadog.profiling import ddup
     from ddtrace.profiling.collector.threading import ThreadingRLockCollector
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.lock_utils import LineNo  # noqa: F401
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
 

--- a/tests/profiling/collector/test_threading_asyncio.py
+++ b/tests/profiling/collector/test_threading_asyncio.py
@@ -4,7 +4,6 @@ import pytest
 @pytest.mark.subprocess(
     env=dict(
         DD_PROFILING_CAPTURE_PCT="100",
-        DD_PROFILING_OUTPUT_PPROF="/tmp/asyncio_lock_acquire_events",
         DD_PROFILING_FILE_PATH=__file__,
     ),
     err=None,
@@ -17,6 +16,7 @@ def test_lock_acquire_events():
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
+    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -35,21 +35,21 @@ def test_lock_acquire_events():
         async_run(_lock())
         lock.release()  # !RELEASE! test_lock_acquire_events_2
 
-    # start a complete profiler so asyncio policy is setup
-    p = profiler.Profiler()
-    p.start()
-    t = threading.Thread(target=asyncio_run_func, name="foobar")
-    t.start()
-    t.join()
-    p.stop()
+    with with_profiling_test_agent() as agent_client:
+        # start a complete profiler so asyncio policy is setup
+        p = profiler.Profiler()
+        p.start()
+        t = threading.Thread(target=asyncio_run_func, name="foobar")
+        t.start()
+        t.join()
+        p.stop()
 
-    expected_filename = "test_threading_asyncio.py"
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+        expected_filename = "test_threading_asyncio.py"
 
-    linenos_1 = get_lock_linenos("test_lock_acquire_events_1")
-    linenos_2 = get_lock_linenos("test_lock_acquire_events_2")
+        linenos_1 = get_lock_linenos("test_lock_acquire_events_1")
+        linenos_2 = get_lock_linenos("test_lock_acquire_events_2")
 
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
     task_name_regex = r"Task-\d+$"
 

--- a/tests/profiling/collector/test_threading_asyncio.py
+++ b/tests/profiling/collector/test_threading_asyncio.py
@@ -16,7 +16,6 @@ def test_lock_acquire_events():
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.lock_utils import get_lock_linenos
     from tests.profiling.collector.lock_utils import init_linenos
-    from tests.profiling.utils import with_profiling_test_agent
 
     init_linenos(os.environ["DD_PROFILING_FILE_PATH"])
 
@@ -35,21 +34,20 @@ def test_lock_acquire_events():
         async_run(_lock())
         lock.release()  # !RELEASE! test_lock_acquire_events_2
 
-    with with_profiling_test_agent() as agent_client:
-        # start a complete profiler so asyncio policy is setup
-        p = profiler.Profiler()
-        p.start()
-        t = threading.Thread(target=asyncio_run_func, name="foobar")
-        t.start()
-        t.join()
-        p.stop()
+    # start a complete profiler so asyncio policy is setup
+    p = profiler.Profiler()
+    p.start()
+    t = threading.Thread(target=asyncio_run_func, name="foobar")
+    t.start()
+    t.join()
+    p.stop()
 
-        expected_filename = "test_threading_asyncio.py"
+    expected_filename = "test_threading_asyncio.py"
 
-        linenos_1 = get_lock_linenos("test_lock_acquire_events_1")
-        linenos_2 = get_lock_linenos("test_lock_acquire_events_2")
+    linenos_1 = get_lock_linenos("test_lock_acquire_events_1")
+    linenos_2 = get_lock_linenos("test_lock_acquire_events_2")
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     task_name_regex = r"Task-\d+$"
 

--- a/tests/profiling/collector/test_uvloop_multi_threaded.py
+++ b/tests/profiling/collector/test_uvloop_multi_threaded.py
@@ -7,16 +7,10 @@ uvloop_available = test_utils.uvloop_available()
 
 
 @pytest.mark.skipif(not uvloop_available, reason="uvloop is not installed in this environment")
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_uvloop_multi_threaded",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_uvloop_multi_threaded() -> None:
     import asyncio
-    import os
     import threading
     from threading import Event
     import time
@@ -26,6 +20,7 @@ def test_uvloop_multi_threaded() -> None:
 
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_utils import ProfilerContextManager
+    from tests.profiling.utils import with_profiling_test_agent
 
     sleep_time = 0.2
     loop_run_time = 3
@@ -43,30 +38,30 @@ def test_uvloop_multi_threaded() -> None:
         await t1
         # await asyncio.wait(fs=(t1,), return_when=asyncio.ALL_COMPLETED)
 
-    with ProfilerContextManager():
-        event = Event()
+    with with_profiling_test_agent() as agent_client:
+        with ProfilerContextManager():
+            event = Event()
 
-        def threaded_func() -> None:
-            # uvloop.run only affects the current Thread
-            # event is passed to the coroutine so we're sure it's set AFTER the loop has been
-            # started.
-            uvloop.run(outer("uvloop", event))
+            def threaded_func() -> None:
+                # uvloop.run only affects the current Thread
+                # event is passed to the coroutine so we're sure it's set AFTER the loop has been
+                # started.
+                uvloop.run(outer("uvloop", event))
 
-        thread = threading.Thread(target=threaded_func, name="UvloopThread")
-        thread.start()
+            thread = threading.Thread(target=threaded_func, name="UvloopThread")
+            thread.start()
 
-        # Wait for the thread to start, then give it some time to start uvloop
-        event.wait()
-        time.sleep(0.05)
+            # Wait for the thread to start, then give it some time to start uvloop
+            event.wait()
+            time.sleep(0.05)
 
-        # Now run our coroutine with "pure asyncio"
-        asyncio.run(outer("pure_asyncio"))
+            # Now run our coroutine with "pure asyncio"
+            asyncio.run(outer("pure_asyncio"))
 
-        # Wait for the thread to finish
-        thread.join()
+            # Wait for the thread to finish
+            thread.join()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
     assert len(samples) > 0

--- a/tests/profiling/collector/test_uvloop_multi_threaded.py
+++ b/tests/profiling/collector/test_uvloop_multi_threaded.py
@@ -20,7 +20,6 @@ def test_uvloop_multi_threaded() -> None:
 
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_utils import ProfilerContextManager
-    from tests.profiling.utils import with_profiling_test_agent
 
     sleep_time = 0.2
     loop_run_time = 3
@@ -38,30 +37,29 @@ def test_uvloop_multi_threaded() -> None:
         await t1
         # await asyncio.wait(fs=(t1,), return_when=asyncio.ALL_COMPLETED)
 
-    with with_profiling_test_agent() as agent_client:
-        with ProfilerContextManager():
-            event = Event()
+    with ProfilerContextManager():
+        event = Event()
 
-            def threaded_func() -> None:
-                # uvloop.run only affects the current Thread
-                # event is passed to the coroutine so we're sure it's set AFTER the loop has been
-                # started.
-                uvloop.run(outer("uvloop", event))
+        def threaded_func() -> None:
+            # uvloop.run only affects the current Thread
+            # event is passed to the coroutine so we're sure it's set AFTER the loop has been
+            # started.
+            uvloop.run(outer("uvloop", event))
 
-            thread = threading.Thread(target=threaded_func, name="UvloopThread")
-            thread.start()
+        thread = threading.Thread(target=threaded_func, name="UvloopThread")
+        thread.start()
 
-            # Wait for the thread to start, then give it some time to start uvloop
-            event.wait()
-            time.sleep(0.05)
+        # Wait for the thread to start, then give it some time to start uvloop
+        event.wait()
+        time.sleep(0.05)
 
-            # Now run our coroutine with "pure asyncio"
-            asyncio.run(outer("pure_asyncio"))
+        # Now run our coroutine with "pure asyncio"
+        asyncio.run(outer("pure_asyncio"))
 
-            # Wait for the thread to finish
-            thread.join()
+        # Wait for the thread to finish
+        thread.join()
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
     assert len(samples) > 0

--- a/tests/profiling/collector/test_uvloop_variations.py
+++ b/tests/profiling/collector/test_uvloop_variations.py
@@ -7,17 +7,11 @@ uvloop_available = test_utils.uvloop_available()
 
 
 @pytest.mark.skipif(not uvloop_available, reason="uvloop is not installed in this environment")
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_uvloop_variations",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_uvloop_variations_install_and_run() -> None:
     """Test that we properly profile Tasks when running uvloop with uvloop.install, then asyncio.run."""
     import asyncio
-    import os
     import time
 
     import uvloop
@@ -25,6 +19,7 @@ def test_uvloop_variations_install_and_run() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_utils import ProfilerContextManager
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -46,12 +41,12 @@ def test_uvloop_variations_install_and_run() -> None:
         t2 = asyncio.create_task(inner2(), name="inner 2")
         await asyncio.wait(fs=(t1, t2), return_when=asyncio.ALL_COMPLETED)
 
-    with ProfilerContextManager():
-        uvloop.install()
-        asyncio.run(outer())
+    with with_profiling_test_agent() as agent_client:
+        with ProfilerContextManager():
+            uvloop.install()
+            asyncio.run(outer())
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
     assert len(samples) > 0
@@ -129,17 +124,11 @@ def test_uvloop_variations_install_and_run() -> None:
 
 
 @pytest.mark.skipif(not uvloop_available, reason="uvloop is not installed in this environment")
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_uvloop_variations_uvloop_run",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_uvloop_variations_uvloop_run() -> None:
     """Test that we properly profile Tasks when running uvloop with uvloop.run."""
     import asyncio
-    import os
     import time
 
     import uvloop
@@ -147,6 +136,7 @@ def test_uvloop_variations_uvloop_run() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_utils import ProfilerContextManager
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -168,11 +158,11 @@ def test_uvloop_variations_uvloop_run() -> None:
         t2 = asyncio.create_task(inner2(), name="inner 2")
         await asyncio.wait(fs=(t1, t2), return_when=asyncio.ALL_COMPLETED)
 
-    with ProfilerContextManager():
-        uvloop.run(outer())
+    with with_profiling_test_agent() as agent_client:
+        with ProfilerContextManager():
+            uvloop.run(outer())
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
     assert len(samples) > 0
@@ -250,17 +240,11 @@ def test_uvloop_variations_uvloop_run() -> None:
 
 
 @pytest.mark.skipif(not uvloop_available, reason="uvloop is not installed in this environment")
-@pytest.mark.subprocess(
-    env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_uvloop_variations_import_uvloop_dont_use_it",
-    ),
-    err=None,
-)
+@pytest.mark.subprocess
 # For macOS: err=None ignores expected stderr from tracer failing to connect to agent (not relevant to this test)
 def test_uvloop_variations_import_uvloop_dont_use_it() -> None:
     """Test that we properly profile Tasks when importing uvloop but not using it."""
     import asyncio
-    import os
     import time
 
     import uvloop  # noqa: F401
@@ -268,6 +252,7 @@ def test_uvloop_variations_import_uvloop_dont_use_it() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_utils import ProfilerContextManager
+    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -289,12 +274,12 @@ def test_uvloop_variations_import_uvloop_dont_use_it() -> None:
         t2 = asyncio.create_task(inner2(), name="inner 2")
         await asyncio.wait(fs=(t1, t2), return_when=asyncio.ALL_COMPLETED)
 
-    with ProfilerContextManager():
-        # uvloop is not installed nor used!
-        asyncio.run(outer())
+    with with_profiling_test_agent() as agent_client:
+        with ProfilerContextManager():
+            # uvloop is not installed nor used!
+            asyncio.run(outer())
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    profile = pprof_utils.parse_newest_profile(output_filename)
+        profile = pprof_utils.get_profile_from_agent(agent_client)
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
     assert len(samples) > 0

--- a/tests/profiling/collector/test_uvloop_variations.py
+++ b/tests/profiling/collector/test_uvloop_variations.py
@@ -19,7 +19,6 @@ def test_uvloop_variations_install_and_run() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_utils import ProfilerContextManager
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -41,12 +40,11 @@ def test_uvloop_variations_install_and_run() -> None:
         t2 = asyncio.create_task(inner2(), name="inner 2")
         await asyncio.wait(fs=(t1, t2), return_when=asyncio.ALL_COMPLETED)
 
-    with with_profiling_test_agent() as agent_client:
-        with ProfilerContextManager():
-            uvloop.install()
-            asyncio.run(outer())
+    with ProfilerContextManager():
+        uvloop.install()
+        asyncio.run(outer())
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
     assert len(samples) > 0
@@ -136,7 +134,6 @@ def test_uvloop_variations_uvloop_run() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_utils import ProfilerContextManager
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -158,11 +155,10 @@ def test_uvloop_variations_uvloop_run() -> None:
         t2 = asyncio.create_task(inner2(), name="inner 2")
         await asyncio.wait(fs=(t1, t2), return_when=asyncio.ALL_COMPLETED)
 
-    with with_profiling_test_agent() as agent_client:
-        with ProfilerContextManager():
-            uvloop.run(outer())
+    with ProfilerContextManager():
+        uvloop.run(outer())
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
     assert len(samples) > 0
@@ -252,7 +248,6 @@ def test_uvloop_variations_import_uvloop_dont_use_it() -> None:
     from ddtrace.internal.datadog.profiling import stack
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_utils import ProfilerContextManager
-    from tests.profiling.utils import with_profiling_test_agent
 
     assert stack.is_available, stack.failure_msg
 
@@ -274,12 +269,11 @@ def test_uvloop_variations_import_uvloop_dont_use_it() -> None:
         t2 = asyncio.create_task(inner2(), name="inner 2")
         await asyncio.wait(fs=(t1, t2), return_when=asyncio.ALL_COMPLETED)
 
-    with with_profiling_test_agent() as agent_client:
-        with ProfilerContextManager():
-            # uvloop is not installed nor used!
-            asyncio.run(outer())
+    with ProfilerContextManager():
+        # uvloop is not installed nor used!
+        asyncio.run(outer())
 
-        profile = pprof_utils.get_profile_from_agent(agent_client)
+    profile = pprof_utils.get_profile_from_agent()
 
     samples = pprof_utils.get_samples_with_label_key(profile, "task name")
     assert len(samples) > 0

--- a/tests/profiling/conftest.py
+++ b/tests/profiling/conftest.py
@@ -3,12 +3,15 @@ import pytest
 from tests.profiling.utils import with_profiling_test_agent
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def profiling_test_agent():
-    """Pytest fixture that starts a local profiling capture server for a test.
+    """Start a self-contained mini agent for every profiling test.
 
-    Sets _DD_PROFILING_TEST_AGENT_URL so the ddup uploader routes profile uploads
-    to the capture server. Yields a _ProfilingCaptureServer scoped to the test.
+    Autouse so that subprocess tests automatically inherit _DD_PROFILING_TEST_TOKEN
+    and _DD_PROFILING_TEST_PROXY_URL without needing to call with_profiling_test_agent()
+    inside the subprocess function body.  The yielded _ProfilingMiniAgentClient is
+    available to non-subprocess tests that declare profiling_test_agent as a fixture
+    parameter.
     """
     with with_profiling_test_agent() as client:
         yield client

--- a/tests/profiling/conftest.py
+++ b/tests/profiling/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+from tests.profiling.utils import with_profiling_test_agent
+
+
+@pytest.fixture
+def profiling_test_agent():
+    """Pytest fixture that starts a local profiling capture server for a test.
+
+    Sets _DD_PROFILING_TEST_AGENT_URL so the ddup uploader routes profile uploads
+    to the capture server. Yields a _ProfilingCaptureServer scoped to the test.
+    """
+    with with_profiling_test_agent() as client:
+        yield client

--- a/tests/profiling/test_accuracy.py
+++ b/tests/profiling/test_accuracy.py
@@ -74,28 +74,29 @@ def assert_within_tolerance(
 
 @pytest.mark.subprocess(
     env=dict(
-        DD_PROFILING_OUTPUT_PPROF="/tmp/test_accuracy_stack.pprof",
         _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED="0",
     )
 )
 def test_accuracy_stack():
     import collections
-    import os
 
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
     from tests.profiling.test_accuracy import assert_almost_equal
     from tests.profiling.test_accuracy import assert_within_tolerance
     from tests.profiling.test_accuracy import spend_16
+    from tests.profiling.utils import get_profile_from_agent
+    from tests.profiling.utils import with_profiling_test_agent
 
     # Set this to 100 so we don't sleep too often and mess with the precision.
-    p = profiler.Profiler()
-    p.start()
-    spend_16()
-    p.stop()
-    wall_times = collections.defaultdict(lambda: 0)
-    cpu_times = collections.defaultdict(lambda: 0)
-    profile = pprof_utils.parse_newest_profile(os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid()))
+    with with_profiling_test_agent() as agent_client:
+        p = profiler.Profiler()
+        p.start()
+        spend_16()
+        p.stop()
+        wall_times = collections.defaultdict(lambda: 0)
+        cpu_times = collections.defaultdict(lambda: 0)
+        profile = get_profile_from_agent(agent_client)
 
     for sample in profile.sample:
         wall_time_index = pprof_utils.get_sample_type_index(profile, "wall-time")

--- a/tests/profiling/test_accuracy.py
+++ b/tests/profiling/test_accuracy.py
@@ -82,21 +82,19 @@ def test_accuracy_stack():
 
     from ddtrace.profiling import profiler
     from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.pprof_utils import get_profile_from_agent
     from tests.profiling.test_accuracy import assert_almost_equal
     from tests.profiling.test_accuracy import assert_within_tolerance
     from tests.profiling.test_accuracy import spend_16
-    from tests.profiling.utils import get_profile_from_agent
-    from tests.profiling.utils import with_profiling_test_agent
 
     # Set this to 100 so we don't sleep too often and mess with the precision.
-    with with_profiling_test_agent() as agent_client:
-        p = profiler.Profiler()
-        p.start()
-        spend_16()
-        p.stop()
-        wall_times = collections.defaultdict(lambda: 0)
-        cpu_times = collections.defaultdict(lambda: 0)
-        profile = get_profile_from_agent(agent_client)
+    p = profiler.Profiler()
+    p.start()
+    spend_16()
+    p.stop()
+    wall_times = collections.defaultdict(lambda: 0)
+    cpu_times = collections.defaultdict(lambda: 0)
+    profile = get_profile_from_agent()
 
     for sample in profile.sample:
         wall_time_index = pprof_utils.get_sample_type_index(profile, "wall-time")

--- a/tests/profiling/test_gunicorn.py
+++ b/tests/profiling/test_gunicorn.py
@@ -17,7 +17,8 @@ import pytest
 from typing_extensions import TypeAlias
 
 from tests.profiling.collector import pprof_utils
-from tests.profiling.utils import get_all_profiles_from_agent
+from tests.profiling.collector.pprof_utils import parse_pid_from_request
+from tests.profiling.utils import get_all_requests_from_agent
 
 
 # DEV: gunicorn tests are hard to debug, so keeping these print statements for
@@ -129,7 +130,8 @@ def _test_gunicorn(
     debug_print("Retrieving profiles from capture server")
     # Multiple uploads may arrive (periodic scheduler + shutdown flush + master process).
     # Search all of them for the worker profile that has cpu-time samples with fib.
-    profiles = get_all_profiles_from_agent(agent_client)
+    reqs = get_all_requests_from_agent(agent_client)
+    profiles = [pprof_utils.parse_profile_from_request(r) for r in reqs]
 
     # DEV: somehow the filename is reported as either __init__.py or gunicorn-app.py
     # when run on GitLab CI. We need to match either of these two.
@@ -325,10 +327,13 @@ def test_gunicorn_profile_export_count_two_workers(
     except subprocess.TimeoutExpired:
         pytest.fail(f"Failed to terminate gunicorn process: {output}")
 
-    # With 2 workers + 1 master process, expect at least 2 profiling uploads
-    # (one per worker minimum; master may or may not upload depending on timing).
-    profiles = get_all_profiles_from_agent(agent_client)
-    assert len(profiles) >= 2, f"Expected at least 2 profiling uploads (one per worker), got {len(profiles)}"
+    # Expect one upload per worker; poll until both worker PIDs have uploaded.
+    reqs = get_all_requests_from_agent(agent_client, min_count=2)
+    upload_pids = {parse_pid_from_request(req) for req in reqs}
+    for wpid in worker_pids:
+        assert wpid in upload_pids, (
+            f"Worker PID {wpid} did not upload a profile. Worker PIDs: {worker_pids}, uploaded PIDs: {upload_pids}"
+        )
 
 
 def test_gunicorn_profile_export_count_two_workers_flush_false(

--- a/tests/profiling/test_gunicorn.py
+++ b/tests/profiling/test_gunicorn.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import concurrent.futures
 import os
-import pathlib
 import re
 import signal
 import subprocess
@@ -18,6 +17,8 @@ import pytest
 from typing_extensions import TypeAlias
 
 from tests.profiling.collector import pprof_utils
+from tests.profiling.utils import get_all_profiles_from_agent
+from tests.profiling.utils import with_profiling_test_agent
 
 
 # DEV: gunicorn tests are hard to debug, so keeping these print statements for
@@ -74,100 +75,96 @@ def _get_worker_pids(stdout: str) -> list[int]:
     return [int(_) for _ in re.findall(r"Booting worker with pid: (\d+)", stdout)]
 
 
-def _get_profile_files(filename_prefix: str) -> list[pathlib.Path]:
-    prefix = pathlib.Path(filename_prefix)
-    return sorted(prefix.parent.glob(prefix.name + ".*.pprof"))
-
-
-def _get_profile_pid(profile_file: pathlib.Path) -> int:
-    # pprof file format: <prefix>.<pid>.<counter>.pprof
-    _, pid, _, ext = profile_file.name.rsplit(".", 3)
-    assert ext == "pprof"
-    return int(pid)
-
-
 def _test_gunicorn(
     gunicorn: RunGunicornFunc,
-    tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
     *args: str,
 ) -> None:
-    filename = str(tmp_path / "gunicorn.pprof")
-    monkeypatch.setenv("DD_PROFILING_OUTPUT_PPROF", filename)
     monkeypatch.setenv("_DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED", "0")
 
     debug_print("Creating gunicorn workers")
     # DEV: We only start 1 worker to simplify the test
-    proc = gunicorn("-w", "1", *args)
-    # Wait for the workers to start
-    time.sleep(5)
+    with with_profiling_test_agent() as agent_client:
+        proc = gunicorn("-w", "1", *args)
+        # Wait for the workers to start
+        time.sleep(5)
 
-    if proc.poll() is not None:
-        pytest.fail("Gunicorn failed to start")
+        if proc.poll() is not None:
+            pytest.fail("Gunicorn failed to start")
 
-    debug_print("Making request to gunicorn server")
-    try:
-        with urllib.request.urlopen("http://127.0.0.1:7644", timeout=5) as f:
-            status_code = f.getcode()
-            assert status_code == 200, status_code
-            response = f.read().decode()
-            debug_print(response)
-    except Exception as e:
-        proc.terminate()
+        debug_print("Making request to gunicorn server")
+        try:
+            with urllib.request.urlopen("http://127.0.0.1:7644", timeout=5) as f:
+                status_code = f.getcode()
+                assert status_code == 200, status_code
+                response = f.read().decode()
+                debug_print(response)
+        except Exception as e:
+            proc.terminate()
+            assert proc.stdout is not None
+            output = proc.stdout.read().decode()
+            print(output)
+            pytest.fail(f"Failed to make request to gunicorn server {e}")
+        finally:
+            # Need to terminate the process to get the output and release the port
+            proc.terminate()
+
+        debug_print("Reading gunicorn worker output to get PIDs")
         assert proc.stdout is not None
         output = proc.stdout.read().decode()
-        print(output)
-        pytest.fail(f"Failed to make request to gunicorn server {e}")
-    finally:
-        # Need to terminate the process to get the output and release the port
-        proc.terminate()
+        worker_pids = _get_worker_pids(output)
+        debug_print(f"Gunicorn worker PIDs: {worker_pids}")
 
-    debug_print("Reading gunicorn worker output to get PIDs")
-    assert proc.stdout is not None
-    output = proc.stdout.read().decode()
-    worker_pids = _get_worker_pids(output)
-    debug_print(f"Gunicorn worker PIDs: {worker_pids}")
+        for line in output.splitlines():
+            debug_print(line)
 
-    for line in output.splitlines():
-        debug_print(line)
+        assert len(worker_pids) == 1, output
 
-    assert len(worker_pids) == 1, output
+        debug_print("Waiting for gunicorn process to terminate")
+        try:
+            assert proc.wait(timeout=5) == 0, output
+        except subprocess.TimeoutExpired:
+            pytest.fail(f"Failed to terminate gunicorn process: {output}")
+        assert "module 'threading' has no attribute '_active'" not in output, output
 
-    debug_print("Waiting for gunicorn process to terminate")
-    try:
-        assert proc.wait(timeout=5) == 0, output
-    except subprocess.TimeoutExpired:
-        pytest.fail(f"Failed to terminate gunicorn process: {output}")
-    assert "module 'threading' has no attribute '_active'" not in output, output
-
-    for pid in worker_pids:
-        debug_print(f"Reading pprof file with prefix {filename}.{pid}")
-        profile = pprof_utils.parse_newest_profile(f"{filename}.{pid}", allow_penultimate=True)
-        # This returns a list of samples that have non-zero cpu-time
-        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-        assert len(samples) > 0
+        debug_print("Retrieving profiles from capture server")
+        # Multiple uploads may arrive (periodic scheduler + shutdown flush + master process).
+        # Search all of them for the worker profile that has cpu-time samples with fib.
+        profiles = get_all_profiles_from_agent(agent_client)
 
         # DEV: somehow the filename is reported as either __init__.py or gunicorn-app.py
         # when run on GitLab CI. We need to match either of these two.
         filename_regex = r"^(?:__init__\.py|gunicorn-app\.py)$"
-
         expected_location = pprof_utils.StackLocation(function_name="fib", filename=filename_regex, line_no=9)
 
-        pprof_utils.assert_profile_has_sample(
-            profile,
-            samples=samples,
-            # DEV: we expect multiple locations as fibonacci is recursive
-            expected_sample=pprof_utils.StackEvent(locations=[expected_location, expected_location]),
+        found = False
+        for profile in profiles:
+            samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+            if not samples:
+                continue
+            try:
+                pprof_utils.assert_profile_has_sample(
+                    profile,
+                    samples=samples,
+                    # DEV: we expect multiple locations as fibonacci is recursive
+                    expected_sample=pprof_utils.StackEvent(locations=[expected_location, expected_location]),
+                )
+                found = True
+                break
+            except AssertionError:
+                continue
+        assert found, (
+            f"Expected fib samples not found in any of {len(profiles)} profile upload(s). "
+            "Worker may not have been profiled during the request."
         )
 
 
 def test_gunicorn(
     gunicorn: RunGunicornFunc,
-    tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     args: tuple[str, ...] = ("-k", "gevent") if TESTING_GEVENT else ()
-    _test_gunicorn(gunicorn, tmp_path, monkeypatch, *args)
+    _test_gunicorn(gunicorn, monkeypatch, *args)
 
 
 def _run_sigterm_graceful_shutdown_test(
@@ -290,106 +287,110 @@ def test_gunicorn_gevent_sigterm_graceful_shutdown(monkeypatch: pytest.MonkeyPat
 
 def test_gunicorn_profile_export_count_two_workers(
     gunicorn: RunGunicornFunc,
-    tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    filename = str(tmp_path / "gunicorn-count.pprof")
-    monkeypatch.setenv("DD_PROFILING_OUTPUT_PPROF", filename)
     monkeypatch.setenv("_DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED", "0")
 
     args: tuple[str, ...] = ("-k", "gevent") if TESTING_GEVENT else ()
-    proc = gunicorn("-w", "2", *args, app="tests.profiling.gunicorn_count_app:app")
-    time.sleep(5)
 
-    if proc.poll() is not None:
+    with with_profiling_test_agent() as agent_client:
+        proc = gunicorn("-w", "2", *args, app="tests.profiling.gunicorn_count_app:app")
+        time.sleep(5)
+
+        if proc.poll() is not None:
+            assert proc.stdout is not None
+            output = proc.stdout.read().decode()
+            pytest.fail(f"Gunicorn failed to start: {output}")
+
+        try:
+            for _ in range(4):
+                with urllib.request.urlopen("http://127.0.0.1:7644", timeout=5) as f:
+                    assert f.getcode() == 200
+        except Exception as e:
+            proc.terminate()
+            assert proc.stdout is not None
+            output = proc.stdout.read().decode()
+            pytest.fail(f"Failed to make request to gunicorn server {e}: {output}")
+        finally:
+            proc.terminate()
+
         assert proc.stdout is not None
         output = proc.stdout.read().decode()
-        pytest.fail(f"Gunicorn failed to start: {output}")
+        worker_pids = _get_worker_pids(output)
+        assert len(worker_pids) == 2, output
 
-    try:
-        for _ in range(4):
-            with urllib.request.urlopen("http://127.0.0.1:7644", timeout=5) as f:
-                assert f.getcode() == 200
-    except Exception as e:
-        proc.terminate()
-        assert proc.stdout is not None
-        output = proc.stdout.read().decode()
-        pytest.fail(f"Failed to make request to gunicorn server {e}: {output}")
-    finally:
-        proc.terminate()
+        try:
+            assert proc.wait(timeout=5) == 0, output
+        except subprocess.TimeoutExpired:
+            pytest.fail(f"Failed to terminate gunicorn process: {output}")
 
-    assert proc.stdout is not None
-    output = proc.stdout.read().decode()
-    worker_pids = _get_worker_pids(output)
-    assert len(worker_pids) == 2, output
-
-    try:
-        assert proc.wait(timeout=5) == 0, output
-    except subprocess.TimeoutExpired:
-        pytest.fail(f"Failed to terminate gunicorn process: {output}")
-
-    profile_files = _get_profile_files(filename)
-    exported_pids = {_get_profile_pid(p) for p in profile_files}
-    expected_pids = {proc.pid, *worker_pids}
-
-    assert exported_pids == expected_pids, [str(p) for p in profile_files]
-    assert len(profile_files) == 3, [str(p) for p in profile_files]
+        # With 2 workers + 1 master process, expect at least 2 profiling uploads
+        # (one per worker minimum; master may or may not upload depending on timing).
+        profiles = get_all_profiles_from_agent(agent_client)
+        assert len(profiles) >= 2, f"Expected at least 2 profiling uploads (one per worker), got {len(profiles)}"
 
 
 def test_gunicorn_profile_export_count_two_workers_flush_false(
     gunicorn: RunGunicornFunc,
-    tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    filename = str(tmp_path / "gunicorn-count-flush-false.pprof")
-    monkeypatch.setenv("DD_PROFILING_OUTPUT_PPROF", filename)
     monkeypatch.setenv("_DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED", "0")
 
     args: tuple[str, ...] = ("-k", "gevent") if TESTING_GEVENT else ()
-    proc = subprocess.Popen(
-        [
-            "ddtrace-run",
-            "gunicorn",
-            "--bind",
-            "127.0.0.1:7644",
-            "--worker-tmp-dir",
-            _WORKER_TMP_DIR,
-            "-c",
-            os.path.dirname(__file__) + "/gunicorn.conf.py",
-            "--chdir",
-            os.path.dirname(__file__),
-            "-w",
-            "2",
-            *args,
-            "tests.profiling.gunicorn_count_app:app",
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        start_new_session=True,
-    )
 
-    time.sleep(5)
-    if proc.poll() is not None:
-        assert proc.stdout is not None
-        output = proc.stdout.read().decode()
-        pytest.fail(f"Gunicorn failed to start: {output}")
+    with with_profiling_test_agent() as agent_client:
+        proc = subprocess.Popen(
+            [
+                "ddtrace-run",
+                "gunicorn",
+                "--bind",
+                "127.0.0.1:7644",
+                "--worker-tmp-dir",
+                _WORKER_TMP_DIR,
+                "-c",
+                os.path.dirname(__file__) + "/gunicorn.conf.py",
+                "--chdir",
+                os.path.dirname(__file__),
+                "-w",
+                "2",
+                *args,
+                "tests.profiling.gunicorn_count_app:app",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
 
-    try:
-        with urllib.request.urlopen("http://127.0.0.1:7644", timeout=5) as f:
-            assert f.getcode() == 200
-    except Exception as e:
+        time.sleep(5)
+        if proc.poll() is not None:
+            assert proc.stdout is not None
+            output = proc.stdout.read().decode()
+            pytest.fail(f"Gunicorn failed to start: {output}")
+
+        try:
+            with urllib.request.urlopen("http://127.0.0.1:7644", timeout=5) as f:
+                assert f.getcode() == 200
+        except Exception as e:
+            os.killpg(proc.pid, signal.SIGKILL)
+            assert proc.stdout is not None
+            output = proc.stdout.read().decode()
+            pytest.fail(f"Failed to make request to gunicorn server {e}: {output}")
+
+        # Clear any periodic uploads that happened before we issue SIGKILL.
+        agent_client.clear()
+
         os.killpg(proc.pid, signal.SIGKILL)
         assert proc.stdout is not None
         output = proc.stdout.read().decode()
-        pytest.fail(f"Failed to make request to gunicorn server {e}: {output}")
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pytest.fail(f"Failed to kill gunicorn process group: {output}")
 
-    os.killpg(proc.pid, signal.SIGKILL)
-    assert proc.stdout is not None
-    output = proc.stdout.read().decode()
-    try:
-        proc.wait(timeout=5)
-    except subprocess.TimeoutExpired:
-        pytest.fail(f"Failed to kill gunicorn process group: {output}")
+        # After SIGKILL (no graceful shutdown), no additional profiling data
+        # should be uploaded — SIGKILL doesn't allow atexit/shutdown flushes.
+        import time as _time
 
-    profile_files = _get_profile_files(filename)
-    assert profile_files == [], [str(p) for p in profile_files]
+        _time.sleep(1)  # give any in-flight uploads a moment to arrive
+        profiles = agent_client.profiling_requests()
+        assert profiles == [], f"Expected no profiling uploads after SIGKILL, got {len(profiles)}"

--- a/tests/profiling/test_gunicorn.py
+++ b/tests/profiling/test_gunicorn.py
@@ -18,7 +18,6 @@ from typing_extensions import TypeAlias
 
 from tests.profiling.collector import pprof_utils
 from tests.profiling.utils import get_all_profiles_from_agent
-from tests.profiling.utils import with_profiling_test_agent
 
 
 # DEV: gunicorn tests are hard to debug, so keeping these print statements for
@@ -78,93 +77,94 @@ def _get_worker_pids(stdout: str) -> list[int]:
 def _test_gunicorn(
     gunicorn: RunGunicornFunc,
     monkeypatch: pytest.MonkeyPatch,
+    agent_client,
     *args: str,
 ) -> None:
     monkeypatch.setenv("_DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED", "0")
 
     debug_print("Creating gunicorn workers")
     # DEV: We only start 1 worker to simplify the test
-    with with_profiling_test_agent() as agent_client:
-        proc = gunicorn("-w", "1", *args)
-        # Wait for the workers to start
-        time.sleep(5)
+    proc = gunicorn("-w", "1", *args)
+    # Wait for the workers to start
+    time.sleep(5)
 
-        if proc.poll() is not None:
-            pytest.fail("Gunicorn failed to start")
+    if proc.poll() is not None:
+        pytest.fail("Gunicorn failed to start")
 
-        debug_print("Making request to gunicorn server")
-        try:
-            with urllib.request.urlopen("http://127.0.0.1:7644", timeout=5) as f:
-                status_code = f.getcode()
-                assert status_code == 200, status_code
-                response = f.read().decode()
-                debug_print(response)
-        except Exception as e:
-            proc.terminate()
-            assert proc.stdout is not None
-            output = proc.stdout.read().decode()
-            print(output)
-            pytest.fail(f"Failed to make request to gunicorn server {e}")
-        finally:
-            # Need to terminate the process to get the output and release the port
-            proc.terminate()
-
-        debug_print("Reading gunicorn worker output to get PIDs")
+    debug_print("Making request to gunicorn server")
+    try:
+        with urllib.request.urlopen("http://127.0.0.1:7644", timeout=5) as f:
+            status_code = f.getcode()
+            assert status_code == 200, status_code
+            response = f.read().decode()
+            debug_print(response)
+    except Exception as e:
+        proc.terminate()
         assert proc.stdout is not None
         output = proc.stdout.read().decode()
-        worker_pids = _get_worker_pids(output)
-        debug_print(f"Gunicorn worker PIDs: {worker_pids}")
+        print(output)
+        pytest.fail(f"Failed to make request to gunicorn server {e}")
+    finally:
+        # Need to terminate the process to get the output and release the port
+        proc.terminate()
 
-        for line in output.splitlines():
-            debug_print(line)
+    debug_print("Reading gunicorn worker output to get PIDs")
+    assert proc.stdout is not None
+    output = proc.stdout.read().decode()
+    worker_pids = _get_worker_pids(output)
+    debug_print(f"Gunicorn worker PIDs: {worker_pids}")
 
-        assert len(worker_pids) == 1, output
+    for line in output.splitlines():
+        debug_print(line)
 
-        debug_print("Waiting for gunicorn process to terminate")
+    assert len(worker_pids) == 1, output
+
+    debug_print("Waiting for gunicorn process to terminate")
+    try:
+        assert proc.wait(timeout=5) == 0, output
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"Failed to terminate gunicorn process: {output}")
+    assert "module 'threading' has no attribute '_active'" not in output, output
+
+    debug_print("Retrieving profiles from capture server")
+    # Multiple uploads may arrive (periodic scheduler + shutdown flush + master process).
+    # Search all of them for the worker profile that has cpu-time samples with fib.
+    profiles = get_all_profiles_from_agent(agent_client)
+
+    # DEV: somehow the filename is reported as either __init__.py or gunicorn-app.py
+    # when run on GitLab CI. We need to match either of these two.
+    filename_regex = r"^(?:__init__\.py|gunicorn-app\.py)$"
+    expected_location = pprof_utils.StackLocation(function_name="fib", filename=filename_regex, line_no=9)
+
+    found = False
+    for profile in profiles:
+        samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+        if not samples:
+            continue
         try:
-            assert proc.wait(timeout=5) == 0, output
-        except subprocess.TimeoutExpired:
-            pytest.fail(f"Failed to terminate gunicorn process: {output}")
-        assert "module 'threading' has no attribute '_active'" not in output, output
-
-        debug_print("Retrieving profiles from capture server")
-        # Multiple uploads may arrive (periodic scheduler + shutdown flush + master process).
-        # Search all of them for the worker profile that has cpu-time samples with fib.
-        profiles = get_all_profiles_from_agent(agent_client)
-
-        # DEV: somehow the filename is reported as either __init__.py or gunicorn-app.py
-        # when run on GitLab CI. We need to match either of these two.
-        filename_regex = r"^(?:__init__\.py|gunicorn-app\.py)$"
-        expected_location = pprof_utils.StackLocation(function_name="fib", filename=filename_regex, line_no=9)
-
-        found = False
-        for profile in profiles:
-            samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-            if not samples:
-                continue
-            try:
-                pprof_utils.assert_profile_has_sample(
-                    profile,
-                    samples=samples,
-                    # DEV: we expect multiple locations as fibonacci is recursive
-                    expected_sample=pprof_utils.StackEvent(locations=[expected_location, expected_location]),
-                )
-                found = True
-                break
-            except AssertionError:
-                continue
-        assert found, (
-            f"Expected fib samples not found in any of {len(profiles)} profile upload(s). "
-            "Worker may not have been profiled during the request."
-        )
+            pprof_utils.assert_profile_has_sample(
+                profile,
+                samples=samples,
+                # DEV: we expect multiple locations as fibonacci is recursive
+                expected_sample=pprof_utils.StackEvent(locations=[expected_location, expected_location]),
+            )
+            found = True
+            break
+        except AssertionError:
+            continue
+    assert found, (
+        f"Expected fib samples not found in any of {len(profiles)} profile upload(s). "
+        "Worker may not have been profiled during the request."
+    )
 
 
 def test_gunicorn(
     gunicorn: RunGunicornFunc,
     monkeypatch: pytest.MonkeyPatch,
+    profiling_test_agent,
 ) -> None:
     args: tuple[str, ...] = ("-k", "gevent") if TESTING_GEVENT else ()
-    _test_gunicorn(gunicorn, monkeypatch, *args)
+    _test_gunicorn(gunicorn, monkeypatch, profiling_test_agent, *args)
 
 
 def _run_sigterm_graceful_shutdown_test(
@@ -288,109 +288,111 @@ def test_gunicorn_gevent_sigterm_graceful_shutdown(monkeypatch: pytest.MonkeyPat
 def test_gunicorn_profile_export_count_two_workers(
     gunicorn: RunGunicornFunc,
     monkeypatch: pytest.MonkeyPatch,
+    profiling_test_agent,
 ) -> None:
     monkeypatch.setenv("_DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED", "0")
 
     args: tuple[str, ...] = ("-k", "gevent") if TESTING_GEVENT else ()
 
-    with with_profiling_test_agent() as agent_client:
-        proc = gunicorn("-w", "2", *args, app="tests.profiling.gunicorn_count_app:app")
-        time.sleep(5)
+    agent_client = profiling_test_agent
+    proc = gunicorn("-w", "2", *args, app="tests.profiling.gunicorn_count_app:app")
+    time.sleep(5)
 
-        if proc.poll() is not None:
-            assert proc.stdout is not None
-            output = proc.stdout.read().decode()
-            pytest.fail(f"Gunicorn failed to start: {output}")
-
-        try:
-            for _ in range(4):
-                with urllib.request.urlopen("http://127.0.0.1:7644", timeout=5) as f:
-                    assert f.getcode() == 200
-        except Exception as e:
-            proc.terminate()
-            assert proc.stdout is not None
-            output = proc.stdout.read().decode()
-            pytest.fail(f"Failed to make request to gunicorn server {e}: {output}")
-        finally:
-            proc.terminate()
-
+    if proc.poll() is not None:
         assert proc.stdout is not None
         output = proc.stdout.read().decode()
-        worker_pids = _get_worker_pids(output)
-        assert len(worker_pids) == 2, output
+        pytest.fail(f"Gunicorn failed to start: {output}")
 
-        try:
-            assert proc.wait(timeout=5) == 0, output
-        except subprocess.TimeoutExpired:
-            pytest.fail(f"Failed to terminate gunicorn process: {output}")
+    try:
+        for _ in range(4):
+            with urllib.request.urlopen("http://127.0.0.1:7644", timeout=5) as f:
+                assert f.getcode() == 200
+    except Exception as e:
+        proc.terminate()
+        assert proc.stdout is not None
+        output = proc.stdout.read().decode()
+        pytest.fail(f"Failed to make request to gunicorn server {e}: {output}")
+    finally:
+        proc.terminate()
 
-        # With 2 workers + 1 master process, expect at least 2 profiling uploads
-        # (one per worker minimum; master may or may not upload depending on timing).
-        profiles = get_all_profiles_from_agent(agent_client)
-        assert len(profiles) >= 2, f"Expected at least 2 profiling uploads (one per worker), got {len(profiles)}"
+    assert proc.stdout is not None
+    output = proc.stdout.read().decode()
+    worker_pids = _get_worker_pids(output)
+    assert len(worker_pids) == 2, output
+
+    try:
+        assert proc.wait(timeout=5) == 0, output
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"Failed to terminate gunicorn process: {output}")
+
+    # With 2 workers + 1 master process, expect at least 2 profiling uploads
+    # (one per worker minimum; master may or may not upload depending on timing).
+    profiles = get_all_profiles_from_agent(agent_client)
+    assert len(profiles) >= 2, f"Expected at least 2 profiling uploads (one per worker), got {len(profiles)}"
 
 
 def test_gunicorn_profile_export_count_two_workers_flush_false(
     gunicorn: RunGunicornFunc,
     monkeypatch: pytest.MonkeyPatch,
+    profiling_test_agent,
 ) -> None:
     monkeypatch.setenv("_DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED", "0")
 
     args: tuple[str, ...] = ("-k", "gevent") if TESTING_GEVENT else ()
 
-    with with_profiling_test_agent() as agent_client:
-        proc = subprocess.Popen(
-            [
-                "ddtrace-run",
-                "gunicorn",
-                "--bind",
-                "127.0.0.1:7644",
-                "--worker-tmp-dir",
-                _WORKER_TMP_DIR,
-                "-c",
-                os.path.dirname(__file__) + "/gunicorn.conf.py",
-                "--chdir",
-                os.path.dirname(__file__),
-                "-w",
-                "2",
-                *args,
-                "tests.profiling.gunicorn_count_app:app",
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            start_new_session=True,
-        )
+    agent_client = profiling_test_agent
+    proc = subprocess.Popen(
+        [
+            "ddtrace-run",
+            "gunicorn",
+            "--bind",
+            "127.0.0.1:7644",
+            "--worker-tmp-dir",
+            _WORKER_TMP_DIR,
+            "-c",
+            os.path.dirname(__file__) + "/gunicorn.conf.py",
+            "--chdir",
+            os.path.dirname(__file__),
+            "-w",
+            "2",
+            *args,
+            "tests.profiling.gunicorn_count_app:app",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
 
-        time.sleep(5)
-        if proc.poll() is not None:
-            assert proc.stdout is not None
-            output = proc.stdout.read().decode()
-            pytest.fail(f"Gunicorn failed to start: {output}")
+    time.sleep(5)
+    if proc.poll() is not None:
+        assert proc.stdout is not None
+        output = proc.stdout.read().decode()
+        pytest.fail(f"Gunicorn failed to start: {output}")
 
-        try:
-            with urllib.request.urlopen("http://127.0.0.1:7644", timeout=5) as f:
-                assert f.getcode() == 200
-        except Exception as e:
-            os.killpg(proc.pid, signal.SIGKILL)
-            assert proc.stdout is not None
-            output = proc.stdout.read().decode()
-            pytest.fail(f"Failed to make request to gunicorn server {e}: {output}")
-
-        # Clear any periodic uploads that happened before we issue SIGKILL.
-        agent_client.clear()
-
+    try:
+        with urllib.request.urlopen("http://127.0.0.1:7644", timeout=5) as f:
+            assert f.getcode() == 200
+    except Exception as e:
         os.killpg(proc.pid, signal.SIGKILL)
         assert proc.stdout is not None
         output = proc.stdout.read().decode()
-        try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            pytest.fail(f"Failed to kill gunicorn process group: {output}")
+        pytest.fail(f"Failed to make request to gunicorn server {e}: {output}")
 
-        # After SIGKILL (no graceful shutdown), no additional profiling data
-        # should be uploaded — SIGKILL doesn't allow atexit/shutdown flushes.
-        import time as _time
+    # Clear any periodic uploads that happened before we issue SIGKILL.
+    agent_client.clear()
 
-        _time.sleep(1)  # give any in-flight uploads a moment to arrive
-        profiles = agent_client.profiling_requests()
-        assert profiles == [], f"Expected no profiling uploads after SIGKILL, got {len(profiles)}"
+    os.killpg(proc.pid, signal.SIGKILL)
+    assert proc.stdout is not None
+    output = proc.stdout.read().decode()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"Failed to kill gunicorn process group: {output}")
+
+    # After SIGKILL (no graceful shutdown), no additional profiling data
+    # should be uploaded — SIGKILL doesn't allow atexit/shutdown flushes.
+    import time as _time
+
+    _time.sleep(1)  # give any in-flight uploads a moment to arrive
+    profiles = agent_client.profiling_requests()
+    assert profiles == [], f"Expected no profiling uploads after SIGKILL, got {len(profiles)}"

--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -185,7 +185,7 @@ methods = multiprocessing.get_all_start_methods()
     set(methods) - {"forkserver", "fork"},
 )
 def test_multiprocessing(method: str) -> None:
-    from tests.profiling.utils import get_all_profiles_from_agent
+    from tests.profiling.utils import get_all_requests_from_agent
 
     env = os.environ.copy()
     env["DD_PROFILING_ENABLED"] = "1"
@@ -198,13 +198,21 @@ def test_multiprocessing(method: str) -> None:
         env=env,
     )
     assert exitcode == 0, (stdout, stderr)
-    profiles = get_all_profiles_from_agent()
-    # Expect at least 2 profiles: one for the parent process and one for the child
-    assert len(profiles) >= 2, f"Expected at least 2 profiling uploads (parent + child), got {len(profiles)}"
-    # At least one profile must have cpu-time samples (early/empty flush profiles are allowed)
-    assert any(len(pprof_utils.get_samples_with_value_type(p, "cpu-time")) > 0 for p in profiles), (
-        "No profiling uploads had cpu-time samples"
+    reqs = get_all_requests_from_agent(min_count=2)
+    # Group profiles by PID; require at least 2 distinct PIDs (parent + child).
+    from collections import defaultdict
+
+    profiles_by_pid: "dict[int, list]" = defaultdict(list)
+    for req in reqs:
+        pid = pprof_utils.parse_pid_from_request(req)
+        profiles_by_pid[pid].append(pprof_utils.parse_profile_from_request(req))
+    assert len(profiles_by_pid) >= 2, (
+        f"Expected profiles from at least 2 processes (parent + child), got PIDs: {list(profiles_by_pid.keys())}"
     )
+    for pid, pid_profiles in profiles_by_pid.items():
+        assert any(len(pprof_utils.get_samples_with_value_type(p, "cpu-time")) > 0 for p in pid_profiles), (
+            f"Process {pid} did not upload any profile with cpu-time samples"
+        )
 
 
 @pytest.mark.subprocess(

--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -37,6 +37,34 @@ def test_call_script_gevent():
     assert exitcode == 0, (stdout, stderr)
 
 
+def test_dd_profiling_output_pprof(tmp_path) -> None:
+    """Verify that DD_PROFILING_OUTPUT_PPROF writes pprof files to disk.
+
+    This code path is used for local/one-off debugging (e.g. inspecting profiles
+    with pprof without a running agent).  It must continue to work independently
+    of the mock-agent test infrastructure.
+    """
+    output_prefix = str(tmp_path / "test_output")
+    env = os.environ.copy()
+    env["DD_PROFILING_ENABLED"] = "1"
+    env["DD_PROFILING_CAPTURE_PCT"] = "100"
+    env["DD_PROFILING_OUTPUT_PPROF"] = output_prefix
+    stdout, stderr, exitcode, _ = call_program(
+        "ddtrace-run",
+        sys.executable,
+        os.path.join(os.path.dirname(__file__), "simple_program.py"),
+        env=env,
+    )
+    if sys.platform == "win32":
+        assert exitcode == 0, (stdout, stderr)
+    else:
+        assert exitcode == 42, (stdout, stderr)
+
+    profile = pprof_utils.parse_newest_profile(output_prefix)
+    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
+    assert len(samples) > 0
+
+
 def test_call_script_pprof_output() -> None:
     """This checks if the pprof output and atexit register work correctly.
 

--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -7,8 +7,7 @@ import pytest
 
 from tests.profiling.collector import lock_utils
 from tests.profiling.collector import pprof_utils
-from tests.profiling.utils import get_profile_from_agent
-from tests.profiling.utils import with_profiling_test_agent
+from tests.profiling.collector.pprof_utils import get_profile_from_agent
 from tests.utils import call_program
 
 
@@ -43,22 +42,21 @@ def test_call_script_pprof_output() -> None:
 
     The script does not run for one minute, so if the `stop_on_exit` flag is broken, this test will fail.
     """
-    with with_profiling_test_agent() as agent_client:
-        env = os.environ.copy()
-        env["DD_PROFILING_CAPTURE_PCT"] = "100"
-        env["DD_PROFILING_ENABLED"] = "1"
-        stdout, stderr, exitcode, _ = call_program(
-            "ddtrace-run",
-            sys.executable,
-            os.path.join(os.path.dirname(__file__), "simple_program.py"),
-            env=env,
-        )
-        if sys.platform == "win32":
-            assert exitcode == 0, (stdout, stderr)
-        else:
-            assert exitcode == 42, (stdout, stderr)
+    env = os.environ.copy()
+    env["DD_PROFILING_CAPTURE_PCT"] = "100"
+    env["DD_PROFILING_ENABLED"] = "1"
+    stdout, stderr, exitcode, _ = call_program(
+        "ddtrace-run",
+        sys.executable,
+        os.path.join(os.path.dirname(__file__), "simple_program.py"),
+        env=env,
+    )
+    if sys.platform == "win32":
+        assert exitcode == 0, (stdout, stderr)
+    else:
+        assert exitcode == 42, (stdout, stderr)
 
-        profile = get_profile_from_agent(agent_client)
+    profile = get_profile_from_agent()
     samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
     assert len(samples) > 0
 
@@ -108,14 +106,13 @@ def test_fork() -> None:
         ),
     ]
 
-    with with_profiling_test_agent() as agent_client:
-        env = os.environ.copy()
-        env["DD_PROFILING_CAPTURE_PCT"] = "100"
-        stdout, stderr, exitcode, pid = call_program(
-            sys.executable, os.path.join(os.path.dirname(__file__), "simple_program_fork.py"), env=env
-        )
-        assert exitcode == 0, stderr
-        profiles = get_all_profiles_from_agent(agent_client)
+    env = os.environ.copy()
+    env["DD_PROFILING_CAPTURE_PCT"] = "100"
+    stdout, stderr, exitcode, pid = call_program(
+        sys.executable, os.path.join(os.path.dirname(__file__), "simple_program_fork.py"), env=env
+    )
+    assert exitcode == 0, stderr
+    profiles = get_all_profiles_from_agent()
     assert len(profiles) >= 2, f"Expected at least 2 profiling uploads (parent + child), got {len(profiles)}"
 
     # Identify parent and child profiles by the events they contain:
@@ -190,19 +187,18 @@ methods = multiprocessing.get_all_start_methods()
 def test_multiprocessing(method: str) -> None:
     from tests.profiling.utils import get_all_profiles_from_agent
 
-    with with_profiling_test_agent() as agent_client:
-        env = os.environ.copy()
-        env["DD_PROFILING_ENABLED"] = "1"
-        env["DD_PROFILING_CAPTURE_PCT"] = "100"
-        stdout, stderr, exitcode, _ = call_program(
-            "ddtrace-run",
-            sys.executable,
-            os.path.join(os.path.dirname(__file__), "_test_multiprocessing.py"),
-            method,
-            env=env,
-        )
-        assert exitcode == 0, (stdout, stderr)
-        profiles = get_all_profiles_from_agent(agent_client)
+    env = os.environ.copy()
+    env["DD_PROFILING_ENABLED"] = "1"
+    env["DD_PROFILING_CAPTURE_PCT"] = "100"
+    stdout, stderr, exitcode, _ = call_program(
+        "ddtrace-run",
+        sys.executable,
+        os.path.join(os.path.dirname(__file__), "_test_multiprocessing.py"),
+        method,
+        env=env,
+    )
+    assert exitcode == 0, (stdout, stderr)
+    profiles = get_all_profiles_from_agent()
     # Expect at least 2 profiles: one for the parent process and one for the child
     assert len(profiles) >= 2, f"Expected at least 2 profiling uploads (parent + child), got {len(profiles)}"
     # At least one profile must have cpu-time samples (early/empty flush profiles are allowed)

--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -1,13 +1,14 @@
 # -*- encoding: utf-8 -*-
 import multiprocessing
 import os
-from pathlib import Path
 import sys
 
 import pytest
 
 from tests.profiling.collector import lock_utils
 from tests.profiling.collector import pprof_utils
+from tests.profiling.utils import get_profile_from_agent
+from tests.profiling.utils import with_profiling_test_agent
 from tests.utils import call_program
 
 
@@ -37,52 +38,34 @@ def test_call_script_gevent():
     assert exitcode == 0, (stdout, stderr)
 
 
-def test_call_script_pprof_output(tmp_path: Path) -> None:
+def test_call_script_pprof_output() -> None:
     """This checks if the pprof output and atexit register work correctly.
 
     The script does not run for one minute, so if the `stop_on_exit` flag is broken, this test will fail.
     """
-    filename = str(tmp_path / "pprof")
-    env = os.environ.copy()
-    env["DD_PROFILING_OUTPUT_PPROF"] = filename
-    env["DD_PROFILING_CAPTURE_PCT"] = "100"
-    env["DD_PROFILING_ENABLED"] = "1"
-    stdout, stderr, exitcode, _ = call_program(
-        "ddtrace-run",
-        sys.executable,
-        os.path.join(os.path.dirname(__file__), "simple_program.py"),
-        env=env,
-    )
-    if sys.platform == "win32":
-        assert exitcode == 0, (stdout, stderr)
-    else:
-        assert exitcode == 42, (stdout, stderr)
+    with with_profiling_test_agent() as agent_client:
+        env = os.environ.copy()
+        env["DD_PROFILING_CAPTURE_PCT"] = "100"
+        env["DD_PROFILING_ENABLED"] = "1"
+        stdout, stderr, exitcode, _ = call_program(
+            "ddtrace-run",
+            sys.executable,
+            os.path.join(os.path.dirname(__file__), "simple_program.py"),
+            env=env,
+        )
+        if sys.platform == "win32":
+            assert exitcode == 0, (stdout, stderr)
+        else:
+            assert exitcode == 42, (stdout, stderr)
 
-    stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
-    _, pid = list(s.strip() for s in stdout.strip().split("\n"))
-    profile = pprof_utils.parse_newest_profile(f"{filename}.{pid}", allow_penultimate=True)
+        profile = get_profile_from_agent(agent_client)
     samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
     assert len(samples) > 0
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="fork only available on Unix")
-def test_fork(tmp_path: Path) -> None:
-    filename = str(tmp_path / "pprof")
-    env = os.environ.copy()
-    env["DD_PROFILING_OUTPUT_PPROF"] = filename
-    env["DD_PROFILING_CAPTURE_PCT"] = "100"
-    stdout, stderr, exitcode, pid = call_program(
-        sys.executable, os.path.join(os.path.dirname(__file__), "simple_program_fork.py"), env=env
-    )
-    assert exitcode == 0, stderr
-    stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
-    child_pid = stdout.strip()
-
-    # Merge all pprof files for parent PID
-    all_files_for_pid = sorted([x for x in os.listdir(tmp_path) if ".pprof" in x])
-    parent_files = [str(tmp_path / f) for f in all_files_for_pid if f".{str(pid)}." in f]
-    parent_profiles = [pprof_utils.parse_profile(f) for f in parent_files]
-    parent_profile = pprof_utils.merge_profiles(parent_profiles)
+def test_fork() -> None:
+    from tests.profiling.utils import get_all_profiles_from_agent
 
     parent_expected_acquire_events = [
         pprof_utils.LockAcquireEvent(
@@ -100,6 +83,71 @@ def test_fork(tmp_path: Path) -> None:
             lock_name="lock",
         ),
     ]
+    child_expected_acquire_events = [
+        # After fork(), we clear the samples in child, so we only have one
+        # lock acquire event
+        pprof_utils.LockAcquireEvent(
+            caller_name="<module>",
+            filename="simple_program_fork.py",
+            linenos=lock_utils.LineNo(create=24, acquire=25, release=26),
+            lock_name="lock",
+        ),
+    ]
+    child_expected_release_events = [
+        pprof_utils.LockReleaseEvent(
+            caller_name="<module>",
+            filename="simple_program_fork.py",
+            linenos=lock_utils.LineNo(create=11, acquire=12, release=21),
+            lock_name="lock",
+        ),
+        pprof_utils.LockReleaseEvent(
+            caller_name="<module>",
+            filename="simple_program_fork.py",
+            linenos=lock_utils.LineNo(create=24, acquire=25, release=26),
+            lock_name="lock",
+        ),
+    ]
+
+    with with_profiling_test_agent() as agent_client:
+        env = os.environ.copy()
+        env["DD_PROFILING_CAPTURE_PCT"] = "100"
+        stdout, stderr, exitcode, pid = call_program(
+            sys.executable, os.path.join(os.path.dirname(__file__), "simple_program_fork.py"), env=env
+        )
+        assert exitcode == 0, stderr
+        profiles = get_all_profiles_from_agent(agent_client)
+    assert len(profiles) >= 2, f"Expected at least 2 profiling uploads (parent + child), got {len(profiles)}"
+
+    # Identify parent and child profiles by the events they contain:
+    # The parent profile has lock events from lines 11/12/28 (original lock),
+    # while the child profile only has events from lines 24/25/26 (new lock after fork).
+    parent_profile = None
+    child_profile = None
+    for profile in profiles:
+        try:
+            pprof_utils.assert_lock_events(
+                profile,
+                expected_acquire_events=parent_expected_acquire_events,
+                expected_release_events=parent_expected_release_events,
+            )
+            parent_profile = profile
+        except AssertionError:
+            pass
+
+        try:
+            pprof_utils.assert_lock_events(
+                profile,
+                expected_acquire_events=child_expected_acquire_events,
+                expected_release_events=child_expected_release_events,
+            )
+            child_profile = profile
+        except AssertionError:
+            pass
+
+    assert parent_profile is not None, "No profile found with parent lock events (lines 11/12/28)"
+    assert child_profile is not None, "No profile found with child lock events (lines 24/25/26)"
+
+    # Verify parent profile has the expected events
     pprof_utils.assert_lock_events(
         parent_profile,
         expected_acquire_events=parent_expected_acquire_events,
@@ -107,9 +155,6 @@ def test_fork(tmp_path: Path) -> None:
         print_samples_on_failure=True,
     )
 
-    # Merge all pprof files for child PID
-    child_files = [str(tmp_path / f) for f in all_files_for_pid if f".{str(child_pid)}." in f]
-    child_profile = pprof_utils.merge_profiles([pprof_utils.parse_profile(f) for f in child_files])
     # We expect the child profile to not have lock events from the parent process
     # Note that assert_lock_events function only checks that the given events
     # exists, and doesn't assert that other events don't exist.
@@ -121,30 +166,8 @@ def test_fork(tmp_path: Path) -> None:
         )
     pprof_utils.assert_lock_events(
         child_profile,
-        expected_acquire_events=[
-            # After fork(), we clear the samples in child, so we only have one
-            # lock acquire event
-            pprof_utils.LockAcquireEvent(
-                caller_name="<module>",
-                filename="simple_program_fork.py",
-                linenos=lock_utils.LineNo(create=24, acquire=25, release=26),
-                lock_name="lock",
-            ),
-        ],
-        expected_release_events=[
-            pprof_utils.LockReleaseEvent(
-                caller_name="<module>",
-                filename="simple_program_fork.py",
-                linenos=lock_utils.LineNo(create=11, acquire=12, release=21),
-                lock_name="lock",
-            ),
-            pprof_utils.LockReleaseEvent(
-                caller_name="<module>",
-                filename="simple_program_fork.py",
-                linenos=lock_utils.LineNo(create=24, acquire=25, release=26),
-                lock_name="lock",
-            ),
-        ],
+        expected_acquire_events=child_expected_acquire_events,
+        expected_release_events=child_expected_release_events,
         print_samples_on_failure=True,
     )
 
@@ -164,28 +187,28 @@ methods = multiprocessing.get_all_start_methods()
     "method",
     set(methods) - {"forkserver", "fork"},
 )
-def test_multiprocessing(method: str, tmp_path: Path) -> None:
-    filename = str(tmp_path / "pprof")
-    env = os.environ.copy()
-    env["DD_PROFILING_OUTPUT_PPROF"] = filename
-    env["DD_PROFILING_ENABLED"] = "1"
-    env["DD_PROFILING_CAPTURE_PCT"] = "100"
-    stdout, stderr, exitcode, _ = call_program(
-        "ddtrace-run",
-        sys.executable,
-        os.path.join(os.path.dirname(__file__), "_test_multiprocessing.py"),
-        method,
-        env=env,
+def test_multiprocessing(method: str) -> None:
+    from tests.profiling.utils import get_all_profiles_from_agent
+
+    with with_profiling_test_agent() as agent_client:
+        env = os.environ.copy()
+        env["DD_PROFILING_ENABLED"] = "1"
+        env["DD_PROFILING_CAPTURE_PCT"] = "100"
+        stdout, stderr, exitcode, _ = call_program(
+            "ddtrace-run",
+            sys.executable,
+            os.path.join(os.path.dirname(__file__), "_test_multiprocessing.py"),
+            method,
+            env=env,
+        )
+        assert exitcode == 0, (stdout, stderr)
+        profiles = get_all_profiles_from_agent(agent_client)
+    # Expect at least 2 profiles: one for the parent process and one for the child
+    assert len(profiles) >= 2, f"Expected at least 2 profiling uploads (parent + child), got {len(profiles)}"
+    # At least one profile must have cpu-time samples (early/empty flush profiles are allowed)
+    assert any(len(pprof_utils.get_samples_with_value_type(p, "cpu-time")) > 0 for p in profiles), (
+        "No profiling uploads had cpu-time samples"
     )
-    assert exitcode == 0, (stdout, stderr)
-    stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
-    pid, child_pid = list(s.strip() for s in stdout.strip().split("\n"))
-    profile = pprof_utils.parse_newest_profile(f"{filename}.{pid}")
-    samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
-    assert len(samples) > 0
-    child_profile = pprof_utils.parse_newest_profile(filename + "." + str(child_pid))
-    child_samples = pprof_utils.get_samples_with_value_type(child_profile, "cpu-time")
-    assert len(child_samples) > 0
 
 
 @pytest.mark.subprocess(

--- a/tests/profiling/test_pytorch.py
+++ b/tests/profiling/test_pytorch.py
@@ -4,6 +4,8 @@ import sys
 import pytest
 
 from tests.profiling.collector import pprof_utils
+from tests.profiling.utils import get_profile_from_agent
+from tests.profiling.utils import with_profiling_test_agent
 from tests.utils import call_program
 
 
@@ -16,7 +18,7 @@ except ImportError:
 
 
 @pytest.mark.skipif(not _HAS_TORCH, reason="torch is not installed")
-def test_call_script_pytorch_cpu(tmp_path, monkeypatch):
+def test_call_script_pytorch_cpu(monkeypatch):
     """The torch profiler integration should reconstruct the operator call tree.
 
     Each torch event's stack is built by walking the ``cpu_parent`` chain, so a
@@ -24,16 +26,14 @@ def test_call_script_pytorch_cpu(tmp_path, monkeypatch):
     a multi-frame stack rooted at the ``PYTORCH_DeviceType.CPU`` pseudo-frame,
     rather than as a flat two-frame stack.
     """
-    filename = str(tmp_path / "pprof")
-    monkeypatch.setenv("DD_PROFILING_OUTPUT_PPROF", filename)
     monkeypatch.setenv("DD_PROFILING_ENABLED", "1")
     monkeypatch.setenv("DD_PROFILING_PYTORCH_ENABLED", "1")
-    _, stderr, exitcode, _ = call_program(
-        "ddtrace-run", sys.executable, os.path.join(os.path.dirname(__file__), "simple_program_pytorch_cpu.py")
-    )
-    assert exitcode == 0, f"Profiler exited with code {exitcode}. Stderr: {stderr}"
-
-    profile = pprof_utils.parse_newest_profile(filename)
+    with with_profiling_test_agent() as agent_client:
+        _, stderr, exitcode, _ = call_program(
+            "ddtrace-run", sys.executable, os.path.join(os.path.dirname(__file__), "simple_program_pytorch_cpu.py")
+        )
+        assert exitcode == 0, f"Profiler exited with code {exitcode}. Stderr: {stderr}"
+        profile = get_profile_from_agent(agent_client)
     samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
     assert len(samples) > 0, "Expected at least one cpu-time sample"
 
@@ -58,20 +58,18 @@ def test_call_script_pytorch_cpu(tmp_path, monkeypatch):
 
 
 @pytest.mark.skipif(not os.getenv("DD_PROFILING_PYTORCH_ENABLED", False), reason="Not testing pytorch GPU")
-def test_call_script_pytorch_gpu(tmp_path, monkeypatch):
+def test_call_script_pytorch_gpu(monkeypatch):
     from ddtrace.profiling.collector.pytorch import _DEVICE_FRAME_FILE_NAME
     from ddtrace.profiling.collector.pytorch import _FILE_PLACEHOLDER
 
-    filename = str(tmp_path / "pprof")
-    monkeypatch.setenv("DD_PROFILING_OUTPUT_PPROF", filename)
     monkeypatch.setenv("DD_PROFILING_ENABLED", "1")
     monkeypatch.setenv("DD_PROFILING_PYTORCH_ENABLED", "1")
-    _, stderr, exitcode, _ = call_program(
-        "ddtrace-run", sys.executable, os.path.join(os.path.dirname(__file__), "simple_program_pytorch_gpu.py")
-    )
-    assert exitcode == 0, f"Profiler exited with code {exitcode}. Stderr: {stderr}"
-
-    profile = pprof_utils.parse_newest_profile(filename)
+    with with_profiling_test_agent() as agent_client:
+        _, stderr, exitcode, _ = call_program(
+            "ddtrace-run", sys.executable, os.path.join(os.path.dirname(__file__), "simple_program_pytorch_gpu.py")
+        )
+        assert exitcode == 0, f"Profiler exited with code {exitcode}. Stderr: {stderr}"
+        profile = get_profile_from_agent(agent_client)
     samples = pprof_utils.get_samples_with_value_type(profile, "gpu-time")
     assert len(samples) > 0
     print("number of gpu time samples: ", len(samples))

--- a/tests/profiling/test_pytorch.py
+++ b/tests/profiling/test_pytorch.py
@@ -4,8 +4,7 @@ import sys
 import pytest
 
 from tests.profiling.collector import pprof_utils
-from tests.profiling.utils import get_profile_from_agent
-from tests.profiling.utils import with_profiling_test_agent
+from tests.profiling.collector.pprof_utils import get_profile_from_agent
 from tests.utils import call_program
 
 
@@ -28,12 +27,11 @@ def test_call_script_pytorch_cpu(monkeypatch):
     """
     monkeypatch.setenv("DD_PROFILING_ENABLED", "1")
     monkeypatch.setenv("DD_PROFILING_PYTORCH_ENABLED", "1")
-    with with_profiling_test_agent() as agent_client:
-        _, stderr, exitcode, _ = call_program(
-            "ddtrace-run", sys.executable, os.path.join(os.path.dirname(__file__), "simple_program_pytorch_cpu.py")
-        )
-        assert exitcode == 0, f"Profiler exited with code {exitcode}. Stderr: {stderr}"
-        profile = get_profile_from_agent(agent_client)
+    _, stderr, exitcode, _ = call_program(
+        "ddtrace-run", sys.executable, os.path.join(os.path.dirname(__file__), "simple_program_pytorch_cpu.py")
+    )
+    assert exitcode == 0, f"Profiler exited with code {exitcode}. Stderr: {stderr}"
+    profile = get_profile_from_agent()
     samples = pprof_utils.get_samples_with_value_type(profile, "cpu-time")
     assert len(samples) > 0, "Expected at least one cpu-time sample"
 
@@ -64,12 +62,11 @@ def test_call_script_pytorch_gpu(monkeypatch):
 
     monkeypatch.setenv("DD_PROFILING_ENABLED", "1")
     monkeypatch.setenv("DD_PROFILING_PYTORCH_ENABLED", "1")
-    with with_profiling_test_agent() as agent_client:
-        _, stderr, exitcode, _ = call_program(
-            "ddtrace-run", sys.executable, os.path.join(os.path.dirname(__file__), "simple_program_pytorch_gpu.py")
-        )
-        assert exitcode == 0, f"Profiler exited with code {exitcode}. Stderr: {stderr}"
-        profile = get_profile_from_agent(agent_client)
+    _, stderr, exitcode, _ = call_program(
+        "ddtrace-run", sys.executable, os.path.join(os.path.dirname(__file__), "simple_program_pytorch_gpu.py")
+    )
+    assert exitcode == 0, f"Profiler exited with code {exitcode}. Stderr: {stderr}"
+    profile = get_profile_from_agent()
     samples = pprof_utils.get_samples_with_value_type(profile, "gpu-time")
     assert len(samples) > 0
     print("number of gpu time samples: ", len(samples))

--- a/tests/profiling/test_uwsgi.py
+++ b/tests/profiling/test_uwsgi.py
@@ -36,7 +36,6 @@ from ddtrace.profiling import profiler
 from tests.contrib.uwsgi import run_uwsgi
 from tests.profiling.collector import pprof_utils
 from tests.profiling.utils import get_all_profiles_from_agent
-from tests.profiling.utils import with_profiling_test_agent
 
 
 # uwsgi is not available on Windows
@@ -181,14 +180,13 @@ def test_uwsgi_threads_enabled(uwsgi: Callable[..., subprocess.Popen[bytes]], mo
     - After running for a few seconds, the profiler collects wall-time samples
     - The profile is received by the test agent with wall-time samples
     """
-    with with_profiling_test_agent() as agent_client:
-        proc = uwsgi("--enable-threads")
-        _get_worker_pids(proc.stdout, 1)
-        # Give some time to the process to actually startup
-        time.sleep(3)
-        proc.terminate()
-        assert proc.wait() == 30
-        profiles = get_all_profiles_from_agent(agent_client)
+    proc = uwsgi("--enable-threads")
+    _get_worker_pids(proc.stdout, 1)
+    # Give some time to the process to actually startup
+    time.sleep(3)
+    proc.terminate()
+    assert proc.wait() == 30
+    profiles = get_all_profiles_from_agent()
     assert len(profiles) >= 1, f"Expected at least 1 profiling upload, got {len(profiles)}"
     for profile in profiles:
         samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
@@ -267,14 +265,13 @@ def test_uwsgi_threads_processes_primary(
     - Each worker independently collects wall-time samples
     - Profiles are received by the test agent with wall-time samples
     """
-    with with_profiling_test_agent() as agent_client:
-        proc = uwsgi("--enable-threads", "--master", "--py-call-uwsgi-fork-hooks", "--processes", "2")
-        _get_worker_pids(proc.stdout, 2)
-        # Give some time to child to actually startup
-        time.sleep(3)
-        proc.terminate()
-        assert proc.wait() == 0
-        profiles = get_all_profiles_from_agent(agent_client)
+    proc = uwsgi("--enable-threads", "--master", "--py-call-uwsgi-fork-hooks", "--processes", "2")
+    _get_worker_pids(proc.stdout, 2)
+    # Give some time to child to actually startup
+    time.sleep(3)
+    proc.terminate()
+    assert proc.wait() == 0
+    profiles = get_all_profiles_from_agent()
     assert len(profiles) >= 2, f"Expected at least 2 profiling uploads (one per worker), got {len(profiles)}"
     for profile in profiles:
         samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
@@ -299,16 +296,15 @@ def test_uwsgi_threads_processes_primary_lazy_apps(
     """
     monkeypatch.setenv("DD_PROFILING_UPLOAD_INTERVAL", "1")
 
-    with with_profiling_test_agent() as agent_client:
-        # For uwsgi<2.0.30, --skip-atexit is required to avoid crashes when
-        # the child process exits.
-        proc = uwsgi("--enable-threads", "--master", "--processes", "2", "--lazy-apps", "--skip-atexit")
-        _get_worker_pids(proc.stdout, 2, 2)
-        # Give some time to child to actually startup and output a profile
-        time.sleep(3)
-        proc.terminate()
-        assert proc.wait() == 0
-        profiles = get_all_profiles_from_agent(agent_client)
+    # For uwsgi<2.0.30, --skip-atexit is required to avoid crashes when
+    # the child process exits.
+    proc = uwsgi("--enable-threads", "--master", "--processes", "2", "--lazy-apps", "--skip-atexit")
+    _get_worker_pids(proc.stdout, 2, 2)
+    # Give some time to child to actually startup and output a profile
+    time.sleep(3)
+    proc.terminate()
+    assert proc.wait() == 0
+    profiles = get_all_profiles_from_agent()
     assert len(profiles) >= 2, f"Expected at least 2 profiling uploads (one per worker), got {len(profiles)}"
     for profile in profiles:
         samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
@@ -336,38 +332,37 @@ def test_uwsgi_threads_processes_no_primary_lazy_apps(
     """
     monkeypatch.setenv("DD_PROFILING_UPLOAD_INTERVAL", "1")
 
-    with with_profiling_test_agent() as agent_client:
-        # For uwsgi<2.0.30, --skip-atexit is required to avoid crashes when
-        # the child process exits.
-        proc = uwsgi("--enable-threads", "--processes", "2", "--lazy-apps", "--skip-atexit")
-        worker_pids = _get_worker_pids(proc.stdout, 2, 2)
-        assert len(worker_pids) == 2
+    # For uwsgi<2.0.30, --skip-atexit is required to avoid crashes when
+    # the child process exits.
+    proc = uwsgi("--enable-threads", "--processes", "2", "--lazy-apps", "--skip-atexit")
+    worker_pids = _get_worker_pids(proc.stdout, 2, 2)
+    assert len(worker_pids) == 2
 
-        # Give some time to child to actually startup before terminating the master
-        time.sleep(3)
+    # Give some time to child to actually startup before terminating the master
+    time.sleep(3)
 
-        # Kill master process
-        parent_pid: int = worker_pids[0]
-        os.kill(parent_pid, signal.SIGTERM)
+    # Kill master process
+    parent_pid: int = worker_pids[0]
+    os.kill(parent_pid, signal.SIGTERM)
 
-        # Wait for master to exit
-        res_pid, res_status = os.waitpid(parent_pid, 0)
-        print("")
-        print(f"INFO: Master process {parent_pid} exited with status {res_status} and pid {res_pid}")
+    # Wait for master to exit
+    res_pid, res_status = os.waitpid(parent_pid, 0)
+    print("")
+    print(f"INFO: Master process {parent_pid} exited with status {res_status} and pid {res_pid}")
 
-        # Attempt to kill worker proc once
-        worker_pid: int = worker_pids[1]
-        print(f"DEBUG: Checking worker {worker_pid} status after master exit:")
-        try:
-            os.kill(worker_pid, 0)
-            print(f"WARNING: Worker {worker_pid} is a zombie (will be cleaned up by init).")
+    # Attempt to kill worker proc once
+    worker_pid: int = worker_pids[1]
+    print(f"DEBUG: Checking worker {worker_pid} status after master exit:")
+    try:
+        os.kill(worker_pid, 0)
+        print(f"WARNING: Worker {worker_pid} is a zombie (will be cleaned up by init).")
 
-            os.kill(worker_pid, signal.SIGKILL)
-            print(f"WARNING: Worker {worker_pid} could not be killed with SIGKILL (will be cleaned up by init).")
-        except OSError:
-            print(f"INFO: Worker {worker_pid} was successfully killed.")
+        os.kill(worker_pid, signal.SIGKILL)
+        print(f"WARNING: Worker {worker_pid} could not be killed with SIGKILL (will be cleaned up by init).")
+    except OSError:
+        print(f"INFO: Worker {worker_pid} was successfully killed.")
 
-        profiles = get_all_profiles_from_agent(agent_client)
+    profiles = get_all_profiles_from_agent()
     assert len(profiles) >= 2, f"Expected at least 2 profiling uploads (one per worker), got {len(profiles)}"
     for profile in profiles:
         samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")

--- a/tests/profiling/test_uwsgi.py
+++ b/tests/profiling/test_uwsgi.py
@@ -15,7 +15,6 @@ The tests spawn actual uwsgi processes and verify:
 2. Valid configurations produce actual profile samples in each worker
 """
 
-import glob
 from importlib.metadata import version
 import logging
 import os
@@ -27,7 +26,6 @@ from subprocess import TimeoutExpired
 import sys
 import time
 from typing import IO
-from typing import TYPE_CHECKING
 from typing import Callable
 from typing import Generator
 from typing import Optional
@@ -37,10 +35,8 @@ import pytest
 from ddtrace.profiling import profiler
 from tests.contrib.uwsgi import run_uwsgi
 from tests.profiling.collector import pprof_utils
-
-
-if TYPE_CHECKING:
-    from tests.profiling.collector import pprof_pb2  # pyright: ignore[reportMissingModuleSource]
+from tests.profiling.utils import get_all_profiles_from_agent
+from tests.profiling.utils import with_profiling_test_agent
 
 
 # uwsgi is not available on Windows
@@ -62,6 +58,9 @@ def uwsgi(
 ) -> Generator[Callable[..., subprocess.Popen[bytes]], None, None]:
     # Do not ignore profiler so we have samples in the output pprof
     monkeypatch.setenv("DD_PROFILING_IGNORE_PROFILER", "0")
+    # Force frequent uploads so the profiler uploads during the short test window
+    # rather than waiting for the default 60s interval or relying on atexit.
+    monkeypatch.setenv("DD_PROFILING_UPLOAD_INTERVAL", "1")
     # Do not use pytest tmpdir fixtures which generate directories longer than allowed for a socket file name
     socket_name = str(tmp_path / "uwsgi.sock")
 
@@ -170,9 +169,7 @@ def test_uwsgi_threads_number_set(uwsgi: Callable[..., subprocess.Popen[bytes]])
     assert THREADS_MSG not in stdout
 
 
-def test_uwsgi_threads_enabled(
-    uwsgi: Callable[..., subprocess.Popen[bytes]], tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_uwsgi_threads_enabled(uwsgi: Callable[..., subprocess.Popen[bytes]], monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that profiler works correctly with a single uwsgi worker.
 
     This is the simplest valid configuration:
@@ -182,18 +179,18 @@ def test_uwsgi_threads_enabled(
     The test verifies that:
     - The worker starts successfully and we can parse its PID from stdout
     - After running for a few seconds, the profiler collects wall-time samples
-    - The profile is written to the output file with the worker's PID suffix
+    - The profile is received by the test agent with wall-time samples
     """
-    filename = str(tmp_path / "uwsgi.pprof")
-    monkeypatch.setenv("DD_PROFILING_OUTPUT_PPROF", filename)
-    proc = uwsgi("--enable-threads")
-    worker_pids: list[int] = _get_worker_pids(proc.stdout, 1)
-    # Give some time to the process to actually startup
-    time.sleep(3)
-    proc.terminate()
-    assert proc.wait() == 30
-    for pid in worker_pids:
-        profile = pprof_utils.parse_newest_profile("%s.%d" % (filename, pid))
+    with with_profiling_test_agent() as agent_client:
+        proc = uwsgi("--enable-threads")
+        _get_worker_pids(proc.stdout, 1)
+        # Give some time to the process to actually startup
+        time.sleep(3)
+        proc.terminate()
+        assert proc.wait() == 30
+        profiles = get_all_profiles_from_agent(agent_client)
+    assert len(profiles) >= 1, f"Expected at least 1 profiling upload, got {len(profiles)}"
+    for profile in profiles:
         samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
         assert len(samples) > 0
 
@@ -253,32 +250,8 @@ def _get_worker_pids(stdout: Optional[IO[bytes]], num_worker: int, num_app_start
     return worker_pids
 
 
-def _wait_for_profile_samples(
-    filename_prefix: str, pid: int, value_type: str, timeout: float = 10.0, interval: float = 0.1
-) -> list["pprof_pb2.Sample"]:
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        try:
-            files = glob.glob(f"{filename_prefix}.{pid}.*.pprof")
-            if not files:
-                raise FileNotFoundError(f"No profile files found for {filename_prefix}")
-
-            profiles = [pprof_utils.parse_profile(f) for f in files]
-            profile = pprof_utils.merge_profiles(profiles)
-        except (IndexError, FileNotFoundError):
-            time.sleep(interval)
-            continue
-
-        samples = pprof_utils.get_samples_with_value_type(profile, value_type)
-        if samples:
-            return samples
-        time.sleep(interval)
-
-    assert False, "Timed out waiting for %s samples for pid %d" % (value_type, pid)
-
-
 def test_uwsgi_threads_processes_primary(
-    uwsgi: Callable[..., subprocess.Popen[bytes]], tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    uwsgi: Callable[..., subprocess.Popen[bytes]], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test that profiler works correctly with multiple workers and master process.
 
@@ -292,24 +265,24 @@ def test_uwsgi_threads_processes_primary(
     to restart the profiler in each worker after fork. The test verifies that:
     - Both workers start successfully
     - Each worker independently collects wall-time samples
-    - Profiles are written with each worker's PID suffix
+    - Profiles are received by the test agent with wall-time samples
     """
-    filename = str(tmp_path / "uwsgi.pprof")
-    monkeypatch.setenv("DD_PROFILING_OUTPUT_PPROF", filename)
-    proc = uwsgi("--enable-threads", "--master", "--py-call-uwsgi-fork-hooks", "--processes", "2")
-    worker_pids = _get_worker_pids(proc.stdout, 2)
-    # Give some time to child to actually startup
-    time.sleep(3)
-    proc.terminate()
-    assert proc.wait() == 0
-    for pid in worker_pids:
-        profile = pprof_utils.parse_newest_profile("%s.%d" % (filename, pid))
+    with with_profiling_test_agent() as agent_client:
+        proc = uwsgi("--enable-threads", "--master", "--py-call-uwsgi-fork-hooks", "--processes", "2")
+        _get_worker_pids(proc.stdout, 2)
+        # Give some time to child to actually startup
+        time.sleep(3)
+        proc.terminate()
+        assert proc.wait() == 0
+        profiles = get_all_profiles_from_agent(agent_client)
+    assert len(profiles) >= 2, f"Expected at least 2 profiling uploads (one per worker), got {len(profiles)}"
+    for profile in profiles:
         samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
         assert len(samples) > 0
 
 
 def test_uwsgi_threads_processes_primary_lazy_apps(
-    uwsgi: Callable[..., subprocess.Popen[bytes]], tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    uwsgi: Callable[..., subprocess.Popen[bytes]], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test profiler with --lazy-apps mode (app loaded independently in each worker).
 
@@ -324,23 +297,26 @@ def test_uwsgi_threads_processes_primary_lazy_apps(
 
     The test verifies that each worker independently collects profile samples.
     """
-    filename = str(tmp_path / "uwsgi.pprof")
-    monkeypatch.setenv("DD_PROFILING_OUTPUT_PPROF", filename)
     monkeypatch.setenv("DD_PROFILING_UPLOAD_INTERVAL", "1")
-    # For uwsgi<2.0.30, --skip-atexit is required to avoid crashes when
-    # the child process exits.
-    proc = uwsgi("--enable-threads", "--master", "--processes", "2", "--lazy-apps", "--skip-atexit")
-    worker_pids = _get_worker_pids(proc.stdout, 2, 2)
-    # Give some time to child to actually startup and output a profile
-    time.sleep(3)
-    proc.terminate()
-    assert proc.wait() == 0
-    for pid in worker_pids:
-        _wait_for_profile_samples(filename, pid, "wall-time")
+
+    with with_profiling_test_agent() as agent_client:
+        # For uwsgi<2.0.30, --skip-atexit is required to avoid crashes when
+        # the child process exits.
+        proc = uwsgi("--enable-threads", "--master", "--processes", "2", "--lazy-apps", "--skip-atexit")
+        _get_worker_pids(proc.stdout, 2, 2)
+        # Give some time to child to actually startup and output a profile
+        time.sleep(3)
+        proc.terminate()
+        assert proc.wait() == 0
+        profiles = get_all_profiles_from_agent(agent_client)
+    assert len(profiles) >= 2, f"Expected at least 2 profiling uploads (one per worker), got {len(profiles)}"
+    for profile in profiles:
+        samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
+        assert len(samples) > 0
 
 
 def test_uwsgi_threads_processes_no_primary_lazy_apps(
-    uwsgi: Callable[..., subprocess.Popen[bytes]], tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    uwsgi: Callable[..., subprocess.Popen[bytes]], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Test profiler with --lazy-apps but WITHOUT --master.
 
@@ -358,41 +334,44 @@ def test_uwsgi_threads_processes_no_primary_lazy_apps(
     Note: Without --master, termination is more complex - we manually kill processes
     and handle the case where workers may become zombies.
     """
-    filename = str(tmp_path / "uwsgi.pprof")
-    monkeypatch.setenv("DD_PROFILING_OUTPUT_PPROF", filename)
     monkeypatch.setenv("DD_PROFILING_UPLOAD_INTERVAL", "1")
-    # For uwsgi<2.0.30, --skip-atexit is required to avoid crashes when
-    # the child process exits.
-    proc = uwsgi("--enable-threads", "--processes", "2", "--lazy-apps", "--skip-atexit")
-    worker_pids = _get_worker_pids(proc.stdout, 2, 2)
-    assert len(worker_pids) == 2
 
-    # Give some time to child to actually startup before terminating the master
-    time.sleep(3)
+    with with_profiling_test_agent() as agent_client:
+        # For uwsgi<2.0.30, --skip-atexit is required to avoid crashes when
+        # the child process exits.
+        proc = uwsgi("--enable-threads", "--processes", "2", "--lazy-apps", "--skip-atexit")
+        worker_pids = _get_worker_pids(proc.stdout, 2, 2)
+        assert len(worker_pids) == 2
 
-    # Kill master process
-    parent_pid: int = worker_pids[0]
-    os.kill(parent_pid, signal.SIGTERM)
+        # Give some time to child to actually startup before terminating the master
+        time.sleep(3)
 
-    # Wait for master to exit
-    res_pid, res_status = os.waitpid(parent_pid, 0)
-    print("")
-    print(f"INFO: Master process {parent_pid} exited with status {res_status} and pid {res_pid}")
+        # Kill master process
+        parent_pid: int = worker_pids[0]
+        os.kill(parent_pid, signal.SIGTERM)
 
-    # Attempt to kill worker proc once
-    worker_pid: int = worker_pids[1]
-    print(f"DEBUG: Checking worker {worker_pid} status after master exit:")
-    try:
-        os.kill(worker_pid, 0)
-        print(f"WARNING: Worker {worker_pid} is a zombie (will be cleaned up by init).")
+        # Wait for master to exit
+        res_pid, res_status = os.waitpid(parent_pid, 0)
+        print("")
+        print(f"INFO: Master process {parent_pid} exited with status {res_status} and pid {res_pid}")
 
-        os.kill(worker_pid, signal.SIGKILL)
-        print(f"WARNING: Worker {worker_pid} could not be killed with SIGKILL (will be cleaned up by init).")
-    except OSError:
-        print(f"INFO: Worker {worker_pid} was successfully killed.")
+        # Attempt to kill worker proc once
+        worker_pid: int = worker_pids[1]
+        print(f"DEBUG: Checking worker {worker_pid} status after master exit:")
+        try:
+            os.kill(worker_pid, 0)
+            print(f"WARNING: Worker {worker_pid} is a zombie (will be cleaned up by init).")
 
-    for pid in worker_pids:
-        _wait_for_profile_samples(filename, pid, "wall-time")
+            os.kill(worker_pid, signal.SIGKILL)
+            print(f"WARNING: Worker {worker_pid} could not be killed with SIGKILL (will be cleaned up by init).")
+        except OSError:
+            print(f"INFO: Worker {worker_pid} was successfully killed.")
+
+        profiles = get_all_profiles_from_agent(agent_client)
+    assert len(profiles) >= 2, f"Expected at least 2 profiling uploads (one per worker), got {len(profiles)}"
+    for profile in profiles:
+        samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
+        assert len(samples) > 0
 
 
 @pytest.mark.parametrize("lazy_flag", ["--lazy-apps", "--lazy"])

--- a/tests/profiling/utils.py
+++ b/tests/profiling/utils.py
@@ -1,0 +1,187 @@
+# Utility functions and context managers for profiling tests that capture HTTP uploads.
+#
+# Why not use ddapm_test_agent with session tokens?
+# libdatadog's ddog_prof_Endpoint_agent(base_url) appends /profiling/v1/input to
+# the path, which strips any query params we'd append (e.g. ?test_session_token=...).
+# That means we can't use the test agent's session-token routing for profiling. A
+# local capture server avoids the problem entirely: each test gets its own port.
+from contextlib import contextmanager
+import http.server
+import os
+import socketserver
+import threading
+import time
+from typing import Generator
+
+
+class _ProfilingCaptureServer:
+    """Minimal HTTP server that captures profiling uploads from ddup.
+
+    Provides the same profiling_requests() interface as TestAgentClient so that
+    pprof_utils.get_profile_from_agent() and related helpers work unchanged.
+
+    Each instance binds to an OS-assigned free port and runs in a daemon thread.
+    """
+
+    def __init__(self) -> None:
+        self._captured: list[dict] = []
+        self._server: socketserver.TCPServer
+        self._thread: threading.Thread
+        self.port: int = 0
+
+    def start(self) -> None:
+        captured = self._captured
+
+        class _Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(length)
+                # Normalise header keys to lower-case to match TestAgentRequest convention
+                captured.append(
+                    {
+                        "headers": {k.lower(): v for k, v in self.headers.items()},
+                        "body": body,
+                        "url": self.path,
+                    }
+                )
+                self.send_response(200)
+                self.end_headers()
+
+            def log_message(self, *args: object) -> None:
+                pass  # silence request logs in test output
+
+        # Port 0 -> OS picks an available port
+        server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), _Handler)
+        server.allow_reuse_address = True
+        self._server = server
+        self.port = server.server_address[1]
+        self._thread = threading.Thread(target=server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._server.shutdown()
+        self._thread.join(timeout=5)
+
+    def profiling_requests(self) -> list[dict]:
+        return list(self._captured)
+
+    def clear(self) -> None:
+        self._captured.clear()
+
+
+@contextmanager
+def with_profiling_test_agent() -> Generator[_ProfilingCaptureServer, None, None]:
+    """Context manager that starts a local capture server and configures ddup to upload to it.
+
+    Two mechanisms route profiler uploads to the capture server:
+    - ddup.config_url(): sets _upload_url_override in the ddup module for in-process use.
+      Checked once per upload (module variable), no os.environ call on the hot path.
+    - _DD_PROFILING_TEST_AGENT_URL env var: inherited by exec-based child processes
+      (gunicorn workers, uwsgi). They read it once at module import time.
+
+    Yields a _ProfilingCaptureServer whose profiling_requests() / clear() methods
+    mirror the TestAgentClient interface used by pprof_utils helpers.
+    """
+    from ddtrace.internal.datadog.profiling import ddup
+
+    server = _ProfilingCaptureServer()
+    server.start()
+    url = f"http://127.0.0.1:{server.port}"
+    # Set env var for exec-based child processes (gunicorn workers, uwsgi) that
+    # read it once at module import time via _upload_url_override initialisation.
+    os.environ["_DD_PROFILING_TEST_AGENT_URL"] = url
+    # Call config_url() for in-process use when the compiled binary supports it.
+    # Falls back gracefully to env-var-only on older binaries.
+    _config_url = getattr(ddup, "config_url", None)
+    if _config_url is not None:
+        _config_url(url)
+    try:
+        server.clear()
+        yield server
+    finally:
+        server.clear()
+        server.stop()
+        if _config_url is not None:
+            _config_url(None)
+        del os.environ["_DD_PROFILING_TEST_AGENT_URL"]
+
+
+def get_profile_from_agent(
+    client: _ProfilingCaptureServer,
+    timeout: float = 30.0,
+    poll_interval: float = 0.5,
+    assert_samples: bool = True,
+):
+    """Poll the test agent until at least one profiling upload appears, then return the parsed profile.
+
+    Delegates to pprof_utils.get_profile_from_agent, which is also importable directly
+    inside @pytest.mark.subprocess test functions via ``from tests.profiling.collector import pprof_utils``.
+    """
+    from tests.profiling.collector.pprof_utils import get_profile_from_agent as _impl
+
+    return _impl(client, timeout=timeout, poll_interval=poll_interval, assert_samples=assert_samples)
+
+
+def get_all_profiles_from_agent(
+    client: _ProfilingCaptureServer,
+    timeout: float = 30.0,
+    poll_interval: float = 0.5,
+):
+    """Poll the test agent and return all profiling uploads parsed as pprof profiles.
+
+    Waits until at least one upload appears, then returns all of them.
+    """
+    from tests.profiling.collector.pprof_utils import parse_profile_from_request
+
+    end_time = time.time() + timeout
+    while time.time() < end_time:
+        reqs = client.profiling_requests()
+        if reqs:
+            return [parse_profile_from_request(req) for req in reqs]
+        time.sleep(poll_interval)
+
+    raise AssertionError(f"No profiling uploads received within {timeout}s")
+
+
+def get_all_metadata_from_agent(
+    client: _ProfilingCaptureServer,
+    min_count: int = 1,
+    timeout: float = 30.0,
+    poll_interval: float = 0.5,
+) -> "list[dict]":
+    """Poll the test agent and return internal_metadata dicts from all profiling uploads.
+
+    Waits until at least min_count uploads with parseable internal_metadata appear.
+    Useful for tests that check metrics like sample_count, greenlet_count, etc.
+    """
+    from tests.profiling.collector.pprof_utils import parse_internal_metadata_from_request
+
+    end_time = time.time() + timeout
+    last_parse_error: str = ""
+    while time.time() < end_time:
+        reqs = client.profiling_requests()
+        if reqs:
+            results = []
+            parse_errors = []
+            for req in reqs:
+                try:
+                    results.append(parse_internal_metadata_from_request(req))
+                except Exception as e:
+                    parse_errors.append(str(e))
+            if len(results) >= min_count:
+                return results
+            # Uploads arrived but metadata not parseable -- fail fast with diagnostics
+            # rather than timing out after 30s.
+            if parse_errors and not results:
+                raise AssertionError(
+                    f"Got {len(reqs)} profiling upload(s) but could not parse internal_metadata.\n"
+                    f"Parse error: {parse_errors[-1]}"
+                )
+            if parse_errors:
+                last_parse_error = parse_errors[-1]
+        time.sleep(poll_interval)
+
+    detail = f"\nLast parse error: {last_parse_error}" if last_parse_error else ""
+    raise AssertionError(
+        f"Expected at least {min_count} profiling upload(s) with internal_metadata within {timeout}s{detail}"
+    )

--- a/tests/profiling/utils.py
+++ b/tests/profiling/utils.py
@@ -179,26 +179,44 @@ def clear_agent_session() -> None:
     _client_from_env().clear()
 
 
+def get_all_requests_from_agent(
+    client: "Optional[_ProfilingMiniAgentClient]" = None,
+    min_count: int = 1,
+    timeout: float = 30.0,
+    poll_interval: float = 0.5,
+) -> "list[dict]":
+    """Poll the mini agent and return raw request dicts.
+
+    Keeps polling until at least min_count uploads have arrived.
+    When called without a client, builds one automatically from env vars set by the parent fixture.
+    """
+    _client = client or _client_from_env()
+    end_time = time.time() + timeout
+    reqs: "list[dict]" = []
+    while time.time() < end_time:
+        reqs = _client.profiling_requests()
+        if len(reqs) >= min_count:
+            return reqs
+        time.sleep(poll_interval)
+
+    raise AssertionError(f"Expected at least {min_count} profiling upload(s) within {timeout}s, got {len(reqs)}")
+
+
 def get_all_profiles_from_agent(
     client: "Optional[_ProfilingMiniAgentClient]" = None,
+    min_count: int = 1,
     timeout: float = 30.0,
     poll_interval: float = 0.5,
 ):
     """Poll the mini agent and return all profiling uploads parsed as pprof profiles.
 
+    Keeps polling until at least min_count uploads have arrived.
     When called without a client, builds one automatically from env vars set by the parent fixture.
     """
     from tests.profiling.collector.pprof_utils import parse_profile_from_request
 
-    _client = client or _client_from_env()
-    end_time = time.time() + timeout
-    while time.time() < end_time:
-        reqs = _client.profiling_requests()
-        if reqs:
-            return [parse_profile_from_request(req) for req in reqs]
-        time.sleep(poll_interval)
-
-    raise AssertionError(f"No profiling uploads received within {timeout}s")
+    reqs = get_all_requests_from_agent(client=client, min_count=min_count, timeout=timeout, poll_interval=poll_interval)
+    return [parse_profile_from_request(req) for req in reqs]
 
 
 def get_all_metadata_from_agent(

--- a/tests/profiling/utils.py
+++ b/tests/profiling/utils.py
@@ -1,56 +1,117 @@
-# Utility functions and context managers for profiling tests that capture HTTP uploads.
+# Utility functions and context managers for profiling tests.
 #
-# Why not use ddapm_test_agent with session tokens?
-# libdatadog's ddog_prof_Endpoint_agent(base_url) appends /profiling/v1/input to
-# the path, which strips any query params we'd append (e.g. ?test_session_token=...).
-# That means we can't use the test agent's session-token routing for profiling. A
-# local capture server avoids the problem entirely: each test gets its own port.
+# Architecture: a self-contained _ProfilingMiniAgent HTTP server runs per fixture
+# invocation.  ddup is configured to upload to
+# http://127.0.0.1:{PORT}/session/{TOKEN}/profiling/v1/input
+# (libdatadog appends /profiling/v1/input to whatever base URL we give it).
+# The mini agent stores uploads keyed by token and serves a query API so that
+# _ProfilingMiniAgentClient.profiling_requests() / clear() work the same way as
+# TestAgentClient for other test domains.
+#
+# No external ddapm-test-agent required: profiling tests are self-contained.
+import base64
 from contextlib import contextmanager
 import http.server
+import json
 import os
 import socketserver
 import threading
 import time
 from typing import Generator
+from typing import Optional
+import uuid
+
+from tests.profiling.collector.pprof_utils import _client_from_env
+from tests.profiling.collector.pprof_utils import _ProfilingMiniAgentClient
 
 
-class _ProfilingCaptureServer:
-    """Minimal HTTP server that captures profiling uploads from ddup.
+class _ProfilingMiniAgent:
+    """Self-contained HTTP server that stores profiling uploads per session token.
 
-    Provides the same profiling_requests() interface as TestAgentClient so that
-    pprof_utils.get_profile_from_agent() and related helpers work unchanged.
+    Receives ddup uploads at:
+        POST /session/{TOKEN}/profiling/v1/input
 
-    Each instance binds to an OS-assigned free port and runs in a daemon thread.
+    Serves query API:
+        GET  /session/{TOKEN}/requests   -> JSON array of stored request dicts
+        GET  /session/{TOKEN}/clear      -> 200, clears stored requests for token
+        GET  /session/{TOKEN}/start      -> 200, no-op (session compatibility shim)
     """
 
     def __init__(self) -> None:
-        self._captured: list[dict] = []
+        self._requests: "dict[str, list[dict]]" = {}
+        self._lock = threading.Lock()
         self._server: socketserver.TCPServer
         self._thread: threading.Thread
         self.port: int = 0
 
     def start(self) -> None:
-        captured = self._captured
+        agent = self
 
         class _Handler(http.server.BaseHTTPRequestHandler):
             def do_POST(self) -> None:
+                # Path: /session/{TOKEN}/profiling/v1/input
+                parts = self.path.split("/")
+                try:
+                    session_idx = parts.index("session")
+                    token = parts[session_idx + 1]
+                    upload_path = "/" + "/".join(parts[session_idx + 2 :])
+                except (ValueError, IndexError):
+                    token = ""
+                    upload_path = self.path
+
                 length = int(self.headers.get("Content-Length", 0))
                 body = self.rfile.read(length)
-                # Normalise header keys to lower-case to match TestAgentRequest convention
-                captured.append(
-                    {
-                        "headers": {k.lower(): v for k, v in self.headers.items()},
-                        "body": body,
-                        "url": self.path,
-                    }
-                )
+
+                if token:
+                    with agent._lock:
+                        if token not in agent._requests:
+                            agent._requests[token] = []
+                        agent._requests[token].append(
+                            {
+                                "headers": {k.lower(): v for k, v in self.headers.items()},
+                                # base64-encode for JSON transport; decoded back in the client
+                                "body": base64.b64encode(body).decode("ascii"),
+                                "url": upload_path,
+                            }
+                        )
+
                 self.send_response(200)
                 self.end_headers()
+
+            def do_GET(self) -> None:
+                # Path: /session/{TOKEN}/{action}
+                parts = self.path.split("/")
+                try:
+                    session_idx = parts.index("session")
+                    token = parts[session_idx + 1]
+                    action = parts[session_idx + 2] if len(parts) > session_idx + 2 else ""
+                except (ValueError, IndexError):
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+
+                if action == "requests":
+                    with agent._lock:
+                        stored = list(agent._requests.get(token, []))
+                    payload = json.dumps(stored).encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(payload)))
+                    self.end_headers()
+                    self.wfile.write(payload)
+                elif action in ("clear", "start"):
+                    if action == "clear":
+                        with agent._lock:
+                            agent._requests.pop(token, None)
+                    self.send_response(200)
+                    self.end_headers()
+                else:
+                    self.send_response(404)
+                    self.end_headers()
 
             def log_message(self, *args: object) -> None:
                 pass  # silence request logs in test output
 
-        # Port 0 -> OS picks an available port
         server = socketserver.ThreadingTCPServer(("127.0.0.1", 0), _Handler)
         server.allow_reuse_address = True
         self._server = server
@@ -62,80 +123,77 @@ class _ProfilingCaptureServer:
         self._server.shutdown()
         self._thread.join(timeout=5)
 
-    def profiling_requests(self) -> list[dict]:
-        return list(self._captured)
-
-    def clear(self) -> None:
-        self._captured.clear()
-
 
 @contextmanager
-def with_profiling_test_agent() -> Generator[_ProfilingCaptureServer, None, None]:
-    """Context manager that starts a local capture server and configures ddup to upload to it.
+def with_profiling_test_agent() -> "Generator":  # yields _ProfilingMiniAgentClient
+    """Context manager that starts a self-contained mini agent and configures ddup to upload to it.
 
-    Two mechanisms route profiler uploads to the capture server:
-    - ddup.config_url(): sets _upload_url_override in the ddup module for in-process use.
-      Checked once per upload (module variable), no os.environ call on the hot path.
-    - _DD_PROFILING_TEST_AGENT_URL env var: inherited by exec-based child processes
-      (gunicorn workers, uwsgi). They read it once at module import time.
+    Generates a unique session token so that concurrent tests are isolated.
+    No external ddapm-test-agent required.
 
-    Yields a _ProfilingCaptureServer whose profiling_requests() / clear() methods
-    mirror the TestAgentClient interface used by pprof_utils helpers.
+    Two mechanisms route profiler uploads to the mini agent:
+    - ddup.config_test_token(): sets module variables in ddup for in-process use.
+    - _DD_PROFILING_TEST_TOKEN / _DD_PROFILING_TEST_PROXY_URL env vars: inherited by
+      exec-based child processes (gunicorn workers, uwsgi) that read them at import time.
+
+    Yields a _ProfilingMiniAgentClient whose profiling_requests() / clear() interface
+    is the same as what pprof_utils helpers expect.
     """
     from ddtrace.internal.datadog.profiling import ddup
 
-    server = _ProfilingCaptureServer()
+    token = str(uuid.uuid4())
+
+    server = _ProfilingMiniAgent()
     server.start()
-    url = f"http://127.0.0.1:{server.port}"
-    # Set env var for exec-based child processes (gunicorn workers, uwsgi) that
-    # read it once at module import time via _upload_url_override initialisation.
-    os.environ["_DD_PROFILING_TEST_AGENT_URL"] = url
-    # Call config_url() for in-process use when the compiled binary supports it.
-    # Falls back gracefully to env-var-only on older binaries.
-    _config_url = getattr(ddup, "config_url", None)
-    if _config_url is not None:
-        _config_url(url)
+    base_url = f"http://127.0.0.1:{server.port}"
+
+    # Env vars for exec-based child processes that read them once at import time.
+    os.environ["_DD_PROFILING_TEST_TOKEN"] = token
+    os.environ["_DD_PROFILING_TEST_PROXY_URL"] = base_url
+
+    # In-process: update ddup module vars directly (faster than relying on env-var re-read).
+    _config_test_token = getattr(ddup, "config_test_token", None)
+    if _config_test_token is not None:
+        _config_test_token(token, base_url)
+
+    client = _ProfilingMiniAgentClient(base_url=base_url, token=token)
     try:
-        server.clear()
-        yield server
+        client.clear()
+        yield client
     finally:
-        server.clear()
+        client.clear()
         server.stop()
-        if _config_url is not None:
-            _config_url(None)
-        del os.environ["_DD_PROFILING_TEST_AGENT_URL"]
+        if _config_test_token is not None:
+            _config_test_token(None, None)
+        del os.environ["_DD_PROFILING_TEST_TOKEN"]
+        del os.environ["_DD_PROFILING_TEST_PROXY_URL"]
 
 
-def get_profile_from_agent(
-    client: _ProfilingCaptureServer,
-    timeout: float = 30.0,
-    poll_interval: float = 0.5,
-    assert_samples: bool = True,
-):
-    """Poll the test agent until at least one profiling upload appears, then return the parsed profile.
+def clear_agent_session() -> None:
+    """Clear the current test session's uploads from the mini agent.
 
-    Delegates to pprof_utils.get_profile_from_agent, which is also importable directly
-    inside @pytest.mark.subprocess test functions via ``from tests.profiling.collector import pprof_utils``.
+    Call this inside a subprocess test between upload/query cycles to discard
+    previously uploaded profiles so the next get_profile_from_agent() call
+    returns only fresh uploads.
     """
-    from tests.profiling.collector.pprof_utils import get_profile_from_agent as _impl
-
-    return _impl(client, timeout=timeout, poll_interval=poll_interval, assert_samples=assert_samples)
+    _client_from_env().clear()
 
 
 def get_all_profiles_from_agent(
-    client: _ProfilingCaptureServer,
+    client: "Optional[_ProfilingMiniAgentClient]" = None,
     timeout: float = 30.0,
     poll_interval: float = 0.5,
 ):
-    """Poll the test agent and return all profiling uploads parsed as pprof profiles.
+    """Poll the mini agent and return all profiling uploads parsed as pprof profiles.
 
-    Waits until at least one upload appears, then returns all of them.
+    When called without a client, builds one automatically from env vars set by the parent fixture.
     """
     from tests.profiling.collector.pprof_utils import parse_profile_from_request
 
+    _client = client or _client_from_env()
     end_time = time.time() + timeout
     while time.time() < end_time:
-        reqs = client.profiling_requests()
+        reqs = _client.profiling_requests()
         if reqs:
             return [parse_profile_from_request(req) for req in reqs]
         time.sleep(poll_interval)
@@ -144,22 +202,23 @@ def get_all_profiles_from_agent(
 
 
 def get_all_metadata_from_agent(
-    client: _ProfilingCaptureServer,
+    client: "Optional[_ProfilingMiniAgentClient]" = None,
     min_count: int = 1,
     timeout: float = 30.0,
     poll_interval: float = 0.5,
 ) -> "list[dict]":
-    """Poll the test agent and return internal_metadata dicts from all profiling uploads.
+    """Poll the mini agent and return internal_metadata dicts from all profiling uploads.
 
     Waits until at least min_count uploads with parseable internal_metadata appear.
-    Useful for tests that check metrics like sample_count, greenlet_count, etc.
+    When called without a client, builds one automatically from env vars set by the parent fixture.
     """
     from tests.profiling.collector.pprof_utils import parse_internal_metadata_from_request
 
+    _client = client or _client_from_env()
     end_time = time.time() + timeout
     last_parse_error: str = ""
     while time.time() < end_time:
-        reqs = client.profiling_requests()
+        reqs = _client.profiling_requests()
         if reqs:
             results = []
             parse_errors = []
@@ -170,8 +229,6 @@ def get_all_metadata_from_agent(
                     parse_errors.append(str(e))
             if len(results) >= min_count:
                 return results
-            # Uploads arrived but metadata not parseable -- fail fast with diagnostics
-            # rather than timing out after 30s.
             if parse_errors and not results:
                 raise AssertionError(
                     f"Got {len(reqs)} profiling upload(s) but could not parse internal_metadata.\n"

--- a/tests/profiling/utils.py
+++ b/tests/profiling/utils.py
@@ -11,6 +11,7 @@
 # No external ddapm-test-agent required: profiling tests are self-contained.
 import base64
 from contextlib import contextmanager
+import http.client as _httplib
 import http.server
 import json
 import os
@@ -19,10 +20,8 @@ import threading
 import time
 from typing import Generator
 from typing import Optional
+import urllib.parse
 import uuid
-
-from tests.profiling.collector.pprof_utils import _client_from_env
-from tests.profiling.collector.pprof_utils import _ProfilingMiniAgentClient
 
 
 class _ProfilingMiniAgent:
@@ -38,7 +37,7 @@ class _ProfilingMiniAgent:
     """
 
     def __init__(self) -> None:
-        self._requests: "dict[str, list[dict]]" = {}
+        self._requests: "dict[str, list[dict[str, object]]]" = {}
         self._lock = threading.Lock()
         self._server: socketserver.TCPServer
         self._thread: threading.Thread
@@ -124,8 +123,57 @@ class _ProfilingMiniAgent:
         self._thread.join(timeout=5)
 
 
+class _ProfilingMiniAgentClient:
+    """HTTP client for _ProfilingMiniAgent.
+
+    Implements the profiling_requests() / clear() interface used by the
+    get_profile_from_agent helpers, so they work whether called in-process or
+    from inside a @pytest.mark.subprocess test body.
+    """
+
+    def __init__(self, base_url: str, token: str) -> None:
+        self._base_url = base_url
+        self._token = token
+
+    def _request(self, method: str, path: str) -> "tuple[int, bytes]":
+        parsed = urllib.parse.urlparse(self._base_url)
+        conn = _httplib.HTTPConnection(parsed.hostname or "127.0.0.1", parsed.port, timeout=10)
+        try:
+            conn.request(method, path)
+            resp = conn.getresponse()
+            return resp.status, resp.read()
+        finally:
+            conn.close()
+
+    def profiling_requests(self) -> "list[dict[str, object]]":
+        """Return all profiling uploads stored under this session token."""
+        status, body = self._request("GET", f"/session/{self._token}/requests")
+        if status != 200:
+            return []
+        stored: "list[dict[str, object]]" = json.loads(body)
+        for req in stored:
+            if isinstance(req.get("body"), str):
+                req["body"] = base64.b64decode(str(req["body"]))
+        return stored
+
+    def clear(self) -> None:
+        """Clear all stored uploads for this session token."""
+        self._request("GET", f"/session/{self._token}/clear")
+
+
+def _client_from_env() -> _ProfilingMiniAgentClient:
+    """Build a _ProfilingMiniAgentClient from env vars set by the parent profiling_test_agent fixture.
+
+    Used by get_profile_from_agent when called without an explicit client inside
+    @pytest.mark.subprocess test bodies.
+    """
+    token = os.environ.get("_DD_PROFILING_TEST_TOKEN", "")
+    base_url = os.environ.get("_DD_PROFILING_TEST_PROXY_URL", "http://127.0.0.1:0")
+    return _ProfilingMiniAgentClient(base_url=base_url, token=token)
+
+
 @contextmanager
-def with_profiling_test_agent() -> "Generator":  # yields _ProfilingMiniAgentClient
+def with_profiling_test_agent() -> "Generator[_ProfilingMiniAgentClient, None, None]":
     """Context manager that starts a self-contained mini agent and configures ddup to upload to it.
 
     Generates a unique session token so that concurrent tests are isolated.
@@ -184,7 +232,7 @@ def get_all_requests_from_agent(
     min_count: int = 1,
     timeout: float = 30.0,
     poll_interval: float = 0.5,
-) -> "list[dict]":
+) -> "list[dict[str, object]]":
     """Poll the mini agent and return raw request dicts.
 
     Keeps polling until at least min_count uploads have arrived.
@@ -192,7 +240,7 @@ def get_all_requests_from_agent(
     """
     _client = client or _client_from_env()
     end_time = time.time() + timeout
-    reqs: "list[dict]" = []
+    reqs: "list[dict[str, object]]" = []
     while time.time() < end_time:
         reqs = _client.profiling_requests()
         if len(reqs) >= min_count:
@@ -224,7 +272,7 @@ def get_all_metadata_from_agent(
     min_count: int = 1,
     timeout: float = 30.0,
     poll_interval: float = 0.5,
-) -> "list[dict]":
+) -> "list[dict[str, object]]":
     """Poll the mini agent and return internal_metadata dicts from all profiling uploads.
 
     Waits until at least min_count uploads with parseable internal_metadata appear.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1182,6 +1182,10 @@ class TestAgentClient:
                 reqs.append(req)
         return reqs
 
+    def profiling_requests(self) -> list[TestAgentRequest]:
+        """Return requests that hit the /profiling/v1/input endpoint."""
+        return [req for req in self.requests() if "/profiling/v1/input" in req.get("url", "")]
+
     def crash_messages(self) -> list[TestAgentRequest]:
         reqs = []
         for req in self.telemetry_requests(telemetry_type="logs"):


### PR DESCRIPTION
note: I recognize there are a gazillion failing tests because of tiny edge cases and also how different python versions treat these type annotations... fixing soon...

## Description
Previously, profiling tests captured profiles by writing .pprof files to disk using `DD_PROFILING_OUTPUT_PPROF`, then reading them back with `parse_newest_profile()`. 

This PR introduces a self-contained `_ProfilingMiniAgent` HTTP server that receives profiles over the same multipart upload path that production uses. Each test gets a unique UUID session token; `ddup` is configured to POST to `{base_url}/session/{token}/profiling/v1/input`.

An autouse profiling_test_agent fixture in `tests/profiling/conftest.py` starts the server and sets `_DD_PROFILING_TEST_TOKEN` / `_DD_PROFILING_TEST_PROXY_URL` in the environment before each test, so subprocess tests inherit them automatically without any per-test boilerplate.

Tests retrieve profiles by `pprof_utils.get_profile_from_agent()`, which polls the mini agent until an upload appears and parses the multipart response.
 
`config_test_token()` is added to `_ddup.pyx` to update the routing at runtime for in-process tests (where ddup is already imported before the fixture sets env vars), and `_get_endpoint()` checks the token before falling back to the real agent URL so production behavior is unaffected.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
