### PR TITLE
fix(aws-payload-tagging): improve aws payload tagging speed

### DIFF
--- a/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
+++ b/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
@@ -66,7 +66,6 @@ class AWSPayloadTagging:
     ]
 
     def __init__(self):
-        self.current_tag_count = 0
         self.validated = False
         self.request_redaction_paths = None
         self.response_redaction_paths = None
@@ -74,9 +73,6 @@ class AWSPayloadTagging:
         # was a meaningful source of overhead.
         self._parsed_request_expressions = []
         self._parsed_response_expressions = []
-        # id()s of values matched by redaction expressions for the current payload. Rebuilt each
-        # call; stored on the instance so _tag_object can check it without an extra parameter.
-        self._current_redacted_ids: set[int] = set()
 
     def expand_payload_as_tags(self, span: Span, result: dict[str, Any], key: str) -> None:
         """
@@ -105,7 +101,7 @@ class AWSPayloadTagging:
         #
         # Only the expression set matching the payload side is evaluated — request paths have no
         # business running against response payloads and vice versa.
-        self._current_redacted_ids = set()
+        redacted_ids: set[int] = set()
         exprs = (
             self._parsed_request_expressions
             if key.startswith("aws.request")
@@ -113,14 +109,14 @@ class AWSPayloadTagging:
         )
         for expr in exprs:
             for match in expr.find(result):
-                self._current_redacted_ids.add(id(match.value))
+                redacted_ids.add(id(match.value))
 
-        self.current_tag_count = 0
+        tag_count = 0
         # flatten the payload into span tags
         for key2, value in result.items():
             escaped_sub_key = key2.replace(".", "\\.")
-            self._tag_object(span, f"{key}.{escaped_sub_key}", value)
-            if self.current_tag_count >= config.botocore.get("payload_tagging_max_tags"):
+            tag_count = self._tag_object(span, f"{key}.{escaped_sub_key}", value, 0, tag_count, redacted_ids)
+            if tag_count >= config.botocore.get("payload_tagging_max_tags"):
                 return
 
     def _should_json_parse(self, obj: Any) -> bool:
@@ -187,7 +183,9 @@ class AWSPayloadTagging:
 
         return []
 
-    def _tag_object(self, span: Span, key: str, obj: Any, depth: int = 0) -> None:
+    def _tag_object(
+        self, span: Span, key: str, obj: Any, depth: int, tag_count: int, redacted_ids: set[int]
+    ) -> int:
         """
         Recursively expands the given AWS payload object and adds the values as flattened Span tags.
         It is not expected that AWS Payloads will be deeply nested so the number of recursive calls should be low.
@@ -208,53 +206,48 @@ class AWSPayloadTagging:
         "aws.response.body.HTTPHeaders.content-length": "5"
         """
         # if we've hit the maximum allowed tags, mark the expansion as incomplete
-        if self.current_tag_count >= config.botocore.get("payload_tagging_max_tags"):
+        if tag_count >= config.botocore.get("payload_tagging_max_tags"):
             span.set_tag(self._INCOMPLETE_TAG, "True")
-            return
-        if id(obj) in self._current_redacted_ids:
-            self.current_tag_count += 1
+            return tag_count
+        if id(obj) in redacted_ids:
             span.set_tag(key, "redacted")
-            return
+            return tag_count + 1
         if obj is None:
-            self.current_tag_count += 1
             span.set_tag(key, obj)
-            return
+            return tag_count + 1
         if depth >= config.botocore.get("payload_tagging_max_depth"):
-            self.current_tag_count += 1
             span.set_tag(
                 key, str(obj)[:_MAX_TAG_VALUE_LENGTH]
             )  # at the maximum depth - set the tag without further expansion
-            return
+            return tag_count + 1
         depth += 1
         if self._should_json_parse(obj):
             try:
                 parsed = json.loads(obj)
-                self._tag_object(span, key, parsed, depth)
+                return self._tag_object(span, key, parsed, depth, tag_count, redacted_ids)
             except ValueError:
-                self.current_tag_count += 1
                 span.set_tag(key, str(obj)[:_MAX_TAG_VALUE_LENGTH])
-            return
+                return tag_count + 1
         if isinstance(obj, (int, float, Decimal)):
-            self.current_tag_count += 1
             span.set_tag(key, str(obj))
-            return
+            return tag_count + 1
         if isinstance(obj, list):
             for k, v in enumerate(obj):
-                self._tag_object(span, f"{key}.{k}", v, depth)
-            return
+                tag_count = self._tag_object(span, f"{key}.{k}", v, depth, tag_count, redacted_ids)
+            return tag_count
         if hasattr(obj, "items"):
             for k, v in obj.items():
                 escaped_key = str(k).replace(".", "\\.")
-                self._tag_object(span, f"{key}.{escaped_key}", v, depth)
-            return
+                tag_count = self._tag_object(span, f"{key}.{escaped_key}", v, depth, tag_count, redacted_ids)
+            return tag_count
         if hasattr(obj, "to_dict"):
             for k, v in obj.to_dict().items():
                 escaped_key = str(k).replace(".", "\\.")
-                self._tag_object(span, f"{key}.{escaped_key}", v, depth)
-            return
+                tag_count = self._tag_object(span, f"{key}.{escaped_key}", v, depth, tag_count, redacted_ids)
+            return tag_count
         try:
             value_as_str = str(obj)
         except Exception:
             value_as_str = "UNKNOWN"
-        self.current_tag_count += 1
         span.set_tag(key, value_as_str)
+        return tag_count + 1

--- a/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
+++ b/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
@@ -2,7 +2,6 @@ from decimal import Decimal
 import json
 from typing import Any
 from typing import Optional
-from typing import Set
 
 from ddtrace import config
 from ddtrace._trace.span import Span
@@ -58,7 +57,7 @@ class AWSPayloadTagging:
         "$..Endpoints.*.Token",
         "$..PlatformApplication.*.PlatformCredential",
         "$..PlatformApplication.*.PlatformPrincipal",
-        "$..Subscriptions.*.Endpoint",
+        "$..Subscriptions[*].Endpoint",
         "$..PhoneNumbers[*].PhoneNumber",
         "$..phoneNumbers[*]",
         # // S3
@@ -71,10 +70,13 @@ class AWSPayloadTagging:
         self.validated = False
         self.request_redaction_paths = None
         self.response_redaction_paths = None
-        # Holds the id()s of payload values that must be emitted as "redacted" for
-        # the current expand_payload_as_tags call. Rebuilt each call. This is stored on the instance to
-        # avoid threading an extra parameter through all recursive _tag_object calls.
-        self._current_redacted_ids: Set[int] = set()
+        # Parsed once on first call and reused; parsing 15+ default paths on every invocation
+        # was a meaningful source of overhead.
+        self._parsed_request_expressions = []
+        self._parsed_response_expressions = []
+        # id()s of values matched by redaction expressions for the current payload. Rebuilt each
+        # call; stored on the instance so _tag_object can check it without an extra parameter.
+        self._current_redacted_ids: set[int] = set()
 
     def expand_payload_as_tags(self, span: Span, result: dict[str, Any], key: str) -> None:
         """
@@ -83,6 +85,8 @@ class AWSPayloadTagging:
         if not self.validated:
             self.request_redaction_paths = self._get_redaction_paths_request()
             self.response_redaction_paths = self._get_redaction_paths_response()
+            self._parsed_request_expressions = [parse(p) for p in self.request_redaction_paths]
+            self._parsed_response_expressions = [parse(p) for p in self.response_redaction_paths]
             self.validated = True
 
         if not self.request_redaction_paths and not self.response_redaction_paths:
@@ -91,10 +95,24 @@ class AWSPayloadTagging:
         if not result:
             return
 
+        # Run redaction expressions read-only against the original payload and record the id() of
+        # each matched value. _tag_object emits "redacted" for any object whose id is in the set,
+        # avoiding the need to deep-copy the payload before mutating it.
+        #
+        # id() is safe here because AWS sensitive values (tokens, keys, passwords) are long strings
+        # that Python does not intern, so each has a unique identity within the dict. Interned
+        # objects (None, True, small ints) are never targeted by redaction paths.
+        #
+        # Only the expression set matching the payload side is evaluated — request paths have no
+        # business running against response payloads and vice versa.
         self._current_redacted_ids = set()
-        all_paths = (self.request_redaction_paths or []) + (self.response_redaction_paths or [])
-        for path in all_paths:
-            for match in parse(path).find(result):
+        exprs = (
+            self._parsed_request_expressions
+            if key.startswith("aws.request")
+            else self._parsed_response_expressions
+        )
+        for expr in exprs:
+            for match in expr.find(result):
                 self._current_redacted_ids.add(id(match.value))
 
         self.current_tag_count = 0
@@ -193,8 +211,6 @@ class AWSPayloadTagging:
         if self.current_tag_count >= config.botocore.get("payload_tagging_max_tags"):
             span.set_tag(self._INCOMPLETE_TAG, "True")
             return
-        # Check to see the redaction set before any other processing. id() is used here
-        # rather than value equality — see the note in expand_payload_as_tags for the rationale.
         if id(obj) in self._current_redacted_ids:
             self.current_tag_count += 1
             span.set_tag(key, "redacted")

--- a/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
+++ b/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
@@ -74,9 +74,8 @@ class AWSPayloadTagging:
         # was a meaningful source of overhead.
         self._parsed_request_expressions = []
         self._parsed_response_expressions = []
-        # Read from config once per expand_payload_as_tags call and stored so _tag_object
+        # Read from config once during initialization and stored so _tag_object
         # doesn't need to call config.botocore.get() on every recursive invocation.
-        self._max_tags: int = 0
         self._max_depth: int = 0
         self._init_lock = threading.Lock()
 

--- a/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
+++ b/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
@@ -74,9 +74,7 @@ class AWSPayloadTagging:
         # was a meaningful source of overhead.
         self._parsed_request_expressions = []
         self._parsed_response_expressions = []
-        # id()s of values matched by redaction expressions for the current payload. Rebuilt each
-        # call; stored on the instance so _tag_object can check it without an extra parameter.
-        self._current_redacted_ids: set[int] = set()
+        # Per-call redaction ids are stored in _REDACTED_ID_SET (ContextVar) to keep shared instances safe.
 
     def expand_payload_as_tags(self, span: Span, result: dict[str, Any], key: str) -> None:
         """
@@ -211,7 +209,7 @@ class AWSPayloadTagging:
         if self.current_tag_count >= config.botocore.get("payload_tagging_max_tags"):
             span.set_tag(self._INCOMPLETE_TAG, "True")
             return
-        if id(obj) in self._current_redacted_ids:
+        if id(obj) in _REDACTED_ID_SET.get():
             self.current_tag_count += 1
             span.set_tag(key, "redacted")
             return

--- a/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
+++ b/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
@@ -222,6 +222,15 @@ class AWSPayloadTagging:
         config_value = config.botocore.get(config_key)
         if not config_value:
             return []
+        config_value = config_value.strip()
+        if not config_value:
+            log.warning(
+                "Payload tagging config %r is whitespace-only and will be ignored. "
+                "Payload tagging will be disabled until the config is corrected.",
+                config_key,
+            )
+            return []
+        config_value = config_value.lower() if config_value.lower() == "all" else config_value
         if not self._validate_json_paths(config_value):
             return []
         defaults = side_defaults + self._REDACTION_PATHS_DEFAULTS

--- a/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
+++ b/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
@@ -87,7 +87,7 @@ class AWSPayloadTagging:
     ]
 
     def __init__(self):
-        self._initialized = False
+        self.validated = False
         # Parsed once on first call and reused; parsing 15+ default paths on every
         # invocation was a meaningful source of overhead.
         self._parsed_request_expressions = []
@@ -102,16 +102,16 @@ class AWSPayloadTagging:
         """
         Expands the JSON payload from various AWS services into tags and sets them on the Span.
         """
-        if not self._initialized:
+        if not self.validated:
             with self._init_lock:
-                if not self._initialized:
+                if not self.validated:
                     request_paths = self._get_redaction_paths("payload_tagging_request", self._REQUEST_REDACTION_PATHS_DEFAULTS)
                     response_paths = self._get_redaction_paths("payload_tagging_response", self._RESPONSE_REDACTION_PATHS_DEFAULTS)
                     self._parsed_request_expressions = [parse(p) for p in request_paths]
                     self._parsed_response_expressions = [parse(p) for p in response_paths]
                     self._max_tags = config.botocore.get("payload_tagging_max_tags")
                     self._max_depth = config.botocore.get("payload_tagging_max_depth")
-                    self._initialized = True
+                    self.validated = True
 
         if not payload:
             return
@@ -188,8 +188,8 @@ class AWSPayloadTagging:
                 if not path.startswith("$"):
                     log.warning(
                         "Invalid JSONPath expression %r in payload tagging config — "
-                        "all custom paths must start with '$'. Custom redaction paths "
-                        "will be ignored; falling back to default redaction paths only.",
+                        "all custom paths must start with '$'. Payload tagging will be "
+                        "disabled until the config is corrected.",
                         path,
                     )
                     return False
@@ -198,15 +198,15 @@ class AWSPayloadTagging:
                 except Exception:
                     log.warning(
                         "Failed to parse JSONPath expression %r in payload tagging config. "
-                        "Custom redaction paths will be ignored; falling back to default redaction paths only.",
+                        "Payload tagging will be disabled until the config is corrected.",
                         path,
                     )
                     return False
             else:
                 log.warning(
                     "Empty JSONPath expression in payload tagging config (check for "
-                    "leading/trailing commas). Custom redaction paths will be ignored; "
-                    "falling back to default redaction paths only.",
+                    "leading/trailing commas). Payload tagging will be disabled until "
+                    "the config is corrected.",
                 )
                 return False
 
@@ -215,18 +215,19 @@ class AWSPayloadTagging:
     def _get_redaction_paths(self, config_key: str, side_defaults: list) -> list:
         """
         Build the redaction path list for one payload side, combining side-specific and
-        shared defaults with any user-provided JSONPaths. Falls back to defaults if custom
-        paths are invalid (warning already emitted by _validate_json_paths).
+        shared defaults with any user-provided JSONPaths. Returns an empty list if the
+        config value is absent or invalid — disabling tagging on misconfiguration is
+        safer than emitting partially-redacted data with unknown custom paths ignored.
         """
         config_value = config.botocore.get(config_key)
         if not config_value:
             return []
+        if not self._validate_json_paths(config_value):
+            return []
         defaults = side_defaults + self._REDACTION_PATHS_DEFAULTS
-        if self._validate_json_paths(config_value):
-            if config_value == "all":
-                return defaults
-            return defaults + [p.strip() for p in config_value.split(",")]
-        return defaults
+        if config_value == "all":
+            return defaults
+        return defaults + [p.strip() for p in config_value.split(",")]
 
     def _tag_children(self, span: Span, key: str, obj: Any, items: Any, depth: int, tag_count: int, ctx: _RedactionContext) -> int:
         """Iterate key-value pairs from a container, redacting or recursing for each child."""

--- a/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
+++ b/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
@@ -208,10 +208,8 @@ class AWSPayloadTagging:
         # if we've hit the maximum allowed tags, mark the expansion as incomplete
         if tag_count >= config.botocore.get("payload_tagging_max_tags"):
             span.set_tag(self._INCOMPLETE_TAG, "True")
-
-            return
-        if id(obj) in _REDACTED_ID_SET.get():
-            self.current_tag_count += 1
+            return tag_count
+        if id(obj) in redacted_ids:
             span.set_tag(key, "redacted")
             return tag_count + 1
         if obj is None:

--- a/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
+++ b/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+from dataclasses import field
 from decimal import Decimal
 import json
 import threading
@@ -6,10 +8,29 @@ from typing import Optional
 
 from ddtrace import config
 from ddtrace._trace.span import Span
+from ddtrace.internal.logger import get_logger
 from ddtrace.vendor.jsonpath_ng import parse
 
 
+log = get_logger(__name__)
+
+
 _MAX_TAG_VALUE_LENGTH = 5000
+
+
+@dataclass
+class _RedactionContext:
+    """Immutable redaction state threaded through _tag_object/_tag_children calls."""
+
+    # (id(parent), field_name_or_index) tuples for known path types;
+    # id(value) ints as a fallback for exotic path types (Slice, Where, etc.).
+    # The two forms never collide — an int check never matches a tuple entry.
+    redacted_ids: set = field(default_factory=set)
+    # id()s of containers that are ancestors of a redacted field, used by the
+    # depth-truncation branch to avoid stringifying objects that would expose secrets.
+    ancestor_ids: set = field(default_factory=set)
+    # Parsed JSONPath expressions for the active payload side.
+    exprs: list = field(default_factory=list)
 
 
 class AWSPayloadTagging:
@@ -29,12 +50,12 @@ class AWSPayloadTagging:
         "$..Targets[*].RedshiftDataParameters.Sql",
         "$..Targets[*].RedshiftDataParameters.Sqls",
         "$..Targets[*].AppSyncParameters.GraphQLOperation",
-        # // S3
+        # S3
         "$..SSEKMSKeyId",
         "$..SSEKMSEncryptionContext",
     ]
     _REQUEST_REDACTION_PATHS_DEFAULTS = [
-        # Sns
+        # SNS
         "$..Attributes.PlatformCredential",
         "$..Attributes.PlatformPrincipal",
         "$..AWSAccountId",
@@ -52,105 +73,107 @@ class AWSPayloadTagging:
         "$..CopySourceSSECustomerKey",
         "$..RestoreRequest.OutputLocation.S3.Encryption.KMSKeyId",
     ]
-
     _RESPONSE_REDACTION_PATHS_DEFAULTS = [
-        # // Sns
+        # SNS
         "$..Endpoints.*.Token",
         "$..PlatformApplication.*.PlatformCredential",
         "$..PlatformApplication.*.PlatformPrincipal",
         "$..Subscriptions[*].Endpoint",
         "$..PhoneNumbers[*].PhoneNumber",
         "$..phoneNumbers[*]",
-        # // S3
+        # S3
         "$..Credentials.SecretAccessKey",
         "$..Credentials.SessionToken",
     ]
 
     def __init__(self):
-        self.validated = False
-        self.request_redaction_paths = None
-        self.response_redaction_paths = None
-        # Parsed once on first call and reused; parsing 15+ default paths on every invocation
-        # was a meaningful source of overhead.
+        self._initialized = False
+        # Parsed once on first call and reused; parsing 15+ default paths on every
+        # invocation was a meaningful source of overhead.
         self._parsed_request_expressions = []
         self._parsed_response_expressions = []
-        # Read from config once per expand_payload_as_tags call and stored so _tag_object
-        # doesn't need to call config.botocore.get() on every recursive invocation.
+        # Read once at initialization from config (env vars set at process start).
         self._max_tags: int = 0
         self._max_depth: int = 0
         self._init_lock = threading.Lock()
 
-    def expand_payload_as_tags(self, span: Span, result: dict[str, Any], key: str) -> None:
+    def expand_payload_as_tags(self, span: Span, payload: dict[str, Any], key: str) -> None:
         """
         Expands the JSON payload from various AWS services into tags and sets them on the Span.
         """
-        if not self.validated:
+        if not self._initialized:
             with self._init_lock:
-                if not self.validated:
-                    self.request_redaction_paths = self._get_redaction_paths_request()
-                    self.response_redaction_paths = self._get_redaction_paths_response()
-                    self._parsed_request_expressions = [parse(p) for p in self.request_redaction_paths]
-                    self._parsed_response_expressions = [parse(p) for p in self.response_redaction_paths]
+                if not self._initialized:
+                    request_paths = self._get_redaction_paths("payload_tagging_request", self._REQUEST_REDACTION_PATHS_DEFAULTS)
+                    response_paths = self._get_redaction_paths("payload_tagging_response", self._RESPONSE_REDACTION_PATHS_DEFAULTS)
+                    self._parsed_request_expressions = [parse(p) for p in request_paths]
+                    self._parsed_response_expressions = [parse(p) for p in response_paths]
                     self._max_tags = config.botocore.get("payload_tagging_max_tags")
                     self._max_depth = config.botocore.get("payload_tagging_max_depth")
-                    self.validated = True
+                    self._initialized = True
 
-        if not self.request_redaction_paths and not self.response_redaction_paths:
+        if not payload:
             return
 
-        if not result:
-            return
-
-        # Run redaction expressions read-only against the original payload. For each match,
-        # record (id(parent_container), field_name_or_index) to identify the location of the
-        # sensitive value rather than the value itself. This avoids false positives from Python's
-        # string interning — two fields holding the same object remain independently addressable.
-        #
-        # Only the expression set matching the payload side is evaluated — request paths have no
-        # business running against response payloads and vice versa.
-        # Mixed set of (id(parent), key) tuples for known path types and id(value) ints as a
-        # fallback for exotic path types (Slice, Where, etc.). The two forms never collide —
-        # an int membership check never matches a tuple entry and vice versa.
-        redacted_ids: set = set()
+        # Select the expression set for this payload side. Empty means the feature is
+        # disabled for this side — return without tagging to avoid emitting unredacted data.
         exprs = (
             self._parsed_request_expressions
             if key.startswith("aws.request")
             else self._parsed_response_expressions
         )
-        for expr in exprs:
-            for match in expr.find(result):
-                path = match.path
-                if hasattr(path, "fields") and path.fields:
-                    redacted_ids.add((id(match.context.value), path.fields[0]))
-                elif hasattr(path, "index"):
-                    redacted_ids.add((id(match.context.value), path.index))
-                else:
-                    # Fallback for Slice, Where, Root, or other exotic match types.
-                    # Falls back to value identity — safe for the long credential strings
-                    # these paths would realistically target.
-                    redacted_ids.add(id(match.value))
+        if not exprs:
+            return
+
+        ctx = self._build_redaction_context(payload, exprs)
 
         tag_count = 0
-        # flatten the payload into span tags
-        for key2, value in result.items():
-            escaped_sub_key = key2.replace(".", "\\.")
-            if (id(result), key2) in redacted_ids:
-                span.set_tag(f"{key}.{escaped_sub_key}", "redacted")
+        for field_name, value in payload.items():
+            escaped_name = field_name.replace(".", "\\.")
+            tag_key = f"{key}.{escaped_name}"
+            if (id(payload), field_name) in ctx.redacted_ids:
+                span.set_tag(tag_key, "redacted")
                 tag_count += 1
             else:
-                tag_count = self._tag_object(span, f"{key}.{escaped_sub_key}", value, 0, tag_count, redacted_ids)
+                tag_count = self._tag_object(span, tag_key, value, 0, tag_count, ctx)
             if tag_count >= self._max_tags:
                 span.set_tag(self._INCOMPLETE_TAG, "True")
                 return
 
-    def _should_json_parse(self, obj: Any) -> bool:
-        if isinstance(obj, (str, bytes)):
-            return True
-        return False
+    def _build_redaction_context(self, payload: Any, exprs: list) -> _RedactionContext:
+        """
+        Run redaction expressions read-only against payload and return a _RedactionContext.
+        Called once for the outer payload and again each time an embedded JSON string is
+        parsed, so every object graph gets fresh sets keyed on the correct object identities.
+        """
+        ctx = _RedactionContext(exprs=exprs)
+        for expr in exprs:
+            for match in expr.find(payload):
+                path = match.path
+                if hasattr(path, "fields") and path.fields:
+                    ctx.redacted_ids.add((id(match.context.value), path.fields[0]))
+                elif hasattr(path, "index"):
+                    ctx.redacted_ids.add((id(match.context.value), path.index))
+                elif match.value is payload:
+                    # Root match ($) — mark every top-level key so the entire payload
+                    # is suppressed via the normal location-based check.
+                    if hasattr(payload, "keys"):
+                        for k in payload:
+                            ctx.redacted_ids.add((id(payload), k))
+                else:
+                    # Fallback for Slice, Where, or other exotic match types
+                    ctx.redacted_ids.add(id(match.value))
+
+                # Walk the context chain to record every ancestor container id
+                current = match
+                while current.context is not None:
+                    ctx.ancestor_ids.add(id(current.context.value))
+                    current = current.context
+        return ctx
 
     def _validate_json_paths(self, paths: Optional[str]) -> bool:
         """
-        Checks whether paths is "all" or all valid JSONPaths
+        Checks whether paths is "all" or all valid JSONPaths.
         """
         if not paths:
             return False  # not enabled
@@ -158,56 +181,68 @@ class AWSPayloadTagging:
         if paths == "all":
             return True  # enabled, use the defaults
 
-        # otherwise validate that we have valid JSONPaths
         for path in paths.split(","):
+            path = path.strip()
             if path:
-                # Require JSONPath to start with "$"
                 if not path.startswith("$"):
+                    log.warning(
+                        "Invalid JSONPath expression %r in payload tagging config — "
+                        "all custom paths must start with '$'. Custom redaction paths "
+                        "will be ignored; falling back to default redaction paths only.",
+                        path,
+                    )
                     return False
                 try:
                     parse(path)
                 except Exception:
+                    log.warning(
+                        "Failed to parse JSONPath expression %r in payload tagging config. "
+                        "Custom redaction paths will be ignored; falling back to default redaction paths only.",
+                        path,
+                    )
                     return False
             else:
+                log.warning(
+                    "Empty JSONPath expression in payload tagging config (check for "
+                    "leading/trailing commas). Custom redaction paths will be ignored; "
+                    "falling back to default redaction paths only.",
+                )
                 return False
 
         return True
 
-    def _get_redaction_paths_response(self) -> list:
+    def _get_redaction_paths(self, config_key: str, side_defaults: list) -> list:
         """
-        Get the list of redaction paths, combining defaults with any user-provided JSONPaths.
+        Build the redaction path list for one payload side, combining side-specific and
+        shared defaults with any user-provided JSONPaths. Falls back to defaults if custom
+        paths are invalid (warning already emitted by _validate_json_paths).
         """
-        if not config.botocore.get("payload_tagging_response"):
+        config_value = config.botocore.get(config_key)
+        if not config_value:
             return []
+        defaults = side_defaults + self._REDACTION_PATHS_DEFAULTS
+        if self._validate_json_paths(config_value):
+            if config_value == "all":
+                return defaults
+            return defaults + [p.strip() for p in config_value.split(",")]
+        return defaults
 
-        response_redaction = config.botocore.get("payload_tagging_response")
-        if self._validate_json_paths(response_redaction):
-            if response_redaction == "all":
-                return self._RESPONSE_REDACTION_PATHS_DEFAULTS + self._REDACTION_PATHS_DEFAULTS
-            return (
-                self._RESPONSE_REDACTION_PATHS_DEFAULTS + self._REDACTION_PATHS_DEFAULTS + response_redaction.split(",")
-            )
+    def _tag_children(self, span: Span, key: str, obj: Any, items: Any, depth: int, tag_count: int, ctx: _RedactionContext) -> int:
+        """Iterate key-value pairs from a container, redacting or recursing for each child."""
+        for k, v in items:
+            escaped_k = str(k).replace(".", "\\.") if isinstance(k, str) else k
+            child_key = f"{key}.{escaped_k}"
+            if (id(obj), k) in ctx.redacted_ids:
+                span.set_tag(child_key, "redacted")
+                tag_count += 1
+            else:
+                tag_count = self._tag_object(span, child_key, v, depth, tag_count, ctx)
+            if tag_count >= self._max_tags:
+                span.set_tag(self._INCOMPLETE_TAG, "True")
+                break
+        return tag_count
 
-        return []
-
-    def _get_redaction_paths_request(self) -> list:
-        """
-        Get the list of redaction paths, combining defaults with any user-provided JSONPaths.
-        """
-        if not config.botocore.get("payload_tagging_request"):
-            return []
-
-        request_redaction = config.botocore.get("payload_tagging_request")
-        if self._validate_json_paths(request_redaction):
-            if request_redaction == "all":
-                return self._REQUEST_REDACTION_PATHS_DEFAULTS + self._REDACTION_PATHS_DEFAULTS
-            return (
-                self._REQUEST_REDACTION_PATHS_DEFAULTS + self._REDACTION_PATHS_DEFAULTS + request_redaction.split(",")
-            )
-
-        return []
-
-    def _tag_object(self, span: Span, key: str, obj: Any, depth: int, tag_count: int, redacted_ids: set) -> int:
+    def _tag_object(self, span: Span, key: str, obj: Any, depth: int, tag_count: int, ctx: _RedactionContext) -> int:
         """
         Recursively expands the given AWS payload object and adds the values as flattened Span tags.
         It is not expected that AWS Payloads will be deeply nested so the number of recursive calls should be low.
@@ -227,27 +262,33 @@ class AWSPayloadTagging:
         "aws.response.body.HTTPHeaders.x-amz-request-id": "SOMEID"
         "aws.response.body.HTTPHeaders.content-length": "5"
         """
-        # if we've hit the maximum allowed tags, mark the expansion as incomplete
         if tag_count >= self._max_tags:
             span.set_tag(self._INCOMPLETE_TAG, "True")
             return tag_count
-        # fallback redaction check for exotic path types stored as id(value) ints
-        if id(obj) in redacted_ids:
+        # Fallback redaction check for exotic path types stored as id(value) ints
+        if id(obj) in ctx.redacted_ids:
             span.set_tag(key, "redacted")
             return tag_count + 1
         if obj is None:
             span.set_tag(key, obj)
             return tag_count + 1
         if depth >= self._max_depth:
-            span.set_tag(
-                key, str(obj)[:_MAX_TAG_VALUE_LENGTH]
-            )  # at the maximum depth - set the tag without further expansion
+            # If this object is an ancestor of a redacted field, stringifying it would
+            # expose sensitive data in clear text — redact the whole subtree instead.
+            if id(obj) in ctx.ancestor_ids:
+                span.set_tag(key, "redacted")
+            else:
+                span.set_tag(key, str(obj)[:_MAX_TAG_VALUE_LENGTH])
             return tag_count + 1
         depth += 1
-        if self._should_json_parse(obj):
+        if isinstance(obj, (str, bytes)):
             try:
                 parsed = json.loads(obj)
-                return self._tag_object(span, key, parsed, depth, tag_count, redacted_ids)
+                # Rebuild the redaction context for the new object graph — the original
+                # context is keyed on id()s from the outer payload and won't match the
+                # fresh objects created by json.loads.
+                new_ctx = self._build_redaction_context(parsed, ctx.exprs)
+                return self._tag_object(span, key, parsed, depth, tag_count, new_ctx)
             except ValueError:
                 span.set_tag(key, str(obj)[:_MAX_TAG_VALUE_LENGTH])
                 return tag_count + 1
@@ -255,44 +296,14 @@ class AWSPayloadTagging:
             span.set_tag(key, str(obj))
             return tag_count + 1
         if isinstance(obj, list):
-            for k, v in enumerate(obj):
-                if (id(obj), k) in redacted_ids:
-                    span.set_tag(f"{key}.{k}", "redacted")
-                    tag_count += 1
-                else:
-                    tag_count = self._tag_object(span, f"{key}.{k}", v, depth, tag_count, redacted_ids)
-                if tag_count >= self._max_tags:
-                    span.set_tag(self._INCOMPLETE_TAG, "True")
-                    break
-            return tag_count
+            return self._tag_children(span, key, obj, enumerate(obj), depth, tag_count, ctx)
         if hasattr(obj, "items"):
-            for k, v in obj.items():
-                escaped_key = str(k).replace(".", "\\.")
-                if (id(obj), k) in redacted_ids:
-                    span.set_tag(f"{key}.{escaped_key}", "redacted")
-                    tag_count += 1
-                else:
-                    tag_count = self._tag_object(span, f"{key}.{escaped_key}", v, depth, tag_count, redacted_ids)
-                if tag_count >= self._max_tags:
-                    span.set_tag(self._INCOMPLETE_TAG, "True")
-                    break
-            return tag_count
+            return self._tag_children(span, key, obj, obj.items(), depth, tag_count, ctx)
         if hasattr(obj, "to_dict"):
-            for k, v in obj.to_dict().items():
-                escaped_key = str(k).replace(".", "\\.")
-                if (id(obj), k) in redacted_ids:
-                    span.set_tag(f"{key}.{escaped_key}", "redacted")
-                    tag_count += 1
-                else:
-                    tag_count = self._tag_object(span, f"{key}.{escaped_key}", v, depth, tag_count, redacted_ids)
-                if tag_count >= self._max_tags:
-                    span.set_tag(self._INCOMPLETE_TAG, "True")
-                    break
-            return tag_count
+            return self._tag_children(span, key, obj, obj.to_dict().items(), depth, tag_count, ctx)
         try:
             value_as_str = str(obj)
         except Exception:
             value_as_str = "UNKNOWN"
         span.set_tag(key, value_as_str)
         return tag_count + 1
-

--- a/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
+++ b/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
@@ -1,8 +1,8 @@
-import copy
 from decimal import Decimal
 import json
 from typing import Any
 from typing import Optional
+from typing import Set
 
 from ddtrace import config
 from ddtrace._trace.span import Span
@@ -71,6 +71,10 @@ class AWSPayloadTagging:
         self.validated = False
         self.request_redaction_paths = None
         self.response_redaction_paths = None
+        # Holds the id()s of payload values that must be emitted as "redacted" for
+        # the current expand_payload_as_tags call. Rebuilt each call. This is stored on the instance to
+        # avoid threading an extra parameter through all recursive _tag_object calls.
+        self._current_redacted_ids: Set[int] = set()
 
     def expand_payload_as_tags(self, span: Span, result: dict[str, Any], key: str) -> None:
         """
@@ -87,16 +91,15 @@ class AWSPayloadTagging:
         if not result:
             return
 
-        # we will be redacting at least one of request/response
-        redacted_dict = copy.deepcopy(result)
-        self.current_tag_count = 0
-        if self.request_redaction_paths:
-            self._redact_json(redacted_dict, span, self.request_redaction_paths)
-        if self.response_redaction_paths:
-            self._redact_json(redacted_dict, span, self.response_redaction_paths)
+        self._current_redacted_ids = set()
+        all_paths = (self.request_redaction_paths or []) + (self.response_redaction_paths or [])
+        for path in all_paths:
+            for match in parse(path).find(result):
+                self._current_redacted_ids.add(id(match.value))
 
+        self.current_tag_count = 0
         # flatten the payload into span tags
-        for key2, value in redacted_dict.items():
+        for key2, value in result.items():
             escaped_sub_key = key2.replace(".", "\\.")
             self._tag_object(span, f"{key}.{escaped_sub_key}", value)
             if self.current_tag_count >= config.botocore.get("payload_tagging_max_tags"):
@@ -131,15 +134,6 @@ class AWSPayloadTagging:
                 return False
 
         return True
-
-    def _redact_json(self, data: dict[str, Any], span: Span, paths: list) -> None:
-        """
-        Redact sensitive data in the JSON payload based on default and user-provided JSONPath expressions
-        """
-        for path in paths:
-            expression = parse(path)
-            for match in expression.find(data):
-                match.context.value[match.path.fields[0]] = "redacted"
 
     def _get_redaction_paths_response(self) -> list:
         """
@@ -198,6 +192,12 @@ class AWSPayloadTagging:
         # if we've hit the maximum allowed tags, mark the expansion as incomplete
         if self.current_tag_count >= config.botocore.get("payload_tagging_max_tags"):
             span.set_tag(self._INCOMPLETE_TAG, "True")
+            return
+        # AIDEV-NOTE: Check the redaction set before any other processing. id() is used here
+        # rather than value equality — see the note in expand_payload_as_tags for the rationale.
+        if id(obj) in self._current_redacted_ids:
+            self.current_tag_count += 1
+            span.set_tag(key, "redacted")
             return
         if obj is None:
             self.current_tag_count += 1

--- a/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
+++ b/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 import json
+import threading
 from typing import Any
 from typing import Optional
 
@@ -73,17 +74,26 @@ class AWSPayloadTagging:
         # was a meaningful source of overhead.
         self._parsed_request_expressions = []
         self._parsed_response_expressions = []
+        # Read from config once per expand_payload_as_tags call and stored so _tag_object
+        # doesn't need to call config.botocore.get() on every recursive invocation.
+        self._max_tags: int = 0
+        self._max_depth: int = 0
+        self._init_lock = threading.Lock()
 
     def expand_payload_as_tags(self, span: Span, result: dict[str, Any], key: str) -> None:
         """
         Expands the JSON payload from various AWS services into tags and sets them on the Span.
         """
         if not self.validated:
-            self.request_redaction_paths = self._get_redaction_paths_request()
-            self.response_redaction_paths = self._get_redaction_paths_response()
-            self._parsed_request_expressions = [parse(p) for p in self.request_redaction_paths]
-            self._parsed_response_expressions = [parse(p) for p in self.response_redaction_paths]
-            self.validated = True
+            with self._init_lock:
+                if not self.validated:
+                    self.request_redaction_paths = self._get_redaction_paths_request()
+                    self.response_redaction_paths = self._get_redaction_paths_response()
+                    self._parsed_request_expressions = [parse(p) for p in self.request_redaction_paths]
+                    self._parsed_response_expressions = [parse(p) for p in self.response_redaction_paths]
+                    self._max_tags = config.botocore.get("payload_tagging_max_tags")
+                    self._max_depth = config.botocore.get("payload_tagging_max_depth")
+                    self.validated = True
 
         if not self.request_redaction_paths and not self.response_redaction_paths:
             return
@@ -91,17 +101,17 @@ class AWSPayloadTagging:
         if not result:
             return
 
-        # Run redaction expressions read-only against the original payload and record the id() of
-        # each matched value. _tag_object emits "redacted" for any object whose id is in the set,
-        # avoiding the need to deep-copy the payload before mutating it.
-        #
-        # id() is safe here because AWS sensitive values (tokens, keys, passwords) are long strings
-        # that Python does not intern, so each has a unique identity within the dict. Interned
-        # objects (None, True, small ints) are never targeted by redaction paths.
+        # Run redaction expressions read-only against the original payload. For each match,
+        # record (id(parent_container), field_name_or_index) to identify the location of the
+        # sensitive value rather than the value itself. This avoids false positives from Python's
+        # string interning — two fields holding the same object remain independently addressable.
         #
         # Only the expression set matching the payload side is evaluated — request paths have no
         # business running against response payloads and vice versa.
-        redacted_ids: set[int] = set()
+        # Mixed set of (id(parent), key) tuples for known path types and id(value) ints as a
+        # fallback for exotic path types (Slice, Where, etc.). The two forms never collide —
+        # an int membership check never matches a tuple entry and vice versa.
+        redacted_ids: set = set()
         exprs = (
             self._parsed_request_expressions
             if key.startswith("aws.request")
@@ -109,14 +119,28 @@ class AWSPayloadTagging:
         )
         for expr in exprs:
             for match in expr.find(result):
-                redacted_ids.add(id(match.value))
+                path = match.path
+                if hasattr(path, "fields") and path.fields:
+                    redacted_ids.add((id(match.context.value), path.fields[0]))
+                elif hasattr(path, "index"):
+                    redacted_ids.add((id(match.context.value), path.index))
+                else:
+                    # Fallback for Slice, Where, Root, or other exotic match types.
+                    # Falls back to value identity — safe for the long credential strings
+                    # these paths would realistically target.
+                    redacted_ids.add(id(match.value))
 
         tag_count = 0
         # flatten the payload into span tags
         for key2, value in result.items():
             escaped_sub_key = key2.replace(".", "\\.")
-            tag_count = self._tag_object(span, f"{key}.{escaped_sub_key}", value, 0, tag_count, redacted_ids)
-            if tag_count >= config.botocore.get("payload_tagging_max_tags"):
+            if (id(result), key2) in redacted_ids:
+                span.set_tag(f"{key}.{escaped_sub_key}", "redacted")
+                tag_count += 1
+            else:
+                tag_count = self._tag_object(span, f"{key}.{escaped_sub_key}", value, 0, tag_count, redacted_ids)
+            if tag_count >= self._max_tags:
+                span.set_tag(self._INCOMPLETE_TAG, "True")
                 return
 
     def _should_json_parse(self, obj: Any) -> bool:
@@ -183,9 +207,7 @@ class AWSPayloadTagging:
 
         return []
 
-    def _tag_object(
-        self, span: Span, key: str, obj: Any, depth: int, tag_count: int, redacted_ids: set[int]
-    ) -> int:
+    def _tag_object(self, span: Span, key: str, obj: Any, depth: int, tag_count: int, redacted_ids: set) -> int:
         """
         Recursively expands the given AWS payload object and adds the values as flattened Span tags.
         It is not expected that AWS Payloads will be deeply nested so the number of recursive calls should be low.
@@ -206,16 +228,17 @@ class AWSPayloadTagging:
         "aws.response.body.HTTPHeaders.content-length": "5"
         """
         # if we've hit the maximum allowed tags, mark the expansion as incomplete
-        if tag_count >= config.botocore.get("payload_tagging_max_tags"):
+        if tag_count >= self._max_tags:
             span.set_tag(self._INCOMPLETE_TAG, "True")
             return tag_count
+        # fallback redaction check for exotic path types stored as id(value) ints
         if id(obj) in redacted_ids:
             span.set_tag(key, "redacted")
             return tag_count + 1
         if obj is None:
             span.set_tag(key, obj)
             return tag_count + 1
-        if depth >= config.botocore.get("payload_tagging_max_depth"):
+        if depth >= self._max_depth:
             span.set_tag(
                 key, str(obj)[:_MAX_TAG_VALUE_LENGTH]
             )  # at the maximum depth - set the tag without further expansion
@@ -233,17 +256,38 @@ class AWSPayloadTagging:
             return tag_count + 1
         if isinstance(obj, list):
             for k, v in enumerate(obj):
-                tag_count = self._tag_object(span, f"{key}.{k}", v, depth, tag_count, redacted_ids)
+                if (id(obj), k) in redacted_ids:
+                    span.set_tag(f"{key}.{k}", "redacted")
+                    tag_count += 1
+                else:
+                    tag_count = self._tag_object(span, f"{key}.{k}", v, depth, tag_count, redacted_ids)
+                if tag_count >= self._max_tags:
+                    span.set_tag(self._INCOMPLETE_TAG, "True")
+                    break
             return tag_count
         if hasattr(obj, "items"):
             for k, v in obj.items():
                 escaped_key = str(k).replace(".", "\\.")
-                tag_count = self._tag_object(span, f"{key}.{escaped_key}", v, depth, tag_count, redacted_ids)
+                if (id(obj), k) in redacted_ids:
+                    span.set_tag(f"{key}.{escaped_key}", "redacted")
+                    tag_count += 1
+                else:
+                    tag_count = self._tag_object(span, f"{key}.{escaped_key}", v, depth, tag_count, redacted_ids)
+                if tag_count >= self._max_tags:
+                    span.set_tag(self._INCOMPLETE_TAG, "True")
+                    break
             return tag_count
         if hasattr(obj, "to_dict"):
             for k, v in obj.to_dict().items():
                 escaped_key = str(k).replace(".", "\\.")
-                tag_count = self._tag_object(span, f"{key}.{escaped_key}", v, depth, tag_count, redacted_ids)
+                if (id(obj), k) in redacted_ids:
+                    span.set_tag(f"{key}.{escaped_key}", "redacted")
+                    tag_count += 1
+                else:
+                    tag_count = self._tag_object(span, f"{key}.{escaped_key}", v, depth, tag_count, redacted_ids)
+                if tag_count >= self._max_tags:
+                    span.set_tag(self._INCOMPLETE_TAG, "True")
+                    break
             return tag_count
         try:
             value_as_str = str(obj)

--- a/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
+++ b/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
@@ -76,6 +76,7 @@ class AWSPayloadTagging:
         self._parsed_response_expressions = []
         # Read from config once during initialization and stored so _tag_object
         # doesn't need to call config.botocore.get() on every recursive invocation.
+        self._max_tags: int = 0
         self._max_depth: int = 0
         self._init_lock = threading.Lock()
 

--- a/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
+++ b/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
@@ -193,7 +193,7 @@ class AWSPayloadTagging:
         if self.current_tag_count >= config.botocore.get("payload_tagging_max_tags"):
             span.set_tag(self._INCOMPLETE_TAG, "True")
             return
-        # AIDEV-NOTE: Check the redaction set before any other processing. id() is used here
+        # Check to see the redaction set before any other processing. id() is used here
         # rather than value equality — see the note in expand_payload_as_tags for the rationale.
         if id(obj) in self._current_redacted_ids:
             self.current_tag_count += 1

--- a/releasenotes/notes/aws-tagging-performance-optimization-9fe46c4ece4c4808.yaml
+++ b/releasenotes/notes/aws-tagging-performance-optimization-9fe46c4ece4c4808.yaml
@@ -1,5 +1,5 @@
 ---
-bug-fixes:
+fixes:
   - |
     aws payload tagging: Stop using copy.deepcopy -- use JSONPath as a read only and collect match values in separate variable.
     aws payload tagging: Cache already parsed expression on cold start instead of reparsing on every invocation.

--- a/releasenotes/notes/aws-tagging-performance-optimization-9fe46c4ece4c4808.yaml
+++ b/releasenotes/notes/aws-tagging-performance-optimization-9fe46c4ece4c4808.yaml
@@ -1,0 +1,6 @@
+---
+bug-fixes:
+  - |
+    aws payload tagging: Stop using copy.deepcopy -- use JSONPath as a read only and collect match values in separate variable.
+    aws payload tagging: Cache already parsed expression on cold start instead of reparsing on every invocation.
+    aws payload tagging: Apply only the matching side's expression. (Request vs. Response)

--- a/releasenotes/notes/aws-tagging-performance-optimization-9fe46c4ece4c4808.yaml
+++ b/releasenotes/notes/aws-tagging-performance-optimization-9fe46c4ece4c4808.yaml
@@ -1,6 +1,4 @@
 ---
 fixes:
   - |
-    aws payload tagging: Stop using copy.deepcopy -- use JSONPath as a read only and collect match values in separate variable.
-    aws payload tagging: Cache already parsed expression on cold start instead of reparsing on every invocation.
-    aws payload tagging: Apply only the matching side's expression. (Request vs. Response)
+    aws payload tagging: Improve performance by avoiding deepcopy, caching parsed JSONPath expressions, and only evaluating request/response redaction paths for the matching payload.


### PR DESCRIPTION
## Description

[apmsvls-94] This improves the performance of  aws payload tags  before we were doing multiple things to greatly slow down the performance of processing the aws payload tagging. 

I made the following changes:
* instead of using copy.deepcopy. The JSON expressions are ran read only and only collecting the tags that need to be modified. 
* Caching the already parsed expressions on the first invocation to reduce the amount of redundant work. 
* Apply only the expression rules to the to the appropriate side of the service. ex. Response data with response rules and only request rules against request data. 

## Testing
On top of our own existing tests I had a test environment built to benchmark the changes. 

  | Run 1 avg | Run 2 avg | Run 3 avg | Overall avg
-- | -- | -- | -- | --
Slow (unpatched) | 12.041s | 11.754s | 11.859s | 11.884s
Patched | 0.643s | 0.423s | 0.418s | 0.500s
Fast (disabled) | 0.583s | 0.262s | 0.350s | 0.399s

Which attributes to approximately 23.8x speed up of the function. This is a significant improvement of the code. 

## Risks

There are no risks to this change as it still properly redacts tags as needed and collects the payload request. 

## Additional Notes

None
