### PR TITLE
ci(system-tests): update pinned system-tests ref

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -95,11 +95,11 @@ jobs:
   serverless-system-tests:
     needs: [serverless-system-tests-build-layer]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@9daccd578f30ad15d66011b3550f4f35b2e9be52
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@77e6da9b53639436525bf7bfb076723e18e102c3
     secrets: inherit
     with:
       library: python_lambda
-      ref: '9daccd578f30ad15d66011b3550f4f35b2e9be52'
+      ref: '77e6da9b53639436525bf7bfb076723e18e102c3'
       binaries_artifact: serverless_system_tests_binaries
       scenarios_groups: lambda_end_to_end
       skip_empty_scenarios: true
@@ -126,11 +126,11 @@ jobs:
     if: github.event_name != 'schedule' || github.event.repository.fork == false
     needs: [integration-frameworks-combine-wheels]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@9daccd578f30ad15d66011b3550f4f35b2e9be52
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@77e6da9b53639436525bf7bfb076723e18e102c3
     secrets: inherit
     with:
       library: python
-      ref: '9daccd578f30ad15d66011b3550f4f35b2e9be52'
+      ref: '77e6da9b53639436525bf7bfb076723e18e102c3'
       scenarios: INTEGRATION_FRAMEWORKS
       binaries_artifact: integration-frameworks-wheels
       push_to_test_optimization: true
@@ -138,10 +138,10 @@ jobs:
   tracer-release:
     needs:
       - download-s3-wheels
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@9daccd578f30ad15d66011b3550f4f35b2e9be52
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@77e6da9b53639436525bf7bfb076723e18e102c3
     with:
       library: python
-      ref: '9daccd578f30ad15d66011b3550f4f35b2e9be52'
+      ref: '77e6da9b53639436525bf7bfb076723e18e102c3'
       binaries_artifact: wheels-manylinux_x86_64
       desired_execution_time: 900
       scenarios_groups: tracer-release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "9daccd578f30ad15d66011b3550f4f35b2e9be52"
+  SYSTEM_TESTS_REF: "77e6da9b53639436525bf7bfb076723e18e102c3"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
   PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v103334885-be1888c-profiling_native"


### PR DESCRIPTION
## Motivation

FFE system tests are failing on the fork deadlock PR because Agent 7.81.0 now sends feature-flag evaluation metrics through `/api/intake/metrics/v3/series`, while the pinned dd-trace-py system-tests ref only reads `/api/v2/series`. That makes valid SDK behavior appear as missing metrics and can block releasing/backporting the incident fix on maintained 4.x lines.

https://github.com/DataDog/dd-trace-py/pull/18920

```
_________ Test_FFE_Eval_Reason_Disabled.test_ffe_eval_reason_disabled __________

self = <tests.ffe.test_flag_eval_metrics.Test_FFE_Eval_Reason_Disabled object at 0x7f639aa78c80>

    def test_ffe_eval_reason_disabled(self):
        """Test that disabled flag produces reason=disabled."""
        assert self.r.status_code == 200, f"Flag evaluation failed: {self.r.text}"

        metrics = find_eval_metrics(self.flag_key)
>       assert len(metrics) > 0, f"Expected metric for flag '{self.flag_key}', found none. All: {find_eval_metrics()}"
E       AssertionError: Expected metric for flag 'reason-disabled-flag', found none. All: []
E       assert 0 > 0
E        +  where 0 = len([])
```

## Changes and Decisions

This updates the dd-trace-py system-tests pin from `9daccd578f30ad15d66011b3550f4f35b2e9be52` to `77e6da9b53639436525bf7bfb076723e18e102c3` using `scripts/update-system-tests-version.py`. I chose to update the shared system-tests pin rather than patch the Python FFE tests because the v3 metrics decoder already exists upstream in DataDog/system-tests and is the harness-side compatibility fix for Agent 7.81+ metrics intake. The GitHub reusable workflow refs and GitLab `SYSTEM_TESTS_REF` now point at the same updated system-tests commit.

## Validation

- `git diff --check`
- `scripts/lint spelling .github/workflows/system-tests.yml .gitlab-ci.yml`
- Verified `DataDog/system-tests@77e6da9b53639436525bf7bfb076723e18e102c3` includes `DataDog/system-tests#7144` / `e7a981570f4fcf6270a9cdd316d65b7c3ccf4359`, which decodes `/api/intake/metrics/v3/series` and includes that path in `get_metrics()`.