### PR TITLE
fix(tracer): lightweight fork reset in child

### DIFF
--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -552,15 +552,15 @@ class SpanAggregator(SpanProcessor):
     ) -> None:
         """
         Resets the internal state of the SpanAggregator, including the writer, sampling processor,
-        user-defined processors, and optionally the trace buffer and span metrics.
+        and user-defined processors, and optionally the trace buffer and span metrics.
 
-        This method is typically used after a process fork or during runtime reconfiguration.
-        Arguments that are None will not override existing values.
+        This method is typically used during runtime reconfiguration (e.g. Tracer.configure()).
+        It must not be used after a fork -- see reset_after_fork(). Arguments that are None will
+        not override existing values.
         """
-        if not reset_buffer:
-            # Flush any encoded spans in the writer's buffer. This operation ensures encoded spans
-            # are not dropped when the writer is recreated. This operation should not be handled after a fork.
-            self.writer.flush_queue()
+        # Flush any encoded spans in the writer's buffer. This operation ensures encoded spans
+        # are not dropped when the writer is recreated.
+        self.writer.flush_queue()
         # Re-create the writer to ensure it is consistent with updated configurations (ex: api_version)
         self.writer = self.writer.recreate(appsec_enabled=appsec_enabled, llmobs_enabled=llmobs_enabled)
 
@@ -574,10 +574,29 @@ class SpanAggregator(SpanProcessor):
             self.user_processors = user_processors
 
         # Reset the trace buffer and span metrics.
-        # Useful when forking to prevent sending duplicate spans from parent and child processes.
         if reset_buffer:
             self._traces = defaultdict(lambda: _Trace())
             self._span_metrics = {
                 "spans_created": defaultdict(int),
                 "spans_finished": defaultdict(int),
             }
+
+    def reset_after_fork(self) -> None:
+        """
+        Resets the internal state of the SpanAggregator after a fork, without blocking.
+
+        The writer's periodic thread was already stopped by forksafe hooks before the fork and
+        does not survive it, so reset() (which calls recreate(), which stops and joins the
+        worker) must not be used here -- it would block forever waiting on a thread that no
+        longer exists. writer.reset_after_fork() only rebuilds the fork-unsafe bits (buffers,
+        connections/native handles) without touching the worker/service state.
+
+        The trace buffer and span metrics are also cleared, to prevent sending duplicate spans
+        from parent and child processes.
+        """
+        self.writer.reset_after_fork()
+        self._traces = defaultdict(lambda: _Trace())
+        self._span_metrics = {
+            "spans_created": defaultdict(int),
+            "spans_finished": defaultdict(int),
+        }

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -403,12 +403,22 @@ class Tracer(object):
 
     def _child_after_fork(self):
         self._pid = getpid()
-        self._recreate(reset_buffer=True)
+        self._reset_after_fork()
         self._new_process = True
         # Re-dispatch activation post-fork: native code clears profiler span links; inherited context is unchanged.
         active = self.context_provider.active()
         if active is not None:
             core.dispatch("ddtrace.context_provider.activate", (active,))
+
+    def _reset_after_fork(self) -> None:
+        """Re-initialize the tracer's processors and trace writer after a fork, without blocking.
+
+        See SpanAggregator.reset_after_fork() for why this must not go through _recreate().
+        """
+        self._span_aggregator.reset_after_fork()
+        self._span_processors = _default_span_processors_factory(
+            self._endpoint_call_counter_span_processor,
+        )
 
     def _recreate(
         self,
@@ -419,7 +429,10 @@ class Tracer(object):
         llmobs_enabled: Optional[bool] = None,
         reset_buffer: bool = True,
     ) -> None:
-        """Re-initialize the tracer's processors and trace writer"""
+        """Re-initialize the tracer's processors and trace writer.
+
+        This must not be used after a fork -- see _reset_after_fork().
+        """
         # Stop the writer.
         # This will stop the periodic thread in HTTPWriters, preventing memory leaks and unnecessary I/O.
         self._span_aggregator.reset(

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -136,6 +136,16 @@ class TraceWriter(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
+    def reset_after_fork(self) -> None:
+        """Reset the writer's state in a forked child.
+
+        Unlike :meth:`recreate`, this must not stop/join the periodic worker: fork-safety
+        hooks already guarantee it was stopped before the fork, and its OS thread does not
+        survive fork regardless. Only fork-unsafe resources (buffers, sockets, native
+        handles) need to be dropped/rebuilt here.
+        """
+
+    @abc.abstractmethod
     def write(self, spans: Optional[list["Span"]] = None) -> None:
         pass
 
@@ -166,6 +176,9 @@ class LogWriter(TraceWriter):
         return writer
 
     def stop(self, timeout: Optional[float] = None) -> None:
+        return
+
+    def reset_after_fork(self) -> None:
         return
 
     def write(self, spans: Optional[list["Span"]] = None) -> None:
@@ -517,6 +530,22 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
         # FIXME: don't join() on stop(), let the caller handle this
         super(HTTPWriter, self)._stop_service()
         self.join(timeout=timeout)
+
+    def reset_after_fork(self) -> None:
+        # The periodic worker's OS thread does not survive fork; forksafe hooks already
+        # guarantee it was stopped before the fork happened, so there's nothing to stop()/join()
+        # here. The connection's socket fd is inherited/shared with the parent though, so it
+        # must be dropped (not reused) -- a fresh one is opened lazily on next flush, same as
+        # for a newly constructed writer.
+        self._reset_connection()
+        self._clients = [
+            client.__class__(self._buffer_size, self._max_payload_size)  # type: ignore[call-arg,arg-type]
+            for client in self._clients
+        ]
+        self._metrics = defaultdict(int)
+        self._drop_sma = SimpleMovingAverage(DEFAULT_SMA_WINDOW)
+        self._worker = None
+        self.status = service.ServiceStatus.STOPPED
 
     def on_shutdown(self):
         try:
@@ -1083,6 +1112,28 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         # FIXME: don't join() on stop(), let the caller handle this
         super(NativeWriter, self)._stop_service()
         self.join(timeout=timeout)
+
+    def reset_after_fork(self) -> None:
+        # The periodic worker's OS thread does not survive fork; forksafe hooks already
+        # guarantee it was stopped before the fork happened, so there's nothing to stop()/join()
+        # here. The exporter's own background workers (agent /info poller, telemetry, stats
+        # flush) are dropped by the shared native runtime's fork handling and are never
+        # resurrected for an existing TraceExporter, so it must be rebuilt to get them back.
+        #
+        # The old exporter must be explicitly drop()'d (a no-op discard) before being replaced.
+        # Otherwise, letting its refcount hit zero here triggers TraceExporterPy's Rust Drop impl,
+        # which calls the blocking, network-aware shutdown() -- and since the shared runtime's
+        # worker threads are gone post-fork, that call can hang forever instead of timing out.
+        self._exporter.drop()
+        self._exporter = self._create_exporter()
+        self._clients = [
+            client.__class__(self._buffer_size, self._max_payload_size)  # type: ignore[call-arg,arg-type]
+            for client in self._clients
+        ]
+        self._metrics = defaultdict(int)
+        self._drop_sma = SimpleMovingAverage(DEFAULT_SMA_WINDOW)
+        self._worker = None
+        self.status = service.ServiceStatus.STOPPED
 
     def on_shutdown(self):
         try:

--- a/releasenotes/notes/fix-tracer-lightweight-fork-cleanup-be93f0607f3b69ad.yaml
+++ b/releasenotes/notes/fix-tracer-lightweight-fork-cleanup-be93f0607f3b69ad.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    tracer: fixed an issue that could have caused fork child processes to hang
+    indefinitely.

--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -265,6 +265,9 @@ def test_custom_writer():
         def recreate(self) -> TraceWriter:
             return self
 
+        def reset_after_fork(self) -> None:
+            pass
+
         def stop(self, timeout: Optional[float] = None) -> None:
             pass
 

--- a/tests/tracer/test_processors.py
+++ b/tests/tracer/test_processors.py
@@ -208,6 +208,44 @@ def test_aggregator_reset_with_args():
     assert len(aggr._span_metrics["spans_created"]) == 1
 
 
+def test_aggregator_reset_after_fork_does_not_recreate_writer():
+    """
+    Test that reset_after_fork() rebuilds the writer's fork-unsafe internals in place (via
+    writer.reset_after_fork()) rather than replacing the writer object with recreate(), and
+    resets trace buffers/span metrics like reset() does. Unlike reset(), it must never call
+    writer.recreate()/stop()/join(), since the worker's OS thread does not survive a fork.
+    """
+    dd_proc = DummyProcessor()
+    user_proc = DummyProcessor()
+    aggr = SpanAggregator(
+        partial_flush_enabled=False,
+        partial_flush_min_spans=1,
+        dd_processors=[dd_proc],
+        user_processors=[user_proc],
+    )
+    writer = NativeWriter("http://localhost:8126")
+    aggr.writer = writer
+    span = Span("span", on_finish=[aggr.on_span_finish])
+    aggr.on_span_start(span)
+
+    assert span.trace_id in aggr._traces
+    assert len(aggr._span_metrics["spans_created"]) == 1
+
+    with (
+        mock.patch.object(writer, "recreate") as mock_recreate,
+        mock.patch.object(writer, "reset_after_fork") as mock_reset_after_fork,
+    ):
+        aggr.reset_after_fork()
+
+    mock_recreate.assert_not_called()
+    mock_reset_after_fork.assert_called_once()
+    assert aggr.writer is writer
+    assert dd_proc in aggr.dd_processors
+    assert user_proc in aggr.user_processors
+    assert not aggr._traces
+    assert len(aggr._span_metrics["spans_created"]) == 0
+
+
 def test_aggregator_bad_processor():
     class Proc(TraceProcessor):
         def process_trace(self, trace):

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -1873,6 +1873,39 @@ def test_fork_pid():
     assert exit_code == 12
 
 
+def test_tracer_child_after_fork_uses_reset_after_fork_not_recreate(tracer):
+    """
+    _child_after_fork() must go through SpanAggregator.reset_after_fork(), never reset()/recreate() --
+    the writer's periodic thread does not survive a fork, so recreate() (which stops and joins the
+    worker) would block forever in the child.
+    """
+    with (
+        mock.patch.object(tracer._span_aggregator, "reset_after_fork") as mock_reset_after_fork,
+        mock.patch.object(tracer._span_aggregator, "reset") as mock_reset,
+    ):
+        tracer._child_after_fork()
+
+    mock_reset_after_fork.assert_called_once_with()
+    mock_reset.assert_not_called()
+
+
+def test_tracer_recreate_uses_reset_not_reset_after_fork(tracer):
+    """
+    Non-fork callers of _recreate() (Tracer.configure(), CI Visibility's recorder, the Tornado
+    integration) rely on it fully rebuilding the writer -- e.g. to pick up a new intake URL or
+    updated api_version -- so it must keep going through SpanAggregator.reset()/writer.recreate(),
+    not the fork-only lightweight reset_after_fork() path.
+    """
+    with (
+        mock.patch.object(tracer._span_aggregator, "reset_after_fork") as mock_reset_after_fork,
+        mock.patch.object(tracer._span_aggregator, "reset") as mock_reset,
+    ):
+        tracer._recreate()
+
+    mock_reset.assert_called_once()
+    mock_reset_after_fork.assert_not_called()
+
+
 @pytest.mark.subprocess
 def test_tracer_api_version():
     from ddtrace.internal.encoding import MsgpackEncoderV05

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -21,6 +21,7 @@ from ddtrace.internal.encoding import MSGPACK_ENCODERS
 from ddtrace.internal.native._native import IoError
 from ddtrace.internal.native._native import NetworkError
 from ddtrace.internal.runtime import get_runtime_id
+from ddtrace.internal.service import ServiceStatus
 from ddtrace.internal.settings._opentelemetry import ExporterConfig
 from ddtrace.internal.settings._opentelemetry import _is_otlp_traces_exporter_enabled
 from ddtrace.internal.uds import UDSHTTPConnection
@@ -991,6 +992,63 @@ def test_writer_recreate_keeps_response_callback():
     writer = writer.recreate()
     assert isinstance(writer, NativeWriter)
     assert writer._response_cb is response_callback
+
+
+@pytest.mark.parametrize("writer_class", (AgentlessTraceWriter, NativeWriter))
+def test_reset_after_fork_does_not_stop_or_join_worker(writer_class):
+    """reset_after_fork() must never touch the (already-gone) periodic worker.
+
+    Unlike recreate(), it must not call stop()/join() -- those would block forever in a forked
+    child, since the worker's OS thread does not survive fork and fork-safety hooks already
+    guarantee it was stopped before the fork happened.
+    """
+    writer_args = ("http://dne:1234", "an-api-key") if writer_class is AgentlessTraceWriter else ("http://dne:1234",)
+    writer = writer_class(*writer_args)
+    writer.start()
+    try:
+        with mock.patch.object(writer, "stop") as mock_stop, mock.patch.object(writer, "join") as mock_join:
+            writer.reset_after_fork()
+            mock_stop.assert_not_called()
+            mock_join.assert_not_called()
+    finally:
+        writer._worker = None
+        writer.status = ServiceStatus.STOPPED
+
+
+def test_reset_after_fork_http_writer_drops_connection_and_buffers():
+    writer = AgentlessTraceWriter("http://dne:1234", "an-api-key")
+    writer._encoder.put([Span("foobar")])
+    conn = mock.Mock()
+    writer._conn = conn
+    old_clients = list(writer._clients)
+
+    writer.reset_after_fork()
+
+    conn.close.assert_called_once()
+    assert writer._conn is None
+    assert writer._clients != old_clients
+    assert writer._worker is None
+    assert writer.status == ServiceStatus.STOPPED
+
+
+def test_reset_after_fork_native_writer_rebuilds_exporter():
+    writer = NativeWriter("http://dne:1234")
+    # The native TraceExporter type doesn't allow patching its methods directly, so swap in a
+    # mock to spy on the calls reset_after_fork() makes against the old exporter before discarding it.
+    old_exporter = mock.Mock(spec=writer._exporter)
+    writer._exporter = old_exporter
+    old_clients = list(writer._clients)
+
+    writer.reset_after_fork()
+
+    # The old exporter must be explicitly drop()'d before being discarded. Otherwise, letting its
+    # refcount hit zero triggers the Rust-side Drop impl, which calls the blocking shutdown() --
+    # and since the shared runtime's worker threads don't survive fork, that call can hang forever.
+    old_exporter.drop.assert_called_once_with()
+    assert writer._exporter is not old_exporter
+    assert writer._clients != old_clients
+    assert writer._worker is None
+    assert writer.status == ServiceStatus.STOPPED
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

We refactor the tracer to make sure that it can perform a more lightweight clean up after a fork. Crucially, we make sure that there are no blocking operations being performed during a fork hook.