### PR TITLE
fix(iast): deduplicate unvalidated redirect by evidence value

### DIFF
--- a/ddtrace/appsec/_iast/taint_sinks/unvalidated_redirect.py
+++ b/ddtrace/appsec/_iast/taint_sinks/unvalidated_redirect.py
@@ -2,6 +2,7 @@ from typing import Text
 
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._constants import IAST_SPAN_TAGS
+from ddtrace.appsec._iast._iast_request_context import get_iast_reporter
 from ddtrace.appsec._iast._iast_request_context_base import is_iast_request_enabled
 from ddtrace.appsec._iast._logs import iast_error
 from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_sink
@@ -86,6 +87,33 @@ class UnvalidatedRedirect(VulnerabilityBase):
     secure_mark = VulnerabilityType.UNVALIDATED_REDIRECT
 
 
+def _already_reported_unvalidated_redirect(value: Text) -> bool:
+    """Return True if an UNVALIDATED_REDIRECT with the same evidence value was already
+    reported in the current request.
+
+    A single ``redirect(location)`` reaches IAST through two independent code paths that
+    report at different locations (so hash-based deduplication cannot merge them): the
+    ``redirect()`` wrapper (reports at the app call site) and the ``Location`` header sink,
+    which fires again when Werkzeug re-writes the header during WSGI response finalization
+    (``Response.get_wsgi_headers`` runs ``iri_to_uri(location)``, producing a *new* string
+    that does not carry the ``secure_mark`` set on the original). Relying on the secure mark
+    to suppress the duplicate is therefore flaky; deduplicating on the already-reported
+    evidence value is not.
+
+    Only vulnerabilities that were actually emitted are stored in the reporter, so skipping
+    on a match can only ever collapse a duplicate (2 -> 1) and never suppress the sole
+    report (1 -> 0)."""
+    if isinstance(value, (bytes, bytearray)):
+        value = value.decode("utf-8", "ignore")
+    report = get_iast_reporter()
+    if report is None:
+        return False
+    return any(
+        vuln.type == VULN_UNVALIDATED_REDIRECT and vuln.evidence.value == value
+        for vuln in report.vulnerabilities
+    )
+
+
 def _iast_report_unvalidated_redirect(headers):
     if headers and isinstance(headers, IAST.TEXT_TYPES):
         try:
@@ -94,7 +122,7 @@ def _iast_report_unvalidated_redirect(headers):
             )
 
             if is_tainted:
-                if UnvalidatedRedirect.has_quota():
+                if UnvalidatedRedirect.has_quota() and not _already_reported_unvalidated_redirect(headers):
                     UnvalidatedRedirect.report(evidence_value=headers)
                 add_secure_mark(headers, [VulnerabilityType.UNVALIDATED_REDIRECT])
 

--- a/releasenotes/notes/fix_iast_unvalidated_redirect_double_report-17f37bb5e81f42fe.yaml
+++ b/releasenotes/notes/fix_iast_unvalidated_redirect_double_report-17f37bb5e81f42fe.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Code Security (IAST): fixed a spurious duplicate ``UNVALIDATED_REDIRECT`` vulnerability
+    reported for a single ``redirect()`` call. A redirect is detected both at the framework
+    ``redirect()`` call site and at the ``Location`` header sink, which fires a second time when
+    the web framework re-writes the header during response finalization using a newly derived
+    string that did not carry the internal secure mark. The two reports have different locations,
+    so hash deduplication could not merge them. The sink now deduplicates on the already-reported
+    evidence value within the request, keeping a single vulnerability without suppressing the
+    legitimate report.

--- a/tests/appsec/iast/taint_sinks/test_unvalidated_redirect.py
+++ b/tests/appsec/iast/taint_sinks/test_unvalidated_redirect.py
@@ -72,6 +72,47 @@ def test_unvalidated_redirect_secure_mark_applied_even_when_dedup_filters(iast_c
     )
 
 
+def test_unvalidated_redirect_deduplicated_across_distinct_objects_same_value(iast_context_defaults):
+    """Regression test: a single redirect must yield one vulnerability even when the second
+    detection path sees a DIFFERENT string object that carries taint but not the secure mark.
+
+    Flask's ``redirect(location)`` reports once at the call site, then Werkzeug re-writes the
+    ``Location`` header during WSGI finalization via ``get_wsgi_headers`` ->
+    ``iri_to_uri(location)``, which returns a *new* string. That copy does not carry the
+    ``secure_mark`` placed on the original ``location``, so the secure-mark dedup cannot stop
+    the header sink from reporting a duplicate (with a different location, so hash dedup can't
+    merge it either). The fix deduplicates on the already-reported evidence value.
+    """
+    original = taint_pyobject(
+        "http://evil.com/redir",
+        source_name="location",
+        source_value="http://evil.com/redir",
+        source_origin=OriginType.PARAMETER,
+    )
+    # First detection path (e.g. flask.redirect wrapper) reports and secure-marks `original`.
+    _iast_report_unvalidated_redirect(original)
+    report = get_iast_reporter()
+    assert report is not None
+    assert len(list(report.vulnerabilities)) == 1
+
+    # Second detection path receives a *distinct* tainted string with the same value and no
+    # secure mark (mimicking the iri_to_uri copy). Without value dedup this reports again.
+    finalization_copy = taint_pyobject(
+        "http://evil.com/redir",
+        source_name="location",
+        source_value="http://evil.com/redir",
+        source_origin=OriginType.PARAMETER,
+    )
+    assert UnvalidatedRedirect.is_tainted_pyobject(finalization_copy) is True
+    _iast_report_unvalidated_redirect(finalization_copy)
+
+    vulns_after = list(get_iast_reporter().vulnerabilities)
+    assert len(vulns_after) == 1, (
+        f"Expected exactly 1 vulnerability but got {len(vulns_after)}; the duplicate from the "
+        "WSGI-finalization Location re-write (distinct object, same value) was not deduplicated"
+    )
+
+
 def test_unvalidated_redirect_secure_mark_applied_when_quota_exhausted(iast_context_defaults):
     """Regression test: secure mark must be applied even when vulnerability quota is exhausted.
 


### PR DESCRIPTION
A single redirect(location) reaches IAST through two paths that report at different locations (so hash dedup cannot merge them): the redirect() wrapper and the Location header sink. The header sink fires a second time when Werkzeug re-writes the header during WSGI finalization (get_wsgi_headers -> iri_to_uri), producing a new string that does not carry the secure_mark on the original, so the secure-mark-based dedup (#17105) flakily fails -> 2 vulnerabilities.

Skip reporting an unvalidated redirect whose evidence value was already reported this request. Only emitted vulnerabilities are in the reporter, so this collapses the duplicate (2->1) without ever suppressing the sole report (1->0).

## Description

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
