### PR TITLE
fix(aap): advertise blocking capabilities after one-click activation

### DIFF
--- a/ddtrace/appsec/_capabilities.py
+++ b/ddtrace/appsec/_capabilities.py
@@ -60,6 +60,9 @@ _ALL_ASM_BLOCKING = (
 _ALL_RASP = Flags.ASM_RASP_SQLI | Flags.ASM_RASP_LFI | Flags.ASM_RASP_SSRF | Flags.ASM_RASP_SHI | Flags.ASM_RASP_CMDI
 _FEATURE_REQUIRED = Flags.ASM_ACTIVATION | Flags.ASM_AUTO_USER
 
+# Mask of every bit _rc_capabilities() may set, so re-advertising replaces only ASM-owned bits.
+_ALL_ASM_CAPABILITIES = Flags.ASM_ACTIVATION | Flags.ASM_AUTO_USER | _ALL_ASM_BLOCKING | _ALL_RASP
+
 
 def _asm_feature_is_required() -> bool:
     flags = _rc_capabilities()

--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -4,6 +4,7 @@ from typing import Any
 from typing import Optional
 from typing import Sequence
 
+from ddtrace.appsec._capabilities import _ALL_ASM_CAPABILITIES
 from ddtrace.appsec._capabilities import _asm_feature_is_required
 from ddtrace.appsec._capabilities import _rc_capabilities
 from ddtrace.appsec._constants import APPSEC
@@ -169,6 +170,9 @@ def _process_asm_features(payload_list: list[Payload], cache: dict[str, dict[str
             disable_asm()
     if "auto_user_instrum" in result:
         asm_config._auto_user_instrumentation_rc_mode = result["auto_user_instrum"].get("mode", None)
+    if "asm" in result or "auto_user_instrum" in result:
+        # Re-advertise capabilities so blocking/RASP follow one-click activation/deactivation.
+        remoteconfig_poller.update_capabilities(_ALL_ASM_CAPABILITIES, _rc_capabilities())
 
 
 def disable_asm() -> None:

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -450,6 +450,10 @@ class RemoteConfigClient:
         for capability in capabilities:
             self._capabilities |= capability
 
+    def update_capabilities(self, mask: int, capabilities: int) -> None:
+        """Replace the bits within ``mask`` with ``capabilities`` (can clear bits, unlike add_capabilities)."""
+        self._capabilities = (self._capabilities & ~mask) | (capabilities & mask)
+
     def update_product_callback(self, product_name: str, callback: RCCallback) -> bool:
         """Update the callback for a registered product."""
         if product_name in self._product_callbacks:

--- a/ddtrace/internal/remoteconfig/worker.py
+++ b/ddtrace/internal/remoteconfig/worker.py
@@ -189,6 +189,10 @@ class RemoteConfigPoller(periodic.PeriodicService):
         except Exception:
             log.debug("error starting the RCM client", exc_info=True)
 
+    def update_capabilities(self, mask: enum.IntFlag, capabilities: enum.IntFlag) -> None:
+        """Re-advertise ``capabilities`` within ``mask`` when a product's set changes after registration."""
+        self._client.update_capabilities(int(mask), int(capabilities))
+
     def enable_product(self, product: str) -> None:
         """Enable a product to be included in client payloads.
 

--- a/releasenotes/notes/asm-rc-capabilities-one-click-82a42347f0d0cc7c.yaml
+++ b/releasenotes/notes/asm-rc-capabilities-one-click-82a42347f0d0cc7c.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    AAP: Fix blocking capabilities (IP, user, in-app WAF and custom rules) not being
+    advertised when AAP is enabled through one-click (remote) activation instead of the
+    ``DD_APPSEC_ENABLED`` environment variable, which could make the Threat Protection panel
+    wrongly report that a library update was required. Capabilities are now re-advertised on
+    remote activation and deactivation.

--- a/releasenotes/notes/asm-rc-capabilities-one-click-82a42347f0d0cc7c.yaml
+++ b/releasenotes/notes/asm-rc-capabilities-one-click-82a42347f0d0cc7c.yaml
@@ -1,8 +1,5 @@
 ---
 fixes:
   - |
-    AAP: Fix blocking capabilities (IP, user, in-app WAF and custom rules) not being
-    advertised when AAP is enabled through one-click (remote) activation instead of the
-    ``DD_APPSEC_ENABLED`` environment variable, which could make the Threat Protection panel
-    wrongly report that a library update was required. Capabilities are now re-advertised on
-    remote activation and deactivation.
+    AAP: Fix an issue which could make the Threat Protection panel wrongly report
+    that a library update was required.

--- a/tests/appsec/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/appsec/test_remoteconfiguration.py
@@ -169,6 +169,45 @@ def test_rc_activation_capabilities(tracer, rc_poller, env_rules, expected):
         assert _appsec_rc_capabilities() == expected
 
 
+def test_rc_capabilities_updated_after_one_click_activation(tracer, rc_poller):
+    """Regression test for capabilities not being advertised after one-click activation.
+
+    Capabilities are computed once at registration time (while AppSec is still disabled
+    for a remotely-activated service) and the RC client only accumulates them. Before the
+    fix, the client kept advertising only ASM_ACTIVATION after a one-click activation, so
+    the backend reported "UPDATE REQUIRED" for blocking even though it was fully functional.
+    The client bitmask must reflect the live ASM state after activation and deactivation.
+    """
+    from ddtrace.appsec._capabilities import _ALL_ASM_BLOCKING
+    from ddtrace.appsec._capabilities import Flags
+    from ddtrace.appsec._capabilities import _rc_capabilities
+
+    enable_config = [build_payload("ASM_FEATURES", {"asm": {"enabled": True}}, "config")]
+    disable_config = [build_payload("ASM_FEATURES", {"asm": {}}, "config")]
+
+    with override_global_config(dict(_remote_config_enabled=True, _asm_enabled=False, _asm_can_be_enabled=True)):
+        enable_appsec_rc()
+
+        # AppSec is not enabled yet (remote activation pending): no blocking capabilities.
+        assert rc_poller._client._capabilities & int(_ALL_ASM_BLOCKING) == 0
+        assert rc_poller._client._capabilities & int(Flags.ASM_ACTIVATION)
+
+        # One-click activation: blocking (and RASP) capabilities must now be advertised.
+        _appsec_callback(enable_config)
+        assert asm_config._asm_enabled
+        assert rc_poller._client._capabilities & int(_ALL_ASM_BLOCKING) == int(_ALL_ASM_BLOCKING)
+        assert rc_poller._client._capabilities == int(_rc_capabilities())
+
+        # One-click deactivation: blocking capabilities must be dropped again.
+        _appsec_callback(disable_config)
+        assert not asm_config._asm_enabled
+        assert rc_poller._client._capabilities & int(_ALL_ASM_BLOCKING) == 0
+        assert rc_poller._client._capabilities & int(Flags.ASM_ACTIVATION)
+        assert rc_poller._client._capabilities == int(_rc_capabilities())
+
+    disable_appsec_rc()
+
+
 def test_rc_activation_validate_products(tracer, rc_poller):
     with override_global_config(dict(_asm_enabled=False, _remote_config_enabled=True, api_version="v0.4")):
         assert not rc_poller._worker


### PR DESCRIPTION
APPSEC-69019

## Description

When AAP is enabled via one-click (remote) activation instead of `DD_APPSEC_ENABLED`, the RC blocking capabilities (IP, user, in-app WAF, custom rules) were never advertised, so Threat Protection wrongly reported "UPDATE REQUIRED". Capabilities are computed once at startup (while AppSec is still off for a remote-activated service) and the client only OR-accumulates them. Fix: re-advertise `_rc_capabilities()` on remote activation/deactivation via a new masked `update_capabilities()` that can also clear ASM-owned bits.

## Testing

New regression test asserting the client bitmask across activation→deactivation (fails without the fix). `appsec` RC tests and `internal` RC suite pass; lint/typing clean.

## Risks

Low — scoped to ASM-owned capability bits; `add_capabilities` and the env-var path are unchanged.

## Additional Notes

Workaround for customers: set `DD_APPSEC_ENABLED=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)