### PR TITLE
fix(tracing): prevent possible deadlock in fork child

### DIFF
--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -479,35 +479,23 @@ typedef struct periodic_thread
     std::unique_ptr<std::thread> _thread;
 } PeriodicThread;
 
-static int
-remove_periodic_thread_entries_for_self(PyObject* periodic_threads, PeriodicThread* self)
+// ----------------------------------------------------------------------------
+// Remove self's entry from the periodic-thread registry, but ONLY if the entry
+// still maps to self. Thread ids are recyclable: after a worker exits, a newer
+// worker can reuse its ident and register itself. A stale thread (via its own
+// exit, fork cleanup, or a GC-triggered dealloc) must therefore never delete by
+// ident blindly, or it evicts the live worker that reused the id. PyDict_GetItem
+// returns a borrowed ref and never raises; the GIL must be held so the
+// get/delete pair is atomic.
+static void
+unregister_periodic_thread_if_self(PyObject* periodic_threads, PyObject* ident, PyObject* self)
 {
-    if (periodic_threads == NULL)
-        return 0;
-
-    PyObject* keys = PyDict_Keys(periodic_threads);
-    if (keys == NULL)
-        return -1;
-
-    Py_ssize_t size = PyList_GET_SIZE(keys);
-    for (Py_ssize_t i = 0; i < size; i++) {
-        PyObject* key = PyList_GET_ITEM(keys, i); // Borrowed reference.
-        PyObject* value = PyDict_GetItemWithError(periodic_threads, key);
-        if (value == NULL) {
-            if (PyErr_Occurred()) {
-                Py_DECREF(keys);
-                return -1;
-            }
-            continue;
-        }
-        if (value == (PyObject*)self && PyDict_DelItem(periodic_threads, key) < 0) {
-            Py_DECREF(keys);
-            return -1;
-        }
+    if (periodic_threads == NULL || ident == NULL)
+        return;
+    if (PyDict_GetItem(periodic_threads, ident) == self) {
+        if (PyDict_DelItem(periodic_threads, ident) < 0)
+            PyErr_Clear();
     }
-
-    Py_DECREF(keys);
-    return 0;
 }
 
 // ----------------------------------------------------------------------------
@@ -735,14 +723,12 @@ _PeriodicThread_do_start(PeriodicThread* self, bool reset_next_call_time = false
 
                     // Retrieve the thread ID
                     {
-                        // On a re-register (fork restart) drop any stale entries
-                        // for this worker before installing the real child thread
-                        // id. Skipped on first start (ident is None), where there
-                        // is nothing to clean and a full scan would be overhead.
-                        if (self->ident != Py_None && state->periodic_threads != NULL) {
-                            if (remove_periodic_thread_entries_for_self(state->periodic_threads, self) < 0)
-                                PyErr_Clear();
-                        }
+                        // On a re-register (fork restart) drop the stale entry for
+                        // this worker before installing the real child thread id.
+                        // Skipped on first start (ident is None), where there is
+                        // nothing to clean.
+                        if (self->ident != Py_None)
+                            unregister_periodic_thread_if_self(state->periodic_threads, self->ident, (PyObject*)self);
                         Py_DECREF(self->ident);
                         self->ident = PyLong_FromLong((long)PyThreadState_Get()->thread_id);
 
@@ -826,7 +812,7 @@ _PeriodicThread_do_start(PeriodicThread* self, bool reset_next_call_time = false
                             PeriodicThread__on_shutdown(self);
 
                         // Remove the thread from the mapping of active threads.
-                        PyDict_DelItem(state->periodic_threads, self->ident);
+                        unregister_periodic_thread_if_self(state->periodic_threads, self->ident, (PyObject*)self);
                     }
 
                     // Inner scope ends here. GILGuard::~GILGuard releases the GIL and
@@ -1109,14 +1095,11 @@ PeriodicThread__after_fork(PeriodicThread* self, PyObject* args, PyObject* kwarg
         // exited in the parent; leaving it set means join() returns immediately
         // rather than blocking indefinitely.
 
-        // Remove the stale parent-process ident from periodic_threads so
-        // this thread is not picked up by subsequent fork cycles. The thread
-        // removes itself on exit, so the entry may already be gone — ignore
-        // the KeyError in that case.
-        if (self->ident != Py_None && self->_state != nullptr && self->_state->periodic_threads != NULL) {
-            if (PyDict_DelItem(self->_state->periodic_threads, self->ident) < 0)
-                PyErr_Clear();
-        }
+        // Remove the stale parent-process ident from periodic_threads so this
+        // thread is not picked up by subsequent fork cycles. The thread removes
+        // itself on exit, so the entry may already be gone.
+        if (self->ident != Py_None && self->_state != nullptr)
+            unregister_periodic_thread_if_self(self->_state->periodic_threads, self->ident, (PyObject*)self);
         Py_DECREF(self->ident);
         Py_INCREF(Py_None);
         self->ident = Py_None;
@@ -1174,14 +1157,10 @@ PeriodicThread_dealloc(PeriodicThread* self)
     //
     // Full cleanup is therefore correct in all cases;
 
-    // Unmap the PeriodicThread from periodic_threads. Use unconditional DelItem
-    // + error clear instead of Contains+DelItem to avoid a TOCTOU race in
-    // free-threaded mode: another thread may delete the key between the two
-    // calls. KeyError on a missing key is harmless.
-    if (self->ident != NULL && self->_state != nullptr && self->_state->periodic_threads != NULL) {
-        if (PyDict_DelItem(self->_state->periodic_threads, self->ident) < 0)
-            PyErr_Clear();
-    }
+    // Unmap the PeriodicThread from periodic_threads, but only if the entry
+    // still belongs to self (see unregister_periodic_thread_if_self).
+    if (self->ident != NULL && self->_state != nullptr)
+        unregister_periodic_thread_if_self(self->_state->periodic_threads, self->ident, (PyObject*)self);
 
     PeriodicThread_clear(self);
 

--- a/releasenotes/notes/fix-fork-child-periodic-thread-deadlock-622b59e666e71705.yaml
+++ b/releasenotes/notes/fix-fork-child-periodic-thread-deadlock-622b59e666e71705.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    tracing: This fix resolves a rare issue that could cause an application to
+    hang after forking a child process.

--- a/tests/internal/test_periodic.py
+++ b/tests/internal/test_periodic.py
@@ -738,6 +738,152 @@ def test_periodic_thread_stop_without_join_forksafe():
         t.join()
 
 
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
+@pytest.mark.subprocess(
+    timeout=120,
+    # The regression signal is the exit status only: 0 = all forks reaped
+    # cleanly, non-zero = a child hung or exited abnormally. Skip the stdout and
+    # stderr checks because a full-featured startup can log benign noise, and the
+    # reproduction does not depend on traces actually reaching an agent.
+    out=None,
+    err=None,
+    env=dict(
+        # Populate the full periodic-thread set (writer, profiler, runtime
+        # metrics, remote config, telemetry) so the recycled-ident hazard has
+        # live workers to collide with. Remote config and telemetry are on by
+        # default and profiling/runtime metrics are not, but enable all of them
+        # explicitly so the scenario is deterministic regardless of defaults.
+        DD_PROFILING_ENABLED="true",
+        DD_RUNTIME_METRICS_ENABLED="true",
+        DD_REMOTE_CONFIGURATION_ENABLED="true",
+        DD_INSTRUMENTATION_TELEMETRY_ENABLED="true",
+    ),
+)
+def test_writer_recreate_fork_child_does_not_deadlock():
+    """Regression: a forked child must not hang joining a periodic thread that an
+    identity-blind registry delete dropped after a recycled thread id.
+
+    Root cause (``ddtrace/internal/_threads.cpp``): entries in the module-level
+    ``periodic_threads`` dict were deleted by thread ident without checking that
+    the entry still belonged to the deleting thread. Thread ids are recyclable,
+    so this sequence corrupted the registry and deadlocked a fork child:
+
+      1. The tracer recreates its writer; the old writer worker exits, freeing
+         its thread id and removing its ``periodic_threads`` entry.
+      2. A new writer worker starts and the OS recycles that same thread id,
+         registering ``periodic_threads[ident] = new_worker``.
+      3. Cyclic GC later collects the dropped old-writer<->worker reference
+         cycle; the old worker's ``tp_dealloc`` runs
+         ``PyDict_DelItem(periodic_threads, ident)`` which — because the id was
+         recycled — evicts the LIVE new worker's entry.
+      4. The live worker is now absent from ``periodic_threads``, so
+         ``threads._before_fork`` never stops/joins it and its ``_stopped``
+         event is never set.
+      5. In the child, ``_child_after_fork`` recreates the writer, which stops
+         and joins that worker via ``PeriodicThread.join(None)`` — waiting
+         forever on a condition variable nothing will ever set. The child hangs.
+
+    The fix guards every by-ident registry delete with an identity check
+    (``PyDict_GetItem(...) == self``), so a stale thread can only remove its own
+    entry, never a live worker that recycled the id.
+
+    This drives the real scenario: ``writer.recreate()`` + ``gc.collect()`` +
+    ``os.fork()`` in a loop, with each child writing a span and exiting. The
+    parent watches each child with a ``waitpid(WNOHANG)`` deadline (no signals),
+    SIGKILLs any child that hangs, and also fails if a child exits abnormally
+    (e.g. a native fault from the same corruption). A hang or fault therefore
+    fails the test rather than hanging the suite, and the subprocess ``timeout``
+    is a backstop.
+
+    Note: reproducing the eviction requires the OS to recycle the freed
+    writer-worker thread id, which is libc/timing dependent, so this is a
+    best-effort probabilistic reproduction. The sanity check below guards
+    against the test silently degrading into a no-op if the periodic threads
+    fail to start.
+    """
+    import gc
+    import os
+    import time
+
+    import ddtrace.auto  # noqa: F401  # start tracer + periodic threads
+    from ddtrace.internal._threads import periodic_threads
+    from ddtrace.trace import tracer
+
+    NFORKS = 25
+    # Generous: children exit in milliseconds, so only a genuine hang waits this
+    # long. Large enough that a slow child on an oversubscribed CI host is not
+    # mistaken for a hang.
+    DEADLINE = 30.0
+
+    # Warm up: emit a span so the tracer and its periodic threads are running,
+    # then let them all spin up.
+    with tracer.trace("warmup"):
+        pass
+    time.sleep(1.0)
+
+    # Anti-rot guard: the recycled-ident collision only arises with periodic
+    # threads actually running. If the feature set failed to start, the test
+    # would pass vacuously and silently stop guarding the regression.
+    assert len(periodic_threads) >= 3, (
+        "expected several periodic threads to be running; got %d — the fork "
+        "scenario would not exercise the recycled-ident path" % len(periodic_threads)
+    )
+
+    def _one_fork(idx):
+        # Churn the writer and force a cyclic GC so a dropped old-worker cycle is
+        # collected while a new worker may have recycled the freed thread id.
+        agg = tracer._span_aggregator
+        agg.writer = agg.writer.recreate()
+        with tracer.trace("pre-%d" % idx):
+            pass
+        gc.collect()
+
+        pid = os.fork()
+        if pid == 0:
+            # Child: _child_after_fork already ran in the at-fork hooks. If the
+            # bug is present the child never reaches here — it deadlocks in
+            # _child_after_fork -> writer.recreate -> PeriodicThread.join(None).
+            try:
+                with tracer.trace("child-%d" % idx):
+                    pass
+            finally:
+                os._exit(0)
+
+        # Parent: signal-free watchdog. Poll for the child; SIGKILL and report a
+        # hang if it does not exit within the deadline. Return the child's wait
+        # status word, or None if it hung.
+        deadline = time.monotonic() + DEADLINE
+        while True:
+            try:
+                wpid, status = os.waitpid(pid, os.WNOHANG)
+            except ChildProcessError:
+                return 0  # already reaped; treat as a clean exit
+            if wpid == pid:
+                return status
+            if time.monotonic() > deadline:
+                try:
+                    os.kill(pid, 9)
+                    os.waitpid(pid, 0)
+                except (ChildProcessError, ProcessLookupError):
+                    pass
+                return None  # hung
+            time.sleep(0.02)
+
+    failed = False
+    for i in range(NFORKS):
+        status = _one_fork(i)
+        # None => the child hung (deadlocked in the at-fork hook). A non-zero
+        # status => the child crashed or exited abnormally (e.g. a native fault
+        # from the same registry corruption). Either is a regression.
+        if status is None or not (os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0):
+            failed = True
+            break
+
+    # Exit hard so the code reflects only whether a child hung/faulted, skipping
+    # the interpreter's atexit join of the periodic threads.
+    os._exit(2 if failed else 0)
+
+
 def test_periodic_thread_naming():
     """Test that native thread names are set correctly with various formats.
 

--- a/tests/internal/test_periodic.py
+++ b/tests/internal/test_periodic.py
@@ -763,7 +763,7 @@ def test_writer_recreate_fork_child_does_not_deadlock():
     """Regression: a forked child must not hang joining a periodic thread that an
     identity-blind registry delete dropped after a recycled thread id.
 
-    Root cause (``ddtrace/internal/_threads.cpp``): entries in the module-level
+    Root cause (ddtrace/internal/_threads.cpp): entries in the module-level
     ``periodic_threads`` dict were deleted by thread ident without checking that
     the entry still belonged to the deleting thread. Thread ids are recyclable,
     so this sequence corrupted the registry and deadlocked a fork child:


### PR DESCRIPTION
## Description

Live periodic threads can be orphaned from the `periodic_threads` tracker when a thread ident of a stopped thread is reused.

The necessary steps:

1. Worker 1 is started and tracked in `periodic_threads`
2. Worker 1 is stopped and removed from `periodic_threads`
3. Worker 2 is started, re-uses Worker 1's ident, and is tracked in `periodic_threads`
4. Worker 1 is GC'd triggering a call to remove it from `periodic_threads`
5. Re-removing Worker 1's ident from `periodic_threads` then orphans Worker 2 such that it is no longer tracked
6. `os.fork()` is called, and pre-fork hooks are not called on Worker 2 since it is not tracked in `periodic_threads`
7. post-fork hooks are called, Worker 2 is in a deadlocked state

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
