### PR TITLE
feat(ci-visibility): add pagination metrics for known tests fetch

### DIFF
--- a/ddtrace/internal/ci_visibility/_api_client.py
+++ b/ddtrace/internal/ci_visibility/_api_client.py
@@ -35,7 +35,10 @@ from ddtrace.internal.ci_visibility.telemetry.api_request import record_api_requ
 from ddtrace.internal.ci_visibility.telemetry.constants import ERROR_TYPES
 from ddtrace.internal.ci_visibility.telemetry.constants import GIT_TELEMETRY
 from ddtrace.internal.ci_visibility.telemetry.early_flake_detection import EARLY_FLAKE_DETECTION_TELEMETRY
+from ddtrace.internal.ci_visibility.telemetry.early_flake_detection import record_early_flake_detection_pages_fetched
 from ddtrace.internal.ci_visibility.telemetry.early_flake_detection import record_early_flake_detection_tests_count
+from ddtrace.internal.ci_visibility.telemetry.early_flake_detection import record_early_flake_detection_total_fetch_ms
+from ddtrace.internal.ci_visibility.telemetry.early_flake_detection import record_early_flake_detection_total_request_ms
 from ddtrace.internal.ci_visibility.telemetry.git import record_settings_response
 from ddtrace.internal.ci_visibility.telemetry.itr import SKIPPABLE_TESTS_TELEMETRY
 from ddtrace.internal.ci_visibility.telemetry.itr import record_skippable_count
@@ -579,7 +582,15 @@ class _TestVisibilityAPIClientBase(abc.ABC):
         page_state: t.Optional[str] = None
         max_pages = _get_known_tests_max_pages()
 
+        pages_fetched = 0
+        total_request_ms = 0.0
+        from ddtrace.internal.utils.time import StopWatch
+
+        fetch_sw = StopWatch()
+        fetch_sw.start()
+
         for page_number in range(max_pages):
+            pages_fetched += 1
             # First page: empty page_info lets backend use its default max (10k).
             # Subsequent pages: only send page_state.
             request_page_info: dict[str, t.Any] = {} if page_state is None else {"page_state": page_state}
@@ -599,9 +610,13 @@ class _TestVisibilityAPIClientBase(abc.ABC):
             }
 
             try:
+                request_sw = StopWatch()
+                request_sw.start()
                 parsed_response = self._do_request_with_telemetry(
                     "POST", KNOWN_TESTS_ENDPOINT, payload, metric_names, read_from_cache=read_from_cache
                 )
+                request_sw.stop()
+                total_request_ms += request_sw.elapsed() * 1000
             except Exception:  # noqa: E722
                 return None
 
@@ -651,7 +666,11 @@ class _TestVisibilityAPIClientBase(abc.ABC):
             record_api_request_error(metric_names.error, ERROR_TYPES.BAD_JSON)
             return None
 
+        fetch_sw.stop()
         record_early_flake_detection_tests_count(len(known_test_ids))
+        record_early_flake_detection_pages_fetched(pages_fetched)
+        record_early_flake_detection_total_fetch_ms(fetch_sw.elapsed() * 1000)
+        record_early_flake_detection_total_request_ms(total_request_ms)
 
         return known_test_ids
 

--- a/ddtrace/internal/ci_visibility/telemetry/early_flake_detection.py
+++ b/ddtrace/internal/ci_visibility/telemetry/early_flake_detection.py
@@ -23,3 +23,30 @@ def record_early_flake_detection_tests_count(early_flake_detection_count: int):
         EARLY_FLAKE_DETECTION_TELEMETRY.RESPONSE_TESTS.value,
         early_flake_detection_count,
     )
+
+
+def record_early_flake_detection_pages_fetched(pages: int):
+    log.debug("Recording early flake detection pages fetched telemetry: %s", pages)
+    telemetry_writer.add_distribution_metric(
+        TELEMETRY_NAMESPACE.CIVISIBILITY,
+        "early_flake_detection.pages_fetched",
+        pages,
+    )
+
+
+def record_early_flake_detection_total_fetch_ms(total_ms: float):
+    log.debug("Recording early flake detection total fetch ms telemetry: %s", total_ms)
+    telemetry_writer.add_distribution_metric(
+        TELEMETRY_NAMESPACE.CIVISIBILITY,
+        "early_flake_detection.total_fetch_ms",
+        total_ms,
+    )
+
+
+def record_early_flake_detection_total_request_ms(total_ms: float):
+    log.debug("Recording early flake detection total request ms telemetry: %s", total_ms)
+    telemetry_writer.add_distribution_metric(
+        TELEMETRY_NAMESPACE.CIVISIBILITY,
+        "early_flake_detection.total_request_ms",
+        total_ms,
+    )

--- a/ddtrace/testing/internal/api_client.py
+++ b/ddtrace/testing/internal/api_client.py
@@ -141,7 +141,15 @@ class APIClient:
         known_test_ids: set[TestRef] = set()
         max_pages = _get_known_tests_max_pages()
 
+        pages_fetched = 0
+        total_request_ms = 0.0
+        from ddtrace.internal.utils.time import StopWatch
+
+        fetch_sw = StopWatch()
+        fetch_sw.start()
+
         for page_number in range(max_pages):
+            pages_fetched += 1
             # First page: empty page_info lets backend use its default max (10k).
             # Subsequent pages: only send page_state.
             page_info: dict[str, t.Any] = {} if page_state is None else {"page_state": page_state}
@@ -168,8 +176,12 @@ class APIClient:
                 return set()
 
             try:
+                request_sw = StopWatch()
+                request_sw.start()
                 result = self.connector.post_json("/api/v2/ci/libraries/tests", request_data, telemetry=telemetry)
                 result.on_error_raise_exception()
+                request_sw.stop()
+                total_request_ms += request_sw.elapsed() * 1000
 
             except Exception as e:
                 log.warning("Error getting known tests from API: %s", e)
@@ -218,7 +230,11 @@ class APIClient:
             self.configuration_errors[TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS] = "true"
             return set()
 
+        fetch_sw.stop()
         self.telemetry_api.record_known_tests_count(len(known_test_ids))
+        self.telemetry_api.record_known_tests_pages_fetched(pages_fetched)
+        self.telemetry_api.record_known_tests_total_fetch_ms(fetch_sw.elapsed() * 1000)
+        self.telemetry_api.record_known_tests_total_request_ms(total_request_ms)
         return known_test_ids
 
     def get_test_management_properties(

--- a/ddtrace/testing/internal/telemetry.py
+++ b/ddtrace/testing/internal/telemetry.py
@@ -149,6 +149,15 @@ class TelemetryAPI:
     def record_known_tests_count(self, count: int) -> None:
         self.add_distribution_metric("known_tests.response_tests", count)
 
+    def record_known_tests_pages_fetched(self, pages: int) -> None:
+        self.add_distribution_metric("known_tests.pages_fetched", pages)
+
+    def record_known_tests_total_fetch_ms(self, total_ms: float) -> None:
+        self.add_distribution_metric("known_tests.total_fetch_ms", total_ms)
+
+    def record_known_tests_total_request_ms(self, total_ms: float) -> None:
+        self.add_distribution_metric("known_tests.total_request_ms", total_ms)
+
     def record_skippable_count(self, count: int, level: ITRSkippingLevel) -> None:
         skippable_count_metric = (
             "itr_skippable_tests.response_suites"

--- a/releasenotes/notes/ci-visibility-known-tests-pagination-metrics-25820734.yaml
+++ b/releasenotes/notes/ci-visibility-known-tests-pagination-metrics-25820734.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    CI Visibility: Add pagination metrics for known tests fetch (pages_fetched, total_fetch_ms, total_request_ms)

--- a/tests/ci_visibility/api_client/test_ci_visibility_api_client_unique_tests_responses.py
+++ b/tests/ci_visibility/api_client/test_ci_visibility_api_client_unique_tests_responses.py
@@ -67,8 +67,27 @@ class TestTestVisibilityAPIClientKnownTestResponses(TestTestVisibilityAPIClientB
     def test_civisibility_api_client_known_tests_parsed(self, known_test_response, expected_tests):
         """Tests that the client correctly returns known tests from API response"""
         client = self._get_test_client()
-        with mock.patch.object(client, "_do_request", return_value=known_test_response):
+        with (
+            mock.patch.object(client, "_do_request", return_value=known_test_response),
+            mock.patch(
+                "ddtrace.internal.ci_visibility._api_client.record_early_flake_detection_tests_count"
+            ) as mock_count,
+            mock.patch(
+                "ddtrace.internal.ci_visibility._api_client.record_early_flake_detection_pages_fetched"
+            ) as mock_pages,
+            mock.patch(
+                "ddtrace.internal.ci_visibility._api_client.record_early_flake_detection_total_fetch_ms"
+            ) as mock_fetch_ms,
+            mock.patch(
+                "ddtrace.internal.ci_visibility._api_client.record_early_flake_detection_total_request_ms"
+            ) as mock_request_ms,
+        ):
             assert client.fetch_known_tests(read_from_cache=False) == expected_tests
+            # Verify pagination metrics were recorded
+            mock_count.assert_called_once_with(len(expected_tests))
+            mock_pages.assert_called_once_with(1)
+            mock_fetch_ms.assert_called_once()
+            mock_request_ms.assert_called_once()
 
     @pytest.mark.parametrize(
         "do_request_side_effect",
@@ -105,9 +124,26 @@ class TestTestVisibilityAPIClientKnownTestResponses(TestTestVisibilityAPIClientB
         with (
             mock.patch.object(client, "_do_request", side_effect=[do_request_side_effect] * 5),
             mock.patch("ddtrace.internal.utils.retry.sleep"),
+            mock.patch(
+                "ddtrace.internal.ci_visibility._api_client.record_early_flake_detection_tests_count"
+            ) as mock_count,
+            mock.patch(
+                "ddtrace.internal.ci_visibility._api_client.record_early_flake_detection_pages_fetched"
+            ) as mock_pages,
+            mock.patch(
+                "ddtrace.internal.ci_visibility._api_client.record_early_flake_detection_total_fetch_ms"
+            ) as mock_fetch_ms,
+            mock.patch(
+                "ddtrace.internal.ci_visibility._api_client.record_early_flake_detection_total_request_ms"
+            ) as mock_request_ms,
         ):
             settings = client.fetch_known_tests(read_from_cache=False)
             assert settings is None
+            # No pagination metrics should be emitted on failure
+            mock_count.assert_not_called()
+            mock_pages.assert_not_called()
+            mock_fetch_ms.assert_not_called()
+            mock_request_ms.assert_not_called()
 
     def test_civisibility_api_client_known_tests_paginated(self):
         client = self._get_test_client()
@@ -120,7 +156,31 @@ class TestTestVisibilityAPIClientKnownTestResponses(TestTestVisibilityAPIClientB
             page_info={"cursor": None, "size": 1, "has_next": False},
         )
 
-        with mock.patch.object(client, "_do_request", side_effect=[response_page_1, response_page_2]):
-            assert client.fetch_known_tests(read_from_cache=False) == set(
+        with (
+            mock.patch.object(client, "_do_request", side_effect=[response_page_1, response_page_2]),
+            mock.patch(
+                "ddtrace.internal.ci_visibility._api_client.record_early_flake_detection_tests_count"
+            ) as mock_count,
+            mock.patch(
+                "ddtrace.internal.ci_visibility._api_client.record_early_flake_detection_pages_fetched"
+            ) as mock_pages,
+            mock.patch(
+                "ddtrace.internal.ci_visibility._api_client.record_early_flake_detection_total_fetch_ms"
+            ) as mock_fetch_ms,
+            mock.patch(
+                "ddtrace.internal.ci_visibility._api_client.record_early_flake_detection_total_request_ms"
+            ) as mock_request_ms,
+        ):
+            expected_tests = set(
                 _make_fqdn_test_ids([("module1", "suite1.py", "test1"), ("module1", "suite1.py", "test2")])
             )
+            assert client.fetch_known_tests(read_from_cache=False) == expected_tests
+            # Verify 2 pages were fetched and timing metrics were recorded
+            mock_count.assert_called_once_with(2)
+            mock_pages.assert_called_once_with(2)
+            mock_fetch_ms.assert_called_once()
+            mock_request_ms.assert_called_once()
+            # Total fetch time should be >= sum of request times
+            total_fetch_ms = mock_fetch_ms.call_args[0][0]
+            total_request_ms = mock_request_ms.call_args[0][0]
+            assert total_fetch_ms >= total_request_ms

--- a/tests/testing/internal/test_api_client.py
+++ b/tests/testing/internal/test_api_client.py
@@ -412,6 +412,12 @@ class TestAPIClientGetKnownTests:
             TestRef(SuiteRef(ModuleRef("some-module"), "test_second.py"), "test_03"),
         }
 
+        # Verify pagination metrics
+        assert mock_telemetry.record_known_tests_pages_fetched.call_count == 1
+        assert mock_telemetry.record_known_tests_pages_fetched.call_args_list[0][0][0] == 1
+        assert mock_telemetry.record_known_tests_total_fetch_ms.call_count == 1
+        assert mock_telemetry.record_known_tests_total_request_ms.call_count == 1
+
     def test_get_known_tests_pagination_sends_page_info_correctly(self, mock_telemetry: Mock) -> None:
         """First page sends empty page_info; second page sends only page_state."""
         page1_response = {
@@ -468,6 +474,16 @@ class TestAPIClientGetKnownTests:
             TestRef(SuiteRef(ModuleRef("mod1"), "suite1.py"), "test_a"),
             TestRef(SuiteRef(ModuleRef("mod2"), "suite2.py"), "test_b"),
         }
+
+        # Verify pagination metrics
+        assert mock_telemetry.record_known_tests_pages_fetched.call_count == 1
+        assert mock_telemetry.record_known_tests_pages_fetched.call_args_list[0][0][0] == 2
+        assert mock_telemetry.record_known_tests_total_fetch_ms.call_count == 1
+        assert mock_telemetry.record_known_tests_total_request_ms.call_count == 1
+        # Total fetch time should be >= sum of request times
+        total_fetch_ms = mock_telemetry.record_known_tests_total_fetch_ms.call_args_list[0][0][0]
+        total_request_ms = mock_telemetry.record_known_tests_total_request_ms.call_args_list[0][0][0]
+        assert total_fetch_ms >= total_request_ms
 
     def test_get_known_tests_max_pages_limit_bails_and_disables_known_tests(
         self, mock_telemetry: Mock, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
@@ -539,6 +555,20 @@ class TestAPIClientGetKnownTests:
         assert "Known tests pagination exceeded max pages: 2" in caplog.text
         assert known_tests == set()
         assert api_client.configuration_errors == {TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS: "true"}
+
+        # No pagination metrics should be emitted on failure
+        assert (
+            not hasattr(mock_telemetry, "record_known_tests_pages_fetched")
+            or mock_telemetry.record_known_tests_pages_fetched.call_count == 0
+        )
+        assert (
+            not hasattr(mock_telemetry, "record_known_tests_total_fetch_ms")
+            or mock_telemetry.record_known_tests_total_fetch_ms.call_count == 0
+        )
+        assert (
+            not hasattr(mock_telemetry, "record_known_tests_total_request_ms")
+            or mock_telemetry.record_known_tests_total_request_ms.call_count == 0
+        )
 
     def test_get_known_tests_max_pages_zero_uses_default(
         self, mock_telemetry: Mock, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
@@ -624,6 +654,20 @@ class TestAPIClientGetKnownTests:
             call(ErrorType.BAD_JSON)
         ]
 
+        # No pagination metrics should be emitted on failure
+        assert (
+            not hasattr(mock_telemetry, "record_known_tests_pages_fetched")
+            or mock_telemetry.record_known_tests_pages_fetched.call_count == 0
+        )
+        assert (
+            not hasattr(mock_telemetry, "record_known_tests_total_fetch_ms")
+            or mock_telemetry.record_known_tests_total_fetch_ms.call_count == 0
+        )
+        assert (
+            not hasattr(mock_telemetry, "record_known_tests_total_request_ms")
+            or mock_telemetry.record_known_tests_total_request_ms.call_count == 0
+        )
+
     def test_get_known_tests_missing_git_data(self, mock_telemetry: Mock, caplog: pytest.LogCaptureFixture) -> None:
         mock_connector = mock_backend_connector().build()
         mock_connector_setup = Mock()
@@ -654,6 +698,20 @@ class TestAPIClientGetKnownTests:
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == [
             call(ErrorType.UNKNOWN)
         ]
+
+        # No pagination metrics should be emitted on failure
+        assert (
+            not hasattr(mock_telemetry, "record_known_tests_pages_fetched")
+            or mock_telemetry.record_known_tests_pages_fetched.call_count == 0
+        )
+        assert (
+            not hasattr(mock_telemetry, "record_known_tests_total_fetch_ms")
+            or mock_telemetry.record_known_tests_total_fetch_ms.call_count == 0
+        )
+        assert (
+            not hasattr(mock_telemetry, "record_known_tests_total_request_ms")
+            or mock_telemetry.record_known_tests_total_request_ms.call_count == 0
+        )
 
     def test_get_known_tests_fail_http_request(self, mock_telemetry: Mock, caplog: pytest.LogCaptureFixture) -> None:
         mock_connector = Mock()
@@ -689,6 +747,20 @@ class TestAPIClientGetKnownTests:
         assert known_tests == set()
         assert api_client.configuration_errors == {TestTag.LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS: "true"}
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == []
+
+        # No pagination metrics should be emitted on failure
+        assert (
+            not hasattr(mock_telemetry, "record_known_tests_pages_fetched")
+            or mock_telemetry.record_known_tests_pages_fetched.call_count == 0
+        )
+        assert (
+            not hasattr(mock_telemetry, "record_known_tests_total_fetch_ms")
+            or mock_telemetry.record_known_tests_total_fetch_ms.call_count == 0
+        )
+        assert (
+            not hasattr(mock_telemetry, "record_known_tests_total_request_ms")
+            or mock_telemetry.record_known_tests_total_request_ms.call_count == 0
+        )
 
     def test_get_known_tests_errors_in_response(self, mock_telemetry: Mock, caplog: pytest.LogCaptureFixture) -> None:
         mock_connector = (
@@ -728,6 +800,20 @@ class TestAPIClientGetKnownTests:
         assert mock_telemetry.with_request_metric_names.return_value.record_error.call_args_list == [
             call(ErrorType.BAD_JSON)
         ]
+
+        # No pagination metrics should be emitted on failure
+        assert (
+            not hasattr(mock_telemetry, "record_known_tests_pages_fetched")
+            or mock_telemetry.record_known_tests_pages_fetched.call_count == 0
+        )
+        assert (
+            not hasattr(mock_telemetry, "record_known_tests_total_fetch_ms")
+            or mock_telemetry.record_known_tests_total_fetch_ms.call_count == 0
+        )
+        assert (
+            not hasattr(mock_telemetry, "record_known_tests_total_request_ms")
+            or mock_telemetry.record_known_tests_total_request_ms.call_count == 0
+        )
 
 
 class TestAPIClientGetTestManagementTests:


### PR DESCRIPTION
## What does this PR do?

Adds three new distribution metrics to track known tests (Early Flake Detection) pagination behavior:

- `known_tests.pages_fetched` - Number of pages fetched during pagination
- `known_tests.total_fetch_ms` - Wall-clock time from first to last page request
- `known_tests.total_request_ms` - Sum of individual per-page request durations

## Motivation

Currently, only per-request timing is tracked via `known_tests.request`. These new metrics provide observability into:
- How often pagination occurs (single vs multi-page responses)
- Backend pagination performance (total wall-clock time)
- Network overhead vs local processing time (total_fetch_ms vs total_request_ms)

## Implementation Details

Implemented in **both** API clients:
- `ddtrace.testing.internal.api_client` (legacy client)
- `ddtrace.internal.ci_visibility._api_client` (newer client)

Metrics are emitted **only on successful completion** after all pages are fetched. If fetch fails midway (network error, invalid response), metrics are not emitted.

## Testing

- Added comprehensive unit tests for both API clients
- Tests cover single-page, multi-page, and failure scenarios
- All 639 tests pass in ci_visibility suite
- Code formatted with ruff

## Checklist

- [x] Tests added and passing (639 tests total)
- [x] Code formatted (ruff)
- [x] Backward compatible (no breaking changes)
- [x] Follows existing telemetry patterns
- [x] Both legacy and newer clients updated