### PR TITLE
fix(core): avoid fork child periodic thread deadlocks

### DIFF
--- a/ddtrace/internal/threads.py
+++ b/ddtrace/internal/threads.py
@@ -67,6 +67,17 @@ def _safe_restart(start: t.Callable[[], None], name: t.Optional[str] = None) -> 
         log.error("failed to start periodic thread %s: %s", name, e)
 
 
+def _safe_restart_in_child(start: t.Callable[[], None]) -> None:
+    """Invoke a child at-fork restart without touching logging locks."""
+    try:
+        start()
+    except Exception:
+        # AIDEV-NOTE: Never log from after_in_child. Logging handlers may hold
+        # locks inherited from vanished parent threads, so even best-effort
+        # error reporting here can deadlock before os.fork() returns.
+        return
+
+
 class PeriodicThread(_PeriodicThread):
     """A fork-safe periodic thread."""
 
@@ -167,16 +178,17 @@ def _after_fork_child():
     # the child so application code can resume immediately after fork. Parent
     # process threads are still restarted in _after_fork_parent() below.
     for thread in _threads_to_restart_after_fork.copy():
-        log.debug("Restarting thread %s after fork in child", thread.name)
         try:
             thread._after_fork(force=False)
-        except Exception as e:
-            log.error("failed to restart periodic thread %s after fork in child: %s", thread.name, e)
+        except Exception:  # nosec B112
+            # AIDEV-NOTE: Never log from after_in_child. Logging handlers may
+            # hold locks inherited from vanished parent threads, so logging here
+            # can deadlock before os.fork() returns.
+            continue
     _threads_to_restart_after_fork.clear()
 
     for thread_start in _threads_to_start_after_fork.copy():
-        log.debug("Starting thread %s after fork in child", thread_start.__self__.name)
-        _safe_restart(thread_start, thread_start.__self__.name)
+        _safe_restart_in_child(thread_start)
     _threads_to_start_after_fork.clear()
 
 

--- a/releasenotes/notes/fix-fork-child-thread-restart-deadlock.yaml
+++ b/releasenotes/notes/fix-fork-child-thread-restart-deadlock.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    core: Fixes a deadlock that could occur in forked child processes when restarting ddtrace periodic threads after fork.

--- a/scripts/repro_fork_deadlock_logging.py
+++ b/scripts/repro_fork_deadlock_logging.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+Deterministically reproduce a ddtrace fork deadlock caused by logging from an
+``after_in_child`` fork hook.
+
+The important sequence is:
+
+1. A non-fork-safe logging handler lock is held by a background thread.
+2. The process forks while a ddtrace PeriodicThread is active.
+3. ddtrace's child at-fork hook logs while restarting that PeriodicThread.
+4. The child inherits the held handler lock but not the owner thread, so it
+   blocks before returning from os.fork().
+
+Run directly inside an environment with ddtrace installed, or use
+``scripts/run-repro-fork-deadlock.sh``.
+"""
+
+import logging
+import os
+import signal
+import sys
+import threading
+import time
+import typing as t
+
+
+class NonForkSafeHandler(logging.Handler):
+    """A handler whose lock is intentionally not reset after fork.
+
+    stdlib logging handlers are normally reinitialized after fork on modern
+    Python versions. This handler models real-world/custom handlers that guard
+    emit with locks unknown to logging's at-fork reset machinery.
+
+    To isolate the bug we are chasing, this handler only blocks in the forked
+    child. ddtrace also logs in ``before_fork`` in the parent, but this repro is
+    specifically for ``after_in_child`` logging before ``os.fork()`` returns.
+    """
+
+    def __init__(self, external_lock: threading.Lock) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.external_lock = external_lock
+        self.parent_pid = os.getpid()
+
+    def acquire(self) -> None:  # logging.Handler.handle() calls this before emit().
+        if os.getpid() != self.parent_pid:
+            self.external_lock.acquire()
+
+    def release(self) -> None:
+        if os.getpid() != self.parent_pid:
+            self.external_lock.release()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        stderr = sys.__stderr__
+        if stderr is not None:
+            stderr.write(self.format(record) + "\n")
+            stderr.flush()
+
+
+def _hold_lock_forever(lock: threading.Lock, ready: threading.Event) -> None:
+    lock.acquire()
+    ready.set()
+    while True:
+        time.sleep(3600)
+
+
+def _install_deadlocking_logging_handler() -> None:
+    external_lock = threading.Lock()
+    ready = threading.Event()
+    threading.Thread(target=_hold_lock_forever, args=(external_lock, ready), daemon=True).start()
+    if not ready.wait(5):
+        raise RuntimeError("background lock holder did not start")
+
+    root = logging.getLogger()
+    root.handlers[:] = []
+    root.setLevel(logging.DEBUG)
+    handler = NonForkSafeHandler(external_lock)
+    handler.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(message)s"))
+    root.addHandler(handler)
+
+    # Ensure ddtrace.internal.threads debug logs reach the root handler.
+    logging.getLogger("ddtrace.internal.threads").setLevel(logging.DEBUG)
+
+
+def _start_ddtrace_periodic_thread() -> t.Any:
+    from ddtrace.internal.threads import PeriodicThread
+
+    def periodic() -> None:
+        return None
+
+    thread = PeriodicThread(60, periodic, name="repro-periodic-thread")
+    thread.start()
+    return thread
+
+
+def main() -> int:
+    import ddtrace  # noqa: F401
+    from ddtrace.version import __version__
+
+    print(f"ddtrace {__version__}, python {sys.version.split()[0]}, pid {os.getpid()}", flush=True)
+
+    periodic_thread = _start_ddtrace_periodic_thread()
+    _install_deadlocking_logging_handler()
+
+    print("forking once; child should deadlock inside ddtrace's after_in_child logging", flush=True)
+    child_pid = os.fork()
+    if child_pid == 0:
+        # If the bug is fixed, the child reaches this line and exits cleanly.
+        os._exit(0)
+
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        done_pid, status = os.waitpid(child_pid, os.WNOHANG)
+        if done_pid == child_pid:
+            periodic_thread.stop()
+            periodic_thread.join(1)
+            print(f"child exited without deadlock, status={status}", flush=True)
+            return 0
+        time.sleep(0.05)
+
+    os.kill(child_pid, signal.SIGKILL)
+    os.waitpid(child_pid, 0)
+    periodic_thread.stop()
+    periodic_thread.join(1)
+    print("REPRODUCED: child deadlocked before returning from os.fork()", flush=True)
+    return 124
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repro_fork_deadlock_stress.py
+++ b/scripts/repro_fork_deadlock_stress.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Stress-test ddtrace's fork hooks while PeriodicThread instances are active.
+
+Unlike repro_fork_deadlock_logging.py, this does not install a deliberately
+non-fork-safe logging handler. It is intended to look for native post-fork
+restart deadlocks/timeouts under repeated fork activity.
+"""
+
+import logging
+import multiprocessing
+import os
+import signal
+import sys
+import threading
+import time
+import typing as t
+
+
+logging.basicConfig(level=logging.CRITICAL)
+logging.getLogger("ddtrace").disabled = True
+
+import ddtrace  # noqa: E402,F401
+from ddtrace.trace import tracer  # noqa: E402
+from ddtrace.version import __version__  # noqa: E402
+
+
+def safely_fork(timeout_s: float = 0.5) -> int:
+    recv, send = multiprocessing.Pipe(False)
+    child_pid = os.fork()
+
+    if child_pid > 0:
+        send.close()
+        if recv.poll(timeout_s):
+            pid = t.cast(int, recv.recv())
+            os.waitpid(child_pid, 0)
+            return pid
+
+        os.kill(child_pid, signal.SIGKILL)
+        os.waitpid(child_pid, 0)
+        raise TimeoutError(f"child {child_pid} did not reach user code after fork")
+
+    recv.close()
+    send.send(os.getpid())
+    os._exit(0)
+
+
+def main() -> int:
+    print(f"ddtrace {__version__}, python {sys.version.split()[0]}, pid {os.getpid()}", flush=True)
+
+    stop = threading.Event()
+
+    def trace_generator() -> None:
+        while not stop.is_set():
+            with tracer.trace("fork.stress", service="fork-stress"):
+                time.sleep(0.001)
+
+    for _ in range(4):
+        threading.Thread(target=trace_generator, daemon=True).start()
+
+    time.sleep(1)
+
+    successes = 0
+    failures = 0
+    iterations = int(os.environ.get("REPRO_FORK_ITERATIONS", "200"))
+    timeout_s = float(os.environ.get("REPRO_FORK_TIMEOUT", "0.5"))
+
+    for i in range(iterations):
+        try:
+            safely_fork(timeout_s=timeout_s)
+            successes += 1
+        except TimeoutError as e:
+            failures += 1
+            print(f"[TIMEOUT] iteration={i}: {e}", flush=True)
+        time.sleep(0.005)
+
+    stop.set()
+    print(f"=== {successes} OK, {failures} timeouts ===", flush=True)
+    return 124 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-repro-fork-deadlock.sh
+++ b/scripts/run-repro-fork-deadlock.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build an isolated environment, install ddtrace, and run a fork-deadlock
+# reproducer.
+#
+# Env vars:
+#   REPRO_VENV      Path to reuse/create venv (default: .repro-venv-fork-deadlock)
+#   DDTRACE_SOURCE  Package spec to install (default: ddtrace==4.9.1)
+#                  Examples: DDTRACE_SOURCE=ddtrace==3.12.4, DDTRACE_SOURCE=/path/to/dd-trace-py
+#   REPRO_SCRIPT    Script to run (default: scripts/repro_fork_deadlock_logging.py)
+#   REPRO_DD_TRACE_DEBUG Enable ddtrace debug logs (default: true)
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPRO_VENV="${REPRO_VENV:-${ROOT_DIR}/.repro-venv-fork-deadlock}"
+DDTRACE_SOURCE="${DDTRACE_SOURCE:-ddtrace==4.9.1}"
+REPRO_SCRIPT="${REPRO_SCRIPT:-${ROOT_DIR}/scripts/repro_fork_deadlock_logging.py}"
+REPRO_DD_TRACE_DEBUG="${REPRO_DD_TRACE_DEBUG:-true}"
+
+if [[ ! -d "${REPRO_VENV}" ]]; then
+  python3 -m venv "${REPRO_VENV}"
+fi
+
+"${REPRO_VENV}/bin/python" -m pip install -U pip setuptools wheel
+"${REPRO_VENV}/bin/python" -m pip install "${DDTRACE_SOURCE}"
+
+set +e
+DD_TRACE_ENABLED=true DD_TRACE_DEBUG="${REPRO_DD_TRACE_DEBUG}" "${REPRO_VENV}/bin/python" "${REPRO_SCRIPT}"
+status=$?
+set -e
+
+if [[ ${status} -eq 124 ]]; then
+  echo "reproducer observed the deadlock (exit 124)"
+else
+  echo "reproducer did not observe the deadlock (exit ${status})"
+fi
+
+exit "${status}"


### PR DESCRIPTION
## Description

Fixes fork-child deadlocks during ddtrace periodic thread restart by keeping the child `after_in_child` path free of logging.

The deadlock happens when a logging handler lock is held by another thread at fork time. In the forked child, only the forking thread survives, so logging from ddtrace's child at-fork hook can block forever before `os.fork()` returns.

Also adds local repro scripts for the logging deadlock and fork stress scenario.

## Testing

- `scripts/lint fmt ddtrace/internal/threads.py`
- `scripts/lint cformat`
- Pre-commit hooks during commit: format/lint, mypy, codespell, clang-format, bandit, ast-grep, error-log-check
- Manual repro validation:
  - `ddtrace==4.9.1` logging repro: reproduced deadlock, exit `124`
  - `main` without this change, logging repro: reproduced deadlock, exit `124`
  - `main` with logging-only change, logging repro: child exited cleanly, exit `0`
  - `main` with logging-only change, native stress repro: `200 OK, 0 timeouts`
  - Re-adding child at-fork logging while keeping the rest of the change reproduced the deadlock again, exit `124`

## Risks

Low. The child post-fork path now intentionally suppresses restart exceptions rather than logging them, because logging itself is unsafe before `os.fork()` returns.

## Additional Notes

Release note included.
