### PR TITLE
ci(ci-visibility): fix flaky tests

### DIFF
--- a/tests/testing/internal/pytest/test_plugin.py
+++ b/tests/testing/internal/pytest/test_plugin.py
@@ -300,8 +300,16 @@ class TestSkippingAndITRFeatures:
         assert suite.tags.get("test.skipped_by_itr") == "true"
         assert real_session.tests_skipped_by_itr == 1
 
-    def test_pytest_sessionfinish_overrides_no_tests_collected_when_itr_skipped(self, tmp_path: Path) -> None:
-        """When all suites are ITR-skipped, NO_TESTS_COLLECTED exit code is overridden to OK."""
+    @pytest.mark.parametrize("coverage_pct", [None, 75.0])
+    def test_pytest_sessionfinish_overrides_no_tests_collected_when_itr_skipped(
+        self, tmp_path: Path, coverage_pct: t.Optional[float]
+    ) -> None:
+        """When all suites are ITR-skipped, NO_TESTS_COLLECTED exit code is overridden to OK.
+
+        Parametrized over coverage_pct to exercise both the branch where get_coverage_percentage
+        returns None (coverage disabled) and where it returns a value (coverage enabled), ensuring
+        the metrics assignment path is always covered.
+        """
         mock_manager = session_manager_mock().build_mock()
         plugin = TestOptPlugin(session_manager=mock_manager)
         plugin._itr_ignored_suite_paths = [tmp_path / "test_something.py"]
@@ -309,12 +317,21 @@ class TestSkippingAndITRFeatures:
         mock_session = Mock()
         mock_session.exitstatus = pytest.ExitCode.NO_TESTS_COLLECTED
 
-        plugin.pytest_sessionfinish(mock_session)
+        with patch("ddtrace.testing.internal.pytest.plugin.get_coverage_percentage", return_value=coverage_pct):
+            plugin.pytest_sessionfinish(mock_session)
 
         assert mock_session.exitstatus == pytest.ExitCode.OK
+        if coverage_pct is not None:
+            assert plugin.session.metrics[TestTag.CODE_COVERAGE_LINES_PCT] == coverage_pct
 
-    def test_pytest_sessionfinish_no_override_when_no_itr_skips(self) -> None:
-        """NO_TESTS_COLLECTED is not overridden when ITR skipped nothing."""
+    @pytest.mark.parametrize("coverage_pct", [None, 75.0])
+    def test_pytest_sessionfinish_no_override_when_no_itr_skips(self, coverage_pct: t.Optional[float]) -> None:
+        """NO_TESTS_COLLECTED is not overridden when ITR skipped nothing.
+
+        Parametrized over coverage_pct to exercise both the branch where get_coverage_percentage
+        returns None (coverage disabled) and where it returns a value (coverage enabled), ensuring
+        the metrics assignment path is always covered.
+        """
         mock_manager = session_manager_mock().build_mock()
         plugin = TestOptPlugin(session_manager=mock_manager)
         # _itr_ignored_suite_paths is empty (default)
@@ -322,9 +339,12 @@ class TestSkippingAndITRFeatures:
         mock_session = Mock()
         mock_session.exitstatus = pytest.ExitCode.NO_TESTS_COLLECTED
 
-        plugin.pytest_sessionfinish(mock_session)
+        with patch("ddtrace.testing.internal.pytest.plugin.get_coverage_percentage", return_value=coverage_pct):
+            plugin.pytest_sessionfinish(mock_session)
 
         assert mock_session.exitstatus == pytest.ExitCode.NO_TESTS_COLLECTED
+        if coverage_pct is not None:
+            assert plugin.session.metrics[TestTag.CODE_COVERAGE_LINES_PCT] == coverage_pct
 
     def test_pytest_ignore_collect_passes_rootpath_to_is_skippable_suite_path(self, tmp_path: Path) -> None:
         """pytest_ignore_collect passes config.rootpath to is_skippable_suite_path."""

--- a/tests/testing/mocks.py
+++ b/tests/testing/mocks.py
@@ -181,6 +181,7 @@ class SessionManagerMockBuilder:
 
         mock_manager.itr_skipping_level = self._itr_skipping_level
         mock_manager.session = MagicMock()
+        mock_manager.session.metrics = {}
         mock_manager.writer = Mock()
         mock_manager.coverage_writer = Mock()
         mock_manager.telemetry_api = Mock()

--- a/tests/testing/mocks.py
+++ b/tests/testing/mocks.py
@@ -16,6 +16,7 @@ import json
 import os
 from pathlib import Path
 import typing as t
+from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -179,7 +180,7 @@ class SessionManagerMockBuilder:
         mock_manager.env_tags = self._env_tags
 
         mock_manager.itr_skipping_level = self._itr_skipping_level
-        mock_manager.session = Mock()
+        mock_manager.session = MagicMock()
         mock_manager.writer = Mock()
         mock_manager.coverage_writer = Mock()
         mock_manager.telemetry_api = Mock()


### PR DESCRIPTION
## Description

Two tests in `TestSkippingAndITRFeatures` were failing:
- `test_pytest_sessionfinish_no_override_when_no_itr_skips`
- `test_pytest_sessionfinish_overrides_no_tests_collected_when_itr_skipped`

Both tests call `plugin.pytest_sessionfinish(mock_session)`, which (added in #18755) includes a code path that assigns into `self.session.metrics`:

```python
coverage_percentage = get_coverage_percentage(_is_pytest_cov_enabled(session.config))
if coverage_percentage is not None:
    self.session.metrics[TestTag.CODE_COVERAGE_LINES_PCT] = coverage_percentage
```

`self.session` is sourced from `mock_manager.session`, which was a plain `Mock()`. Plain `Mock` objects do not implement magic methods like `__setitem__`, so the dict-style assignment raises `TypeError: 'Mock' object does not support item assignment`.

The failure appeared flaky but was actually consistent: the venv always includes `coverage` and `pytest-cov`, so `get_coverage_percentage()` reliably returns a non-`None` value during the test run, always hitting the failing assignment.

**Fix:**
- `mock_manager.session` changed from `Mock()` to `MagicMock()` so magic methods are supported.
- `mock_manager.session.metrics` is set to a real `{}` dict so `__setitem__`/`__getitem__` round-trip correctly and can be asserted against.
- Both tests are parametrized over `coverage_pct in [None, 75.0]`, patching `get_coverage_percentage` to explicitly exercise both the no-coverage branch and the metrics-assignment branch, making the tests deterministic regardless of the environment.

## Testing

Ran all four parametrized variants locally via `scripts/run-tests`:

```
======================== 4 passed, 9 warnings in 2.15s =========================
```

## Risks

None — test-only change, no production code affected.

## Additional Notes

The root cause was introduced by #18755, which added the `self.session.metrics[...]` assignment inside `pytest_sessionfinish` without updating the mock in `SessionManagerMockBuilder` to support item assignment.