### PR TITLE
fix(profiling): avoid crashing stack sampler with foreign SIGSEGV handlers [backport 4.10]

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/__init__.pyi
+++ b/ddtrace/internal/datadog/profiling/stack/__init__.pyi
@@ -34,6 +34,27 @@ def set_interval(new_interval: float) -> None: ...
 # Memory copy strategy
 def set_fast_copy(enabled: bool) -> None: ...
 def is_safe_copy_failed() -> bool: ...
+def fast_copy_memory_active() -> bool: ...  # test introspection: is safe_memcpy active?
+
+# _set_fast_copy_warmup_seconds is test-only; accessed via _stack (import * skips it).
+
+def uninstall_segv_handler() -> None: ...
+def reinstall_segv_handler() -> None:
+    """Reinstall SIGSEGV/SIGBUS handlers after another component overwrites them.
+
+    This is used to reclaim the signal handlers after faulthandler.enable() or
+    similar overwrites them. Our handler chains to the previous one for non-recovery
+    faults, so both systems coexist correctly.
+    """
+    ...
+
+def segv_handler_installed() -> bool:
+    """Return True if our handler is the installed disposition for SIGSEGV and SIGBUS.
+
+    Primarily test introspection: it queries the live disposition via sigaction(2)
+    for both signals on every call, so it is not free. Do not call it on hot paths.
+    """
+    ...
 
 # span <-> profile association
 def link_span(span: Optional[Union[context.Context, ddspan.Span]]) -> None: ...

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/danger.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/danger.h
@@ -24,6 +24,13 @@
 int
 init_segv_catcher();
 
+void
+uninstall_segv_handler();
+
+// Returns true only if our signal handler owns both SIGSEGV and SIGBUS; false on any error.
+bool
+segv_handler_installed();
+
 #if defined PL_LINUX
 ssize_t
 safe_memcpy_wrapper(pid_t,

--- a/ddtrace/internal/datadog/profiling/stack/include/sampler.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/sampler.hpp
@@ -58,6 +58,9 @@ class Sampler
     std::vector<PyThreadState> thread_candidates;
     void adapt_sampling_interval();
 
+    // Fast-copy startup warmup in seconds.
+    double fast_copy_warmup_seconds = 15.0;
+
     // Tracks whether the sampler was running when prefork was called,
     // so that postfork_parent/restart_after_fork can restore it.
     bool was_running_at_fork_{ false };
@@ -102,6 +105,8 @@ class Sampler
         max_sampling_period_us = std::max(max_interval_us, static_cast<microsecond_t>(g_min_sampling_period_us));
     }
     void set_max_threads_per_sample(unsigned int value) { max_threads_per_sample = value; }
+
+    void set_fast_copy_warmup_seconds(double value) { fast_copy_warmup_seconds = value; }
 
     // Delegates to the StackRenderer to clear its caches after fork
     void postfork_child();

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
@@ -117,6 +117,41 @@ init_segv_catcher()
     return 0;
 }
 
+bool
+segv_handler_installed()
+{
+    // Recovery needs our handler to own BOTH SIGSEGV and SIGBUS
+    // (a copy fault can arrive as either); anything else means we can't recover.
+    const int signals[] = { SIGSEGV, SIGBUS };
+    for (int signo : signals) {
+        struct sigaction current;
+        if (sigaction(signo, nullptr, &current) != 0) {
+            return false;
+        }
+        if (current.sa_sigaction != segv_handler || (current.sa_flags & SA_SIGINFO) == 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void
+uninstall_segv_handler()
+{
+    // Restore the saved previous handlers, removing our handler from the chain.
+    // This is used before letting another component (e.g., faulthandler) install
+    // its own handler, so it saves the correct previous handler rather than ours.
+    // After the other component installs, call init_segv_catcher to reinstall
+    // ours on top, creating the correct non-cyclic chain.
+    struct sigaction current;
+    if (sigaction(SIGSEGV, nullptr, &current) == 0 && current.sa_sigaction == segv_handler) {
+        sigaction(SIGSEGV, &g_old_segv, nullptr);
+    }
+    if (sigaction(SIGBUS, nullptr, &current) == 0 && current.sa_sigaction == segv_handler) {
+        sigaction(SIGBUS, &g_old_bus, nullptr);
+    }
+}
+
 #if defined PL_LINUX
 using safe_memcpy_return_t = ssize_t;
 #elif defined PL_DARWIN

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -202,14 +202,17 @@ Sampler::sampling_thread(const uint64_t seq_num)
     // Mark thread as running
     thread_running.store(true);
 
-    // Re-install SIGSEGV/SIGBUS handlers here, after Python initialization.
-    // The handlers may have been installed during static init, but Python or
-    // libraries (faulthandler, Django, FastAPI) can overwrite them afterwards.
-    // Re-installing here ensures our handler is active when the sampling thread runs.
-    // Only do this once to avoid overwriting g_old_segv with our own handler.
+    // (Re)install our SIGSEGV/SIGBUS handlers once, but ONLY if we still own them. If a
+    // foreign component we can't wrap (abseil via vLLM/gRPC, PyTorch/CUDA) already owns
+    // them, overwriting it would cause handler-chaining races and make
+    // segv_handler_installed() report incorrectly, so leave it authoritative.
     static std::once_flag segv_handler_once;
     if (fast_copy_active) {
-        std::call_once(segv_handler_once, init_segv_catcher);
+        std::call_once(segv_handler_once, []() {
+            if (segv_handler_installed()) {
+                init_segv_catcher();
+            }
+        });
     }
 
     using namespace std::chrono;
@@ -221,6 +224,25 @@ Sampler::sampling_thread(const uint64_t seq_num)
     // churning entries for long-lived tasks while still bounding growth.
     uint64_t last_cleared_upload_seq = ProfilerState::get().upload_seq.load(std::memory_order_relaxed);
     constexpr uint64_t ephemeral_clear_interval = 25;
+
+    // safe_memcpy recovery needs us to own both handlers (PROF-14568): warm up on the
+    // syscall copy, upgrade only if we still own them, then re-check and fall back.
+    const bool fast_copy_desired = fast_copy_active;
+#if defined PL_LINUX
+    const bool syscall_copy_available = process_vm_readv_available;
+#else
+    const bool syscall_copy_available = true; // mach_vm_read_overwrite is always available
+#endif
+    // Warm up only when fast copy is wanted and a safe fallback path exists to run on.
+    const bool fast_copy_warmup = fast_copy_desired && syscall_copy_available;
+    bool fast_copy_upgraded = !fast_copy_warmup;
+    bool handler_fallback_done = false;
+    const auto fast_copy_warmup_deadline =
+      sample_time_prev + duration_cast<steady_clock::duration>(duration<double>(fast_copy_warmup_seconds));
+    if (fast_copy_warmup) {
+        // Drop to the safe syscall copy for the startup window.
+        set_fast_copy_enabled(false);
+    }
 
     auto* const runtime = &_PyRuntime;
     while (seq_num == thread_seq_num.load()) {
@@ -237,6 +259,48 @@ Sampler::sampling_thread(const uint64_t seq_num)
         auto sample_time_now = steady_clock::now();
         auto wall_time_us = duration_cast<microseconds>(sample_time_now - sample_time_prev).count();
         sample_time_prev = sample_time_now;
+
+        // Foreign handler handling (see notes before the loop); faulthandler's
+        // transient swaps are safe since the sampler is paused around them.
+        if (fast_copy_desired) {
+            if (!fast_copy_upgraded) {
+                // Warmup window: still on the safe syscall copy. Once it elapses,
+                // upgrade to safe_memcpy only if we still own the handlers.
+                if (sample_time_now >= fast_copy_warmup_deadline) {
+                    fast_copy_upgraded = true; // decide once
+                    if (segv_handler_installed()) {
+                        set_fast_copy_enabled(true);
+                    } else {
+                        // Another component already owns a handler; stay on the safe
+                        // syscall copy (already active from warmup) for the life of
+                        // the process.
+                        handler_fallback_done = true;
+                        std::cerr << "ddtrace stack profiler: another component owns the SIGSEGV/SIGBUS "
+                                     "handler; keeping the syscall-based memory copy to avoid crashing."
+                                  << std::endl;
+                    }
+                }
+            } else if (fast_copy_active && !handler_fallback_done && !segv_handler_installed()) {
+                // A handler was taken over after upgrading; fall back permanently
+                // (no debounce). This is not free: it pins the process to the slower
+                // syscall copy for its remaining lifetime, which can meaningfully
+                // degrade sample quality (e.g. on asyncio workloads). We still prefer
+                // it over the alternative, which is crashing under a foreign handler.
+                handler_fallback_done = true;
+                std::cerr << "ddtrace stack profiler: SIGSEGV/SIGBUS handler was taken over by another "
+                             "component; falling back to syscall-based memory copy to avoid crashing."
+                          << std::endl;
+                if (!set_fast_copy_enabled(false)) {
+                    // No safe fallback available (e.g. process_vm_readv blocked), so
+                    // safe_memcpy is still active; reading under a foreign handler would
+                    // crash - stop sampling instead.
+                    std::cerr << "ddtrace stack profiler: no safe memory-copy fallback available; "
+                                 "stopping stack sampling to avoid crashing."
+                              << std::endl;
+                    break;
+                }
+            }
+        }
 
         // Reset per-cycle asyncio task accumulator before iterating sampled threads
         echion->reset_asyncio_task_count();

--- a/ddtrace/internal/datadog/profiling/stack/src/stack.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack.cpp
@@ -7,6 +7,8 @@
 #include "echion/echion_sampler.h"
 #include "echion/vm.h"
 
+#include <cmath>
+
 using namespace Datadog;
 
 static PyObject*
@@ -707,6 +709,42 @@ stack_set_fast_copy(PyObject* Py_UNUSED(self), PyObject* args)
 }
 
 static PyObject*
+stack_uninstall_segv_handler(PyObject* Py_UNUSED(self), PyObject* Py_UNUSED(args))
+{
+    // Temporarily remove our SIGSEGV/SIGBUS handlers, restoring the saved
+    // previous handlers. Call this before letting another component (e.g.,
+    // faulthandler) install its own handler so it doesn't record ours as its
+    // previous handler (which would create a signal-handler cycle).
+    // Follow with stack_reinstall_segv_handler to reinstall on top.
+    if (fast_copy_active) {
+        uninstall_segv_handler();
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject*
+stack_reinstall_segv_handler(PyObject* Py_UNUSED(self), PyObject* Py_UNUSED(args))
+{
+    // Reinstall SIGSEGV/SIGBUS handlers if fast_copy (safe_memcpy) is active.
+    // This is used to reclaim the handler after another component (e.g., Python's
+    // faulthandler module) overwrites it. Our handler chains to the previous one
+    // for non-recovery faults, so both systems coexist correctly.
+    if (fast_copy_active) {
+        init_segv_catcher();
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject*
+stack_segv_handler_installed(PyObject* Py_UNUSED(self), PyObject* Py_UNUSED(args))
+{
+    if (segv_handler_installed()) {
+        Py_RETURN_TRUE;
+    }
+    Py_RETURN_FALSE;
+}
+
+static PyObject*
 stack_is_safe_copy_failed(PyObject* Py_UNUSED(self), PyObject* Py_UNUSED(args))
 {
 // process_vm_readv is always available on macOS
@@ -716,6 +754,41 @@ stack_is_safe_copy_failed(PyObject* Py_UNUSED(self), PyObject* Py_UNUSED(args))
     }
 #endif
     Py_RETURN_FALSE;
+}
+
+static PyObject*
+stack_fast_copy_memory_active(PyObject* Py_UNUSED(self), PyObject* Py_UNUSED(args))
+{
+    if (fast_copy_active) {
+        Py_RETURN_TRUE;
+    }
+    Py_RETURN_FALSE;
+}
+
+static PyObject*
+stack_set_fast_copy_warmup_seconds(PyObject* Py_UNUSED(self), PyObject* args)
+{
+    double seconds_value = 0.0;
+
+    if (!PyArg_ParseTuple(args, "d", &seconds_value)) {
+        return NULL;
+    }
+
+    if (!std::isfinite(seconds_value) || seconds_value < 0.0) {
+        PyErr_SetString(PyExc_ValueError,
+                        "_set_fast_copy_warmup_seconds requires a finite, non-negative number of seconds");
+        return NULL;
+    }
+
+    if (Sampler::get().is_running()) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "_set_fast_copy_warmup_seconds must be called before the sampler is started");
+        return NULL;
+    }
+
+    Sampler::get().set_fast_copy_warmup_seconds(seconds_value);
+
+    Py_RETURN_NONE;
 }
 
 static PyMethodDef stack_methods[] = {
@@ -756,6 +829,26 @@ static PyMethodDef stack_methods[] = {
       stack_is_safe_copy_failed,
       METH_NOARGS,
       "Check if all safe copy methods failed to initialize" },
+    { "fast_copy_memory_active",
+      stack_fast_copy_memory_active,
+      METH_NOARGS,
+      "Return True if the fast safe_memcpy copy path is currently active" },
+    { "_set_fast_copy_warmup_seconds",
+      stack_set_fast_copy_warmup_seconds,
+      METH_VARARGS,
+      "Test-only: set the fast-copy startup warmup duration in seconds (before start)" },
+    { "uninstall_segv_handler",
+      stack_uninstall_segv_handler,
+      METH_NOARGS,
+      "Remove SIGSEGV handler before another component installs its own" },
+    { "reinstall_segv_handler",
+      stack_reinstall_segv_handler,
+      METH_NOARGS,
+      "Reinstall SIGSEGV handler after another component overwrites it" },
+    { "segv_handler_installed",
+      stack_segv_handler_installed,
+      METH_NOARGS,
+      "Return True if ddtrace's handler is the currently installed disposition for SIGSEGV and SIGBUS" },
     // Native call monitoring
     { "start_native_monitoring",
       start_native_monitoring,

--- a/releasenotes/notes/profiling-stack-sampler-foreign-handler-fallback-3d8f1b6a0e25c947.yaml
+++ b/releasenotes/notes/profiling-stack-sampler-foreign-handler-fallback-3d8f1b6a0e25c947.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    profiling: crash fix for stack sampler in case where another
+    component installs its own ``SIGSEGV``/``SIGBUS`` handler that the profiler cannot wrap (e.g. CUDA, PyTorch, etc.).
+    The sampler upgrades to the faster fault-recovery copy if it still owns both fault handlers afterwards.
+    Otherwise, it permanently falls back to the syscall-based copy.

--- a/tests/profiling/collector/test_copy_memory_stats.py
+++ b/tests/profiling/collector/test_copy_memory_stats.py
@@ -80,31 +80,36 @@ def test_fast_copy_memory_disabled():
     ),
     err=None,
 )
-def test_fast_copy_memory_enabled():
-    """fast_copy_memory_enabled is True when _DD_PROFILING_STACK_FAST_COPY=1."""
-    import glob
-    import json
-    import os
+def test_fast_copy_memory_enabled() -> None:
+    """Sampler runs on the syscall copy during warmup, then upgrades to safe_memcpy (PROF-14568)."""
     import time
 
+    # Underscore-prefixed, so only on the _stack submodule (`import *` skips it).
+    from ddtrace.internal.datadog.profiling.stack import _stack
     from ddtrace.profiling import profiler
     from ddtrace.trace import tracer
 
-    p = profiler.Profiler(tracer=tracer)
+    _stack._set_fast_copy_warmup_seconds(1.0)
+
+    p: profiler.Profiler = profiler.Profiler(tracer=tracer)
     p.start()
-    time.sleep(3)
+
+    # Require warmup (False) before accepting the upgrade (True), so the brief
+    # constructor-time True isn't mistaken for it.
+    saw_warmup: bool = False
+    saw_upgrade: bool = False
+    deadline: float = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        active: bool = _stack.fast_copy_memory_active()
+        if not saw_warmup:
+            if active is False:
+                saw_warmup = True
+        elif active is True:
+            saw_upgrade = True
+            break
+        time.sleep(0.05)
+
     p.stop()
 
-    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
-    files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
-    assert files, "Expected at least one internal_metadata.json file"
-
-    for i, f in enumerate(files):
-        is_last_file = i == len(files) - 1
-        with open(f) as fp:
-            metadata = json.load(fp)
-        if not is_last_file:
-            assert "fast_copy_memory_enabled" in metadata, f"Missing fast_copy_memory_enabled in {f}: {metadata}"
-            assert metadata["fast_copy_memory_enabled"] is True, (
-                f"Expected fast_copy_memory_enabled=true by default: {metadata}"
-            )
+    assert saw_warmup, "Expected the sampler to run on the syscall copy during the warmup window"
+    assert saw_upgrade, "Expected the sampler to upgrade to safe_memcpy after warmup"

--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -6,6 +6,7 @@ import sys
 
 import pytest
 
+from ddtrace.internal.datadog.profiling import stack as _stack_ext
 from tests.profiling.collector import lock_utils
 from tests.profiling.collector import pprof_utils
 from tests.utils import call_program
@@ -215,5 +216,42 @@ def test_profiler_start_up_with_module_clean_up_in_protobuf_app() -> None:
     # This can cause segfaults if we do module clean up with later versions of
     # protobuf. This is a regression test.
     from google.protobuf import empty_pb2  # noqa:F401
+
+    print("OK")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="stack v2 profiler is not available on Windows")
+@pytest.mark.skipif(not _stack_ext.is_available, reason="stack v2 native extension not available")
+@pytest.mark.subprocess(
+    env=dict(_DD_PROFILING_STACK_FAST_COPY="1"),
+    out="OK\n",
+    err=None,
+)
+def test_stack_profiler_foreign_segv_handler_detection() -> None:
+    # Regression test for PROF-14568: safe_memcpy's fault recovery needs us to own
+    # BOTH SIGSEGV and SIGBUS. segv_handler_installed() drives the sampler's
+    # detect-and-fallback decision; assert it flips when either signal is taken over.
+    import signal
+
+    from ddtrace.internal.datadog.profiling import stack
+
+    # Our handler is installed by the extension's constructor on import.
+    assert stack.segv_handler_installed() is True
+
+    # A foreign component overwrites the SIGSEGV disposition: ownership must flip.
+    signal.signal(signal.SIGSEGV, signal.SIG_DFL)
+    assert stack.segv_handler_installed() is False
+
+    # Reclaiming the handler is detected too.
+    stack.reinstall_segv_handler()
+    assert stack.segv_handler_installed() is True
+
+    # Losing only SIGBUS is just as unsafe as losing SIGSEGV: the predicate must
+    # report we no longer own the handler even though SIGSEGV is still ours.
+    signal.signal(signal.SIGBUS, signal.SIG_DFL)
+    assert stack.segv_handler_installed() is False
+
+    stack.reinstall_segv_handler()
+    assert stack.segv_handler_installed() is True
 
     print("OK")


### PR DESCRIPTION
* https://datadoghq.atlassian.net/browse/PROF-15342
* properly fixes https://datadoghq.atlassian.net/browse/PROF-14568 (work-around)
* customer issue: https://datadoghq.atlassian.net/browse/AIPTS-1715

Backport #18798 to 4.10.

## Summary

Hardens the stack sampler against foreign `SIGSEGV`/`SIGBUS` handlers (CUDA/PyTorch/etc.): startup warmup on syscall copy, ownership checks each cycle, permanent fallback when another component owns the handler.

4.10-specific: preserved ephemeral string-table clearing in the sampler loop (`clear_ephemeral` / `set_string_table_ephemeral_count`).

## Test plan

- [ ] CI green on 4.10 profiling suites
- [x] Local: cherry-pick conflicts resolved; ephemeral 4.10 behavior merged into backported `sampler.cpp`