### PR TITLE
feat(llmobs): propagate session_id across distributed traces [MLOB-7756]

### DIFF
--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -43,7 +43,7 @@ class LLMObsSamplingDecision(str, Enum):
 LLMOBS_SUBMITTED_TAG_KEY = "_dd.llmobs.submitted"
 PROPAGATED_ML_APP_KEY = "_dd.p.llmobs_ml_app"
 PROPAGATED_LLMOBS_TRACE_ID_KEY = "_dd.p.llmobs_trace_id"
-PROPAGATED_SESSION_ID_KEY = "_dd.p.llmobs_session_id"
+PROPAGATED_SESSION_ID_KEY = "_dd.p.session_id"
 LLMOBS_TRACE_ID = "_ml_obs.llmobs_trace_id"  # Deprecated: use get_llmobs_trace_id() from ddtrace.llmobs._utils
 
 UNKNOWN_MODEL_PROVIDER = "unknown"

--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -43,6 +43,7 @@ class LLMObsSamplingDecision(str, Enum):
 LLMOBS_SUBMITTED_TAG_KEY = "_dd.llmobs.submitted"
 PROPAGATED_ML_APP_KEY = "_dd.p.llmobs_ml_app"
 PROPAGATED_LLMOBS_TRACE_ID_KEY = "_dd.p.llmobs_trace_id"
+PROPAGATED_SESSION_ID_KEY = "_dd.p.llmobs_session_id"
 LLMOBS_TRACE_ID = "_ml_obs.llmobs_trace_id"  # Deprecated: use get_llmobs_trace_id() from ddtrace.llmobs._utils
 
 UNKNOWN_MODEL_PROVIDER = "unknown"

--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -43,7 +43,7 @@ class LLMObsSamplingDecision(str, Enum):
 LLMOBS_SUBMITTED_TAG_KEY = "_dd.llmobs.submitted"
 PROPAGATED_ML_APP_KEY = "_dd.p.llmobs_ml_app"
 PROPAGATED_LLMOBS_TRACE_ID_KEY = "_dd.p.llmobs_trace_id"
-PROPAGATED_SESSION_ID_KEY = "_dd.p.session_id"
+PROPAGATED_SESSION_ID_KEY = "_dd.p.llmobs_sid"
 LLMOBS_TRACE_ID = "_ml_obs.llmobs_trace_id"  # Deprecated: use get_llmobs_trace_id() from ddtrace.llmobs._utils
 
 UNKNOWN_MODEL_PROVIDER = "unknown"

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -84,6 +84,7 @@ from ddtrace.llmobs._constants import PROPAGATED_ML_APP_KEY
 from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
 from ddtrace.llmobs._constants import PROPAGATED_SAMPLE_RATE
 from ddtrace.llmobs._constants import PROPAGATED_SAMPLING_DECISION
+from ddtrace.llmobs._constants import PROPAGATED_SESSION_ID_KEY
 from ddtrace.llmobs._constants import ROOT_PARENT_ID
 from ddtrace.llmobs._constants import SESSION_ID
 from ddtrace.llmobs._constants import SPAN_START_WHILE_DISABLED_WARNING
@@ -2083,7 +2084,7 @@ class LLMObs(Service):
     def _activate_llmobs_span(self, span: Span) -> None:
         """Propagate the llmobs parent spanID, traceID, ml_app, and session_id and activate the new span.
         ml_app precedence: parent span._store > distributed context > global config > service.
-        session_id is optional and only propagated from span._store
+        session_id is optional and propagated from the parent span._store or the distributed context.
         """
         llmobs_parent = self._llmobs_context_provider.active()
         if llmobs_parent:
@@ -2099,7 +2100,7 @@ class LLMObs(Service):
                 # We store LLMObs trace ID on span context as decimal strings for distributed context propagation
                 llmobs_trace_id = _normalize_wire_trace_id_to_hex(parent_ctx._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY))
                 ml_app = parent_ctx._meta.get(PROPAGATED_ML_APP_KEY)
-                session_id = None
+                session_id = parent_ctx._meta.get(PROPAGATED_SESSION_ID_KEY)
                 sample_rate = parent_ctx._meta.get(PROPAGATED_SAMPLE_RATE)
                 sampling_decision = parent_ctx._meta.get(PROPAGATED_SAMPLING_DECISION)
         else:
@@ -3053,15 +3054,18 @@ class LLMObs(Service):
         parent_id = str(active_context.span_id) if active_context is not None else ROOT_PARENT_ID
 
         ml_app = None
+        session_id = None
         if isinstance(active_span, Span):
             # meta_struct holds canonical hex so have to convert to decimal wire format
             ml_app = get_llmobs_ml_app(active_span)
+            session_id = get_llmobs_session_id(active_span)
             wire_trace_id = _trace_id_to_wire(get_llmobs_trace_id(active_span))
             sample_rate = get_llmobs_sample_rate(active_span)
             sampling_decision = get_llmobs_sampling_decision(active_span)
         elif active_context is not None:
             # Context._meta always holds decimal wire format so we can read directly
             ml_app = resolve_ml_app(active_context._meta.get(PROPAGATED_ML_APP_KEY))
+            session_id = active_context._meta.get(PROPAGATED_SESSION_ID_KEY)
             wire_trace_id = active_context._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY) or str(generate_128bit_trace_id())
             sample_rate = active_context._meta.get(PROPAGATED_SAMPLE_RATE)
             sampling_decision = active_context._meta.get(PROPAGATED_SAMPLING_DECISION)
@@ -3077,6 +3081,8 @@ class LLMObs(Service):
 
         if ml_app is not None:
             span_context._meta[PROPAGATED_ML_APP_KEY] = ml_app
+        if session_id is not None:
+            span_context._meta[PROPAGATED_SESSION_ID_KEY] = session_id
         if sample_rate is not None:
             span_context._meta[PROPAGATED_SAMPLE_RATE] = sample_rate
         if sampling_decision is not None:
@@ -3146,6 +3152,7 @@ class LLMObs(Service):
             parent_llmobs_trace_id = context._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY)
             propagated_sample_rate = context._meta.get(PROPAGATED_SAMPLE_RATE)
             propagated_sampling_decision = context._meta.get(PROPAGATED_SAMPLING_DECISION)
+            propagated_session_id = context._meta.get(PROPAGATED_SESSION_ID_KEY)
             # `PROPAGATED_LLMOBS_TRACE_ID_KEY` on `Context._meta` is wire-format (decimal).
             # Store the inbound value as-is and defer normalization to the reader
             # (`_activate_llmobs_span`, Context-parent branch) so we never apply
@@ -3161,6 +3168,8 @@ class LLMObs(Service):
                     llmobs_context._meta[PROPAGATED_SAMPLE_RATE] = propagated_sample_rate
                 if propagated_sampling_decision is not None:
                     llmobs_context._meta[PROPAGATED_SAMPLING_DECISION] = propagated_sampling_decision
+                if propagated_session_id is not None:
+                    llmobs_context._meta[PROPAGATED_SESSION_ID_KEY] = propagated_session_id
                 cls._instance._llmobs_context_provider.activate(llmobs_context)
                 error = "missing_parent_llmobs_trace_id"
                 return
@@ -3170,6 +3179,8 @@ class LLMObs(Service):
                 llmobs_context._meta[PROPAGATED_SAMPLE_RATE] = propagated_sample_rate
             if propagated_sampling_decision is not None:
                 llmobs_context._meta[PROPAGATED_SAMPLING_DECISION] = propagated_sampling_decision
+            if propagated_session_id is not None:
+                llmobs_context._meta[PROPAGATED_SESSION_ID_KEY] = propagated_session_id
             cls._instance._llmobs_context_provider.activate(llmobs_context)
         finally:
             telemetry.record_activate_distributed_headers(error)

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -2202,6 +2202,11 @@ class LLMObs(Service):
         )
         if _decorator:
             _annotate_llmobs_span_data(span, tags={"decorator": "1"})
+        # First session in the trace becomes the trace-level default (first-writer wins), so later
+        # spans under a session-less parent fall back to it and it propagates across services.
+        effective_session_id = get_llmobs_session_id(span)
+        if effective_session_id and span.context._meta.get(PROPAGATED_SESSION_ID_KEY) is None:
+            span.context._meta[PROPAGATED_SESSION_ID_KEY] = effective_session_id
         log.debug(
             "Starting LLMObs span: %s, span_kind: %s, ml_app: %s",
             name,

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -3063,18 +3063,15 @@ class LLMObs(Service):
         parent_id = str(active_context.span_id) if active_context is not None else ROOT_PARENT_ID
 
         ml_app = None
-        session_id = None
         if isinstance(active_span, Span):
             # meta_struct holds canonical hex so have to convert to decimal wire format
             ml_app = get_llmobs_ml_app(active_span)
-            session_id = get_llmobs_session_id(active_span)
             wire_trace_id = _trace_id_to_wire(get_llmobs_trace_id(active_span))
             sample_rate = get_llmobs_sample_rate(active_span)
             sampling_decision = get_llmobs_sampling_decision(active_span)
         elif active_context is not None:
             # Context._meta always holds decimal wire format so we can read directly
             ml_app = resolve_ml_app(active_context._meta.get(PROPAGATED_ML_APP_KEY))
-            session_id = active_context._meta.get(PROPAGATED_SESSION_ID_KEY)
             wire_trace_id = active_context._meta.get(PROPAGATED_LLMOBS_TRACE_ID_KEY) or str(generate_128bit_trace_id())
             sample_rate = active_context._meta.get(PROPAGATED_SAMPLE_RATE)
             sampling_decision = active_context._meta.get(PROPAGATED_SAMPLING_DECISION)
@@ -3090,8 +3087,6 @@ class LLMObs(Service):
 
         if ml_app is not None:
             span_context._meta[PROPAGATED_ML_APP_KEY] = ml_app
-        if session_id is not None:
-            span_context._meta[PROPAGATED_SESSION_ID_KEY] = session_id
         if sample_rate is not None:
             span_context._meta[PROPAGATED_SAMPLE_RATE] = sample_rate
         if sampling_decision is not None:

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -2110,6 +2110,10 @@ class LLMObs(Service):
             sampling_decision = self._sample_span(span)
         llmobs_trace_id = llmobs_trace_id or format_trace_id(generate_128bit_trace_id())
         ml_app = resolve_ml_app(ml_app or span.context._meta.get(PROPAGATED_ML_APP_KEY))
+        # Fall back to the trace-level default session when the parent chain carries none (e.g. a
+        # span under a session-less parent). The default is the first session set anywhere in the
+        # trace; an explicit session_id on this span still overrides it (applied after activation).
+        session_id = session_id or span.context._meta.get(PROPAGATED_SESSION_ID_KEY)
 
         resolved_name = span.name
         if span.name in _STANDARD_INTEGRATION_SPAN_NAMES and span.resource != "":

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -27,7 +27,6 @@ from ddtrace.llmobs._constants import INTERNAL_QUERY_VARIABLE_KEYS
 from ddtrace.llmobs._constants import LLMOBS_STRUCT
 from ddtrace.llmobs._constants import ML_APP
 from ddtrace.llmobs._constants import ML_APP_DEFAULT
-from ddtrace.llmobs._constants import PROPAGATED_SESSION_ID_KEY
 from ddtrace.llmobs._constants import SESSION_ID
 from ddtrace.llmobs.types import Document
 from ddtrace.llmobs.types import Message
@@ -634,12 +633,6 @@ def _annotate_llmobs_span_data(
             llmobs_span_data[LLMOBS_STRUCT.SESSION_ID] = session_id
             llmobs_span_data[LLMOBS_STRUCT.TAGS]["session_id"] = session_id
             span._set_ctx_item(SESSION_ID, session_id)
-            # The first session_id seen in a trace becomes the trace-level default: it is stored on
-            # the trace-shared propagating context so later spans whose parent chain carries no
-            # session (e.g. siblings under a session-less parent) fall back to it, and it propagates
-            # across service boundaries. An explicit session_id on a span still overrides locally.
-            if span.context._meta.get(PROPAGATED_SESSION_ID_KEY) is None:
-                span.context._meta[PROPAGATED_SESSION_ID_KEY] = session_id
         if span_links is not None:
             llmobs_span_data[LLMOBS_STRUCT.SPAN_LINKS] = span_links
         if config is not None:

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -27,6 +27,7 @@ from ddtrace.llmobs._constants import INTERNAL_QUERY_VARIABLE_KEYS
 from ddtrace.llmobs._constants import LLMOBS_STRUCT
 from ddtrace.llmobs._constants import ML_APP
 from ddtrace.llmobs._constants import ML_APP_DEFAULT
+from ddtrace.llmobs._constants import PROPAGATED_SESSION_ID_KEY
 from ddtrace.llmobs._constants import SESSION_ID
 from ddtrace.llmobs.types import Document
 from ddtrace.llmobs.types import Message
@@ -633,6 +634,12 @@ def _annotate_llmobs_span_data(
             llmobs_span_data[LLMOBS_STRUCT.SESSION_ID] = session_id
             llmobs_span_data[LLMOBS_STRUCT.TAGS]["session_id"] = session_id
             span._set_ctx_item(SESSION_ID, session_id)
+            # The first session_id seen in a trace becomes the trace-level default: it is stored on
+            # the trace-shared propagating context so later spans whose parent chain carries no
+            # session (e.g. siblings under a session-less parent) fall back to it, and it propagates
+            # across service boundaries. An explicit session_id on a span still overrides locally.
+            if span.context._meta.get(PROPAGATED_SESSION_ID_KEY) is None:
+                span.context._meta[PROPAGATED_SESSION_ID_KEY] = session_id
         if span_links is not None:
             llmobs_span_data[LLMOBS_STRUCT.SPAN_LINKS] = span_links
         if config is not None:

--- a/releasenotes/notes/llmobs-propagate-session-id-4a06a4bc6ecb4ef7.yaml
+++ b/releasenotes/notes/llmobs-propagate-session-id-4a06a4bc6ecb4ef7.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    LLM Observability: Introduces cross-service propagation of ``session_id``.
+    When a distributed trace crosses a service boundary, LLM Observability spans
+    in the downstream service now inherit the ``session_id`` set on the upstream
+    service's span, so all spans in the session are grouped together. A
+    ``session_id`` set explicitly on a span still takes precedence over a
+    propagated one.

--- a/releasenotes/notes/llmobs-propagate-session-id-4a06a4bc6ecb4ef7.yaml
+++ b/releasenotes/notes/llmobs-propagate-session-id-4a06a4bc6ecb4ef7.yaml
@@ -1,9 +1,9 @@
 ---
 features:
   - |
-    LLM Observability: Introduces cross-service propagation of ``session_id``.
-    When a distributed trace crosses a service boundary, LLM Observability spans
-    in the downstream service now inherit the ``session_id`` set on the upstream
-    service's span, so all spans in the session are grouped together. A
-    ``session_id`` set explicitly on a span still takes precedence over a
-    propagated one.
+    LLM Observability: ``session_id`` now propagates to following spans in a
+    trace. The first ``session_id`` set in a trace becomes the trace default, so
+    later spans that do not set one - including spans under a session-less parent
+    and spans in downstream services across a distributed trace - are grouped
+    into that session. A ``session_id`` set explicitly on a span still takes
+    precedence over the inherited or propagated value.

--- a/releasenotes/notes/llmobs-propagate-session-id-4a06a4bc6ecb4ef7.yaml
+++ b/releasenotes/notes/llmobs-propagate-session-id-4a06a4bc6ecb4ef7.yaml
@@ -2,8 +2,5 @@
 features:
   - |
     LLM Observability: ``session_id`` now propagates to following spans in a
-    trace. The first ``session_id`` set in a trace becomes the trace default, so
-    later spans that do not set one - including spans under a session-less parent
-    and spans in downstream services across a distributed trace - are grouped
-    into that session. A ``session_id`` set explicitly on a span still takes
+    trace. If ``session_id`` is set explicitly on a span, this will take
     precedence over the inherited or propagated value.

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -14,12 +14,14 @@ from ddtrace.llmobs._constants import PROPAGATED_ML_APP_KEY
 from ddtrace.llmobs._constants import PROPAGATED_PARENT_ID_KEY
 from ddtrace.llmobs._constants import PROPAGATED_SAMPLE_RATE
 from ddtrace.llmobs._constants import PROPAGATED_SAMPLING_DECISION
+from ddtrace.llmobs._constants import PROPAGATED_SESSION_ID_KEY
 from ddtrace.llmobs._constants import ROOT_PARENT_ID
 from ddtrace.llmobs._constants import LLMObsSamplingDecision
 from ddtrace.llmobs._utils import get_llmobs_ml_app
 from ddtrace.llmobs._utils import get_llmobs_parent_id
 from ddtrace.llmobs._utils import get_llmobs_sample_rate
 from ddtrace.llmobs._utils import get_llmobs_sampling_decision
+from ddtrace.llmobs._utils import get_llmobs_session_id
 from ddtrace.llmobs._utils import get_llmobs_span_kind
 from ddtrace.llmobs._utils import get_llmobs_trace_id
 from ddtrace.trace import Context
@@ -57,6 +59,18 @@ def test_inject_llmobs_ml_app_override(llmobs):
     with llmobs.workflow(name="LLMObs span", ml_app="test-ml-app") as span:
         llmobs._inject_llmobs_context(span.context, {})
     assert span.context._meta.get(PROPAGATED_ML_APP_KEY) == "test-ml-app"
+
+
+def test_inject_llmobs_session_id(llmobs):
+    with llmobs.workflow(name="LLMObs span", session_id="test-session-id") as span:
+        llmobs._inject_llmobs_context(span.context, {})
+    assert span.context._meta.get(PROPAGATED_SESSION_ID_KEY) == "test-session-id"
+
+
+def test_inject_llmobs_no_session_id(llmobs):
+    with llmobs.workflow(name="LLMObs span") as span:
+        llmobs._inject_llmobs_context(span.context, {})
+    assert span.context._meta.get(PROPAGATED_SESSION_ID_KEY) is None
 
 
 def test_inject_llmobs_parent_id_nested_llmobs_non_llmobs(llmobs):
@@ -345,6 +359,60 @@ print(json.dumps(headers))
     llmobs.activate_distributed_headers(headers)
     with llmobs.llm(name="llm_model") as llm_span:
         assert get_llmobs_ml_app(llm_span) == "twice-propagated-ml-app"
+
+
+def test_activate_distributed_headers_for_session_id(ddtrace_run_python_code_in_subprocess, llmobs):
+    """A session_id set on service A's root LLMObs span is inherited by service B's LLMObs child span."""
+    code = """
+import json
+
+from ddtrace import tracer
+from ddtrace.llmobs import LLMObs
+
+LLMObs.enable(ml_app="test-app", site="datad0g.com", api_key="dummy-key", agentless_enabled=True)
+
+with LLMObs.workflow(name="LLMObs span", session_id="session-from-service-a") as root_span:
+    with tracer.trace("Non-LLMObs span") as child_span:
+        headers = LLMObs.inject_distributed_headers({}, span=child_span)
+
+print(json.dumps(headers))
+"""
+    env = os.environ.copy()
+    env.update({"DD_TRACE_ENABLED": "0"})
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=env)
+    assert status == 0, (stdout, stderr)
+
+    headers = json.loads(stdout.decode())
+    llmobs.activate_distributed_headers(headers)
+    with llmobs.llm(name="llm_model") as llm_span:
+        assert get_llmobs_session_id(llm_span) == "session-from-service-a"
+
+
+def test_activate_distributed_headers_local_session_id_wins(ddtrace_run_python_code_in_subprocess, llmobs):
+    """An explicit session_id on service B's span overrides the session propagated from service A."""
+    code = """
+import json
+
+from ddtrace import tracer
+from ddtrace.llmobs import LLMObs
+
+LLMObs.enable(ml_app="test-app", site="datad0g.com", api_key="dummy-key", agentless_enabled=True)
+
+with LLMObs.workflow(name="LLMObs span", session_id="session-from-service-a") as root_span:
+    with tracer.trace("Non-LLMObs span") as child_span:
+        headers = LLMObs.inject_distributed_headers({}, span=child_span)
+
+print(json.dumps(headers))
+"""
+    env = os.environ.copy()
+    env.update({"DD_TRACE_ENABLED": "0"})
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=env)
+    assert status == 0, (stdout, stderr)
+
+    headers = json.loads(stdout.decode())
+    llmobs.activate_distributed_headers(headers)
+    with llmobs.llm(name="llm_model", session_id="local-session") as llm_span:
+        assert get_llmobs_session_id(llm_span) == "local-session"
 
 
 def test_activate_distributed_headers_does_not_propagate_if_no_llmobs_spans(

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -95,6 +95,24 @@ def test_session_id_local_override_beats_trace_default(llmobs):
     assert get_llmobs_session_id(default_span) == "trace-session"
 
 
+def test_injection_propagates_trace_default_session_not_override(llmobs):
+    """Injecting while an override child is active propagates the trace default, not the override,
+    and does not corrupt the trace default for later spans.
+    """
+    with llmobs.workflow(name="root"):  # no session on the root
+        with llmobs.llm(name="first", session_id="trace-session"):  # establishes the trace default
+            pass
+        with llmobs.llm(name="override", session_id="override-session") as override_span:
+            headers = llmobs.inject_distributed_headers({}, span=override_span)
+        with llmobs.llm(name="later") as later_span:  # sibling created after the override
+            pass
+    tags = headers.get("x-datadog-tags", "")
+    assert "_dd.p.llmobs_session_id=trace-session" in tags
+    assert "_dd.p.llmobs_session_id=override-session" not in tags
+    # the override must not have replaced the trace default for later spans
+    assert get_llmobs_session_id(later_span) == "trace-session"
+
+
 def test_inject_llmobs_parent_id_nested_llmobs_non_llmobs(llmobs):
     with llmobs.workflow("LLMObs span") as root_span:
         with llmobs._instance.tracer.trace("Non-LLMObs span") as span:
@@ -435,6 +453,40 @@ print(json.dumps(headers))
     llmobs.activate_distributed_headers(headers)
     with llmobs.llm(name="llm_model", session_id="local-session") as llm_span:
         assert get_llmobs_session_id(llm_span) == "local-session"
+
+
+def test_activate_distributed_headers_propagates_trace_default_over_override(
+    ddtrace_run_python_code_in_subprocess, llmobs
+):
+    """When an override child is active at injection time, service B inherits the trace default
+    (the first session set in the trace), not the active override.
+    """
+    code = """
+import json
+
+from ddtrace import tracer
+from ddtrace.llmobs import LLMObs
+
+LLMObs.enable(ml_app="test-app", site="datad0g.com", api_key="dummy-key", agentless_enabled=True)
+
+with LLMObs.workflow(name="root"):  # no session; the first child sets the trace default
+    with LLMObs.llm(name="first", session_id="trace-session"):
+        pass
+    with LLMObs.llm(name="override", session_id="override-session"):
+        with tracer.trace("Non-LLMObs span") as child_span:
+            headers = LLMObs.inject_distributed_headers({}, span=child_span)
+
+print(json.dumps(headers))
+"""
+    env = os.environ.copy()
+    env.update({"DD_TRACE_ENABLED": "0"})
+    stdout, stderr, status, _ = ddtrace_run_python_code_in_subprocess(code=code, env=env)
+    assert status == 0, (stdout, stderr)
+
+    headers = json.loads(stdout.decode())
+    llmobs.activate_distributed_headers(headers)
+    with llmobs.llm(name="llm_model") as llm_span:
+        assert get_llmobs_session_id(llm_span) == "trace-session"
 
 
 def test_activate_distributed_headers_does_not_propagate_if_no_llmobs_spans(

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -107,8 +107,8 @@ def test_injection_propagates_trace_default_session_not_override(llmobs):
         with llmobs.llm(name="later") as later_span:  # sibling created after the override
             pass
     tags = headers.get("x-datadog-tags", "")
-    assert "_dd.p.llmobs_session_id=trace-session" in tags
-    assert "_dd.p.llmobs_session_id=override-session" not in tags
+    assert "_dd.p.session_id=trace-session" in tags
+    assert "_dd.p.session_id=override-session" not in tags
     # the override must not have replaced the trace default for later spans
     assert get_llmobs_session_id(later_span) == "trace-session"
 

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -73,6 +73,28 @@ def test_inject_llmobs_no_session_id(llmobs):
     assert span.context._meta.get(PROPAGATED_SESSION_ID_KEY) is None
 
 
+def test_session_id_trace_default_fills_sibling_gap(llmobs):
+    """The first session set in a trace becomes the default; a sibling under a session-less parent inherits it."""
+    with llmobs.workflow(name="root"):  # no session on the root
+        with llmobs.llm(name="first", session_id="trace-session") as first:
+            pass
+        with llmobs.llm(name="second") as second:  # sibling, no explicit session
+            pass
+    assert get_llmobs_session_id(first) == "trace-session"
+    assert get_llmobs_session_id(second) == "trace-session"
+
+
+def test_session_id_local_override_beats_trace_default(llmobs):
+    """An explicit session_id overrides the trace default locally; gap spans still get the default."""
+    with llmobs.workflow(name="root", session_id="trace-session"):
+        with llmobs.llm(name="override", session_id="other-session") as override_span:
+            pass
+        with llmobs.llm(name="default") as default_span:  # no explicit session
+            pass
+    assert get_llmobs_session_id(override_span) == "other-session"
+    assert get_llmobs_session_id(default_span) == "trace-session"
+
+
 def test_inject_llmobs_parent_id_nested_llmobs_non_llmobs(llmobs):
     with llmobs.workflow("LLMObs span") as root_span:
         with llmobs._instance.tracer.trace("Non-LLMObs span") as span:

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -107,8 +107,8 @@ def test_injection_propagates_trace_default_session_not_override(llmobs):
         with llmobs.llm(name="later") as later_span:  # sibling created after the override
             pass
     tags = headers.get("x-datadog-tags", "")
-    assert "_dd.p.session_id=trace-session" in tags
-    assert "_dd.p.session_id=override-session" not in tags
+    assert "_dd.p.llmobs_sid=trace-session" in tags
+    assert "_dd.p.llmobs_sid=override-session" not in tags
     # the override must not have replaced the trace default for later spans
     assert get_llmobs_session_id(later_span) == "trace-session"
 


### PR DESCRIPTION
This PR adds propagation support for the LLMObs `session_id` across distributed contexts. This PR also establishes the first seen `session_id` as the default for all subsequent spans in the trace.

Annotation contexts / explicit session tagging are still respected with the consequence that one trace can have multiple session IDs (this is the current accepted behavior).

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

[Simulating a distributed session](https://github.com/ncybul/sdk-manual-testing/blob/master/cross_service.py) ([trace](https://app.datadoghq.com/llm/traces?query=%40ml_app%3Asdk-manual-testing%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&is_llm_session=false&refresh_mode=sliding&selectedTab=overview&sp=%5B%7B%22p%22%3A%7B%22eventId%22%3A%22AwAAAZ9Her5LhIWFvQAAABhBWjlIZXI1TEFBQUhjUkhSTTROd0FBQUEAAAAkMDE5ZjQ3N2EtZjJmYy00ZThhLWI1OTYtN2U0M2U3NDI0YmFhAAAF4w%22%7D%2C%22i%22%3A%22llm-obs-panel%22%7D%5D&spanId=1706347288156013108&start=1783607073040&end=1783610673040&paused=false))
- `session_id:my-session` set in service A which calls service B and inherits the same session ID

[Simulating default session being applied to subsequent spans in a trace unless explicitly annotated](https://github.com/ncybul/sdk-manual-testing/blob/master/in_process.py) ([trace](https://app.datadoghq.com/llm/traces?query=%40ml_app%3Asdk-manual-testing%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&is_llm_session=false&refresh_mode=sliding&selectedTab=overview&sp=%5B%7B%22p%22%3A%7B%22eventId%22%3A%22AwAAAZ9Hf--jl2WBRQAAABhBWjlIZi0takFBQ19vQ0UyalFQX0FBQUEAAAAkMDE5ZjQ3ODAtMDRiMC00NGVlLTk0MTgtN2VlNDdkMDc5ZDcwAAADRw%22%7D%2C%22i%22%3A%22llm-obs-panel%22%7D%5D&spanId=9624447665336394777&start=1783610133070&end=1783611033070&paused=false))
- first span sets `session_id:my-session` which is inherited by subsequent spans except those explicitly annotated with `session_id:other-session`

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
