### PR TITLE
chore(iast): resolve symbol_db sha1 at call time to avoid weak-hash false positive

### DIFF
--- a/ddtrace/internal/symbol_db/symbols.py
+++ b/ddtrace/internal/symbol_db/symbols.py
@@ -4,7 +4,7 @@ from dataclasses import field
 import dis
 from enum import Enum
 import gzip
-from hashlib import sha1
+import hashlib
 from inspect import CO_VARARGS
 from inspect import CO_VARKEYWORDS
 from inspect import isasyncgenfunction
@@ -237,8 +237,12 @@ class Scope:
 
         # usedforsecurity=False: this sha1 computes a git-blob identity hash of the
         # module source, not a security digest. It also prevents IAST from flagging
-        # this internal use as a weak-hash false positive (APPSEC-68795).
-        source_git_hash = sha1(usedforsecurity=False)  # nosec B324
+        # this internal use as a weak-hash false positive (APPSEC-68795). Resolve
+        # hashlib.sha1 at call time (not via a module-level `from hashlib import
+        # sha1`) so the call goes through IAST's wrapped constructor when patched:
+        # symbol_db can be imported before patch_iast() runs, which would otherwise
+        # freeze a stale, unwrapped reference and leave the object untracked.
+        source_git_hash = hashlib.sha1(usedforsecurity=False)  # nosec B324
         source_git_hash.update(f"blob {module_origin.stat().st_size}\0".encode())
         with module_origin.open("rb") as f:
             for chunk in iter(lambda: f.read(8192), b""):

--- a/tests/appsec/iast/taint_sinks/test_weak_hash.py
+++ b/tests/appsec/iast/taint_sinks/test_weak_hash.py
@@ -395,6 +395,42 @@ def test_weak_hash_symbol_db_not_reported(iast_context_defaults):
     assert span_report is None
 
 
+def test_weak_hash_symbol_db_resolves_sha1_at_call_time(iast_context_defaults):
+    """Regression test for APPSEC-68795 (import-ordering variant).
+
+    When Symbol Database is enabled at startup, ``symbol_db/symbols.py`` is
+    imported before ``patch_iast()`` runs. A module-level ``from hashlib import
+    sha1`` would freeze a stale, unwrapped reference, so ``sha1(usedforsecurity
+    =False)`` would bypass IAST's wrapped constructor and the object would never
+    be tracked as safe. ``symbols`` must resolve ``hashlib.sha1`` at call time so
+    the call always goes through whatever constructor is currently installed.
+    """
+    import hashlib
+    from pathlib import Path
+
+    from ddtrace.internal.module import origin
+    from ddtrace.internal.symbol_db.symbols import Scope
+    from ddtrace.internal.symbol_db.symbols import ScopeData
+    import tests.appsec.iast.fixtures.taint_sinks.weak_algorithms as module_to_hash
+
+    # Rebind hashlib.sha1 *after* symbols has been imported. If symbols captured
+    # the constructor at import time this spy is never seen; call-time resolution
+    # routes through it.
+    original_sha1 = hashlib.sha1
+    called = []
+
+    def spy_sha1(*args, **kwargs):
+        called.append(kwargs)
+        return original_sha1(*args, **kwargs)
+
+    module_origin = origin(module_to_hash)
+    with mock.patch("hashlib.sha1", side_effect=spy_sha1):
+        Scope._get_from(module_to_hash, ScopeData(origin=Path(str(module_origin)), seen=set()))
+
+    assert called, "symbol_db must resolve hashlib.sha1 at call time, not via a frozen import binding"
+    assert called[0].get("usedforsecurity") is False
+
+
 def test_parametrized_weak_hash_no_exception():
     """Verify that parametrized_weak_hash doesn't raise any exceptions."""
     try:


### PR DESCRIPTION
## Description

Follow-up hardening for #18836 (weak-hash false positive from the symbol_db git-blob hash).

That PR passed `usedforsecurity=False` to suppress the IAST report, but relied on IAST's `wrapped_init_function` intercepting the `sha1()` call to record it. `symbol_db/symbols.py` used a **module-level `from hashlib import sha1`**, which freezes the constructor reference at *import* time.

When Symbol Database is enabled at startup, `symbol_db.bootstrap()` (via remoteconfig → `SymbolDatabaseUploader`) imports `symbols.py` **before** `patch_iast()` runs in post_preload. So the frozen `sha1` name pointed at the original, unwrapped constructor — `sha1(usedforsecurity=False)` bypassed IAST's wrapper, the hash object was never tracked as safe, and the type-level `_hashlib.HASH.hexdigest` wrapper (installed independently of construction) could still report the weak-hash false positive in the production Symbol DB flow.

## Fix

Resolve `hashlib.sha1` at **call time** (`import hashlib` + `hashlib.sha1(...)`) instead of freezing it at import time. IAST's `patch()` installs the init wrapper and the digest wrapper together, so whenever the digest wrapper is live the init wrapper is too — a call-time lookup always routes through the tracking path.

## Testing

- Added `test_weak_hash_symbol_db_resolves_sha1_at_call_time`, which rebinds `hashlib.sha1` with a spy *after* `symbols` is imported and asserts the spy is called with `usedforsecurity=False`. This reproduces the import-ordering scenario the previous test did not cover — it fails on the old frozen-binding code and passes with the call-time resolution.
- Existing `test_weak_hash_symbol_db_not_reported` still passes.

## Related

- Follow-up to #18836
- JIRA: [APPSEC-68795](https://datadoghq.atlassian.net/browse/APPSEC-68795)

## Changelog

Not user-impacting on its own — robustness follow-up to the fix already released via #18836, whose release note covers the behavior. `changelog/no-changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[APPSEC-68795]: https://datadoghq.atlassian.net/browse/APPSEC-68795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ