### PR TITLE
Bisection build: 4.9.1 + no-shutdown-on-drop + no-child-fork-flush (noshutdown2)

### DIFF
--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -1011,7 +1011,7 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         try:
             self.periodic()
         finally:
-            self._exporter.shutdown(3_000_000_000)  # 3 seconds timeout
+            pass
 
 
 def _use_log_writer() -> bool:

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -200,7 +200,7 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
             processing_interval = config._trace_writer_interval_seconds
         if timeout is None:
             timeout = agent_config.trace_agent_timeout_seconds
-        super(HTTPWriter, self).__init__(interval=processing_interval)
+        super(HTTPWriter, self).__init__(interval=processing_interval, autorestart=False)
         self.intake_url = intake_url
         self._intake_accepts_gzip = use_gzip
         self._buffer_size = buffer_size
@@ -682,7 +682,7 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
             if "X-Datadog-Test-Session-Token" in additional_header:
                 test_session_token = additional_header["X-Datadog-Test-Session-Token"]
 
-        super(NativeWriter, self).__init__(interval=processing_interval)
+        super(NativeWriter, self).__init__(interval=processing_interval, autorestart=False)
         self.intake_url = intake_url
         self._otlp_endpoint = otlp_endpoint
         self._buffer_size = buffer_size

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.9.1+noshutdown1"
+version = "4.9.1+noshutdown2"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.9.1"
+version = "4.9.1+noshutdown1"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }

--- a/src/native/data_pipeline/mod.rs
+++ b/src/native/data_pipeline/mod.rs
@@ -263,14 +263,6 @@ impl TraceExporterPy {
     }
 }
 
-impl Drop for TraceExporterPy {
-    fn drop(&mut self) {
-        if let Some(exporter) = self.inner.take() {
-            let _ = exporter.shutdown(Some(Duration::from_secs(3)));
-        }
-    }
-}
-
 #[pymodule]
 pub fn register_data_pipeline(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<TraceExporterBuilderPy>()?;


### PR DESCRIPTION
Bisection build to test the fork-timeout hypothesis on a **v4.9.1 base**.

Combines two fork-related changes on top of v4.9.1:

1. Vianney's `no-shutdown-on-drop` change (#18876):
   - `WriteWriter.on_shutdown`: drop the blocking `self._exporter.shutdown(3s)` call.
   - Native `impl Drop for TraceExporterPy`: removed entirely (no blocking `shutdown` on drop).
2. #18262 (`fix(tracer): avoid flushing traces from the child in case of fork`):
   - `HTTPWriter`/`NativeWriter` periodic service init now uses `autorestart=False`, so the writer thread does not restart-and-flush in the forked child.

Plus a version marker `4.9.1+noshutdown2` in `pyproject.toml` so the staging rollout is unambiguously identifiable on the fork-timeout dashboard.

This is a bigger hammer than `dropfix1` (which relied on the Python-side `_child_after_fork` calling `exporter.drop()` and did not eliminate the timeouts): here no blocking shutdown runs at exporter destruction at all, and the child no longer restarts the writer to flush.

Not for merge — staging bisection only.
