### PR TITLE
ci(build): use bash instead of zsh on tart macOS runners

### DIFF
--- a/.gitlab/multi-os-tests.yml
+++ b/.gitlab/multi-os-tests.yml
@@ -43,7 +43,7 @@ os tests macos:
     WHEEL_PATTERN: "macosx*arm64.whl"
     PLATFORM: "macOS"
     # Use bash instead of the Tart VM's default zsh
-    TART_EXECUTOR_SHELL: "/bin/bash"
+    TART_EXECUTOR_SHELL: "/bin/bash -l"
   script:
     - |
       for PYTHON_VERSION in 3.10 3.12 3.14; do

--- a/.gitlab/multi-os-tests.yml
+++ b/.gitlab/multi-os-tests.yml
@@ -34,17 +34,16 @@ os tests ubuntu:
     - apt-get update && apt-get install -y curl
     - bash .gitlab/scripts/multi-os-tests.sh
 
-# Tart VMs default to using zsh instead of bash
 os tests macos:
   extends: .multi_os_test_base
   image: "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/ci-platform-machine-images/tart-vm:dd-trace-py-sonoma-latest"
-  tags: ["macos:sonoma-tart"]
+  tags: ["macos:tart"]
   needs: [ "build macos arm64" ]
   variables:
     WHEEL_PATTERN: "macosx*arm64.whl"
     PLATFORM: "macOS"
-    # Disables collapsable sections in multi-line scripts due to incompatibility with zsh
-    FF_SCRIPT_SECTIONS: "false"
+    # Use bash instead of the Tart VM's default zsh
+    TART_EXECUTOR_SHELL: "/bin/bash"
   script:
     - |
       for PYTHON_VERSION in 3.10 3.12 3.14; do

--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -178,7 +178,7 @@ variables:
   variables:
     ARCH_TAG: "arm64"
     # Use bash instead of the Tart VM's default zsh
-    TART_EXECUTOR_SHELL: "/bin/bash"
+    TART_EXECUTOR_SHELL: "/bin/bash -l"
     SCCACHE_BUCKET: "dd-sccache-storage-us1-ddbuild-io"
     SCCACHE_REGION: "us-east-1"
   before_script: |

--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -171,19 +171,17 @@ variables:
   variables:
     ARCH_TAG: "amd64"
 
-# Tart VMs default to using zsh instead of bash
 "build macos arm64":
   extends: .build_macos_base
   image: "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/ci-platform-machine-images/tart-vm:dd-trace-py-sonoma-latest"
-  tags: [ "macos:sonoma-tart" ]
+  tags: [ "macos:tart" ]
   variables:
     ARCH_TAG: "arm64"
-    # Disables collapsable sections in multi-line scripts due to incompatibility with zsh
-    FF_SCRIPT_SECTIONS: "false"
+    # Use bash instead of the Tart VM's default zsh
+    TART_EXECUTOR_SHELL: "/bin/bash"
     SCCACHE_BUCKET: "dd-sccache-storage-us1-ddbuild-io"
     SCCACHE_REGION: "us-east-1"
   before_script: |
-    setopt shwordsplit 2>/dev/null || true
     set -euo pipefail
     # sccache hardcodes the IMDS IP (169.254.169.254) and ignores $AWS_EC2_METADATA_SERVICE_ENDPOINT,
     # so resolve creds from the tart iam-proxy beforehand


### PR DESCRIPTION
## Description

Follow-up to #17501. It was requested in the past to use `bash` over `zsh` in the jobs using that tart runners.

Sets `TART_EXECUTOR_SHELL="/bin/bash -l"` on the tart macOS jobs so the [gitlab-tart-executor](https://github.com/cirruslabs/gitlab-tart-executor) runs bash instead of the VM's default zsh.

This removes the zsh-specific workarounds that were added when the tart runners were introduced:
- `setopt shwordsplit` in `build macos arm64`'s `before_script`
- `FF_SCRIPT_SECTIONS: "false"` on `build macos arm64` and `os tests macos` (disabled because GitLab's collapsible script-section wrapper was incompatible with zsh)

Also renames the runner tag from `macos:sonoma-tart` to `macos:tart`.

## Testing

- [x] CI pipeline passes with `build macos arm64` and `os tests macos` running under bash on `macos:tart` runners

## Additional Notes

CI-only change, no user-facing impact — will add the `changelog/no-changelog` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)