### PR TITLE
Bisection build: 4.9.1 + writer stop_service join timeout (jointimeout1)

### DIFF
--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -503,7 +503,7 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
 
     def _stop_service(
         self,
-        timeout: Optional[float] = None,
+        timeout: Optional[float] = 0.1,
     ) -> None:
         # FIXME: don't join() on stop(), let the caller handle this
         super(HTTPWriter, self)._stop_service()

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -509,8 +509,8 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
         super(HTTPWriter, self)._stop_service()
         try:
             self.join(timeout=timeout)
-        except:
-            log.error("Join on periodic thread failed", exc_info=True))
+        except Exception:
+            log.error("Join on periodic thread failed", exc_info=True)
 
     def on_shutdown(self):
         try:

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -507,7 +507,10 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
     ) -> None:
         # FIXME: don't join() on stop(), let the caller handle this
         super(HTTPWriter, self)._stop_service()
-        self.join(timeout=timeout)
+        try:
+            self.join(timeout=timeout)
+        except:
+            log.error("Join on periodic thread failed", exc_info=True))
 
     def on_shutdown(self):
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.9.1"
+version = "4.9.1+jointimeout1"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }


### PR DESCRIPTION
Bisection build to test the fork-timeout hypothesis on a **v4.9.1 base**.

Builds Vianney's #18895 (`vianney/skip-join-in-stop-service`) on top of v4.9.1:
- `HTTPWriter._stop_service`: default join `timeout` changed from `None` (unbounded) to `0.1s`, and `self.join(timeout=timeout)` wrapped in `try/except` so a failed/slow join no longer blocks shutdown.

Fix applied on top of the head branch: the original `log.error("Join on periodic thread failed", exc_info=True))` had an extra `)` (a `SyntaxError` that would break `import ddtrace`); corrected here and switched the bare `except:` to `except Exception:`. Verified `writer.py` parses.

Version marker `4.9.1+jointimeout1` in `pyproject.toml` for the fork-timeout dashboard.

Prior builds (`dropfix1`, `noshutdown2`) targeted the exporter Drop/shutdown path and `forkfix2193` targeted the libdatadog before-fork worker pause — none eliminated the timeouts. This one targets the writer `_stop_service` join blocking during shutdown.

Not for merge — staging bisection only.