### PR TITLE
ci(profiling): add pre-push clang-tidy hook for native changes

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -33,6 +33,24 @@ Individual pre-commit hooks (run in numeric order):
 | `08-run-sg` | Runs `ast-grep scan` on staged Python files using rules in `.sg/rules/`. Catches anti-patterns and deprecated API usage. Skipped when no Python files are staged. |
 | `09-run-error-log-check` | Checks that `log.error()`, `add_error_log`, and `iast_error` calls use constant string literals as their first argument (LOG001) |
 
+### pre-push (blocking)
+Runs before `git push`. A non-zero exit code **aborts the push**. Contains:
+
+| Hook | Description |
+|------|-------------|
+| `01-clang-tidy-profiling` | When the push includes changes to the profiling native extension's C/C++ sources or headers, runs the same clang-tidy analysis as the CI `clang-tidy profiling` job (`-warnings-as-errors='*'`, via `ddtrace/internal/datadog/profiling/run_clang_tidy.sh`). Catches issues plain clang-format cannot, e.g. `clang-analyzer-optin.performance.Padding` (excessive struct padding). No-op when no profiling native files changed. |
+
+The clang-tidy hook is heavier than a format check (it needs `clang-tidy` 18+, `cmake`, and `jq`), so it only runs on push, only when relevant files changed, and reuses a cached build dir. clang-tidy has no auto-fix for these diagnostics, so the hook only **detects** — it never edits files.
+
+Escape hatches:
+```bash
+git push --no-verify                          # skip all pre-push hooks
+SKIP_CLANG_TIDY_PROFILING=1 git push          # skip only this check
+DDTRACE_PREPUSH_CLANG_TIDY_STRICT=1 git push  # fail (not skip) if the toolchain is missing
+```
+
+When the toolchain is not installed the hook prints a note and lets the push through (relying on CI), unless strict mode is set.
+
 ### post-merge (non-blocking)
 Runs after `git pull` or `git merge`. Non-zero exit codes are logged but **do not block** the operation (the merge has already completed). Contains:
 - **check-native-changes**: Detects changes to native code files (C, C++, Rust, Cython) and Python dependency files, and alerts you to rebuild or reinstall
@@ -214,6 +232,8 @@ hooks/
 ├── pre-commit/              # Pre-commit hooks
 │   ├── ...
 │   └── 08-run-sg            # ast-grep scan on staged Python files
+├── pre-push/                # Pre-push hooks
+│   └── 01-clang-tidy-profiling # clang-tidy on profiling native changes
 ├── post-merge/              # Post-merge hooks
 │   └── check-native-changes # Detects native code and dependency changes
 ├── post-checkout/           # Post-checkout hooks

--- a/hooks/autohook.sh
+++ b/hooks/autohook.sh
@@ -36,6 +36,7 @@ echo() {
 install() {
     hook_types=(
         "pre-commit"
+        "pre-push"
         "post-merge"
         "post-checkout"
     )
@@ -96,10 +97,10 @@ main() {
             done
             if [[ $hook_exit_code != 0 ]]
             then
-              if [[ $hook_type == "pre-commit" || $hook_type == "commit-msg" ]]
+              if [[ $hook_type == "pre-commit" || $hook_type == "commit-msg" || $hook_type == "pre-push" ]]
               then
                 echo ""
-                echo "The following $hook_type hooks failed — aborting commit:"
+                echo "The following $hook_type hooks failed — aborting $hook_type:"
                 for s in "${failed_scripts[@]}"; do
                     echo "  x $s"
                 done

--- a/hooks/pre-push/01-clang-tidy-profiling
+++ b/hooks/pre-push/01-clang-tidy-profiling
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Pre-push hook: run clang-tidy on the profiling native extension when a push
+# includes changes to its C/C++ sources or headers.
+#
+# Motivation: the "clang-tidy profiling" GitLab job runs with
+# `-warnings-as-errors='*'` and catches issues that plain clang-format cannot,
+# e.g. clang-analyzer-optin.performance.Padding (excessive struct padding). These
+# only surface in CI today, costing a full round-trip. Running the same analysis
+# locally before push catches them early. clang-tidy has no auto-fix for most of
+# these diagnostics, so this hook only *detects* — it does not modify files.
+#
+# It is gated on profiling native changes and is a no-op otherwise. Because the
+# analysis needs a full toolchain (clang-tidy 18+, cmake, jq) it is skipped with
+# a friendly note when the toolchain is missing, unless strict mode is enabled.
+#
+# Escape hatches:
+#   git push --no-verify                       # skip all pre-push hooks
+#   SKIP_CLANG_TIDY_PROFILING=1 git push       # skip just this check
+#   DDTRACE_PREPUSH_CLANG_TIDY_STRICT=1 git push  # fail (not skip) if toolchain missing
+
+set -euo pipefail
+
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log() { printf "%b\n" "$@"; }
+
+if [[ "${SKIP_CLANG_TIDY_PROFILING:-0}" == "1" ]]; then
+    log "${YELLOW}clang-tidy profiling pre-push check skipped (SKIP_CLANG_TIDY_PROFILING=1).${NC}"
+    exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PROFILING_DIR="${REPO_ROOT}/ddtrace/internal/datadog/profiling"
+RUN_SCRIPT="${PROFILING_DIR}/run_clang_tidy.sh"
+ZERO="0000000000000000000000000000000000000000"
+
+# Only C/C++ under the profiling tree matter for this analysis.
+PROFILING_CPP_RE='^ddtrace/internal/datadog/profiling/.*\.(c|cc|cpp|h|hpp)$'
+
+# Collect the set of files this push would add relative to origin/main. Reads the
+# standard pre-push stdin format: "<local_ref> <local_sha> <remote_ref> <remote_sha>".
+collect_changed_files() {
+    local local_ref local_sha remote_ref remote_sha base
+    while read -r local_ref local_sha remote_ref remote_sha; do
+        [[ "${local_sha}" == "${ZERO}" ]] && continue # branch deletion
+        if [[ "${remote_sha}" == "${ZERO}" ]]; then
+            # New branch on the remote: diff against the merge-base with main.
+            base="$(git merge-base "${local_sha}" origin/main 2>/dev/null || true)"
+        else
+            base="${remote_sha}"
+        fi
+        if [[ -n "${base}" ]]; then
+            git diff --name-only "${base}" "${local_sha}" 2>/dev/null || true
+        else
+            git show --pretty="" --name-only "${local_sha}" 2>/dev/null || true
+        fi
+    done | sort -u
+}
+
+CHANGED_FILES="$(collect_changed_files || true)"
+if ! grep -qE "${PROFILING_CPP_RE}" <<<"${CHANGED_FILES}"; then
+    exit 0 # no profiling native changes in this push
+fi
+
+log "${BLUE}Profiling native changes detected in this push — running clang-tidy...${NC}"
+
+# Verify the toolchain is present before attempting the (heavy) analysis.
+missing=()
+have_run_clang_tidy=0
+for cmd in run-clang-tidy run-clang-tidy-20 run-clang-tidy-19 run-clang-tidy-18; do
+    if command -v "${cmd}" >/dev/null 2>&1; then
+        have_run_clang_tidy=1
+        break
+    fi
+done
+[[ "${have_run_clang_tidy}" == "0" ]] && ! command -v clang-tidy >/dev/null 2>&1 && missing+=("clang-tidy / run-clang-tidy (v18+)")
+command -v cmake >/dev/null 2>&1 || missing+=("cmake")
+command -v jq >/dev/null 2>&1 || missing+=("jq")
+[[ -f "${RUN_SCRIPT}" ]] || missing+=("${RUN_SCRIPT}")
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+    log "${YELLOW}clang-tidy profiling check skipped — missing:${NC}"
+    for m in "${missing[@]}"; do log "  ${YELLOW}•${NC} ${m}"; done
+    if [[ "${DDTRACE_PREPUSH_CLANG_TIDY_STRICT:-0}" == "1" ]]; then
+        log "${RED}Strict mode (DDTRACE_PREPUSH_CLANG_TIDY_STRICT=1): failing.${NC}"
+        exit 1
+    fi
+    log "${YELLOW}Install the toolchain (clang-tidy 18+, cmake, jq) to enable this check,${NC}"
+    log "${YELLOW}or rely on the CI 'clang-tidy profiling' job. Continuing push.${NC}"
+    exit 0
+fi
+
+# run_clang_tidy.sh caches its build dir, so repeat runs only re-analyze deltas.
+if ! bash "${RUN_SCRIPT}"; then
+    log ""
+    log "${RED}clang-tidy found issues in the profiling native code (see above).${NC}"
+    log "${YELLOW}This is the same analysis as the CI 'clang-tidy profiling' job.${NC}"
+    log "${YELLOW}Fix the reported diagnostics, or bypass with one of:${NC}"
+    log "  ${GREEN}SKIP_CLANG_TIDY_PROFILING=1 git push${NC}"
+    log "  ${GREEN}git push --no-verify${NC}"
+    exit 1
+fi
+
+log "${GREEN}clang-tidy profiling check passed.${NC}"
+exit 0


### PR DESCRIPTION
## Description

The "clang-tidy profiling" GitLab job runs with -warnings-as-errors and catches issues plain clang-format cannot (e.g. clang-analyzer-optin.performance.Padding), but only in CI, costing a round-trip. Add an Autohook pre-push stage that runs the same analysis locally when a push touches the profiling extension C/C++ files.

### Why

Discovered the issue when working on another PR. Had to make the following change manually: https://github.com/DataDog/dd-trace-py/pull/18798/changes/e7bc7f9e68ee0640a3a379a5fb71e477e8aeeb08

### Changes

- Wire a blocking "pre-push" stage into hooks/autohook.sh (install + abort-on-fail).
- hooks/pre-push/01-clang-tidy-profiling: gated on profiling native changes, reuses run_clang_tidy.sh with its cached build dir, and skips gracefully with a note when the toolchain (clang-tidy 18+, cmake, jq) is absent. Escape hatches: SKIP_CLANG_TIDY_PROFILING=1, --no-verify, DDTRACE_PREPUSH_CLANG_TIDY_STRICT=1.

## Testing

TODO

## Additional Notes

* `clang-tidy` has no auto-fix for these diagnostics, so the hook only detects. Author would have to manually make the changes (just as they would have to currently do when the CI job fails)
