### PR TITLE
ci: allow detect circular imports to fail on release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -376,6 +376,10 @@ detect_circular_imports:
   stage: tests
   needs: []
   extends: .testrunner
+  rules:
+    - if: $RELEASE_ALLOW_TEST_FAILURES == "true"
+      allow_failure: true
+    - allow_failure: false
   script:
     - pip install uv
     - cd ..


### PR DESCRIPTION
## Description

Allow us to control if detect circular imports should be allowed to fail on release pipelines.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
