### PR TITLE
Bisection build: 4.9.1 + libdatadog before-fork non-blocking fix (forkfix2193)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.9.1"
+version = "4.9.1+forkfix2193"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }

--- a/src/native/Cargo.toml
+++ b/src/native/Cargo.toml
@@ -22,29 +22,29 @@ libc = { version = "0.2", optional = true }
 rand = "0.9"
 rustc-hash = "1.1"
 serde = "1.0"
-datadog-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0", optional = true, version = "1.0.0", features = ["pyo3"] }
+datadog-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "b3e431dd19d36b69384cbd75c90456287bd1d0a7", optional = true, version = "1.0.0", features = ["pyo3"] }
 serde_json = "1.0"
-datadog-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0" }
-libdd-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0" }
-libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0", optional = true }
-libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0", optional = true }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0" }
-libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0" }
-libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0" }
-libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0" }
-libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0", optional = true, features = [
+datadog-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "b3e431dd19d36b69384cbd75c90456287bd1d0a7" }
+libdd-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "b3e431dd19d36b69384cbd75c90456287bd1d0a7" }
+libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "b3e431dd19d36b69384cbd75c90456287bd1d0a7", optional = true }
+libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "b3e431dd19d36b69384cbd75c90456287bd1d0a7", optional = true }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "b3e431dd19d36b69384cbd75c90456287bd1d0a7" }
+libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "b3e431dd19d36b69384cbd75c90456287bd1d0a7" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "b3e431dd19d36b69384cbd75c90456287bd1d0a7" }
+libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "b3e431dd19d36b69384cbd75c90456287bd1d0a7" }
+libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "b3e431dd19d36b69384cbd75c90456287bd1d0a7" }
+libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "b3e431dd19d36b69384cbd75c90456287bd1d0a7", optional = true, features = [
     "cbindgen",
 ] }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0", optional = true }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "b3e431dd19d36b69384cbd75c90456287bd1d0a7", optional = true }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "b3e431dd19d36b69384cbd75c90456287bd1d0a7" }
 pyo3 = { version = "0.28", features = ["extension-module", "anyhow"] }
 tracing = { version = "0.1", default-features = false }
 pyo3-ffi = { version = "0.28", optional = true }
 
 [build-dependencies]
 pyo3-build-config = "0.28"
-build_common = { git = "https://github.com/DataDog/libdatadog", rev = "v33.0.0", features = [
+build_common = { git = "https://github.com/DataDog/libdatadog", rev = "b3e431dd19d36b69384cbd75c90456287bd1d0a7", features = [
     "cbindgen",
 ] }
 


### PR DESCRIPTION
Bisection build to test the fork-timeout hypothesis on a **v4.9.1 base**.

Repoints every libdatadog crate in `src/native/Cargo.toml` from `v33.0.0` to a branch that is **v33.0.0 + only** the cherry-picked `PausableWorker` fix from DataDog/libdatadog#2193 (`14773a9da30f`). Nothing else from libdatadog `main` is pulled in, so the sole delta vs v33.0.0 is the fork fix.

What #2193 fixes: `PausableWorker`'s task loop selected on the cancellation token *between* `trigger()` and `run()`, but not *during* `run()`. If a fork fired while `run()` was mid-operation (e.g. `AgentInfoFetcher::run()` doing an HTTP GET `/info` to a slow agent), `before_fork()` → `pause()` had to wait for the request to finish. Measured end-to-end: `before_fork()` **3005ms → 1ms**. This matches the ~3s delancie fork-timeout signature.

The fix wraps `run()` in `select!` against the cancellation token, so cancellation interrupts an in-flight `run()`.

libdatadog branch: `juanjux/v33.0.0-forkfix-2193` @ `b3e431dd19d36b69384cbd75c90456287bd1d0a7`
Version marker: `4.9.1+forkfix2193` (for the fork-timeout dashboard).

Note: prior bisection builds (`dropfix1`, `noshutdown2`) targeted the exporter Drop / writer shutdown path and did **not** eliminate the timeouts. This one targets the before-fork worker pause path instead.

Not for merge — staging bisection only.