### PR TITLE
Bisection build: 4.9.1 + non-blocking child-fork writer join (forkjoinfix1)

### DIFF
--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -11,6 +11,7 @@ from typing import Optional
 from typing import TextIO
 
 from ddtrace import config
+from ddtrace.internal import forksafe
 from ddtrace.internal.dist_computing.utils import in_ray_job
 from ddtrace.internal.hostname import get_hostname
 import ddtrace.internal.native as native
@@ -507,6 +508,11 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
     ) -> None:
         # FIXME: don't join() on stop(), let the caller handle this
         super(HTTPWriter, self)._stop_service()
+        if timeout is None and forksafe.is_fork_child():
+            # In a forked child the worker's OS thread does not exist (fork only
+            # copies the calling thread), so a blocking join would wait forever on
+            # a condition variable that is never signaled, hanging os.fork().
+            timeout = 0
         self.join(timeout=timeout)
 
     def on_shutdown(self):
@@ -1005,6 +1011,11 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
     ) -> None:
         # FIXME: don't join() on stop(), let the caller handle this
         super(NativeWriter, self)._stop_service()
+        if timeout is None and forksafe.is_fork_child():
+            # In a forked child the worker's OS thread does not exist (fork only
+            # copies the calling thread), so a blocking join would wait forever on
+            # a condition variable that is never signaled, hanging os.fork().
+            timeout = 0
         self.join(timeout=timeout)
 
     def on_shutdown(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.9.1"
+version = "4.9.1+forkjoinfix1"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }


### PR DESCRIPTION
Bisection build on a **v4.9.1 base**, built from the gdb evidence of a slow-forking delancie worker.

## Root cause (from the stack trace)
The forking thread hangs **inside `os.fork()`'s child at-fork handler**:

```
os.fork() -> PyOS_AfterFork_Child() -> run_at_forkers()
  -> tracer._child_after_fork -> _recreate -> SpanAggregator.reset
    -> writer.recreate() -> self.stop() -> _stop_service
      -> self.join(timeout=None) -> PeriodicThread_join
        -> std::condition_variable::wait   [BLOCKS FOREVER]
```

In the forked child the writer's worker OS thread does not exist (fork copies only the calling thread), so the join waits forever on a condition variable that is never signaled — hanging the fork for the full watchdog window. The deployed writer is `NativeWriter` (stack shows `_native…so` + `tokio-rt-worker` + `TraceExporterPy`).

## Fix
In `HTTPWriter._stop_service` and `NativeWriter._stop_service`, when `timeout is None` and we are in a fork child (`forksafe.is_fork_child()`), use a non-blocking join (`timeout=0`). Parent-process shutdown joins are unchanged.

`forksafe.is_fork_child()` is set by `set_fork_child` (the first registered child hook), so it is already `True` by the time `_child_after_fork` runs the writer recreate.

Version marker `4.9.1+forkjoinfix1`.

Prior builds (`dropfix1`, `noshutdown2`, `forkfix2193`, `jointimeout1`) each targeted a different path (exporter Drop/shutdown, libdatadog before-fork pause, HTTPWriter-only stop timeout); this one targets the exact blocking `join()` shown in the stack.

Not for merge — staging bisection only.