### PR TITLE
fix(ci_visibility): auto test retries feature not retrying quarantined tests

### DIFF
--- a/ddtrace/testing/internal/pytest/plugin.py
+++ b/ddtrace/testing/internal/pytest/plugin.py
@@ -776,6 +776,7 @@ class TestOptPlugin:
         # Log teardown. There should be just one teardown logged for all of the retries, because the junitxml plugin
         # closes the <testcase> element when teardown is logged.
         teardown_report = last_reports.get(TestPhase.TEARDOWN)
+        self._apply_quarantine_masking_to_report(test, teardown_report)
         item.ihook.pytest_runtest_logreport(report=teardown_report)
 
     def _check_applicable_retry_handlers(self, test: Test) -> t.Optional[RetryHandler]:

--- a/ddtrace/testing/internal/pytest/plugin.py
+++ b/ddtrace/testing/internal/pytest/plugin.py
@@ -648,6 +648,8 @@ class TestOptPlugin:
                 item, nextitem, test, t.cast(RetryHandler, retry_handler), reports
             )
         else:
+            # Apply quarantine masking before logging reports (non-retry path).
+            self._apply_quarantine_masking(test, reports)
             self._log_test_reports(item, reports)
             test_run.finish()
 
@@ -729,6 +731,29 @@ class TestOptPlugin:
 
         return retry_reports, reports
 
+    def _apply_quarantine_masking(self, test: Test, reports: _ReportGroup) -> None:
+        """Apply quarantine masking to test reports so failures don't break the pipeline.
+
+        For quarantined tests (that are not ATF), this converts failed reports to look like xfail results.
+        This is applied after all retries so that ATR can see real FAIL status during retries.
+        """
+        if not test.is_quarantined() or test.is_attempt_to_fix():
+            return
+
+        for report in reports.values():
+            if report.failed:
+                report.outcome = "skipped"
+                report.wasxfail = "dd_quarantined"
+
+    def _apply_quarantine_masking_to_report(self, test: Test, report: pytest.TestReport) -> None:
+        """Apply quarantine masking to a single report (e.g. the final retry report)."""
+        if not test.is_quarantined() or test.is_attempt_to_fix():
+            return
+
+        if report.outcome == "failed":
+            report.outcome = "skipped"
+            report.wasxfail = "dd_quarantined"
+
     def _log_retry_final_reports(
         self,
         item: pytest.Item,
@@ -742,6 +767,9 @@ class TestOptPlugin:
 
         if extra_failed_report := retry_reports.get_extra_failed_report(test, final_status):
             self.extra_failed_reports.append(extra_failed_report)
+
+        # Apply quarantine masking to the final report after retries are done.
+        self._apply_quarantine_masking_to_report(test, final_report)
 
         item.ihook.pytest_runtest_logreport(report=final_report)
 
@@ -990,6 +1018,10 @@ class TestOptPluginWithProtocol(TestOptPlugin):
 
         ATF tests must NOT use skip or xfail here: ATF takes precedence over quarantine/disable markers, and any
         failed attempt should fail the test from pytest's point of view.
+
+        Quarantined tests also do NOT use xfail here: applying xfail upfront causes pytest to report failures as
+        "skipped" (xfail), which prevents ATR from seeing a FAIL status and retrying. Instead, quarantine masking is
+        applied after all retries in _apply_quarantine_masking.
         """
         if not self.manager.settings.test_management.enabled:
             return
@@ -998,7 +1030,8 @@ class TestOptPluginWithProtocol(TestOptPlugin):
         elif test.is_attempt_to_fix():
             return
         elif test.is_quarantined():
-            item.add_marker(pytest.mark.xfail(strict=False, reason="dd_quarantined", run=True))
+            # Quarantine masking is deferred to _apply_quarantine_masking so ATR can see real FAIL status.
+            return
 
     @catch_and_log_exceptions()
     def pytest_runtest_protocol(self, item: pytest.Item, nextitem: t.Optional[pytest.Item]) -> bool:

--- a/ddtrace/testing/internal/pytest/plugin.py
+++ b/ddtrace/testing/internal/pytest/plugin.py
@@ -737,13 +737,8 @@ class TestOptPlugin:
         For quarantined tests (that are not ATF), this converts failed reports to look like xfail results.
         This is applied after all retries so that ATR can see real FAIL status during retries.
         """
-        if not test.is_quarantined() or test.is_attempt_to_fix():
-            return
-
         for report in reports.values():
-            if report.failed:
-                report.outcome = "skipped"
-                report.wasxfail = "dd_quarantined"
+            self._apply_quarantine_masking_to_report(test, report)
 
     def _apply_quarantine_masking_to_report(self, test: Test, report: pytest.TestReport) -> None:
         """Apply quarantine masking to a single report (e.g. the final retry report)."""

--- a/releasenotes/notes/quarantine-atr-retries-cbde45b064239327.yaml
+++ b/releasenotes/notes/quarantine-atr-retries-cbde45b064239327.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    CI Visibility: This fix resolves an issue where quarantined tests were not retried by Auto Test Retry (ATR). Quarantine masking is now deferred until after ATR completes its retries, allowing the plugin to detect failures and trigger retries before marking tests as quarantined.
+    CI Visibility: This fix resolves an issue where quarantined tests were not retried by Auto Test Retry (ATR).

--- a/releasenotes/notes/quarantine-atr-retries-cbde45b064239327.yaml
+++ b/releasenotes/notes/quarantine-atr-retries-cbde45b064239327.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    CI Visibility: This fix resolves an issue where quarantined tests were not retried by Auto Test Retry (ATR). Quarantine masking is now deferred until after ATR completes its retries, allowing the plugin to detect failures and trigger retries before marking tests as quarantined.

--- a/tests/contrib/pytest/test_pytest_configure_plugin_selection.py
+++ b/tests/contrib/pytest/test_pytest_configure_plugin_selection.py
@@ -230,8 +230,12 @@ class TestPluginClassSelection:
             item.add_marker.assert_not_called()
             assert item.user_properties == []
 
-    def test_child_plugin_uses_xfail_for_quarantine_without_atf(self):
-        """Child plugin uses xfail for quarantined non-ATF tests (same as base)."""
+    def test_child_plugin_defers_quarantine_masking_without_atf(self):
+        """Child plugin does NOT apply xfail for quarantined non-ATF tests.
+
+        Quarantine masking is deferred to after retries so ATR can see real FAIL status.
+        The base plugin still uses xfail because it doesn't control the retry loop.
+        """
         plugin = mock.MagicMock()
         plugin.manager.settings.test_management.enabled = True
 
@@ -245,13 +249,8 @@ class TestPluginClassSelection:
 
         TestOptPluginWithProtocol._apply_test_management_markers(plugin, item=item, test=test)
 
-        xfail_calls = [
-            call
-            for call in item.add_marker.call_args_list
-            if len(call[0]) > 0 and hasattr(call[0][0], "mark") and call[0][0].mark.name == "xfail"
-        ]
-        assert len(xfail_calls) == 1
-        assert xfail_calls[0][0][0].mark.kwargs["reason"] == "dd_quarantined"
+        # No markers should be applied — masking happens after retries in _apply_quarantine_masking.
+        item.add_marker.assert_not_called()
         assert item.user_properties == []
 
     @pytest.mark.parametrize("plugin_class", [TestOptPlugin, TestOptPluginWithProtocol])

--- a/tests/testing/internal/pytest/test_quarantine_atr.py
+++ b/tests/testing/internal/pytest/test_quarantine_atr.py
@@ -1,0 +1,75 @@
+"""Test that quarantined tests interact correctly with ATR (Auto Test Retry).
+
+Verifies that when a test is quarantined and ATR is enabled, ATR retries the
+failing test, and quarantine masking is applied afterwards so the session passes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from _pytest.pytester import Pytester
+
+from ddtrace.testing.internal.settings_data import TestProperties
+from ddtrace.testing.internal.test_data import ModuleRef
+from ddtrace.testing.internal.test_data import SuiteRef
+from ddtrace.testing.internal.test_data import TestRef
+from tests.testing.internal.pytest.utils import assert_stats
+from tests.testing.mocks import EventCapture
+from tests.testing.mocks import mock_api_client_settings
+from tests.testing.mocks import setup_standard_mocks
+
+
+class TestQuarantineWithATR:
+    def test_quarantined_failing_test_is_retried_by_atr(self, pytester: Pytester) -> None:
+        """When a test is quarantined and ATR is enabled, a failing test should be retried by ATR.
+
+        The quarantine masking is deferred until after ATR retries, so ATR sees the real FAIL
+        status and retries up to the default max (5 retries = 6 total runs).
+        The test session should still pass (exit code 0) with the test shown as quarantined.
+        """
+        pytester.makepyfile(
+            test_foo="""
+            def test_quarantined_fail():
+                assert False
+        """
+        )
+
+        test_ref = TestRef(SuiteRef(ModuleRef(""), "test_foo.py"), "test_quarantined_fail")
+        known_tests: set[TestRef] = {test_ref}
+
+        with (
+            patch(
+                "ddtrace.testing.internal.session_manager.APIClient",
+                return_value=mock_api_client_settings(
+                    auto_retries_enabled=True,
+                    test_management_enabled=True,
+                    known_tests_enabled=True,
+                    known_tests=known_tests,
+                    test_management_properties={test_ref: TestProperties(quarantined=True)},
+                ),
+            ),
+            setup_standard_mocks(),
+        ):
+            with EventCapture.capture() as event_capture:
+                result = pytester.inline_run("--ddtrace", "-v", "-s")
+
+        # Quarantined tests should NOT cause a session failure
+        assert result.ret == 0
+
+        # Should show as quarantined, not failed
+        assert_stats(result, quarantined=1)
+
+        # ATR should have retried: 1 initial + 5 retries = 6 test events
+        test_events = list(event_capture.events_by_test_name("test_quarantined_fail"))
+        assert len(test_events) == 6, f"Expected 6 test events (1 initial + 5 retries), got {len(test_events)}"
+
+        # First run: fail, not a retry
+        assert test_events[0]["content"]["meta"].get("test.status") == "fail"
+        assert test_events[0]["content"]["meta"].get("test.is_retry") is None
+
+        # Retries: all fail, marked as retries with ATR reason
+        for i in range(1, len(test_events)):
+            assert test_events[i]["content"]["meta"].get("test.status") == "fail"
+            assert test_events[i]["content"]["meta"].get("test.is_retry") == "true"
+            assert test_events[i]["content"]["meta"].get("test.retry_reason") == "auto_test_retry"


### PR DESCRIPTION
## Description

When a test is quarantined and ATR (Auto Test Retry) is enabled, ATR should retry the failing test before quarantine masking is applied. Previously, the `xfail(strict=False)` marker was applied **before** the test ran, causing pytest to report failures as `skipped` (xfail). Since ATR only retries tests with `TestStatus.FAIL`, it never triggered for quarantined tests.

This fix defers quarantine masking in `TestOptPluginWithProtocol` (the plugin subclass that controls its own retry loop). Instead of applying `xfail` upfront, tests run without it so ATR sees real FAIL status and retries. After all retries complete, quarantine masking is applied to the final report (`outcome="skipped"`, `wasxfail="dd_quarantined"`), so the session still passes and the test shows as "QUARANTINED".

The base `TestOptPlugin._apply_test_management_markers` (used when an external rerun plugin like pytest-rerunfailures or flaky drives execution) is unchanged and still applies `xfail` upfront, since we don't control the retry loop in that case.

### Changes

- **`TestOptPluginWithProtocol._apply_test_management_markers`**: No longer applies `xfail` for quarantined tests. Returns early so ATR sees real FAIL status.
- **New `_apply_quarantine_masking` / `_apply_quarantine_masking_to_report`**: Convert `failed` reports to `skipped` with `wasxfail="dd_quarantined"` after retries complete. Called in both the non-retry path (`_do_test_runs`) and retry path (`_log_retry_final_reports`).

## Testing

New integration test `test_quarantined_failing_test_is_retried_by_atr` in `tests/testing/internal/pytest/test_quarantine_atr.py` verifies:
- Session passes (exit code 0)
- Test shows as `quarantined` (not `failed`)
- ATR retries: 1 initial + 5 retries = 6 test events
- First event: `test.status=fail`, no retry tag
- Retry events: `test.status=fail`, `test.is_retry=true`, `test.retry_reason=auto_test_retry`

## Risks

- The base plugin (external rerun plugin path) is unchanged, so no risk there.
- Quarantined tests without ATR enabled: the non-retry path applies masking via `_apply_quarantine_masking`, so behavior is preserved.

## Additional Notes

- Test spans still carry `test.test_management.is_quarantined=true` tag regardless of the status, so the backend can always identify quarantined tests.
- ATF (Attempt to Fix) takes precedence over quarantine in both plugin classes -- this is unchanged.

## Checklist
- [x] PR author has checked that all the criteria below are met
- The PR description includes an overview of the change
- The PR description articulates the motivation for the change
- The change includes tests OR the PR description describes a testing strategy
- The PR description notes risks associated with the change, if any
- Newly-added code is easy to change
- The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- The change includes or references documentation updates if necessary
- Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))