### PR TITLE
fix(aap): advertise blocking capabilities after one-click activation [backport 3.19]

### DIFF
--- a/ddtrace/appsec/_capabilities.py
+++ b/ddtrace/appsec/_capabilities.py
@@ -60,6 +60,9 @@ _ALL_ASM_BLOCKING = (
 _ALL_RASP = Flags.ASM_RASP_SQLI | Flags.ASM_RASP_LFI | Flags.ASM_RASP_SSRF | Flags.ASM_RASP_SHI | Flags.ASM_RASP_CMDI
 _FEATURE_REQUIRED = Flags.ASM_ACTIVATION | Flags.ASM_AUTO_USER
 
+# Mask of every bit _rc_capabilities() may set, so re-advertising replaces only ASM-owned bits.
+_ALL_ASM_CAPABILITIES = Flags.ASM_ACTIVATION | Flags.ASM_AUTO_USER | _ALL_ASM_BLOCKING | _ALL_RASP
+
 
 def _asm_feature_is_required() -> bool:
     flags = _rc_capabilities()

--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -6,6 +6,7 @@ from typing import List
 from typing import Optional
 from typing import Sequence
 
+from ddtrace.appsec._capabilities import _ALL_ASM_CAPABILITIES
 from ddtrace.appsec._capabilities import _asm_feature_is_required
 from ddtrace.appsec._capabilities import _rc_capabilities
 from ddtrace.appsec._constants import APPSEC
@@ -158,6 +159,9 @@ def _process_asm_features(payload_list: List[Payload], local_tracer: Tracer, cac
             disable_asm(local_tracer)
     if "auto_user_instrum" in result:
         asm_config._auto_user_instrumentation_rc_mode = result["auto_user_instrum"].get("mode", None)
+    if "asm" in result or "auto_user_instrum" in result:
+        # Re-advertise capabilities so blocking/RASP follow one-click activation/deactivation.
+        remoteconfig_poller.update_capabilities(_ALL_ASM_CAPABILITIES, _rc_capabilities())
 
 
 def disable_asm(local_tracer: Tracer):

--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -261,6 +261,10 @@ class RemoteConfigClient:
         for capability in capabilities:
             self._capabilities |= capability
 
+    def update_capabilities(self, mask: int, capabilities: int) -> None:
+        """Replace the bits within ``mask`` with ``capabilities`` (can clear bits, unlike add_capabilities)."""
+        self._capabilities = (self._capabilities & ~mask) | (capabilities & mask)
+
     def update_product_callback(self, product_name: str, callback: Callable) -> bool:
         pubsub_instance = self._products.get(product_name)
         if pubsub_instance:

--- a/ddtrace/internal/remoteconfig/worker.py
+++ b/ddtrace/internal/remoteconfig/worker.py
@@ -179,6 +179,10 @@ class RemoteConfigPoller(periodic.PeriodicService):
         except Exception:
             log.debug("error starting the RCM client", exc_info=True)
 
+    def update_capabilities(self, mask: enum.IntFlag, capabilities: enum.IntFlag) -> None:
+        """Re-advertise ``capabilities`` within ``mask`` when a product's set changes after registration."""
+        self._client.update_capabilities(int(mask), int(capabilities))
+
     def unregister(self, product):
         if rc_config.skip_shutdown:
             # If we are asked to skip shutdown, then we likely don't want to

--- a/releasenotes/notes/asm-rc-capabilities-one-click-82a42347f0d0cc7c.yaml
+++ b/releasenotes/notes/asm-rc-capabilities-one-click-82a42347f0d0cc7c.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    AAP: Fix an issue which could make the Threat Protection panel wrongly report
+    that a library update was required.

--- a/tests/appsec/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/appsec/test_remoteconfiguration.py
@@ -162,6 +162,45 @@ def test_rc_activation_capabilities(tracer, remote_config_worker, env_rules, exp
         assert _appsec_rc_capabilities() == expected
 
 
+def test_rc_capabilities_updated_after_one_click_activation(tracer, remote_config_worker):
+    """Regression test for capabilities not being advertised after one-click activation.
+
+    Capabilities are computed once at registration time (while AppSec is still disabled
+    for a remotely-activated service) and the RC client only accumulates them. Before the
+    fix, the client kept advertising only ASM_ACTIVATION after a one-click activation, so
+    the backend reported "UPDATE REQUIRED" for blocking even though it was fully functional.
+    The client bitmask must reflect the live ASM state after activation and deactivation.
+    """
+    from ddtrace.appsec._capabilities import _ALL_ASM_BLOCKING
+    from ddtrace.appsec._capabilities import Flags
+    from ddtrace.appsec._capabilities import _rc_capabilities
+
+    enable_config = [build_payload("ASM_FEATURES", {"asm": {"enabled": True}}, "config")]
+    disable_config = [build_payload("ASM_FEATURES", {"asm": {}}, "config")]
+
+    with override_global_config(dict(_remote_config_enabled=True, _asm_enabled=False, _asm_can_be_enabled=True)):
+        enable_appsec_rc()
+
+        # AppSec is not enabled yet (remote activation pending): no blocking capabilities.
+        assert remoteconfig_poller._client._capabilities & int(_ALL_ASM_BLOCKING) == 0
+        assert remoteconfig_poller._client._capabilities & int(Flags.ASM_ACTIVATION)
+
+        # One-click activation: blocking (and RASP) capabilities must now be advertised.
+        _appsec_callback(enable_config, test_tracer=tracer)
+        assert asm_config._asm_enabled
+        assert remoteconfig_poller._client._capabilities & int(_ALL_ASM_BLOCKING) == int(_ALL_ASM_BLOCKING)
+        assert remoteconfig_poller._client._capabilities == int(_rc_capabilities())
+
+        # One-click deactivation: blocking capabilities must be dropped again.
+        _appsec_callback(disable_config, test_tracer=tracer)
+        assert not asm_config._asm_enabled
+        assert remoteconfig_poller._client._capabilities & int(_ALL_ASM_BLOCKING) == 0
+        assert remoteconfig_poller._client._capabilities & int(Flags.ASM_ACTIVATION)
+        assert remoteconfig_poller._client._capabilities == int(_rc_capabilities())
+
+    disable_appsec_rc()
+
+
 def test_rc_activation_validate_products(tracer, remote_config_worker):
     with override_global_config(dict(_asm_enabled=False, _remote_config_enabled=True, api_version="v0.4")):
         assert not remoteconfig_poller._worker


### PR DESCRIPTION
APPSEC-69019

## Description

Backport to 3.19 of #18894. When AAP is enabled via one-click (remote) activation instead of `DD_APPSEC_ENABLED`, the RC blocking capabilities (IP, user, in-app WAF, custom rules) were never advertised, so Threat Protection wrongly reported "UPDATE REQUIRED". Fix: re-advertise `_rc_capabilities()` on remote activation/deactivation via a new masked `update_capabilities()` that can also clear ASM-owned bits.

Manually adapted (not a clean cherry-pick) because 3.19 predates the RC single-subscriber / decouple-enablement refactors: the poller uses `register()` and `_process_asm_features(..., local_tracer)`. The fix itself is identical.

## Testing

New regression test asserting the client bitmask across activation→deactivation.

## Risks

Low — scoped to ASM-owned capability bits; `add_capabilities` and the env-var path are unchanged.

## Additional Notes

Workaround for customers: set `DD_APPSEC_ENABLED=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)