### PR TITLE
fix(tracing): prevent possible deadlock in fork child processes

### DIFF
--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -563,9 +563,12 @@ class SpanAggregator(SpanProcessor):
             # are not dropped when the writer is recreated. This operation should not be handled after a fork.
             self.writer.flush_queue()
         # Re-create the writer to ensure it is consistent with updated configurations (ex: api_version)
-        self.writer = self.writer.recreate(
-            appsec_enabled=appsec_enabled, llmobs_enabled=llmobs_enabled, fork_child=fork_child
-        )
+        # Only forward fork_child when set, so custom/third-party TraceWriter implementations whose
+        # recreate() signature predates this keyword keep working on normal (non-fork) reset paths.
+        recreate_kwargs = {"appsec_enabled": appsec_enabled, "llmobs_enabled": llmobs_enabled}
+        if fork_child:
+            recreate_kwargs["fork_child"] = True
+        self.writer = self.writer.recreate(**recreate_kwargs)
 
         if compute_stats is not None:
             self.sampling_processor._compute_stats_enabled = compute_stats

--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -549,6 +549,7 @@ class SpanAggregator(SpanProcessor):
         appsec_enabled: Optional[bool] = None,
         llmobs_enabled: Optional[bool] = None,
         reset_buffer: bool = True,
+        fork_child: bool = False,
     ) -> None:
         """
         Resets the internal state of the SpanAggregator, including the writer, sampling processor,
@@ -562,7 +563,9 @@ class SpanAggregator(SpanProcessor):
             # are not dropped when the writer is recreated. This operation should not be handled after a fork.
             self.writer.flush_queue()
         # Re-create the writer to ensure it is consistent with updated configurations (ex: api_version)
-        self.writer = self.writer.recreate(appsec_enabled=appsec_enabled, llmobs_enabled=llmobs_enabled)
+        self.writer = self.writer.recreate(
+            appsec_enabled=appsec_enabled, llmobs_enabled=llmobs_enabled, fork_child=fork_child
+        )
 
         if compute_stats is not None:
             self.sampling_processor._compute_stats_enabled = compute_stats

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -403,7 +403,7 @@ class Tracer(object):
 
     def _child_after_fork(self):
         self._pid = getpid()
-        self._recreate(reset_buffer=True)
+        self._recreate(reset_buffer=True, fork_child=True)
         self._new_process = True
         # Re-dispatch activation post-fork: native code clears profiler span links; inherited context is unchanged.
         active = self.context_provider.active()
@@ -418,6 +418,7 @@ class Tracer(object):
         appsec_enabled: Optional[bool] = None,
         llmobs_enabled: Optional[bool] = None,
         reset_buffer: bool = True,
+        fork_child: bool = False,
     ) -> None:
         """Re-initialize the tracer's processors and trace writer"""
         # Stop the writer.
@@ -429,6 +430,7 @@ class Tracer(object):
             appsec_enabled=appsec_enabled,
             llmobs_enabled=llmobs_enabled,
             reset_buffer=reset_buffer,
+            fork_child=fork_child,
         )
         self._span_processors = _default_span_processors_factory(
             self._endpoint_call_counter_span_processor,

--- a/ddtrace/internal/ci_visibility/writer.py
+++ b/ddtrace/internal/ci_visibility/writer.py
@@ -229,7 +229,7 @@ class CIVisibilityWriter(HTTPWriter):
             super(CIVisibilityWriter, self).stop(timeout=timeout)
 
     def recreate(
-        self, appsec_enabled: Optional[bool] = None, llmobs_enabled: Optional[bool] = None
+        self, appsec_enabled: Optional[bool] = None, llmobs_enabled: Optional[bool] = None, fork_child: bool = False
     ) -> "CIVisibilityWriter":
         return self.__class__(
             intake_url=self.intake_url,

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -1,9 +1,11 @@
 import abc
 import binascii
 from collections import defaultdict
+import functools
 import gzip
 import sys
 import threading
+import weakref
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
@@ -11,7 +13,6 @@ from typing import Optional
 from typing import TextIO
 
 from ddtrace import config
-from ddtrace.internal import forksafe
 from ddtrace.internal.dist_computing.utils import in_ray_job
 from ddtrace.internal.hostname import get_hostname
 import ddtrace.internal.native as native
@@ -29,6 +30,7 @@ from ddtrace.version import __version__
 
 from ...constants import _KEEP_SPANS_RATE_KEY
 from .. import compat
+from .. import forksafe
 from .. import periodic
 from .. import process_tags
 from .. import service
@@ -110,6 +112,29 @@ class NoEncodableSpansError(Exception):
 DEFAULT_SMA_WINDOW = 10
 
 
+def make_weak_method_hook(bound_method):
+    """
+    Wrap a bound method so that it is called via a weakref to its instance.
+    If the instance has been garbage-collected, the hook is a no-op.
+    """
+    if not hasattr(bound_method, "__self__") or bound_method.__self__ is None:
+        raise TypeError("make_weak_method_hook expects a bound method")
+
+    instance = bound_method.__self__
+    func = bound_method.__func__
+    instance_ref = weakref.ref(instance)
+
+    @functools.wraps(func)
+    def hook(*args, **kwargs):
+        inst = instance_ref()
+        if inst is None:
+            # The instance was garbage-collected
+            return
+        return func(inst, *args, **kwargs)
+
+    return hook
+
+
 def _human_size(nbytes: float) -> str:
     """Return a human-readable size."""
     i = 0
@@ -129,6 +154,7 @@ class TraceWriter(metaclass=abc.ABCMeta):
         self,
         appsec_enabled: Optional[bool] = None,
         llmobs_enabled: Optional[bool] = None,
+        fork_child: bool = False,
     ) -> "TraceWriter":
         pass
 
@@ -157,6 +183,7 @@ class LogWriter(TraceWriter):
         self,
         appsec_enabled: Optional[bool] = None,
         llmobs_enabled: Optional[bool] = None,
+        fork_child: bool = False,
     ) -> "LogWriter":
         """Create a new instance of :class:`LogWriter` using the same settings from this instance
 
@@ -517,11 +544,6 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
     ) -> None:
         # FIXME: don't join() on stop(), let the caller handle this
         super(HTTPWriter, self)._stop_service()
-        if timeout is None and forksafe.is_fork_child():
-            # In a forked child the worker's OS thread does not exist (fork only
-            # copies the calling thread), so a blocking join would wait forever on
-            # a condition variable that is never signaled, hanging os.fork().
-            timeout = 0
         self.join(timeout=timeout)
 
     def on_shutdown(self):
@@ -626,9 +648,14 @@ class AgentlessTraceWriter(HTTPWriter):
         self,
         appsec_enabled: Optional[bool] = None,
         llmobs_enabled: Optional[bool] = None,
+        fork_child: bool = False,
     ) -> "AgentlessTraceWriter":
         try:
-            self.stop()
+            # In a forked child the inherited worker's OS thread does not exist
+            # (fork only copies the calling thread), so a blocking join would wait
+            # forever on a condition variable that is never signaled, hanging
+            # os.fork(). Use a non-blocking stop for that stale worker only.
+            self.stop(timeout=0) if fork_child else self.stop()
         except ServiceStatusError:
             pass
         return self.__class__(
@@ -800,7 +827,27 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         self._response_cb = response_callback
         self._stats_opt_out = stats_opt_out
 
+        before_fork_hook = make_weak_method_hook(self.before_fork_hook)
+        self._fork_hook = before_fork_hook
+        forksafe.register_before_fork(before_fork_hook)
+
         self._exporter = self._create_exporter()
+
+    def before_fork_hook(self):
+        """Bring the native runtime to a stopped state before forking.
+
+        When the PeriodicService is running, its worker's ``_before_fork`` (installed
+        in ``_start_service``) stops+joins the worker and shuts down the native runtime
+        in the parent. When it is not running, there is no worker to do so, so we stop
+        the native runtime here. Either way the child never inherits a live/half-stopped
+        native runtime, which is what caused os.fork() to block on the writer join.
+        """
+        if self.status != service.ServiceStatus.RUNNING:
+            self._exporter.stop_worker()
+
+    def __del__(self):
+        if hasattr(self, "_fork_hook") and self._fork_hook:
+            forksafe.unregister_before_fork(self._fork_hook)
 
     @staticmethod
     def _parse_otlp_headers() -> list:
@@ -859,20 +906,36 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         self._test_session_token = token
         self._exporter = self._create_exporter()
 
+    def _discard_exporter(self) -> None:
+        self._exporter.drop()
+
     def recreate(
         self,
         appsec_enabled: Optional[bool] = None,
         llmobs_enabled: Optional[bool] = None,
+        fork_child: bool = False,
     ) -> "NativeWriter":
         # Ensure AppSec metadata / LLM Observability meta_struct payload is encoded by setting
         # the API version to v0.4.
         try:
             # Stop the writer to ensure it is not running while we reconfigure it.
-            self.stop()
+            # Safety net: in a forked child the inherited worker's OS thread does not
+            # exist (fork only copies the calling thread), so a blocking join would
+            # wait forever on a condition variable that is never signaled, hanging
+            # os.fork(). The before-fork hook should already have stopped it in the
+            # parent, but use a non-blocking stop here for that stale worker just in
+            # case. Parent-side recreations keep the blocking stop so buffered traces
+            # are flushed by on_shutdown().
+            self.stop(timeout=0) if fork_child else self.stop()
         except ServiceStatusError:
             # Writers like AgentWriter may not start until the first trace is encoded.
             # Stopping them before that will raise a ServiceStatusError.
             pass
+        finally:
+            if fork_child:
+                # The inherited native exporter's tokio runtime is unusable in the
+                # child; drop it so the freshly-created writer below builds a new one.
+                self._discard_exporter()
 
         api_version = "v0.4" if (appsec_enabled or llmobs_enabled) else self._api_version
         return self.__class__(
@@ -1086,14 +1149,32 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         self,
         timeout: Optional[float] = None,
     ) -> None:
-        # FIXME: don't join() on stop(), let the caller handle this
-        super(NativeWriter, self)._stop_service()
-        if timeout is None and forksafe.is_fork_child():
-            # In a forked child the worker's OS thread does not exist (fork only
-            # copies the calling thread), so a blocking join would wait forever on
-            # a condition variable that is never signaled, hanging os.fork().
-            timeout = 0
-        self.join(timeout=timeout)
+        try:
+            # FIXME: don't join() on stop(), let the caller handle this
+            super(NativeWriter, self)._stop_service()
+            self.join(timeout=timeout)
+        # Native threads should be stopped even if the writer is not running
+        finally:
+            self._exporter.stop_worker()
+            if self._fork_hook:
+                forksafe.unregister_before_fork(self._fork_hook)
+                self._fork_hook = None
+
+    def _start_service(self, *args, **kwargs):
+        super()._start_service(*args, **kwargs)
+
+        # While the service is running, the generic threads.py before-fork machinery
+        # calls the worker's _before_fork() in the parent. Install one that fully
+        # stops the worker (join) and shuts down the native runtime before the fork,
+        # so the child never inherits a live/half-stopped runtime or a running worker.
+        def _before_fork(worker: periodic.PeriodicThread) -> None:
+            super(periodic.PeriodicThread, worker)._before_fork()
+            super(periodic.PeriodicThread, worker).join()
+            self._exporter.stop_worker()
+
+        assert self._worker is not None  # nosec
+
+        self._worker._before_fork = _before_fork.__get__(self._worker, type(self._worker))
 
     def on_shutdown(self):
         try:

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -1,11 +1,9 @@
 import abc
 import binascii
 from collections import defaultdict
-import functools
 import gzip
 import sys
 import threading
-import weakref
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
@@ -30,7 +28,6 @@ from ddtrace.version import __version__
 
 from ...constants import _KEEP_SPANS_RATE_KEY
 from .. import compat
-from .. import forksafe
 from .. import periodic
 from .. import process_tags
 from .. import service
@@ -110,29 +107,6 @@ class NoEncodableSpansError(Exception):
 # 2s timeout, the java tracer has a 10s timeout, so we set the window size
 # to 10 buckets of 1s duration.
 DEFAULT_SMA_WINDOW = 10
-
-
-def make_weak_method_hook(bound_method):
-    """
-    Wrap a bound method so that it is called via a weakref to its instance.
-    If the instance has been garbage-collected, the hook is a no-op.
-    """
-    if not hasattr(bound_method, "__self__") or bound_method.__self__ is None:
-        raise TypeError("make_weak_method_hook expects a bound method")
-
-    instance = bound_method.__self__
-    func = bound_method.__func__
-    instance_ref = weakref.ref(instance)
-
-    @functools.wraps(func)
-    def hook(*args, **kwargs):
-        inst = instance_ref()
-        if inst is None:
-            # The instance was garbage-collected
-            return
-        return func(inst, *args, **kwargs)
-
-    return hook
 
 
 def _human_size(nbytes: float) -> str:
@@ -827,27 +801,7 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         self._response_cb = response_callback
         self._stats_opt_out = stats_opt_out
 
-        before_fork_hook = make_weak_method_hook(self.before_fork_hook)
-        self._fork_hook = before_fork_hook
-        forksafe.register_before_fork(before_fork_hook)
-
         self._exporter = self._create_exporter()
-
-    def before_fork_hook(self):
-        """Bring the native runtime to a stopped state before forking.
-
-        When the PeriodicService is running, its worker's ``_before_fork`` (installed
-        in ``_start_service``) stops+joins the worker and shuts down the native runtime
-        in the parent. When it is not running, there is no worker to do so, so we stop
-        the native runtime here. Either way the child never inherits a live/half-stopped
-        native runtime, which is what caused os.fork() to block on the writer join.
-        """
-        if self.status != service.ServiceStatus.RUNNING:
-            self._exporter.stop_worker()
-
-    def __del__(self):
-        if hasattr(self, "_fork_hook") and self._fork_hook:
-            forksafe.unregister_before_fork(self._fork_hook)
 
     @staticmethod
     def _parse_otlp_headers() -> list:
@@ -919,13 +873,12 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         # the API version to v0.4.
         try:
             # Stop the writer to ensure it is not running while we reconfigure it.
-            # Safety net: in a forked child the inherited worker's OS thread does not
-            # exist (fork only copies the calling thread), so a blocking join would
-            # wait forever on a condition variable that is never signaled, hanging
-            # os.fork(). The before-fork hook should already have stopped it in the
-            # parent, but use a non-blocking stop here for that stale worker just in
-            # case. Parent-side recreations keep the blocking stop so buffered traces
-            # are flushed by on_shutdown().
+            # In a forked child the inherited worker's OS thread does not exist
+            # (fork only copies the calling thread), so a blocking join would wait
+            # forever on a condition variable that is never signaled, hanging
+            # os.fork(). Use a non-blocking stop for that stale inherited worker
+            # only; parent-side recreations keep the blocking stop so buffered
+            # traces are flushed by on_shutdown().
             self.stop(timeout=0) if fork_child else self.stop()
         except ServiceStatusError:
             # Writers like AgentWriter may not start until the first trace is encoded.
@@ -1149,32 +1102,9 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         self,
         timeout: Optional[float] = None,
     ) -> None:
-        try:
-            # FIXME: don't join() on stop(), let the caller handle this
-            super(NativeWriter, self)._stop_service()
-            self.join(timeout=timeout)
-        # Native threads should be stopped even if the writer is not running
-        finally:
-            self._exporter.stop_worker()
-            if self._fork_hook:
-                forksafe.unregister_before_fork(self._fork_hook)
-                self._fork_hook = None
-
-    def _start_service(self, *args, **kwargs):
-        super()._start_service(*args, **kwargs)
-
-        # While the service is running, the generic threads.py before-fork machinery
-        # calls the worker's _before_fork() in the parent. Install one that fully
-        # stops the worker (join) and shuts down the native runtime before the fork,
-        # so the child never inherits a live/half-stopped runtime or a running worker.
-        def _before_fork(worker: periodic.PeriodicThread) -> None:
-            super(periodic.PeriodicThread, worker)._before_fork()
-            super(periodic.PeriodicThread, worker).join()
-            self._exporter.stop_worker()
-
-        assert self._worker is not None  # nosec
-
-        self._worker._before_fork = _before_fork.__get__(self._worker, type(self._worker))
+        # FIXME: don't join() on stop(), let the caller handle this
+        super(NativeWriter, self)._stop_service()
+        self.join(timeout=timeout)
 
     def on_shutdown(self):
         try:

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -11,6 +11,7 @@ from typing import Optional
 from typing import TextIO
 
 from ddtrace import config
+from ddtrace.internal import forksafe
 from ddtrace.internal.dist_computing.utils import in_ray_job
 from ddtrace.internal.hostname import get_hostname
 import ddtrace.internal.native as native
@@ -516,6 +517,11 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
     ) -> None:
         # FIXME: don't join() on stop(), let the caller handle this
         super(HTTPWriter, self)._stop_service()
+        if timeout is None and forksafe.is_fork_child():
+            # In a forked child the worker's OS thread does not exist (fork only
+            # copies the calling thread), so a blocking join would wait forever on
+            # a condition variable that is never signaled, hanging os.fork().
+            timeout = 0
         self.join(timeout=timeout)
 
     def on_shutdown(self):
@@ -1082,6 +1088,11 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
     ) -> None:
         # FIXME: don't join() on stop(), let the caller handle this
         super(NativeWriter, self)._stop_service()
+        if timeout is None and forksafe.is_fork_child():
+            # In a forked child the worker's OS thread does not exist (fork only
+            # copies the calling thread), so a blocking join would wait forever on
+            # a condition variable that is never signaled, hanging os.fork().
+            timeout = 0
         self.join(timeout=timeout)
 
     def on_shutdown(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.12.0rc1+forkjoinfix1"
+version = "4.12.0rc1+beforefork1"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.12.0rc1+beforefork1"
+version = "4.12.0rc1+forkchilddrop1"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.12.0rc1+forkchilddrop1"
+version = "4.12.0rc1"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.12.0rc1"
+version = "4.12.0rc1+forkjoinfix1"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }


### PR DESCRIPTION
**Not for merge.** Bisection build for the delancie fork-timeout investigation. Builds an S3 wheel (`4.12.0rc1+forkchilddrop1`) to pin into dogweb staging-29.

## Mechanism (from gdb)
The forked child hangs in `PeriodicThread_join`: it inherits the writer's periodic worker object, but `fork()` copies only the calling thread, so the worker's OS thread does not exist in the child. `_child_after_fork -> recreate -> stop() -> join()` then blocks forever on a condition variable that is never signaled.

## What this build does (feasible-on-main subset)
- **Child-side non-blocking join:** an explicit `fork_child` flag is threaded through `tracer._recreate -> SpanAggregator.reset -> writer.recreate`; in the fork-child recreate only, use `stop(timeout=0)` so the stale inherited worker is not joined. Normal (parent) shutdowns keep the blocking join so buffered traces still flush.
- **Drop inherited native runtime:** in the fork-child recreate, `_discard_exporter()` -> `TraceExporter.drop()` so the child builds a fresh exporter instead of reusing the inherited tokio runtime.
- **Backward-compat:** `fork_child` is only forwarded to `recreate()` when True, so custom/third-party `TraceWriter` implementations that predate the keyword keep working on normal reset paths.

## Why not the parent-side before-fork hooks (Brett's idea)
Pausing the native runtime in the parent before fork needs `TraceExporter.stop_worker()`, which does **not** exist in main's libdatadog (v35 exposes only send/shutdown/drop/debug). The `#2193` libdatadog rev handles before-fork internally and was already tested (`forkfix2193`) without fully resolving the timeouts. Federico's #18900 (native `PeriodicThread` primitive rebuild + logging-deadlock fix) is held in reserve as the merge-ready alternative.