### PR TITLE
fix(debugger): stop SymDB fork reinstalls

### DIFF
--- a/ddtrace/internal/symbol_db/remoteconfig.py
+++ b/ddtrace/internal/symbol_db/remoteconfig.py
@@ -19,6 +19,7 @@ log = get_logger(__name__)
 shared_pid_file = SharedStringFile(f"{os.getppid()}-symdb-pids")
 
 MAX_CHILD_UPLOADERS = 1  # max one child
+_permanently_disabled: bool = False
 
 
 class SymbolDatabaseCallback(RCCallback):
@@ -30,6 +31,11 @@ class SymbolDatabaseCallback(RCCallback):
         Args:
             payloads: Sequence of configuration payloads to process
         """
+        global _permanently_disabled
+
+        if _permanently_disabled:
+            return
+
         with shared_pid_file.lock_exclusive() as f:
             if (pid := str(os.getpid())) not in (pids := set(shared_pid_file.peekall_unlocked(f))):
                 # Store the PID of the current process so that we know which processes
@@ -44,6 +50,7 @@ class SymbolDatabaseCallback(RCCallback):
                 # processes. Therefore, we avoid uploading the same symbols from each
                 # child process. We restrict the enablement of Symbol DB to just the
                 # parent process and the first fork child.
+                _permanently_disabled = True
                 remoteconfig_poller.unregister_callback("LIVE_DEBUGGING_SYMBOL_DB")
                 remoteconfig_poller.disable_product("LIVE_DEBUGGING_SYMBOL_DB")
 

--- a/releasenotes/notes/fix-symdb-fork-worker-reinstall.yaml
+++ b/releasenotes/notes/fix-symdb-fork-worker-reinstall.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: fixes Symbol Database reinstallation in forked worker
+    processes after the uploader is disabled, preventing repeated module scans that
+    could cause high memory usage or out-of-memory restarts.

--- a/tests/internal/symbol_db/test_symbols.py
+++ b/tests/internal/symbol_db/test_symbols.py
@@ -1,4 +1,5 @@
 import atexit
+import contextlib
 from importlib.machinery import ModuleSpec
 import os
 from pathlib import Path
@@ -20,11 +21,14 @@ from ddtrace.internal.symbol_db.symbols import _line_ranges
 
 @pytest.fixture(autouse=True, scope="function")
 def pid_file_teardown():
-    from ddtrace.internal.symbol_db.remoteconfig import shared_pid_file
+    from ddtrace.internal.symbol_db import remoteconfig
+
+    remoteconfig._permanently_disabled = False
 
     yield
 
-    shared_pid_file.clear()
+    remoteconfig.shared_pid_file.clear()
+    remoteconfig._permanently_disabled = False
 
 
 def test_symbol_from_code():
@@ -297,6 +301,51 @@ def test_scope_context_upload_skips_empty_batch():
         context.upload()
 
     mock_connector.assert_not_called()
+
+
+def test_symbol_database_callback_stays_disabled_after_child_uninstall():
+    from ddtrace.internal.remoteconfig import ConfigMetadata
+    from ddtrace.internal.remoteconfig import Payload
+    from ddtrace.internal.symbol_db import remoteconfig
+    from ddtrace.internal.symbol_db.remoteconfig import SymbolDatabaseCallback
+    from ddtrace.internal.symbol_db.symbols import SymbolDatabaseUploader
+
+    installed = [True]
+
+    def is_installed():
+        return installed[0]
+
+    def install():
+        installed[0] = True
+
+    def uninstall():
+        installed[0] = False
+
+    callback = SymbolDatabaseCallback()
+    rc_data = [
+        Payload(ConfigMetadata("test", "symdb", "hash", 0, 0), "test", {"upload_symbols": True}),
+    ]
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(mock.patch.object(remoteconfig, "get_ancestor_runtime_id", return_value="runtime_id"))
+        mock_has_forked = stack.enter_context(mock.patch.object(remoteconfig, "has_forked", side_effect=[True, False]))
+        mock_poller = stack.enter_context(mock.patch.object(remoteconfig, "remoteconfig_poller"))
+        stack.enter_context(mock.patch.object(SymbolDatabaseUploader, "is_installed", side_effect=is_installed))
+        mock_install = stack.enter_context(mock.patch.object(SymbolDatabaseUploader, "install", side_effect=install))
+        mock_uninstall = stack.enter_context(
+            mock.patch.object(SymbolDatabaseUploader, "uninstall", side_effect=uninstall)
+        )
+
+        callback(rc_data)
+        callback(rc_data)
+
+    assert remoteconfig._permanently_disabled is True
+    assert installed[0] is False
+    mock_poller.unregister_callback.assert_called_once_with("LIVE_DEBUGGING_SYMBOL_DB")
+    mock_poller.disable_product.assert_called_once_with("LIVE_DEBUGGING_SYMBOL_DB")
+    mock_uninstall.assert_called_once()
+    mock_install.assert_not_called()
+    mock_has_forked.assert_called_once()
 
 
 @pytest.mark.subprocess(ddtrace_run=True, env=dict(DD_SYMBOL_DATABASE_UPLOAD_ENABLED="1"))


### PR DESCRIPTION
<!-- dd-meta {"pullId":"94badcca-3f54-4423-9ec8-891104ece629","source":"chat","resourceId":"110c6857-a89c-4e31-ad31-a1d1c538af2d","workflowId":"6c645b4a-b1f8-40e1-9bcc-c1866cb8af74","codeChangeId":"6c645b4a-b1f8-40e1-9bcc-c1866cb8af74","sourceType":"assistant"} -->
## Description

### Motivation/Summary
Symbol Database remote config callbacks in forked workers can uninstall the uploader and then later reinstall it when an `upload_symbols` payload is processed again. Each reinstall recreates the Symbol Database uploader and rescans `sys.modules`, which can repeatedly allocate memory and contribute to OOM restarts in gunicorn/uvicorn worker processes.
[SymDB Memory Leak in dd-trace-py — PR Plan (Option A)](https://app.datadoghq.com/notebook/14975740/symdb-memory-leak-in-dd-trace-py-%25E2%2580%2594-pr-plan-option-a?link_type=chip)

### Changes
- Added a process-local permanent disable flag once child-worker Symbol Database disablement runs.
- Short-circuit later Symbol Database remote config callbacks in the same process to prevent reinstallation after child uninstall.
- Reset the flag in Symbol Database tests and added regression coverage for the would-be reinstall path.
- Added a release note.

## Testing

- `PYENV_VERSION=3.10.18 UV_PYTHON_DOWNLOADS=never scripts/lint fmt -- ddtrace/internal/symbol_db/remoteconfig.py tests/internal/symbol_db/test_symbols.py`
- `PYENV_VERSION=3.10.18 UV_PYTHON_DOWNLOADS=never scripts/lint style -- ddtrace/internal/symbol_db/remoteconfig.py tests/internal/symbol_db/test_symbols.py`
- `PYENV_VERSION=3.10.18 UV_PYTHON_DOWNLOADS=never scripts/lint spelling -- releasenotes/notes/fix-symdb-fork-worker-reinstall.yaml`
- `python -m py_compile ddtrace/internal/symbol_db/remoteconfig.py tests/internal/symbol_db/test_symbols.py`
- Attempted `scripts/run-tests --venv 15788e4 -- -- tests/internal/symbol_db/test_symbols.py -k 'test_symbol_database_callback_stays_disabled_after_child_uninstall or test_symbols_fork_uploads'`, but the sandbox could not start `testagent` because podman CNI plugins are unavailable.

## Risks

Low. Child processes that disable Symbol Database will keep it disabled until process restart, which matches the existing intent to avoid Symbol Database uploads from forked worker processes.

## Additional Notes

Release note generation through `riot run reno new fix-symdb-fork-worker-reinstall` was attempted but the sandbox could not build the editable package without a Rust toolchain, so the Reno fragment was added manually using the repository format.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/110c6857-a89c-4e31-ad31-a1d1c538af2d)

Comment @datadog to request changes