### PR TITLE
fix(profiling): track signal altstack ownership

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/danger.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/danger.h
@@ -53,6 +53,7 @@ struct ThreadAltStack
     void* mem = nullptr;
     size_t size = 0;
     bool ready = false;
+    bool owns_mapping = false;
 
     int ensure_installed()
     {
@@ -64,6 +65,7 @@ struct ThreadAltStack
         stack_t cur{};
         if (sigaltstack(nullptr, &cur) == 0 && !(cur.ss_flags & SS_DISABLE)) {
             ready = true;
+            owns_mapping = false;
             return 0;
         }
 
@@ -81,19 +83,22 @@ struct ThreadAltStack
         if (sigaltstack(&ss, nullptr) != 0) {
             std::cerr << "Failed to set alt stack. Memory copying may not work. "
                       << "Error: " << strerror(errno) << std::endl;
+            munmap(stack_mem, kAltStackSize);
             return -1;
         }
 
         this->mem = stack_mem;
         this->size = kAltStackSize;
         this->ready = true;
+        this->owns_mapping = true;
 
         return 0;
     }
 
     ~ThreadAltStack()
     {
-        if (!ready) {
+        // Do not disable an alternate signal stack that this ThreadAltStack did not allocate.
+        if (!ready || !owns_mapping || mem == nullptr) {
             return;
         }
 

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/danger.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/danger.h
@@ -61,7 +61,12 @@ struct ThreadAltStack
             return 0;
         }
 
-        // If an altstack is already present, keep it.
+        // An alternate signal stack is already installed on this thread, by the
+        // application, CPython's faulthandler, or libdatadog's crashtracker (which by
+        // default creates and owns its own larger alt stack because CPython's default is
+        // too small). Adopt it rather than replacing it, and record that we do not own
+        // the mapping: the destructor must never disable or free an alt stack we did not
+        // allocate, or we would break the owner's fault handling (e.g. crashtracker).
         stack_t cur{};
         if (sigaltstack(nullptr, &cur) == 0 && !(cur.ss_flags & SS_DISABLE)) {
             ready = true;

--- a/ddtrace/internal/datadog/profiling/stack/test/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/stack/test/CMakeLists.txt
@@ -78,3 +78,7 @@ endfunction()
 
 # Add the tests
 dd_wrapper_add_test(test_thread_span_links test_thread_span_links.cpp)
+
+dd_wrapper_add_test(test_alt_stack_ownership test_alt_stack_ownership.cpp)
+# ThreadAltStack lives in the vendored echion header tree.
+target_include_directories(test_alt_stack_ownership PRIVATE ../echion)

--- a/ddtrace/internal/datadog/profiling/stack/test/test_alt_stack_ownership.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/test/test_alt_stack_ownership.cpp
@@ -1,0 +1,84 @@
+#include "echion/danger.h"
+
+#include <gtest/gtest.h>
+
+#include <csignal>
+#include <sys/mman.h>
+
+namespace {
+
+constexpr size_t kSentinelSize = 1 << 20; // 1 MiB
+
+void
+disable_alt_stack()
+{
+    stack_t disable{};
+    disable.ss_flags = SS_DISABLE;
+    sigaltstack(&disable, nullptr);
+}
+
+} // namespace
+
+// When an alternate signal stack is already installed (by the application, faulthandler, or
+// crashtracker), ThreadAltStack adopts it without owning the mapping, and the destructor must not
+// disable it. Without the owns_mapping guard the destructor would strip the adopted stack during
+// thread-local cleanup and break the owner's fault handling.
+TEST(ThreadAltStackOwnership, DestructorDoesNotDisableAdoptedAltStack)
+{
+    // Start from a known state: no alt stack installed on this thread.
+    disable_alt_stack();
+
+    void* foreign = mmap(nullptr, kSentinelSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(foreign, MAP_FAILED);
+
+    // Pre-install a foreign alt stack, as another component would.
+    stack_t foreign_ss{};
+    foreign_ss.ss_sp = foreign;
+    foreign_ss.ss_size = kSentinelSize;
+    foreign_ss.ss_flags = 0;
+    ASSERT_EQ(sigaltstack(&foreign_ss, nullptr), 0);
+
+    {
+        ThreadAltStack alt;
+        ASSERT_EQ(alt.ensure_installed(), 0);
+        // A stack was already present, so ThreadAltStack adopts it and does not own the mapping.
+        ASSERT_FALSE(alt.owns_mapping);
+
+        // alt goes out of scope here; its destructor runs.
+    }
+
+    // The adopted foreign alt stack must still be installed and not disabled.
+    stack_t cur{};
+    ASSERT_EQ(sigaltstack(nullptr, &cur), 0);
+    EXPECT_EQ(cur.ss_sp, foreign);
+    EXPECT_EQ(cur.ss_flags & SS_DISABLE, 0);
+
+    disable_alt_stack();
+    munmap(foreign, kSentinelSize);
+}
+
+// When ThreadAltStack allocated and owns the alt stack, the destructor disables and frees it at
+// thread-local cleanup.
+TEST(ThreadAltStackOwnership, DestructorDisablesOwnAltStack)
+{
+    disable_alt_stack();
+
+    void* owned_mem = nullptr;
+    {
+        ThreadAltStack alt;
+        ASSERT_EQ(alt.ensure_installed(), 0);
+        ASSERT_TRUE(alt.owns_mapping);
+        owned_mem = alt.mem;
+
+        stack_t cur{};
+        ASSERT_EQ(sigaltstack(nullptr, &cur), 0);
+        ASSERT_EQ(cur.ss_sp, owned_mem);
+        ASSERT_EQ(cur.ss_flags & SS_DISABLE, 0);
+
+        // alt goes out of scope here; its destructor runs and should disable our alt stack.
+    }
+
+    stack_t cur{};
+    ASSERT_EQ(sigaltstack(nullptr, &cur), 0);
+    EXPECT_NE(cur.ss_flags & SS_DISABLE, 0);
+}

--- a/releasenotes/notes/profiling-altstack-ownership-4e353919a8480856.yaml
+++ b/releasenotes/notes/profiling-altstack-ownership-4e353919a8480856.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    profiling: fixes the stack profiler tearing down an alternate signal stack it did not allocate
+    (for example one installed by the application or the crash tracker), which could disable that
+    component's fault handling.


### PR DESCRIPTION
## Description

The profiling safe-copy helper uses a per-thread alternate signal stack for its `SIGSEGV` and `SIGBUS` handlers. When an alternate stack was already installed by the application, CPython's faulthandler, or crashtracker, `ThreadAltStack` reused it but still disabled it during thread-local teardown. That could leave the original owner without its alternate stack and weaken its fault handling.

Track whether `ThreadAltStack` allocated the mapping itself. Teardown now disables and unmaps only profiler-owned stacks, while adopted stacks remain installed for their original owner. The installation failure path also unmaps a profiler allocation when `sigaltstack()` fails.

A release note documents the fault-handling fix.

## Testing

- Passed locally: `ddtrace/internal/datadog/profiling/build_standalone.sh -- RelWithDebInfo stack_test`
  - 4/4 native CTests passed
  - verifies that an adopted alternate stack remains installed after `ThreadAltStack` teardown
  - verifies that a profiler-owned alternate stack is disabled during teardown
- `scripts/lint cformat`

## Risks

Low. The change narrows teardown to resources owned by the profiler and does not alter public APIs or configuration. Profiler-owned alternate stacks retain their existing cleanup behavior.

## Additional Notes

Stacked out from the CPU timer profiler work, #18724, to keep this native safety fix independently reviewable.

Follow-up PR #19026 handles the complementary case where another component replaces a profiler-owned alternate stack after the profiler installs it.

[PROF-14213](https://datadoghq.atlassian.net/browse/PROF-14213)


[PROF-14213]: https://datadoghq.atlassian.net/browse/PROF-14213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ