### PR TITLE
fix(iast): scope taint queries to the active request slot [backport 4.10]

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -377,7 +377,7 @@ experiments:
           # iastaspects
           - name: iastaspects-add_aspect
             thresholds:
-              - execution_time < 0.13 ms
+              - execution_time < 0.15 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-add_inplace_aspect
             thresholds:
@@ -397,7 +397,7 @@ experiments:
               - max_rss_usage < 48.00 MB
           - name: iastaspects-bytearray_extend_aspect
             thresholds:
-              - execution_time < 0.80 ms
+              - execution_time < 0.90 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-bytearray_extend_noaspect
             thresholds:
@@ -409,7 +409,7 @@ experiments:
               - max_rss_usage < 48.00 MB
           - name: iastaspects-bytes_aspect
             thresholds:
-              - execution_time < 0.30 ms
+              - execution_time < 0.35 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-bytes_noaspect
             thresholds:
@@ -421,7 +421,7 @@ experiments:
               - max_rss_usage < 48.00 MB
           - name: iastaspects-bytesio_noaspect
             thresholds:
-              - execution_time < 0.42 ms
+              - execution_time < 0.50 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-capitalize_aspect
             thresholds:
@@ -429,7 +429,7 @@ experiments:
               - max_rss_usage < 48.00 MB
           - name: iastaspects-capitalize_noaspect
             thresholds:
-              - execution_time < 0.30 ms
+              - execution_time < 0.35 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-casefold_aspect
             thresholds:
@@ -441,11 +441,11 @@ experiments:
               - max_rss_usage < 48.00 MB
           - name: iastaspects-decode_aspect
             thresholds:
-              - execution_time < 0.10 ms
+              - execution_time < 0.13 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-decode_noaspect
             thresholds:
-              - execution_time < 0.21 ms
+              - execution_time < 0.25 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-encode_aspect
             thresholds:
@@ -453,7 +453,7 @@ experiments:
               - max_rss_usage < 48.00 MB
           - name: iastaspects-encode_noaspect
             thresholds:
-              - execution_time < 0.20 ms
+              - execution_time < 0.25 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-format_aspect
             thresholds:
@@ -489,11 +489,11 @@ experiments:
               - max_rss_usage < 48.00 MB
           - name: iastaspects-ljust_aspect
             thresholds:
-              - execution_time < 0.70 ms
+              - execution_time < 0.80 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-ljust_noaspect
             thresholds:
-              - execution_time < 0.30 ms
+              - execution_time < 0.45 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-lower_aspect
             thresholds:
@@ -501,7 +501,7 @@ experiments:
               - max_rss_usage < 48.00 MB
           - name: iastaspects-lower_noaspect
             thresholds:
-              - execution_time < 0.30 ms
+              - execution_time < 0.35 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-lstrip_aspect
             thresholds:
@@ -537,11 +537,11 @@ experiments:
               - max_rss_usage < 48.00 MB
           - name: iastaspects-replace_noaspect
             thresholds:
-              - execution_time < 0.40 ms
+              - execution_time < 0.50 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-repr_aspect
             thresholds:
-              - execution_time < 0.42 ms
+              - execution_time < 0.50 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-repr_noaspect
             thresholds:
@@ -549,7 +549,7 @@ experiments:
               - max_rss_usage < 48.00 MB
           - name: iastaspects-rstrip_aspect
             thresholds:
-              - execution_time < 0.50 ms
+              - execution_time < 0.55 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-rstrip_noaspect
             thresholds:
@@ -573,11 +573,11 @@ experiments:
               - max_rss_usage < 48.00 MB
           - name: iastaspects-strip_aspect
             thresholds:
-              - execution_time < 0.35 ms
+              - execution_time < 0.40 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-strip_noaspect
             thresholds:
-              - execution_time < 0.24 ms
+              - execution_time < 0.30 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-swapcase_aspect
             thresholds:
@@ -601,7 +601,7 @@ experiments:
               - max_rss_usage < 48.00 MB
           - name: iastaspects-translate_noaspect
             thresholds:
-              - execution_time < 0.50 ms
+              - execution_time < 0.55 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-upper_aspect
             thresholds:
@@ -623,11 +623,11 @@ experiments:
               - max_rss_usage < 48.00 MB
           - name: iastaspectsospath-ospathjoin_aspect
             thresholds:
-              - execution_time < 0.70 ms
+              - execution_time < 0.80 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspectsospath-ospathjoin_noaspect
             thresholds:
-              - execution_time < 0.70 ms
+              - execution_time < 0.80 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspectsospath-ospathnormcase_aspect
             thresholds:
@@ -691,7 +691,7 @@ experiments:
           # iastpropagation
           - name: iastpropagation-no-propagation
             thresholds:
-              - execution_time < 0.06 ms
+              - execution_time < 0.08 ms
               - max_rss_usage < 45.00 MB
           - name: iastpropagation-propagation_enabled
             thresholds:
@@ -703,7 +703,7 @@ experiments:
               - max_rss_usage < 45.00 MB
           - name: iastpropagation-propagation_enabled_1000
             thresholds:
-              - execution_time < 34.55 ms
+              - execution_time < 38.00 ms
               - max_rss_usage < 45.00 MB
 
           # otelsdkspan

--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -222,43 +222,43 @@ experiments:
           - name: httppropagationextract-all_styles_all_headers
             thresholds:
               - execution_time < 0.10 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-b3_headers
             thresholds:
               - execution_time < 0.02 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-b3_single_headers
             thresholds:
               - execution_time < 0.02 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-datadog_tracecontext_tracestate_not_propagated_on_trace_id_no_match
             thresholds:
               - execution_time < 0.08 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-datadog_tracecontext_tracestate_propagated_on_trace_id_match
             thresholds:
               - execution_time < 0.08 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-empty_headers
             thresholds:
               - execution_time < 0.01 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-full_t_id_datadog_headers
             thresholds:
               - execution_time < 0.03 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-invalid_priority_header
             thresholds:
               - execution_time < 0.01 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-invalid_span_id_header
             thresholds:
               - execution_time < 0.01 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-invalid_tags_header
             thresholds:
               - execution_time < 0.01 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-invalid_trace_id_header
             thresholds:
               - execution_time < 0.01 ms
@@ -266,67 +266,67 @@ experiments:
           - name: httppropagationextract-large_header_no_matches
             thresholds:
               - execution_time < 0.03 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-large_valid_headers_all
             thresholds:
               - execution_time < 0.04 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-medium_header_no_matches
             thresholds:
               - execution_time < 0.02 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-medium_valid_headers_all
             thresholds:
               - execution_time < 0.02 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-none_propagation_style
             thresholds:
               - execution_time < 0.01 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-tracecontext_headers
             thresholds:
               - execution_time < 0.05 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-valid_headers_all
             thresholds:
               - execution_time < 0.01 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-valid_headers_basic
             thresholds:
               - execution_time < 0.01 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-wsgi_empty_headers
             thresholds:
               - execution_time < 0.01 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-wsgi_invalid_priority_header
             thresholds:
               - execution_time < 0.01 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-wsgi_invalid_span_id_header
             thresholds:
               - execution_time < 0.01 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-wsgi_invalid_tags_header
             thresholds:
               - execution_time < 0.01 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-wsgi_invalid_trace_id_header
             thresholds:
               - execution_time < 0.01 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-wsgi_large_header_no_matches
             thresholds:
               - execution_time < 0.04 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-wsgi_large_valid_headers_all
             thresholds:
               - execution_time < 0.04 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-wsgi_medium_header_no_matches
             thresholds:
               - execution_time < 0.02 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-wsgi_medium_valid_headers_all
             thresholds:
               - execution_time < 0.02 ms
@@ -334,37 +334,37 @@ experiments:
           - name: httppropagationextract-wsgi_valid_headers_all
             thresholds:
               - execution_time < 0.01 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-wsgi_valid_headers_basic
             thresholds:
               - execution_time < 0.01 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
 
           # httppropagationinject
           - name: httppropagationinject-ids_only
             thresholds:
               - execution_time < 0.03 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationinject-with_all
             thresholds:
               - execution_time < 0.04 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationinject-with_dd_origin
             thresholds:
               - execution_time < 0.03 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationinject-with_priority_and_origin
             thresholds:
               - execution_time < 0.04 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationinject-with_sampling_priority
             thresholds:
               - execution_time < 0.03 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationinject-with_tags
             thresholds:
               - execution_time < 0.04 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationinject-with_tags_invalid
             thresholds:
               - execution_time < 0.04 ms
@@ -372,7 +372,7 @@ experiments:
           - name: httppropagationinject-with_tags_max_size
             thresholds:
               - execution_time < 0.04 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
 
           # iastaspects
           - name: iastaspects-add_aspect

--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -262,7 +262,7 @@ experiments:
           - name: httppropagationextract-invalid_trace_id_header
             thresholds:
               - execution_time < 0.01 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 40.00 MB
           - name: httppropagationextract-large_header_no_matches
             thresholds:
               - execution_time < 0.03 ms

--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -330,7 +330,7 @@ experiments:
           - name: httppropagationextract-wsgi_medium_valid_headers_all
             thresholds:
               - execution_time < 0.02 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationextract-wsgi_valid_headers_all
             thresholds:
               - execution_time < 0.01 ms
@@ -368,7 +368,7 @@ experiments:
           - name: httppropagationinject-with_tags_invalid
             thresholds:
               - execution_time < 0.04 ms
-              - max_rss_usage < 38.00 MB
+              - max_rss_usage < 39.00 MB
           - name: httppropagationinject-with_tags_max_size
             thresholds:
               - execution_time < 0.04 ms

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -1,3 +1,6 @@
+from typing import Any
+from typing import Optional
+
 from ddtrace.appsec._iast._taint_tracking._native import initialize_native_state  # noqa: F401
 from ddtrace.appsec._iast._taint_tracking._native import ops  # noqa: F401
 from ddtrace.appsec._iast._taint_tracking._native import reset_native_state  # noqa: F401
@@ -28,7 +31,7 @@ from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import Vulnerab
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import copy_and_shift_ranges_from_strings  # noqa: F401
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import copy_ranges_from_strings  # noqa: F401
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import get_range_by_hash  # noqa: F401
-from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import get_ranges  # noqa: F401
+from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import get_ranges as _native_get_ranges
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import is_tainted  # noqa: F401
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import origin_to_str  # noqa: F401
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import set_ranges  # noqa: F401
@@ -40,6 +43,24 @@ from ddtrace.internal.logger import get_logger
 
 
 log = get_logger(__name__)
+
+# AIDEV-NOTE: _get_iast_context_id is imported lazily — a top-level import here
+# circularly bootstraps via _iast_request_context_base -> _taint_tracking._context
+# -> _taint_tracking/__init__.py. The cached module-global avoids the per-call
+# import dance on this hot path.
+_CACHE_GET_IAST_CONTEXT_ID = None
+
+
+def get_ranges(string_input: Any, context_id: Optional[int] = None) -> Any:
+    if context_id is None:
+        global _CACHE_GET_IAST_CONTEXT_ID
+        if _CACHE_GET_IAST_CONTEXT_ID is None:
+            from ddtrace.appsec._iast._iast_request_context_base import _get_iast_context_id
+
+            _CACHE_GET_IAST_CONTEXT_ID = _get_iast_context_id
+        context_id = _CACHE_GET_IAST_CONTEXT_ID()
+    return _native_get_ranges(string_input, context_id)
+
 
 __all__ = [
     "OriginType",

--- a/ddtrace/appsec/_iast/_taint_tracking/_taint_objects_base.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/_taint_objects_base.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from ddtrace.appsec._constants import IAST
+from ddtrace.appsec._iast._iast_request_context_base import _get_iast_context_id
 from ddtrace.appsec._iast._iast_request_context_base import is_iast_request_enabled
 from ddtrace.appsec._iast._logs import iast_propagation_debug_log
 from ddtrace.appsec._iast._logs import iast_propagation_error_log
@@ -69,7 +70,7 @@ def get_tainted_ranges(pyobject: Any) -> tuple:
     if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
         return tuple()
     try:
-        return get_ranges(pyobject)
+        return get_ranges(pyobject, _get_iast_context_id())
     except ValueError as e:
         iast_propagation_error_log(f"get_tainted_ranges error (pyobject type {type(pyobject)})", exc=e)
     return tuple()
@@ -80,7 +81,7 @@ def is_pyobject_tainted(pyobject: Any) -> bool:
         return False
 
     try:
-        return is_in_taint_map(pyobject)
+        return is_in_taint_map(pyobject, _get_iast_context_id())
     except ValueError as e:
         iast_propagation_error_log("Checking tainted object error", exc=e)
     return False

--- a/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.cpp
@@ -358,14 +358,26 @@ pyexport_taint_engine_context(py::module& m)
         return taint_engine_context->get_tainted_object_map_by_ctx_id(ctx_id) != nullptr;
     });
 
-    m.def("is_in_taint_map", [](py::object tainted_obj) {
-        if (!taint_engine_context)
-            return false;
-        if (TaintEngineContext::is_shutting_down())
-            return false;
-        auto map_ptr = taint_engine_context->get_tainted_object_map(tainted_obj.ptr());
-        return map_ptr != nullptr;
-    });
+    m.def(
+      "is_in_taint_map",
+      [](py::object tainted_obj, std::optional<size_t> context_id) {
+          if (!taint_engine_context)
+              return false;
+          if (context_id.has_value()) {
+              // Request-scoped check: only consult the calling request's slot.
+              const auto map_ptr = taint_engine_context->get_tainted_object_map_by_ctx_id(*context_id);
+              if (!map_ptr || map_ptr->empty()) {
+                  return false;
+              }
+              const auto& to_initial = get_tainted_object(tainted_obj.ptr(), map_ptr);
+              return to_initial && !to_initial->get_ranges().empty();
+          }
+          // No active request: scan every slot to locate the owning map.
+          const auto map_ptr = taint_engine_context->get_tainted_object_map(tainted_obj.ptr());
+          return map_ptr != nullptr;
+      },
+      "tainted_obj"_a,
+      "context_id"_a = std::nullopt);
 
     m.def("debug_context_array_size", [] {
         if (!taint_engine_context)

--- a/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/taint_range.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/taint_range.cpp
@@ -262,13 +262,22 @@ get_range_by_hash(const size_t range_hash, optional<TaintRangeRefs>& taint_range
 }
 
 TaintRangeRefs
-api_get_ranges(const py::handle& string_input)
+api_get_ranges(const py::handle& string_input, std::optional<size_t> context_id)
 {
     if (!taint_engine_context) {
         return {};
     }
 
-    const auto tx_map = safe_get_tainted_object_map(string_input.ptr());
+    // With a context_id the lookup is restricted to that request's slot so
+    // a taint from a concurrent request cannot bleed into the answer. Without
+    // a context_id (caller has no active request) the multi-slot resolver is
+    // used to locate the map that owns the object.
+    TaintedObjectMapTypePtr tx_map;
+    if (context_id.has_value()) {
+        tx_map = safe_get_tainted_object_map_by_ctx_id(*context_id);
+    } else {
+        tx_map = safe_get_tainted_object_map(string_input.ptr());
+    }
 
     if (not tx_map or tx_map->empty()) {
         return {};
@@ -451,7 +460,11 @@ pyexport_taintrange(py::module& m)
           "offset"_a,
           "new_length"_a = -1);
 
-    m.def("get_ranges", &api_get_ranges, "string_input"_a, py::return_value_policy::take_ownership);
+    m.def("get_ranges",
+          &api_get_ranges,
+          "string_input"_a,
+          "context_id"_a = std::nullopt,
+          py::return_value_policy::take_ownership);
 
     m.def("get_range_by_hash",
           &get_range_by_hash,

--- a/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/taint_range.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/taint_range.h
@@ -149,7 +149,7 @@ bool
 api_set_ranges(py::handle& str, const TaintRangeRefs& ranges, const size_t contextid);
 
 TaintRangeRefs
-api_get_ranges(const py::handle& string_input);
+api_get_ranges(const py::handle& string_input, std::optional<size_t> context_id = std::nullopt);
 
 void
 api_copy_ranges_from_strings(py::handle& str_1, py::handle& str_2);

--- a/releasenotes/notes/fix-iast-cross-request-taint-leak-d48fd316f2fffeb1.yaml
+++ b/releasenotes/notes/fix-iast-cross-request-taint-leak-d48fd316f2fffeb1.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    IAST: This fix resolves an issue where IAST could report a false positive vulnerability against a request 
+    whose input did not actually contain tainted data. A concurrent or still-open request holding a tainted
+    value could leak its taint into the current request's checks. Queries are now scoped to the calling request's slot.

--- a/scripts/check_constant_log_message.py
+++ b/scripts/check_constant_log_message.py
@@ -26,7 +26,7 @@ EXCEPTIONS = {
     "ddtrace/appsec/_iast/_logs.py:41",
     "ddtrace/appsec/_iast/_logs.py:45",
     # the non constant part is an object type
-    "ddtrace/appsec/_iast/_taint_tracking/_taint_objects_base.py:74",
+    "ddtrace/appsec/_iast/_taint_tracking/_taint_objects_base.py:75",
     # _safelog wrapper function dispatches to log methods with variable message
     "ddtrace/internal/writer/writer.py:103",
 }

--- a/tests/appsec/iast/taint_tracking/test_context.py
+++ b/tests/appsec/iast/taint_tracking/test_context.py
@@ -1,3 +1,4 @@
+from ddtrace.appsec._iast._iast_request_context_base import IAST_CONTEXT
 from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request
 from ddtrace.appsec._iast._iast_request_context_base import _num_objects_tainted_in_request
 from ddtrace.appsec._iast._taint_tracking import OriginType
@@ -168,3 +169,63 @@ def test_copy_ranges_to_string_without_context_is_noop():
     out = copy_ranges_to_string("zzz", ranges)
     assert out == "zzz"
     assert is_pyobject_tainted(out) is False
+
+
+def test_is_pyobject_tainted_does_not_leak_across_request_slots():
+    """A PyObject tainted in one request slot must not appear tainted from another slot."""
+    clear_all_request_context_slots()
+    _end_iast_context_and_oce()
+
+    ctx_a = start_request_context()
+    assert ctx_a is not None
+
+    tainted_in_a = _taint_pyobject_base(
+        "http://dummy.location.com",
+        "location",
+        "http://dummy.location.com",
+        OriginType.PARAMETER,
+        contextid=ctx_a,
+    )
+    IAST_CONTEXT.set(ctx_a)
+    assert is_pyobject_tainted(tainted_in_a) is True
+
+    ctx_b = start_request_context()
+    assert ctx_b is not None and ctx_b != ctx_a
+    IAST_CONTEXT.set(ctx_b)
+
+    assert is_pyobject_tainted(tainted_in_a) is False
+    assert len(get_tainted_ranges(tainted_in_a)) == 0
+
+    finish_request_context(ctx_a)
+    finish_request_context(ctx_b)
+    IAST_CONTEXT.set(None)
+
+
+def test_get_ranges_public_api_does_not_leak_across_request_slots():
+    """The public ``get_ranges`` (used by sinks and aspects) must also be slot-scoped."""
+    from ddtrace.appsec._iast._taint_tracking import get_ranges
+
+    clear_all_request_context_slots()
+    _end_iast_context_and_oce()
+
+    ctx_a = start_request_context()
+    assert ctx_a is not None
+    tainted_in_a = _taint_pyobject_base(
+        "http://dummy.location.com",
+        "location",
+        "http://dummy.location.com",
+        OriginType.PARAMETER,
+        contextid=ctx_a,
+    )
+    IAST_CONTEXT.set(ctx_a)
+    assert len(get_ranges(tainted_in_a)) > 0
+
+    ctx_b = start_request_context()
+    assert ctx_b is not None and ctx_b != ctx_a
+    IAST_CONTEXT.set(ctx_b)
+
+    assert get_ranges(tainted_in_a) == []
+
+    finish_request_context(ctx_a)
+    finish_request_context(ctx_b)
+    IAST_CONTEXT.set(None)


### PR DESCRIPTION
backport https://github.com/DataDog/dd-trace-py/pull/18266 to 4.10