### PR TITLE
chore: Revert "chore(build): include commit sha in pre-release package version (#18290)"

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -392,20 +392,12 @@ download_dependency_wheels:
   tags: [ "arch:amd64" ]
   stage: package
   script:
-    # Prevent git operation errors when the GitLab executor sees the checkout as owned by another user.
-    - git config --global --add safe.directory "${CI_PROJECT_DIR}"
-    - BASE_PACKAGE_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
-    - PACKAGE_VERSION="${BASE_PACKAGE_VERSION}"
-    - |
-      if [[ -z "${CI_COMMIT_TAG:-}" && "${BASE_PACKAGE_VERSION}" != *+* ]]; then
-        PACKAGE_VERSION="${BASE_PACKAGE_VERSION}+g$(git rev-parse --short=7 HEAD)"
-      fi
+    - PACKAGE_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
     - echo "PACKAGE_VERSION=${PACKAGE_VERSION}" | tee -a package_version.env
-    - echo "BASE_PACKAGE_VERSION=${BASE_PACKAGE_VERSION}" | tee -a package_version.env
-    # Validate commit tag matches base version if tag is set
+    # Validate commit tag matches version if tag is set
     - |
       if [ -n "${CI_COMMIT_TAG:-}" ]; then
-        EXPECTED_TAG="v${BASE_PACKAGE_VERSION}"
+        EXPECTED_TAG="v${PACKAGE_VERSION}"
         if [ "${CI_COMMIT_TAG}" != "${EXPECTED_TAG}" ]; then
           echo "[ERROR] CI_COMMIT_TAG (${CI_COMMIT_TAG}) does not match expected tag (${EXPECTED_TAG})"
           exit 1

--- a/setup.py
+++ b/setup.py
@@ -124,9 +124,6 @@ DD_CARGO_ARGS = shlex.split(os.getenv("DD_CARGO_ARGS", ""))
 
 BUILD_PROFILING_NATIVE_TESTS = os.getenv("DD_PROFILING_NATIVE_TESTS", "0").lower() in ("1", "yes", "on", "true")
 
-GIT_COMMIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
-
-
 CURRENT_OS = platform.system()
 SERVERLESS_BUILD = os.getenv("DD_SERVERLESS_BUILD", "0").lower() in ("1", "yes", "on", "true")
 WHEEL_FLAVOR = "-serverless" if SERVERLESS_BUILD else ""
@@ -136,73 +133,6 @@ LIBDDWAF_VERSION = "2.0.0"
 # DEV: update this accordingly when src/native upgrades libdatadog dependency.
 # libdatadog v35.0.0 requires rust 1.87.0.
 RUST_MINIMUM_VERSION = "1.87.0"
-
-
-def get_build_git_commit_sha() -> str:
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--short=7", "HEAD"],
-            cwd=HERE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-            check=True,
-        )
-    except Exception:
-        return ""
-
-    commit_sha = result.stdout.strip()
-    if GIT_COMMIT_SHA_RE.fullmatch(commit_sha):
-        return commit_sha.lower()
-
-    return ""
-
-
-def get_pyproject_package_version() -> str:
-    pyproject = HERE / "pyproject.toml"
-    match = re.search(r'^version = "([^"]+)"$', pyproject.read_text(encoding="utf-8"), flags=re.MULTILINE)
-    if match is None:
-        return ""
-
-    return match.group(1)
-
-
-def get_build_package_version() -> str:
-    # Keep tagged release builds unchanged; non-tagged builds get a commit local version.
-    package_version = get_pyproject_package_version()
-    commit_sha = get_build_git_commit_sha()
-    if not package_version or not commit_sha or "+" in package_version or os.getenv("CI_COMMIT_TAG"):
-        return package_version
-
-    return f"{package_version}+g{commit_sha}"
-
-
-_ORIGINAL_PYPROJECT_CONTENTS: t.Optional[str] = None
-
-
-def update_pyproject_field(field: str, value: str) -> None:
-    global _ORIGINAL_PYPROJECT_CONTENTS
-    pyproject = HERE / "pyproject.toml"
-    contents = pyproject.read_text(encoding="utf-8")
-    if _ORIGINAL_PYPROJECT_CONTENTS is None:
-        _ORIGINAL_PYPROJECT_CONTENTS = contents
-
-    updated_contents, count = re.subn(
-        rf'^{re.escape(field)} = "[^"]+"$',
-        f'{field} = "{value}"',
-        contents,
-        count=1,
-        flags=re.MULTILINE,
-    )
-    if count != 1:
-        raise RuntimeError(f"Unable to update {field!r} in {pyproject}")
-
-    pyproject.write_text(updated_contents, encoding="utf-8")
-
-
-def restore_pyproject() -> None:
-    if _ORIGINAL_PYPROJECT_CONTENTS is not None:
-        (HERE / "pyproject.toml").write_text(_ORIGINAL_PYPROJECT_CONTENTS, encoding="utf-8")
 
 
 def interpose_sccache():
@@ -1794,60 +1724,51 @@ if os.getenv("DD_CYTHONIZE", "1").lower() in ("1", "yes", "on", "true"):
 
 PACKAGE_NAME = f"ddtrace{WHEEL_FLAVOR}"
 if PACKAGE_NAME != "ddtrace":
-    update_pyproject_field("name", PACKAGE_NAME)
-
-BASE_PACKAGE_VERSION = get_pyproject_package_version()
-PACKAGE_VERSION = get_build_package_version()
-if PACKAGE_VERSION and PACKAGE_VERSION != BASE_PACKAGE_VERSION:
-    update_pyproject_field("version", PACKAGE_VERSION)
-
-print(f"INFO: building package '{PACKAGE_NAME}' version '{PACKAGE_VERSION or BASE_PACKAGE_VERSION}'")
+    subprocess.run(["sed", "-i", "-e", f's/^name = ".*"/name = "{PACKAGE_NAME}"/g', "pyproject.toml"])
+print(f"INFO: building package '{PACKAGE_NAME}'")
 
 interpose_sccache()
-try:
-    setup(
-        name="ddtrace",
-        packages=find_packages(
-            exclude=[
-                "tests*",
-                "benchmarks*",
-                "scripts*",
-                # pybind11 vendor is a build-time dependency only; nothing in ddtrace imports it at runtime
-                "ddtrace.appsec._iast._taint_tracking._vendor.pybind11*",
-                # C++ test helpers, not needed at runtime
-                "ddtrace.internal.datadog.profiling.ddup.test*",
-            ]
+setup(
+    name="ddtrace",
+    packages=find_packages(
+        exclude=[
+            "tests*",
+            "benchmarks*",
+            "scripts*",
+            # pybind11 vendor is a build-time dependency only; nothing in ddtrace imports it at runtime
+            "ddtrace.appsec._iast._taint_tracking._vendor.pybind11*",
+            # C++ test helpers, not needed at runtime
+            "ddtrace.internal.datadog.profiling.ddup.test*",
+        ]
+    ),
+    include_package_data=False,
+    package_data={
+        # Type stubs and markers for all packages
+        "": ["*.pyi", "py.typed"],
+        "ddtrace.appsec": ["rules.json"],
+        "ddtrace.appsec._ddwaf": ["libddwaf/*/lib/libddwaf.*"],
+        "ddtrace.appsec.sca": ["_cve_data.json"],
+        "ddtrace.internal": ["third-party.tar.gz"],
+        "ddtrace.internal.datadog.profiling": (
+            ["libdd_wrapper*.*"] + (["test/*"] if BUILD_PROFILING_NATIVE_TESTS else [])
         ),
-        include_package_data=False,
-        package_data={
-            # Type stubs and markers for all packages
-            "": ["*.pyi", "py.typed"],
-            "ddtrace.appsec": ["rules.json"],
-            "ddtrace.appsec._ddwaf": ["libddwaf/*/lib/libddwaf.*"],
-            "ddtrace.appsec.sca": ["_cve_data.json"],
-            "ddtrace.internal": ["third-party.tar.gz"],
-            "ddtrace.internal.datadog.profiling": (
-                ["libdd_wrapper*.*"] + (["test/*"] if BUILD_PROFILING_NATIVE_TESTS else [])
-            ),
-        },
-        zip_safe=False,
-        # enum34 is an enum backport for earlier versions of python
-        # funcsigs backport required for vendored debtcollector
-        cmdclass={
-            "build_ext": CustomBuildExt,
-            "build_py": LibraryDownloader,
-            "build_rust": CustomBuildRust,
-            "clean": CleanLibraries,
-            "ext_hashes": ExtensionHashes,
-        },
-        setup_requires=[
-            "cython",
-            "cmake>=3.24.2,<3.28",
-            "setuptools-rust<2",
-            "patchelf>=0.17.0.0; sys_platform == 'linux'",
-        ],
-        ext_modules=ext_modules + cython_exts + get_exts_for("psutil"),
-        distclass=PatchedDistribution,
-    )
-finally:
-    restore_pyproject()
+    },
+    zip_safe=False,
+    # enum34 is an enum backport for earlier versions of python
+    # funcsigs backport required for vendored debtcollector
+    cmdclass={
+        "build_ext": CustomBuildExt,
+        "build_py": LibraryDownloader,
+        "build_rust": CustomBuildRust,
+        "clean": CleanLibraries,
+        "ext_hashes": ExtensionHashes,
+    },
+    setup_requires=[
+        "cython",
+        "cmake>=3.24.2,<3.28",
+        "setuptools-rust<2",
+        "patchelf>=0.17.0.0; sys_platform == 'linux'",
+    ],
+    ext_modules=ext_modules + cython_exts + get_exts_for("psutil"),
+    distclass=PatchedDistribution,
+)


### PR DESCRIPTION
This reverts commit becc3971bda12ccbd8602770eae52f86fc28bdb3, which broke the build: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1833715438