### PR TITLE
feat(llmobs): inline experiments — publish capture as a baseline experiment (with cost)

### DIFF
--- a/ddtrace/commands/ddtrace_experiment.py
+++ b/ddtrace/commands/ddtrace_experiment.py
@@ -312,6 +312,11 @@ def main() -> None:
         return
 
     # replay
+    if args.publish:
+        # Enable LLM Obs BEFORE importing the app so its LLM integrations are patched before
+        # the app builds its clients — otherwise the replay run's nested LLM/tool spans are
+        # missing (unlike capture, which enables first).
+        _enable_llmobs(args.ml_app)
     _import_target(args.target)  # registers subjects (start fns needed for re-invocation)
     infile = args.infile or runner.DEFAULT_BASELINE_PATH
     if not os.path.exists(infile):
@@ -324,7 +329,7 @@ def main() -> None:
     if args.publish:
         # Run the CURRENT code as the `<name>` experiment over the shared dataset published at
         # capture, and link the compare view to the baseline experiment capture recorded.
-        _enable_llmobs(args.ml_app)
+        # (LLM Obs was already enabled above, before the app import, so nested spans are traced.)
         from ddtrace.llmobs import _inline_experiment_sdk as sdk
 
         for name, cases in baselines.items():

--- a/ddtrace/commands/ddtrace_experiment.py
+++ b/ddtrace/commands/ddtrace_experiment.py
@@ -268,7 +268,12 @@ def main() -> None:
             _flush_llmobs()
             out = args.out or runner.DEFAULT_BASELINE_PATH
             runner.save_baselines(out)  # persist the recorded (input, output) cases locally
-            runner.save_publish_state(out, subject, baseline_experiment_id=sdk._experiment_id(published["baseline"]))
+            runner.save_publish_state(
+                out,
+                subject,
+                baseline_experiment_id=sdk._experiment_id(published["baseline"]),
+                dataset_name=published["dataset_name"],  # replay pulls this exact dataset
+            )
             print("published baseline for %r (ml_app: %s):" % (subject, ml_app))
             print("  baseline -> %s" % (sdk.experiment_url(published["baseline"]) or "?"))
             ds = sdk.dataset_url(published.get("dataset"))
@@ -326,10 +331,15 @@ def main() -> None:
             if name not in ie.registered_experiments():
                 print("  (skipping %r — not registered by %r)" % (name, args.target))
                 continue
-            published = sdk.publish_current(
-                name, cases, comparator, experiment_name=args.experiment_name, project_name=args.project
-            )
             state = runner.load_publish_state(infile, name) or {}
+            published = sdk.publish_current(
+                name,
+                cases,
+                comparator,
+                experiment_name=args.experiment_name,
+                project_name=args.project,
+                dataset_name=state.get("dataset_name"),  # the exact dataset from capture --publish
+            )
             baseline_id = state.get("baseline_experiment_id")
             print("published experiment %r:" % name)
             print("  current  -> %s" % (sdk.experiment_url(published["current"]) or "LLM Obs -> Experiments"))

--- a/ddtrace/commands/ddtrace_experiment.py
+++ b/ddtrace/commands/ddtrace_experiment.py
@@ -172,7 +172,16 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="also enable LLM Obs so the capture run's traces appear in the UI "
         "(needs DD_API_KEY or a Datadog agent); links each case to its trace",
     )
-    cap.add_argument("--ml-app", default=None, help="ml_app for --trace (default: $DD_LLMOBS_ML_APP)")
+    cap.add_argument("--ml-app", default=None, help="ml_app for --trace/--publish (default: $DD_LLMOBS_ML_APP)")
+    cap.add_argument(
+        "--publish",
+        action="store_true",
+        help="publish the capture as the baseline experiment (real run -> real spans + cost) "
+        "and a dataset in LLM Obs; requires the driver module to declare INPUTS (+ SUBJECT). "
+        "Without it, capture stays local (JSON only): no dataset, no cost, no compare.",
+    )
+    cap.add_argument("--project", default=None, help="project name for --publish")
+    cap.add_argument("--experiment-name", default=None, help="experiment name for --publish")
 
     rep = sub.add_parser("replay", parents=[common], help="replay the current code against a persisted baseline")
     rep.add_argument("target", help="module to import (registers the decorated subjects)")
@@ -233,6 +242,42 @@ def main() -> None:
         return
 
     if args.command == "capture":
+        if args.publish:
+            # Publish the capture AS the baseline experiment: run the real boundary through the
+            # engine over the driver's declared INPUTS (one real run -> real spans + cost), and
+            # a dataset. The module must declare INPUTS (+ SUBJECT); LLM Obs is enabled first.
+            ml_app: Optional[str] = _enable_llmobs(args.ml_app)
+            mod, _ = _import_target(args.target)  # registers subjects
+            inputs = getattr(mod, "INPUTS", None)
+            subject = getattr(mod, "SUBJECT", None)
+            registered = ie.registered_experiments()
+            if subject is None and len(registered) == 1:
+                subject = registered[0]
+            if not inputs or subject is None:
+                print(
+                    "capture --publish needs the driver module to declare INPUTS (a list of input "
+                    "dicts, e.g. [{'tickers': ['NVDA']}]) and SUBJECT (the experiment name).",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
+            from ddtrace.llmobs import _inline_experiment_sdk as sdk
+
+            published = sdk.publish_baseline(
+                subject, inputs, project_name=args.project, experiment_name=args.experiment_name
+            )
+            _flush_llmobs()
+            out = args.out or runner.DEFAULT_BASELINE_PATH
+            runner.save_baselines(out)  # persist the recorded (input, output) cases locally
+            runner.save_publish_state(out, subject, baseline_experiment_id=sdk._experiment_id(published["baseline"]))
+            print("published baseline for %r (ml_app: %s):" % (subject, ml_app))
+            print("  baseline -> %s" % (sdk.experiment_url(published["baseline"]) or "?"))
+            ds = sdk.dataset_url(published.get("dataset"))
+            if ds:
+                print("  dataset  -> %s" % ds)
+            print("  (baseline recorded locally -> %s; change code, then `replay --publish`)" % os.path.abspath(out))
+            return
+
+        # Local capture (no --publish): run the driver, record cases, write JSON.
         # Enable LLM Obs BEFORE importing the app so its LLM integrations are patched
         # before the app builds its clients (otherwise the calls aren't traced).
         ml_app = _enable_llmobs(args.ml_app) if args.trace else None
@@ -272,29 +317,28 @@ def main() -> None:
     comparator = runner.comparator_from_spec(args.comparator, ignore)
 
     if args.publish:
-        # Route through the real Experiments SDK so results land in the UI.
-        from ddtrace.internal.settings import env
-        from ddtrace.llmobs import LLMObs
+        # Run the CURRENT code as the `<name>` experiment over the shared dataset published at
+        # capture, and link the compare view to the baseline experiment capture recorded.
+        _enable_llmobs(args.ml_app)
         from ddtrace.llmobs import _inline_experiment_sdk as sdk
 
-        if not LLMObs.enabled:
-            ml_app = args.ml_app or env.get("DD_LLMOBS_ML_APP") or "inline-experiments"
-            LLMObs.enable(ml_app=ml_app, agentless_enabled=True)
         for name, cases in baselines.items():
             if name not in ie.registered_experiments():
                 print("  (skipping %r — not registered by %r)" % (name, args.target))
                 continue
-            result = sdk.run_as_experiment(
+            published = sdk.publish_current(
                 name, cases, comparator, experiment_name=args.experiment_name, project_name=args.project
             )
+            state = runner.load_publish_state(infile, name) or {}
+            baseline_id = state.get("baseline_experiment_id")
             print("published experiment %r:" % name)
-            if result.get("baseline") is not None:
-                print("  baseline -> %s" % (sdk.experiment_url(result["baseline"]) or "?"))
-            print("  current  -> %s" % (sdk.experiment_url(result["current"]) or "LLM Obs -> Experiments"))
-            compare = sdk.compare_url(result.get("baseline"), result["current"], project_name=args.project)
+            print("  current  -> %s" % (sdk.experiment_url(published["current"]) or "LLM Obs -> Experiments"))
+            compare = sdk.compare_url_from_ids(baseline_id, sdk._experiment_id(published["current"]), args.project)
             if compare:
                 print("  compare  -> %s" % compare)
-            dataset = sdk.dataset_url(result.get("dataset"))
+            elif baseline_id is None:
+                print("  (no baseline on record — run `capture --publish` first to get a compare view)")
+            dataset = sdk.dataset_url(published.get("dataset"))
             if dataset:
                 print("  dataset  -> %s" % dataset)
         return

--- a/ddtrace/llmobs/_inline_experiment_runner.py
+++ b/ddtrace/llmobs/_inline_experiment_runner.py
@@ -54,6 +54,36 @@ def load_baselines(path: str = DEFAULT_BASELINE_PATH) -> dict[str, Any]:
     return data
 
 
+# Publish state (baseline experiment id, dataset name) is remembered between the separate
+# `capture --publish` and `replay --publish` invocations in a sidecar next to the baseline,
+# so replay can link the compare view to the baseline experiment capture published.
+def _publish_state_path(baseline_path: str) -> str:
+    return baseline_path + ".publish.json"
+
+
+def save_publish_state(baseline_path: str, name: str, **fields: Any) -> None:
+    path = _publish_state_path(baseline_path)
+    state: dict[str, Any] = {}
+    try:
+        with open(path) as f:
+            state = json.load(f)
+    except (OSError, ValueError):
+        state = {}
+    state[name] = {**state.get(name, {}), **fields}
+    with open(path, "w") as f:
+        json.dump(state, f, indent=2)
+
+
+def load_publish_state(baseline_path: str, name: str) -> Optional[dict[str, Any]]:
+    try:
+        with open(_publish_state_path(baseline_path)) as f:
+            state: dict[str, Any] = json.load(f)
+    except (OSError, ValueError):
+        return None
+    value = state.get(name)
+    return value if isinstance(value, dict) else None
+
+
 # --------------------------------------------------------------------------- #
 # Comparators — "is the new output equivalent to the recorded baseline?"
 # Real LLM output is non-deterministic, so `exact` reports CHANGED on every replay;

--- a/ddtrace/llmobs/_inline_experiment_sdk.py
+++ b/ddtrace/llmobs/_inline_experiment_sdk.py
@@ -16,6 +16,7 @@ from typing import Any
 from typing import Callable
 from typing import Optional
 from urllib.parse import quote
+import uuid
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._inline_experiment import _REGISTRY
@@ -62,6 +63,14 @@ def _make_evaluator(comparator: Callable[[Any, Any], bool]) -> Callable[..., Any
 
 def _dataset_name(name: str) -> str:
     return "inline-experiment-%s" % name
+
+
+def _unique_dataset_name(name: str) -> str:
+    """A fresh dataset name per capture. `create_dataset` reuses+appends on an existing name
+    (accumulating across runs), so each capture gets its own dataset — replay then pulls that
+    exact one and runs over only the examples this capture recorded.
+    """
+    return "%s-%s" % (_dataset_name(name), uuid.uuid4().hex[:8])
 
 
 def experiment_url(experiment: Any) -> Optional[str]:
@@ -132,23 +141,27 @@ def publish_baseline(
     inputs: list[dict[str, Any]],
     project_name: Optional[str] = None,
     experiment_name: Optional[str] = None,
+    dataset_name: Optional[str] = None,
 ) -> dict[str, Any]:
     """``capture --publish``: run the REAL boundary as the ``<name>-baseline`` experiment.
 
-    Creates the dataset from ``inputs`` (kwargs dicts, e.g. ``{"tickers": [...]}``) and runs the
-    actual subject over them through the engine — a single real run, so the baseline carries
-    real spans + token/dollar cost. CAPTURE mode records the produced ``(input, output)`` cases
-    (read via ``captured_cases`` to persist locally), and the dataset's ``expected_output`` is
-    backfilled from them so a later ``current`` run compares against this baseline. Baseline
-    evaluators are the subject's attached evaluators only (no ``regression_match`` — there's
-    nothing to regress against yet). Returns ``{"baseline", "dataset"}``.
+    Creates a fresh dataset (unique name, so it never accumulates records from other captures)
+    from ``inputs`` (kwargs dicts, e.g. ``{"tickers": [...]}``) and runs the actual subject over
+    them through the engine — a single real run, so the baseline carries real spans + token/dollar
+    cost. CAPTURE mode records the produced ``(input, output)`` cases (read via ``captured_cases``
+    to persist locally), and the dataset's ``expected_output`` is backfilled from them so a later
+    ``current`` run compares against this baseline. Baseline evaluators are the subject's attached
+    evaluators only (no ``regression_match`` — nothing to regress against yet). Returns
+    ``{"baseline", "dataset", "dataset_name"}`` (persist ``dataset_name`` so replay pulls this
+    exact dataset).
     """
     from ddtrace.llmobs import LLMObs
     from ddtrace.llmobs._experiment import DatasetRecordNew
 
+    ds_name = dataset_name or _unique_dataset_name(name)
     records: list[DatasetRecordNew] = [{"input_data": inp} for inp in inputs]
     dataset = LLMObs.create_dataset(
-        _dataset_name(name),
+        ds_name,
         project_name=project_name,
         description="Inline-experiment baseline for %r (captured from a real run)." % name,
         records=records,
@@ -168,7 +181,7 @@ def publish_baseline(
     finally:
         _set_mode(Mode.OFF)
     _backfill_expected_output(dataset, name)
-    return {"baseline": baseline, "dataset": dataset}
+    return {"baseline": baseline, "dataset": dataset, "dataset_name": ds_name}
 
 
 def publish_current(
@@ -177,23 +190,28 @@ def publish_current(
     comparator: Callable[[Any, Any], bool],
     project_name: Optional[str] = None,
     experiment_name: Optional[str] = None,
+    dataset_name: Optional[str] = None,
 ) -> dict[str, Any]:
     """``replay --publish``: run the CURRENT code as the ``<name>`` experiment.
 
-    Reuses the shared dataset published at capture (``pull_dataset``), falling back to building
-    it from ``cases`` if that fails. Scored by the ``regression_match`` guard plus the subject's
-    attached evaluators. Returns ``{"current", "dataset"}``.
+    Pulls the *specific* dataset published at capture (``dataset_name`` from the sidecar) so it
+    runs over exactly the captured examples, falling back to a fresh dataset built from ``cases``
+    if none is given or the pull fails. Scored by the ``regression_match`` guard plus the
+    subject's attached evaluators. Returns ``{"current", "dataset"}``.
     """
     from ddtrace.llmobs import LLMObs
     from ddtrace.llmobs._experiment import DatasetRecordNew
 
-    try:
-        dataset = LLMObs.pull_dataset(_dataset_name(name), project_name=project_name)
-    except Exception:
-        log.debug("inline experiment: no baseline dataset to pull; building from local cases", exc_info=True)
+    dataset = None
+    if dataset_name:
+        try:
+            dataset = LLMObs.pull_dataset(dataset_name, project_name=project_name)
+        except Exception:
+            log.debug("inline experiment: could not pull dataset %r; building from cases", dataset_name, exc_info=True)
+    if dataset is None:
         records: list[DatasetRecordNew] = [{"input_data": c["input"], "expected_output": c["output"]} for c in cases]
         dataset = LLMObs.create_dataset(
-            _dataset_name(name),
+            _unique_dataset_name(name),
             project_name=project_name,
             description="Inline-experiment baseline for %r." % name,
             records=records,

--- a/ddtrace/llmobs/_inline_experiment_sdk.py
+++ b/ddtrace/llmobs/_inline_experiment_sdk.py
@@ -60,20 +60,8 @@ def _make_evaluator(comparator: Callable[[Any, Any], bool]) -> Callable[..., Any
     return as_evaluator(comparator, name="regression_match")
 
 
-def _baseline_task(cases: list[dict[str, Any]]) -> Callable[..., Any]:
-    """A task that echoes the captured (recorded) output for each case.
-
-    This is the **baseline reference run**: it re-runs nothing and makes no model calls —
-    it just returns what capture recorded, keyed by the record's input. Publishing it as
-    its own experiment lets the Experiments *compare* view diff baseline vs the current
-    replay immediately, so a user sees value the moment they run ``--publish``.
-    """
-    by_input = {json.dumps(c["input"], sort_keys=True, default=str): c["output"] for c in cases}
-
-    def task(input_data: Any, config: Any) -> Any:
-        return by_input.get(json.dumps(input_data, sort_keys=True, default=str))
-
-    return task
+def _dataset_name(name: str) -> str:
+    return "inline-experiment-%s" % name
 
 
 def experiment_url(experiment: Any) -> Optional[str]:
@@ -89,19 +77,19 @@ def dataset_url(dataset: Any) -> Optional[str]:
     return getattr(dataset, "url", None)
 
 
-def compare_url(baseline: Any, current: Any, project_name: Optional[str] = None) -> Optional[str]:
-    """URL for the Experiments compare view: the ``baseline`` run with ``current`` as the target.
+def compare_url_from_ids(
+    baseline_id: Optional[str], current_id: Optional[str], project_name: Optional[str] = None
+) -> Optional[str]:
+    """URL for the Experiments compare view: baseline is the page, current the compare target.
 
-    The baseline experiment is the page (first id); the current run is the compare target:
-    ``/llm/experiments/{baseline}?compareTargetExperimentId={current}&project=...``.
+    ``/llm/experiments/{baseline}?compareTargetExperimentId={current}&project=...``
     """
     try:
         from ddtrace.llmobs._experiment import _get_base_url
 
-        b, c = _experiment_id(baseline), _experiment_id(current)
-        if not (b and c):
+        if not (baseline_id and current_id):
             return None
-        url = "%s/llm/experiments/%s?compareTargetExperimentId=%s" % (_get_base_url(), b, c)
+        url = "%s/llm/experiments/%s?compareTargetExperimentId=%s" % (_get_base_url(), baseline_id, current_id)
         if project_name:
             url += "&project=%s" % quote(project_name, safe="")
         return url
@@ -110,62 +98,112 @@ def compare_url(baseline: Any, current: Any, project_name: Optional[str] = None)
         return None
 
 
-def run_as_experiment(
+def compare_url(baseline: Any, current: Any, project_name: Optional[str] = None) -> Optional[str]:
+    """Compare-view URL from two experiment objects (baseline vs current)."""
+    return compare_url_from_ids(_experiment_id(baseline), _experiment_id(current), project_name)
+
+
+def _backfill_expected_output(dataset: Any, name: str) -> None:
+    """Set each dataset record's ``expected_output`` to the output captured for its input.
+
+    The baseline run (below) records ``(input, output)`` cases as it executes; matching them
+    back onto the dataset by input (order can differ under concurrency) makes the dataset the
+    shared golden reference, so a later ``current`` run's ``regression_match`` compares against
+    it. Best-effort — never fail the publish over a backfill hiccup.
+    """
+    from ddtrace.llmobs._inline_experiment import captured_cases
+
+    try:
+        by_input = {json.dumps(c["input"], sort_keys=True, default=str): c["output"] for c in captured_cases(name)}
+        changed = False
+        for i, record in enumerate(dataset):
+            key = json.dumps(record.get("input_data"), sort_keys=True, default=str)
+            if key in by_input:
+                dataset.update(i, {"expected_output": by_input[key]})
+                changed = True
+        if changed:
+            dataset.push()
+    except Exception:
+        log.debug("inline experiment: could not backfill baseline expected_output", exc_info=True)
+
+
+def publish_baseline(
     name: str,
-    cases: list[dict[str, Any]],
-    comparator: Callable[[Any, Any], bool],
-    experiment_name: Optional[str] = None,
+    inputs: list[dict[str, Any]],
     project_name: Optional[str] = None,
-    dataset_name: Optional[str] = None,
-    publish_baseline: bool = True,
+    experiment_name: Optional[str] = None,
 ) -> dict[str, Any]:
-    """Create a Dataset from ``cases`` and publish it as LLM Obs experiment(s).
+    """``capture --publish``: run the REAL boundary as the ``<name>-baseline`` experiment.
 
-    Publishes two runs over the same dataset so the compare view has something to diff
-    immediately:
-      * ``baseline`` — echoes the captured outputs (no subject re-run, no model calls); the
-        known-good reference. Skipped when ``publish_baseline`` is False.
-      * ``current`` — replays the subject against the captured inputs (real re-execution).
-
-    Both are scored by the same evaluators (the always-on ``regression_match`` guard first,
-    then the subject's attached evaluators, resolved lazily here — never at import). Returns
-    ``{"current", "baseline", "dataset"}``. Requires ``LLMObs`` to be enabled.
+    Creates the dataset from ``inputs`` (kwargs dicts, e.g. ``{"tickers": [...]}``) and runs the
+    actual subject over them through the engine — a single real run, so the baseline carries
+    real spans + token/dollar cost. CAPTURE mode records the produced ``(input, output)`` cases
+    (read via ``captured_cases`` to persist locally), and the dataset's ``expected_output`` is
+    backfilled from them so a later ``current`` run compares against this baseline. Baseline
+    evaluators are the subject's attached evaluators only (no ``regression_match`` — there's
+    nothing to regress against yet). Returns ``{"baseline", "dataset"}``.
     """
     from ddtrace.llmobs import LLMObs
     from ddtrace.llmobs._experiment import DatasetRecordNew
 
-    records: list[DatasetRecordNew] = [{"input_data": c["input"], "expected_output": c["output"]} for c in cases]
+    records: list[DatasetRecordNew] = [{"input_data": inp} for inp in inputs]
     dataset = LLMObs.create_dataset(
-        dataset_name or ("inline-experiment-%s" % name),
+        _dataset_name(name),
         project_name=project_name,
-        description="Inline-experiment baseline for %r (captured locally)." % name,
+        description="Inline-experiment baseline for %r (captured from a real run)." % name,
         records=records,
     )
     spec = _REGISTRY.get(name, {})
-    evaluators = [_make_evaluator(comparator), *resolve_evaluators(spec.get("evaluators"))]
-    base_name = experiment_name or ("inline-%s" % name)
-
-    # Baseline reference run first (mode stays OFF — the task only echoes stored outputs,
-    # the subject is never invoked), so the compare view can diff it against `current`.
-    baseline = None
-    if publish_baseline:
-        baseline = LLMObs.experiment(
-            base_name + "-baseline",
-            _baseline_task(cases),
-            dataset,
-            evaluators=evaluators,
-            project_name=project_name,
-            tags={"source": "ddtrace-experiment", "inline_role": "baseline"},
-        )
-        baseline.run()
-
-    # Current run: replay the subject. REPLAY so an emit-shape end marker unwinds (set once;
-    # the engine may run tasks concurrently, and a single-function subject is unaffected).
-    current = LLMObs.experiment(
-        base_name,
+    baseline = LLMObs.experiment(
+        (experiment_name or ("inline-%s" % name)) + "-baseline",
         _make_task(name),
         dataset,
-        evaluators=evaluators,
+        evaluators=resolve_evaluators(spec.get("evaluators")),
+        project_name=project_name,
+        tags={"source": "ddtrace-experiment", "inline_role": "baseline"},
+    )
+    _set_mode(Mode.CAPTURE)  # record (input, output) cases as the real run executes
+    try:
+        baseline.run()
+    finally:
+        _set_mode(Mode.OFF)
+    _backfill_expected_output(dataset, name)
+    return {"baseline": baseline, "dataset": dataset}
+
+
+def publish_current(
+    name: str,
+    cases: list[dict[str, Any]],
+    comparator: Callable[[Any, Any], bool],
+    project_name: Optional[str] = None,
+    experiment_name: Optional[str] = None,
+) -> dict[str, Any]:
+    """``replay --publish``: run the CURRENT code as the ``<name>`` experiment.
+
+    Reuses the shared dataset published at capture (``pull_dataset``), falling back to building
+    it from ``cases`` if that fails. Scored by the ``regression_match`` guard plus the subject's
+    attached evaluators. Returns ``{"current", "dataset"}``.
+    """
+    from ddtrace.llmobs import LLMObs
+    from ddtrace.llmobs._experiment import DatasetRecordNew
+
+    try:
+        dataset = LLMObs.pull_dataset(_dataset_name(name), project_name=project_name)
+    except Exception:
+        log.debug("inline experiment: no baseline dataset to pull; building from local cases", exc_info=True)
+        records: list[DatasetRecordNew] = [{"input_data": c["input"], "expected_output": c["output"]} for c in cases]
+        dataset = LLMObs.create_dataset(
+            _dataset_name(name),
+            project_name=project_name,
+            description="Inline-experiment baseline for %r." % name,
+            records=records,
+        )
+    spec = _REGISTRY.get(name, {})
+    current = LLMObs.experiment(
+        experiment_name or ("inline-%s" % name),
+        _make_task(name),
+        dataset,
+        evaluators=[_make_evaluator(comparator), *resolve_evaluators(spec.get("evaluators"))],
         project_name=project_name,
         tags={"source": "ddtrace-experiment", "inline_role": "current"},
     )
@@ -174,4 +212,4 @@ def run_as_experiment(
         current.run()
     finally:
         _set_mode(Mode.OFF)
-    return {"current": current, "baseline": baseline, "dataset": dataset}
+    return {"current": current, "dataset": dataset}

--- a/releasenotes/notes/llmobs-inline-experiments-63f3e96b499c30ee.yaml
+++ b/releasenotes/notes/llmobs-inline-experiments-63f3e96b499c30ee.yaml
@@ -6,13 +6,15 @@ features:
     already-instrumented app with the new ``ddtrace.llmobs.experimental.experiment_start`` /
     ``experiment_end`` decorators (an inert no-op during normal execution), then run it out-of-band
     with the new ``ddtrace-experiment`` command, which captures a baseline and replays the current
-    code against it, reporting per-case ``MATCH`` / ``CHANGED``. Pass ``ddtrace-experiment replay
-    --publish`` to run the replay through the LLM Obs Experiments SDK so results appear in the
-    Experiments UI with eval metrics; ``--publish`` also publishes a companion *baseline*
-    experiment (the captured outputs) over the same dataset and prints a compare-view link, so the
-    baseline-vs-current diff is viewable immediately. Or pass ``ddtrace-experiment capture --trace``
-    to also enable LLM Observability during the capture run so it is viewable as traces (each case
-    linked to its trace). All ``ddtrace-experiment`` subcommands accept ``--env-file`` (and auto-load
+    code against it, reporting per-case ``MATCH`` / ``CHANGED``. Pass ``ddtrace-experiment capture
+    --publish`` to publish the capture as the *baseline* experiment (a real run of the boundary, so
+    it carries real spans and token/dollar cost) plus a Dataset in the LLM Obs Experiments UI; then
+    ``ddtrace-experiment replay --publish`` runs the current code as the *current* experiment over
+    the same dataset and prints a compare-view link (baseline vs current) with eval metrics. Without
+    ``--publish`` capture stays local (a JSON baseline only — no dataset, cost, or compare view). Or
+    pass ``ddtrace-experiment capture --trace`` to enable LLM Observability during a local capture so
+    it is viewable as traces (each case linked to its trace). All ``ddtrace-experiment`` subcommands
+    accept ``--env-file`` (and auto-load
     a ``.env`` in the current directory) to read ``DD_API_KEY`` / ``OPENAI_API_KEY`` / ``DD_LLMOBS_ML_APP``
     etc. without exporting them; real environment variables take precedence. These APIs are
     experimental and may change or be removed without notice.

--- a/tests/llmobs/test_inline_experiment_runner.py
+++ b/tests/llmobs/test_inline_experiment_runner.py
@@ -330,8 +330,9 @@ def test_publish_baseline_runs_real_subject_and_backfills_expected(monkeypatch):
 
     result = sdk.publish_baseline("portfolio", [{"tickers": ["NVDA"]}, {"tickers": ["AAPL", "MSFT"]}])
 
-    # dataset created from inputs; one baseline experiment; no regression_match guard on baseline
-    assert state["dataset_name"] == "inline-experiment-portfolio"
+    # dataset created from inputs with a UNIQUE name (never accumulates across captures)
+    assert state["dataset_name"].startswith("inline-experiment-portfolio-")
+    assert result["dataset_name"] == state["dataset_name"]  # returned for the sidecar
     assert [e.name for e in state["exps"]] == ["inline-portfolio-baseline"]
     assert all(getattr(e, "__name__", "") != "regression_match" for e in (state["exps"][0].evaluators or []))
     # expected_output backfilled from the real run's captured outputs, then pushed
@@ -373,8 +374,10 @@ def test_publish_current_stacks_guard_and_reuses_shared_dataset(monkeypatch):
     def f(x):
         return x
 
-    sdk.publish_current("e", [{"input": {"x": 1}, "output": 1}], runner.structural)
-    assert captured["pulled"] == "inline-experiment-e"  # reused, not recreated
+    sdk.publish_current(
+        "e", [{"input": {"x": 1}, "output": 1}], runner.structural, dataset_name="inline-experiment-e-abc123"
+    )
+    assert captured["pulled"] == "inline-experiment-e-abc123"  # pulls the exact capture dataset
     assert captured["name"] == "inline-e"
     evs = captured["evaluators"]
     assert evs[0].__name__ == "regression_match" and evs[1] is my_check  # guard first, user stacked

--- a/tests/llmobs/test_inline_experiment_runner.py
+++ b/tests/llmobs/test_inline_experiment_runner.py
@@ -275,11 +275,78 @@ def test_replay_scores_attached_evaluators_only_when_enabled():
     assert on["regression_match"] == "match" and on["at_least_as_long"] == "pass"
 
 
-def test_publish_stacks_user_evaluators_behind_guard(monkeypatch):
+class _FakeDataset:
+    def __init__(self, records):
+        self._records = [dict(r) for r in records]
+        self.pushed = False
+        self.url = "http://ds"
+        self._id = "ds1"
+
+    def __iter__(self):
+        return iter(self._records)
+
+    def __getitem__(self, i):
+        return self._records[i]
+
+    def update(self, i, rec):
+        self._records[i].update(rec)
+
+    def push(self):
+        self.pushed = True
+
+
+def test_publish_baseline_runs_real_subject_and_backfills_expected(monkeypatch):
+    state: dict = {}
+
+    class _Exp:
+        def __init__(self, name, task, evaluators):
+            self.name, self._task, self.evaluators, self._id = name, task, evaluators, "id-" + name
+
+        def run(self):
+            # emulate the engine running the task over each dataset input (records cases in CAPTURE)
+            for r in state["dataset"]._records:
+                self._task(r["input_data"], None)
+
+    class _FakeLLMObs:
+        enabled = True
+
+        @staticmethod
+        def create_dataset(name, project_name=None, description="", records=None):
+            state["dataset_name"] = name
+            state["dataset"] = _FakeDataset(records or [])
+            return state["dataset"]
+
+        @staticmethod
+        def experiment(name, task, dataset, evaluators=None, **kw):
+            e = _Exp(name, task, evaluators)
+            state.setdefault("exps", []).append(e)
+            return e
+
+    monkeypatch.setattr(llmobs_pkg, "LLMObs", _FakeLLMObs)
+
+    @experiment_start(name="portfolio", inputs=["tickers"], output=lambda ret: ret[0])
+    def analyze(tickers):
+        return ({"tickers": tickers, "n": len(tickers)}, {"span_id": "s", "trace_id": "t"})
+
+    result = sdk.publish_baseline("portfolio", [{"tickers": ["NVDA"]}, {"tickers": ["AAPL", "MSFT"]}])
+
+    # dataset created from inputs; one baseline experiment; no regression_match guard on baseline
+    assert state["dataset_name"] == "inline-experiment-portfolio"
+    assert [e.name for e in state["exps"]] == ["inline-portfolio-baseline"]
+    assert all(getattr(e, "__name__", "") != "regression_match" for e in (state["exps"][0].evaluators or []))
+    # expected_output backfilled from the real run's captured outputs, then pushed
+    recs = state["dataset"]._records
+    assert recs[0]["expected_output"] == {"tickers": ["NVDA"], "n": 1}
+    assert recs[1]["expected_output"] == {"tickers": ["AAPL", "MSFT"], "n": 2}
+    assert state["dataset"].pushed is True
+    assert result["baseline"]._id == "id-inline-portfolio-baseline"
+
+
+def test_publish_current_stacks_guard_and_reuses_shared_dataset(monkeypatch):
     captured: dict = {}
 
     class _Exp:
-        url = "http://exp"
+        _id = "cur"
 
         def run(self):
             pass
@@ -288,37 +355,36 @@ def test_publish_stacks_user_evaluators_behind_guard(monkeypatch):
         enabled = True
 
         @staticmethod
-        def create_dataset(name, **kw):
+        def pull_dataset(name, project_name=None):
+            captured["pulled"] = name  # reuse the dataset published at capture
             return object()
 
         @staticmethod
         def experiment(name, task, dataset, evaluators=None, **kw):
-            captured["evaluators"] = evaluators
+            captured["name"], captured["evaluators"] = name, evaluators
             return _Exp()
 
     monkeypatch.setattr(llmobs_pkg, "LLMObs", _FakeLLMObs)
 
     def my_check(input_data, output_data, expected_output):
-        return output_data == expected_output
+        return True
 
     @experiment_start(name="e", inputs=["x"], output=lambda r: r, evaluators=lambda: [my_check])
     def f(x):
         return x
 
-    sdk.run_as_experiment("e", [{"input": {"x": 1}, "output": 1}], runner.structural)
+    sdk.publish_current("e", [{"input": {"x": 1}, "output": 1}], runner.structural)
+    assert captured["pulled"] == "inline-experiment-e"  # reused, not recreated
+    assert captured["name"] == "inline-e"
     evs = captured["evaluators"]
-    assert evs[0].__name__ == "regression_match"  # always-on guard first
-    assert evs[1] is my_check  # user evaluator stacked on top
+    assert evs[0].__name__ == "regression_match" and evs[1] is my_check  # guard first, user stacked
 
 
-def test_publish_creates_baseline_and_current_over_same_dataset(monkeypatch):
-    created = []
-    datasets = []
+def test_publish_current_falls_back_to_creating_dataset(monkeypatch):
+    captured: dict = {}
 
     class _Exp:
-        def __init__(self, name):
-            self.name = name
-            self._id = "id-" + name
+        _id = "cur"
 
         def run(self):
             pass
@@ -327,14 +393,17 @@ def test_publish_creates_baseline_and_current_over_same_dataset(monkeypatch):
         enabled = True
 
         @staticmethod
-        def create_dataset(name, **kw):
-            datasets.append(name)
+        def pull_dataset(name, project_name=None):
+            raise RuntimeError("no baseline dataset")
+
+        @staticmethod
+        def create_dataset(name, project_name=None, description="", records=None):
+            captured["records"] = records
             return object()
 
         @staticmethod
         def experiment(name, task, dataset, evaluators=None, **kw):
-            created.append((name, task))
-            return _Exp(name)
+            return _Exp()
 
     monkeypatch.setattr(llmobs_pkg, "LLMObs", _FakeLLMObs)
 
@@ -342,51 +411,22 @@ def test_publish_creates_baseline_and_current_over_same_dataset(monkeypatch):
     def f(x):
         return x
 
-    result = sdk.run_as_experiment("e", [{"input": {"x": 1}, "output": 11}], runner.structural)
-
-    names = [n for n, _ in created]
-    assert names == ["inline-e-baseline", "inline-e"]  # baseline reference first, then current
-    assert datasets == ["inline-experiment-e"]  # both runs share one dataset
-
-    baseline_task = created[0][1]  # the baseline task echoes the captured output (no re-run)
-    assert baseline_task({"x": 1}, None) == 11
-
-    # compare view = baseline experiment page (first id) with current as the compare target
-    cu = sdk.compare_url(result["baseline"], result["current"], project_name="proj x")
-    assert cu and "/llm/experiments/id-inline-e-baseline?compareTargetExperimentId=id-inline-e" in cu
-    assert cu.endswith("&project=proj%20x")  # project is url-encoded
+    sdk.publish_current("e", [{"input": {"x": 1}, "output": 9}], runner.structural)
+    assert captured["records"] == [{"input_data": {"x": 1}, "expected_output": 9}]
 
 
-def test_publish_baseline_can_be_disabled(monkeypatch):
-    created = []
+def test_compare_url_from_ids():
+    u = sdk.compare_url_from_ids("BASE", "CUR", project_name="proj x")
+    assert u.endswith("/llm/experiments/BASE?compareTargetExperimentId=CUR&project=proj%20x")
+    assert sdk.compare_url_from_ids(None, "CUR") is None  # need both ids
 
-    class _E:
-        _id = "x"
 
-        def run(self):
-            pass
-
-    class _FakeLLMObs:
-        enabled = True
-
-        @staticmethod
-        def create_dataset(name, **kw):
-            return object()
-
-        @staticmethod
-        def experiment(name, task, dataset, evaluators=None, **kw):
-            created.append(name)
-            return _E()
-
-    monkeypatch.setattr(llmobs_pkg, "LLMObs", _FakeLLMObs)
-
-    @experiment_start(name="e", inputs=["x"], output=lambda r: r)
-    def f(x):
-        return x
-
-    result = sdk.run_as_experiment("e", [{"input": {"x": 1}, "output": 1}], runner.structural, publish_baseline=False)
-    assert created == ["inline-e"]  # only the current run, no baseline
-    assert result["baseline"] is None
+def test_publish_state_sidecar(tmp_path):
+    base = str(tmp_path / "b.json")
+    runner.save_publish_state(base, "portfolio", baseline_experiment_id="X")
+    runner.save_publish_state(base, "portfolio", dataset_id="D")  # merges into the same entry
+    assert runner.load_publish_state(base, "portfolio") == {"baseline_experiment_id": "X", "dataset_id": "D"}
+    assert runner.load_publish_state(base, "missing") is None
 
 
 # --- CLI helpers ----------------------------------------------------------- #
@@ -394,6 +434,8 @@ def test_cli_arg_parser():
     p = cli._build_arg_parser()
     a = p.parse_args(["capture", "myapp:gen", "--out", "b.json"])
     assert a.command == "capture" and a.target == "myapp:gen" and a.out == "b.json"
+    a = p.parse_args(["capture", "myapp", "--publish", "--project", "p", "--experiment-name", "e"])
+    assert a.publish is True and a.project == "p" and a.experiment_name == "e"
     a = p.parse_args(["replay", "myapp", "--ignore", "a,b"])
     assert a.command == "replay" and a.ignore == "a,b" and a.comparator == "structural"
     a = p.parse_args(["replay", "myapp", "--publish", "--project", "p", "--ml-app", "m"])


### PR DESCRIPTION
## What

Stacked on #18625. Splits inline-experiment publishing across the two phases so the **baseline carries real spans + token/dollar cost**:

- **`capture --publish`** — creates a Dataset from the driver's declared `INPUTS` (+ `SUBJECT`) and runs the **real boundary as the `<name>-baseline` experiment** through the engine (one real run → real cost). CAPTURE mode records the `(input,output)` cases; the dataset's `expected_output` is backfilled from them. The dataset name is **unique per capture** (avoids `create_dataset` accumulation), and the baseline experiment id + dataset name are saved to a `.publish.json` sidecar. Without `--publish`, capture stays local (JSON only).
- **`replay --publish`** — `pull_dataset()` the exact dataset from the sidecar, runs the current code as the `<name>` experiment, and links the compare view (baseline ← current).

SDK: `run_as_experiment` → `publish_baseline` + `publish_current`; `compare_url_from_ids`; runner `save/load_publish_state`. Drivers declare `SUBJECT`/`INPUTS` (see the companion demo PR in `llm-observability`).

## Why

`--publish` previously published an *echo* baseline (no cost). Running the real boundary as the baseline gives an honest before/after — cost + quality deltas — in the compare view.

## Testing

Unit tests (fakes) cover the real-run baseline + backfill, current stacking the guard + pulling the exact dataset, the create fallback, compare URL, and the sidecar. Lint/type/style/compile clean. **Backend-coupled** (`create_dataset`/`pull_dataset`/`Dataset.update`+`push`/`experiment.run`) — not exercisable in unit tests; validate on a live run. Draft: for testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)