### PR TITLE
Add default timeout for join

### DIFF
--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -503,7 +503,7 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
 
     def _stop_service(
         self,
-        timeout: Optional[float] = None,
+        timeout: Optional[float] = 0.1,
     ) -> None:
         # FIXME: don't join() on stop(), let the caller handle this
         super(HTTPWriter, self)._stop_service()

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -507,7 +507,10 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
     ) -> None:
         # FIXME: don't join() on stop(), let the caller handle this
         super(HTTPWriter, self)._stop_service()
-        self.join(timeout=timeout)
+        try:
+            self.join(timeout=timeout)
+        except:
+            log.error("Join on periodic thread failed", exc_info=True)
 
     def on_shutdown(self):
         try:


### PR DESCRIPTION
…ckport 4.9] (#18177)

<!-- Provide an overview of the change and motivation for the change -->
We found that 30s timeout doesn't play well with gunicorn, which has 30s
initialization timout for the worker.

If the user naively calls `openfeature.api.set_provider()` at the
top-level, RC failing to deliver configuration may bring their whole
application down with hard-to-debug `[CRITICAL] WORKER TIMEOUT` error
message.

Decrease default timeout to 10s, which is enough when RC is working but
not too long to cause other issues/upstream timeouts.

<!-- Describe your testing strategy or note what tests are included -->

<!-- Note any risks associated with this change, or "None" if no risks
-->

<!-- Any other information that would be helpful for reviewers --> Part
of incident-54756, follow up to
#16650

Co-authored-by: Oleksii Shmalko <oleksii.shmalko@datadoghq.com>## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
