### PR TITLE
fix(llmobs): sanitize dots in metric keys

### DIFF
--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -541,6 +541,25 @@ def get_tool_version_from_llm_span(llm_span: Span, tool_name: str) -> Optional[s
     return None
 
 
+def _sanitize_metric_key(key):
+    """Replace dots in a metric key with underscores.
+
+    LLMObs ingestion interprets dots in a metric key as nested-path separators, which breaks
+    decoding of the flat numeric metrics map and causes the enclosing span batch to be dropped.
+    Non-string keys are returned unchanged (value validation happens upstream in ``annotate``).
+    """
+    if not isinstance(key, str) or "." not in key:
+        return key
+    sanitized = key.replace(".", "_")
+    log.warning(
+        "LLMObs metric key %r contains '.', which is not supported and would prevent the span from "
+        "being ingested; replacing with %r.",
+        key,
+        sanitized,
+    )
+    return sanitized
+
+
 def _annotate_llmobs_span_data(
     span: Span,
     name: Optional[str] = None,
@@ -625,7 +644,11 @@ def _annotate_llmobs_span_data(
                     if cost_tag not in existing_cost_tags:
                         existing_cost_tags.append(cost_tag)
         if metrics is not None:
-            llmobs_span_data[LLMOBS_STRUCT.METRICS].update(metrics)
+            # LLMObs ingestion treats dots in metric keys as nested-path separators. Because the
+            # metrics field is decoded as a flat map of numeric values, a dotted key (e.g.
+            # "anomaly.query_count") is expanded into a nested map and fails to decode, dropping the
+            # whole span batch. Replace dots with underscores to keep such keys as flat metric keys.
+            llmobs_span_data[LLMOBS_STRUCT.METRICS].update({_sanitize_metric_key(k): v for k, v in metrics.items()})
         if tags is not None:
             # Tag values are serialized as strings, so coerce non-string values here.
             llmobs_span_data[LLMOBS_STRUCT.TAGS].update({k: str(v) for k, v in tags.items()})

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -644,10 +644,6 @@ def _annotate_llmobs_span_data(
                     if cost_tag not in existing_cost_tags:
                         existing_cost_tags.append(cost_tag)
         if metrics is not None:
-            # LLMObs ingestion treats dots in metric keys as nested-path separators. Because the
-            # metrics field is decoded as a flat map of numeric values, a dotted key (e.g.
-            # "anomaly.query_count") is expanded into a nested map and fails to decode, dropping the
-            # whole span batch. Replace dots with underscores to keep such keys as flat metric keys.
             llmobs_span_data[LLMOBS_STRUCT.METRICS].update({_sanitize_metric_key(k): v for k, v in metrics.items()})
         if tags is not None:
             # Tag values are serialized as strings, so coerce non-string values here.

--- a/releasenotes/notes/llmobs-metric-key-dot-sanitize-60221758e3555b02.yaml
+++ b/releasenotes/notes/llmobs-metric-key-dot-sanitize-60221758e3555b02.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    LLM Observability: This fix resolves an issue where annotating a span with a metric key
+    containing a dot (e.g. ``anomaly.query_count``) caused LLM Observability ingestion to
+    interpret the dot as a nested-path separator, producing a nested map that failed to decode
+    and dropped the entire span batch. Dots in metric keys are now replaced with underscores
+    before the span is submitted.

--- a/releasenotes/notes/llmobs-metric-key-dot-sanitize-60221758e3555b02.yaml
+++ b/releasenotes/notes/llmobs-metric-key-dot-sanitize-60221758e3555b02.yaml
@@ -2,7 +2,5 @@
 fixes:
   - |
     LLM Observability: This fix resolves an issue where annotating a span with a metric key
-    containing a dot (e.g. ``anomaly.query_count``) caused LLM Observability ingestion to
-    interpret the dot as a nested-path separator, producing a nested map that failed to decode
-    and dropped the entire span batch. Dots in metric keys are now replaced with underscores
-    before the span is submitted.
+    containing a dot (e.g. ``anomaly.query_count``) prevented the span from being ingested.
+    Dots in metric keys are now replaced with underscores.

--- a/tests/llmobs/test_llmobs_service.py
+++ b/tests/llmobs/test_llmobs_service.py
@@ -1048,6 +1048,20 @@ def test_annotate_metrics_updates(llmobs):
         }
 
 
+def test_annotate_metrics_dotted_keys_sanitized(llmobs):
+    """Dots in metric keys are replaced with underscores so ingestion doesn't nest and drop them."""
+    with llmobs.llm(model_name="test_model") as span:
+        llmobs.annotate(
+            span=span,
+            metrics={"anomaly.query_count": 8, "anomaly.query_error_count": 0, "total_tokens": 30},
+        )
+        assert get_llmobs_metrics(span) == {
+            "anomaly_query_count": 8,
+            "anomaly_query_error_count": 0,
+            "total_tokens": 30,
+        }
+
+
 def test_annotate_metrics_wrong_type(llmobs):
     with llmobs.llm(model_name="test_model") as llm_span:
         with pytest.raises(Exception) as excinfo:


### PR DESCRIPTION
## Description

LLM Observability treats a dot in a metric key as a nested-path separator. The backend `metrics` field decodes as a flat `map[string]float64`, so a dotted key like `anomaly.query_count` expands into a nested map (`{"anomaly": {"query_count": 8}}`), fails CBOR decode in `llm-obs-events-processor`, and **drops the entire span batch** — nothing gets indexed.

Hit by a staging customer (`ml_app:reveng_anomaly_tooling_api`) setting custom metrics with dotted keys via `LLMObs.annotate(metrics=...)`. The SDK already does this for **tags** (`k.replace(".", "_")` in `_llmobs.py`) but not metrics; this PR extends the same treatment to metric keys.

## Fix

- Add `_sanitize_metric_key()` in `ddtrace/llmobs/_utils.py` (`.` → `_` for string keys; logs a warning when a key is rewritten).
- Apply it in `_annotate_llmobs_span_data`, the central funnel for all metric sources, so it covers both `LLMObs.annotate(metrics=...)` and integration-set metrics in both export modes.

Done at annotation time (mode-agnostic) rather than serialization time because the backend `metrics` field can never represent nested metrics — flattening dots is always correct.

## Testing

- New unit test `test_annotate_metrics_dotted_keys_sanitized`.
- `tests/llmobs/test_llmobs_service.py -k annotate_metrics`: 4 passed.

## Risks

Low. Dotted metric keys were already being silently dropped (whole batch), so there was no working prior behavior. A collision is possible if both `a.b` and `a_b` are submitted (second wins) — an accepted edge case.

## Additional Notes

Scope is metrics-only. `metadata` with dotted keys still nests silently on the backend (decodes without error but loses flat-key semantics); can extend in a follow-up if desired.

Claude session: `4aa13fb9-084b-4459-bfda-cc9ee284fc15`
Resume: `claude --resume 4aa13fb9-084b-4459-bfda-cc9ee284fc15`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
