### PR TITLE
feat(llmobs): inline experiments — unified `run` verb (offline default, refresh-publish)

### DIFF
--- a/ddtrace/commands/ddtrace_experiment.py
+++ b/ddtrace/commands/ddtrace_experiment.py
@@ -13,15 +13,14 @@ whether a baseline already exists:
 
 ``run`` is **offline by default**: it records or compares against a local baseline file
 (``.llmobs_experiments.json``) and sets a CI-friendly exit code, with no backend or
-credentials required. ``--publish`` (opt-in) additionally sends the run to LLM Obs
-Experiments as a dataset + experiment so it appears in the UI with cost + eval metrics.
+credentials required. Add ``--publish`` (opt-in) to also send the run to LLM Obs
+Experiments: the first publish is the frozen **baseline** (a real run with cost + eval
+metrics over the subject's auto-managed dataset); every later publish is compared against
+it in the **compare view**. The dataset is refreshed to exactly each run's inputs.
 
 Activation is positive and explicit — the decorators are inert unless this command runs,
 so they are safe to leave in production code. As a one-way fail-safe this command also
 refuses to run when it looks like production (no TTY and ``DD_ENV=prod``).
-
-The legacy ``capture`` / ``replay`` verbs remain as the two halves of ``run`` and will be
-removed once ``run`` fully subsumes them.
 """
 
 from __future__ import annotations
@@ -386,42 +385,6 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     run.add_argument("--experiment-name", default=None, help="experiment name for --publish (default: the subject)")
     run.add_argument("--ml-app", default=None, help="ml_app for --publish (default: $DD_LLMOBS_ML_APP)")
 
-    cap = sub.add_parser("capture", parents=[common], help="run the entrypoint and persist a baseline")
-    cap.add_argument("target", help="module:entrypoint that drives the app (e.g. myapp:generate_traffic)")
-    cap.add_argument("--out", default=None, help="baseline file to write (default: .llmobs_experiments.json)")
-    cap.add_argument(
-        "--trace",
-        action="store_true",
-        help="also enable LLM Obs so the capture run's traces appear in the UI "
-        "(needs DD_API_KEY or a Datadog agent); links each case to its trace",
-    )
-    cap.add_argument("--ml-app", default=None, help="ml_app for --trace (default: $DD_LLMOBS_ML_APP)")
-
-    rep = sub.add_parser("replay", parents=[common], help="replay the current code against a persisted baseline")
-    rep.add_argument("target", help="module to import (registers the decorated subjects)")
-    rep.add_argument(
-        "--in", dest="infile", default=None, help="baseline file to read (default: .llmobs_experiments.json)"
-    )
-    rep.add_argument(
-        "--comparator", default="structural", choices=["exact", "structural", "ignoring"], help="default: structural"
-    )
-    rep.add_argument("--ignore", default="", help="comma-separated keys to ignore (implies the 'ignoring' comparator)")
-    rep.add_argument(
-        "--publish",
-        action="store_true",
-        help="run via the LLM Obs Experiments SDK so results appear in the Experiments UI (needs DD_API_KEY)",
-    )
-    rep.add_argument("--ml-app", default=None, help="ml_app for --publish (default: $DD_LLMOBS_ML_APP)")
-    rep.add_argument("--project", default=None, help="project name for --publish")
-    rep.add_argument("--experiment-name", default=None, help="experiment name for --publish")
-    rep.add_argument(
-        "--evaluate",
-        action="store_true",
-        help="also score the boundary's attached `evaluators` locally and print verdicts "
-        "(may call provider APIs for LLM judges); a failing evaluator gates the exit code. "
-        "On --publish, evaluators always run through the Experiments engine.",
-    )
-
     lst = sub.add_parser("list", parents=[common], help="import the target and list registered experiment subjects")
     lst.add_argument("target", help="module[:entrypoint] to import")
     return parser
@@ -458,90 +421,6 @@ def main() -> None:
     if args.command == "run":
         _cmd_run(args, ie, runner)
         return
-
-    if args.command == "capture":
-        # Enable LLM Obs BEFORE importing the app so its LLM integrations are patched
-        # before the app builds its clients (otherwise the calls aren't traced).
-        ml_app = _enable_llmobs(args.ml_app) if args.trace else None
-        _, entry = _import_target(args.target)  # registers subjects
-        if entry is None:
-            print("capture needs 'module:entrypoint' to drive the app (e.g. myapp:generate_traffic).", file=sys.stderr)
-            sys.exit(2)
-        ie._set_trace(bool(args.trace))
-        ie._set_mode(ie.Mode.CAPTURE)
-        result = entry()
-        if inspect.iscoroutine(result):
-            asyncio.run(result)
-        ie._set_mode(ie.Mode.OFF)
-        ie._set_trace(False)
-        if args.trace:
-            _flush_llmobs()  # ensure the capture run's spans are sent before exit
-        out = args.out or runner.DEFAULT_BASELINE_PATH
-        data = runner.save_baselines(out)
-        case_count = sum(len(v) for v in data.values())
-        print("captured %d case(s) across %d experiment(s) -> %s" % (case_count, len(data), os.path.abspath(out)))
-        if args.trace:
-            linked = sum(1 for cases in data.values() for c in cases if c.get("trace"))
-            print(
-                "traces enabled (ml_app: %s) — %d/%d case(s) linked; view in LLM Observability."
-                % (ml_app, linked, case_count)
-            )
-        return
-
-    # replay
-    _import_target(args.target)  # registers subjects (start fns needed for re-invocation)
-    infile = args.infile or runner.DEFAULT_BASELINE_PATH
-    if not os.path.exists(infile):
-        print("no baseline at %s — run `ddtrace-experiment capture` first." % infile, file=sys.stderr)
-        sys.exit(2)
-    baselines = runner.load_baselines(infile)
-    ignore = [k for k in args.ignore.split(",") if k]
-    comparator = runner.comparator_from_spec(args.comparator, ignore)
-
-    if args.publish:
-        # Route through the real Experiments SDK so results land in the UI.
-        from ddtrace.internal.settings import env
-        from ddtrace.llmobs import LLMObs
-        from ddtrace.llmobs import _inline_experiment_sdk as sdk
-
-        if not LLMObs.enabled:
-            ml_app = args.ml_app or env.get("DD_LLMOBS_ML_APP") or "inline-experiments"
-            LLMObs.enable(ml_app=ml_app, agentless_enabled=True)
-        for name, cases in baselines.items():
-            if name not in ie.registered_experiments():
-                print("  (skipping %r — not registered by %r)" % (name, args.target))
-                continue
-            result = sdk.run_as_experiment(
-                name, cases, comparator, experiment_name=args.experiment_name, project_name=args.project
-            )
-            print("published experiment %r:" % name)
-            if result.get("baseline") is not None:
-                print("  baseline -> %s" % (sdk.experiment_url(result["baseline"]) or "?"))
-            print("  current  -> %s" % (sdk.experiment_url(result["current"]) or "LLM Obs -> Experiments"))
-            compare = sdk.compare_url(result.get("baseline"), result["current"], project_name=args.project)
-            if compare:
-                print("  compare  -> %s" % compare)
-            dataset = sdk.dataset_url(result.get("dataset"))
-            if dataset:
-                print("  dataset  -> %s" % dataset)
-        return
-
-    ie._set_mode(ie.Mode.REPLAY)
-    total: dict[str, int] = {}
-    for name, cases in baselines.items():
-        if name not in ie.registered_experiments():
-            print("  (skipping %r — not registered by %r)" % (name, args.target))
-            continue
-        counts = _print_report(name, runner.replay(name, comparator, cases=cases, score_evaluators=args.evaluate))
-        for k, v in counts.items():
-            total[k] = total.get(k, 0) + v
-    ie._set_mode(ie.Mode.OFF)
-
-    # CI-friendly: non-zero exit if the run errored or never reached its end (exec), the
-    # default comparison evaluator reported `changed`, or (with --evaluate) an attached
-    # evaluator failed OR errored (a check that didn't run isn't a pass).
-    gate = ("CHANGED", "ERROR", "NO_END", "EVAL_FAIL", "EVAL_ERROR")
-    sys.exit(1 if any(total.get(k) for k in gate) else 0)
 
 
 if __name__ == "__main__":

--- a/ddtrace/commands/ddtrace_experiment.py
+++ b/ddtrace/commands/ddtrace_experiment.py
@@ -227,17 +227,19 @@ def _resolve_subject(args: Any, ie: Any, mod: Any) -> str:
 
 
 def _publish_inputs(subject: str, mod: Any, baseline_file: str, runner: Any) -> list[Any]:
-    """Inputs for a first publish: prefer a prior offline baseline's inputs, else module INPUTS."""
+    """This run's inputs: the module's current ``INPUTS`` (what the user is testing now), else
+    a prior offline baseline's inputs. INPUTS wins so editing the module drives the refresh.
+    """
+    module_inputs = getattr(mod, "INPUTS", None)
+    if module_inputs:
+        return list(module_inputs)
     if os.path.exists(baseline_file):
         try:
             cases = runner.load_baselines(baseline_file).get(subject) or []
-            from_baseline = [c["input"] for c in cases if isinstance(c, dict) and "input" in c]
-            if from_baseline:
-                return from_baseline
+            return [c["input"] for c in cases if isinstance(c, dict) and "input" in c]
         except Exception:
             pass
-    module_inputs = getattr(mod, "INPUTS", None)
-    return list(module_inputs) if module_inputs else []
+    return []
 
 
 def _cmd_run_publish(args: Any, ie: Any, runner: Any, baseline_file: str) -> None:
@@ -255,36 +257,43 @@ def _cmd_run_publish(args: Any, ie: Any, runner: Any, baseline_file: str) -> Non
 
     from ddtrace.llmobs import _inline_experiment_sdk as sdk
 
-    ignore = [k for k in args.ignore.split(",") if k]
-    comparator = runner.comparator_from_spec(args.comparator, ignore)
-    meta = None if args.record else runner.load_publish_meta(baseline_file, subject)
+    inputs = _publish_inputs(subject, mod, baseline_file, runner)
+    if not inputs:
+        print(
+            "run --publish: no inputs for %r — define INPUTS in the module or run offline "
+            "`run %s` first to capture some." % (subject, args.target),
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
-    if meta and meta.get("dataset_name") and meta.get("baseline_experiment_id"):
-        published = sdk.publish_current(
+    meta = None if args.record else runner.load_publish_meta(baseline_file, subject)
+    baseline_id = meta.get("baseline_experiment_id") if meta else None
+
+    # Every run is the same operation: sync the stable dataset to this run's inputs and run the
+    # subject as one experiment (scored by the subject's own evaluators). The regression signal
+    # is the compare view, not an in-experiment check.
+    published = sdk.publish_run(subject, inputs, project_name=args.project, experiment_name=args.experiment_name)
+    sync = published.get("sync") or {}
+    print(
+        "published experiment %r  (dataset %s: +%d/-%d, %d kept)"
+        % (
             subject,
-            meta["dataset_name"],
-            comparator,
-            baseline_experiment_id=meta["baseline_experiment_id"],
-            project_name=args.project,
-            experiment_name=args.experiment_name,
+            published["dataset_name"],
+            sync.get("added", 0),
+            sync.get("deleted", 0),
+            sync.get("kept", 0),
         )
-        print("published current experiment %r:" % subject)
-        print("  current -> %s" % (published.get("url") or "LLM Obs -> Experiments"))
-        if published.get("compare_url"):
-            print("  compare -> %s" % published["compare_url"])
+    )
+    print("  run     -> %s" % (published.get("url") or "LLM Obs -> Experiments"))
+
+    if baseline_id:
+        # Compare the current run against the frozen first baseline.
+        compare = sdk.compare_url_from_ids(baseline_id, published["experiment_id"], args.project)
+        if compare:
+            print("  compare -> %s" % compare)
     else:
-        inputs = _publish_inputs(subject, mod, baseline_file, runner)
-        if not inputs:
-            print(
-                "run --publish (first publish): no inputs for %r — run offline `run %s` first to "
-                "capture a baseline, or define INPUTS in the module." % (subject, args.target),
-                file=sys.stderr,
-            )
-            sys.exit(2)
-        published = sdk.publish_baseline(
-            subject, inputs, project_name=args.project, experiment_name=args.experiment_name
-        )
-        # Persist the local baseline + publish state INSIDE the baseline file (no sidecar).
+        # First publish: this run becomes the frozen baseline; also seed the local baseline so
+        # offline `run` has a reference. Nothing to compare against yet.
         runner.write_baseline_cases(baseline_file, subject, published["pairs"])
         runner.save_publish_meta(
             baseline_file,
@@ -293,10 +302,10 @@ def _cmd_run_publish(args: Any, ie: Any, runner: Any, baseline_file: str) -> Non
             baseline_experiment_id=published["experiment_id"],
             project=args.project or "",
         )
-        print("published baseline experiment %r:" % subject)
-        print("  baseline -> %s" % (published.get("url") or "LLM Obs -> Experiments"))
-        print("  dataset  -> %s  (%d case(s))" % (published["dataset_name"], len(published["pairs"])))
-        print("edit your code, then `ddtrace-experiment run %s --publish` to compare." % args.target)
+        print(
+            "  this is the baseline — run `ddtrace-experiment run %s --publish` again after a "
+            "change to get a compare view." % args.target
+        )
     _flush_llmobs()
 
 

--- a/ddtrace/commands/ddtrace_experiment.py
+++ b/ddtrace/commands/ddtrace_experiment.py
@@ -188,6 +188,7 @@ def _run_compare_offline(args: Any, ie: Any, runner: Any, baseline_file: str) ->
     comparator = runner.comparator_from_spec(args.comparator, ignore)
     ie._set_mode(ie.Mode.REPLAY)
     total: dict[str, int] = {}
+    report: dict[str, Any] = {}
     compared = False
     try:
         for name, cases in runner.subject_items(baselines):  # skips the reserved `_publish` block
@@ -197,7 +198,9 @@ def _run_compare_offline(args: Any, ie: Any, runner: Any, baseline_file: str) ->
                 print("  (skipping %r — not registered by %r)" % (name, args.target))
                 continue
             compared = True
-            counts = _print_report(name, runner.replay(name, comparator, cases=cases, score_evaluators=args.evaluate))
+            rows = runner.replay(name, comparator, cases=cases, score_evaluators=args.evaluate)
+            counts = _print_report(name, rows)
+            report[name] = {"counts": counts, "cases": rows}  # full, untruncated
             for k, v in counts.items():
                 total[k] = total.get(k, 0) + v
     finally:
@@ -206,6 +209,12 @@ def _run_compare_offline(args: Any, ie: Any, runner: Any, baseline_file: str) ->
         which = "subject %r" % args.name if args.name else "any registered subject"
         print("run: no baseline cases for %s in %s." % (which, baseline_file), file=sys.stderr)
         sys.exit(2)
+    if args.report:
+        import json
+
+        with open(args.report, "w") as f:
+            json.dump(report, f, default=str, indent=2)
+        print("full report (untruncated input/recorded/new + evals) -> %s" % os.path.abspath(args.report))
     gate = ("CHANGED", "ERROR", "NO_END", "EVAL_FAIL", "EVAL_ERROR")
     sys.exit(1 if any(total.get(k) for k in gate) else 0)
 
@@ -370,6 +379,15 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--comparator", default="structural", choices=["exact", "structural", "ignoring"], help="default: structural"
     )
     run.add_argument("--ignore", default="", help="comma-separated keys to ignore (implies the 'ignoring' comparator)")
+    run.add_argument(
+        "--report",
+        nargs="?",
+        const=".llmobs_experiments.report.json",
+        default=None,
+        help="write the FULL (untruncated) offline comparison — per-case input / recorded / new + all "
+        "evaluator verdicts and reasoning — to a JSON file (default: .llmobs_experiments.report.json). "
+        "The terminal report stays a compact summary.",
+    )
     run.add_argument(
         "--evaluate",
         action="store_true",

--- a/ddtrace/commands/ddtrace_experiment.py
+++ b/ddtrace/commands/ddtrace_experiment.py
@@ -274,7 +274,7 @@ def _cmd_run_publish(args: Any, ie: Any, runner: Any, baseline_file: str) -> Non
     published = sdk.publish_run(subject, inputs, project_name=args.project, experiment_name=args.experiment_name)
     sync = published.get("sync") or {}
     print(
-        "published experiment %r  (dataset %s: +%d/-%d, %d kept)"
+        "published experiment %r over dataset %r  (+%d/-%d, %d kept)"
         % (
             subject,
             published["dataset_name"],
@@ -283,13 +283,15 @@ def _cmd_run_publish(args: Any, ie: Any, runner: Any, baseline_file: str) -> Non
             sync.get("kept", 0),
         )
     )
-    print("  run     -> %s" % (published.get("url") or "LLM Obs -> Experiments"))
+    # Always surface both URLs once they exist.
+    print("  experiment -> %s" % (published.get("url") or "LLM Obs -> Experiments"))
+    print("  dataset    -> %s" % (published.get("dataset_url") or "LLM Obs -> Datasets"))
 
     if baseline_id:
-        # Compare the current run against the frozen first baseline.
+        # A frozen baseline exists -> always link the compare view (baseline vs this run).
         compare = sdk.compare_url_from_ids(baseline_id, published["experiment_id"], args.project)
         if compare:
-            print("  compare -> %s" % compare)
+            print("  compare    -> %s" % compare)
     else:
         # First publish: this run becomes the frozen baseline; also seed the local baseline so
         # offline `run` has a reference. Nothing to compare against yet.
@@ -302,8 +304,8 @@ def _cmd_run_publish(args: Any, ie: Any, runner: Any, baseline_file: str) -> Non
             project=args.project or "",
         )
         print(
-            "  this is the baseline — run `ddtrace-experiment run %s --publish` again after a "
-            "change to get a compare view." % args.target
+            "  (this run is the frozen baseline — run `ddtrace-experiment run %s --publish` again "
+            "after a change to get a compare view)" % args.target
         )
     _flush_llmobs()
 

--- a/ddtrace/commands/ddtrace_experiment.py
+++ b/ddtrace/commands/ddtrace_experiment.py
@@ -2,19 +2,26 @@
 """``ddtrace-experiment`` — run inline experiments (trace-seeded local regression).
 
 The explicit, out-of-band trigger for the ``@experiment_start`` / ``@experiment_end``
-decorators. The typical loop has two steps so a code change can be detected:
+decorators. One verb, ``run``, drives the whole loop and auto-detects the phase from
+whether a baseline already exists:
 
-    # 1. capture a baseline from the current (known-good) code
-    ddtrace-experiment capture myapp:generate_traffic
+    # 1. first run — establish a baseline from the current (known-good) code
+    ddtrace-experiment run myapp:generate_traffic
     # 2. ...edit your prompt/model/logic...
-    # 3. replay the current code against the baseline
-    ddtrace-experiment replay myapp --comparator structural
+    # 3. run again — compare the current code against the baseline
+    ddtrace-experiment run myapp --comparator structural
+
+``run`` is **offline by default**: it records or compares against a local baseline file
+(``.llmobs_experiments.json``) and sets a CI-friendly exit code, with no backend or
+credentials required. ``--publish`` (opt-in) additionally sends the run to LLM Obs
+Experiments as a dataset + experiment so it appears in the UI with cost + eval metrics.
 
 Activation is positive and explicit — the decorators are inert unless this command runs,
 so they are safe to leave in production code. As a one-way fail-safe this command also
 refuses to run when it looks like production (no TTY and ``DD_ENV=prod``).
 
-The baseline is persisted between the two invocations (default: ``.llmobs_experiments.json``).
+The legacy ``capture`` / ``replay`` verbs remain as the two halves of ``run`` and will be
+removed once ``run`` fully subsumes them.
 """
 
 from __future__ import annotations
@@ -148,6 +155,80 @@ def _print_report(name: str, rows: list[dict[str, Any]]) -> dict[str, int]:
     return counts
 
 
+def _run_record_offline(entry: Any, out: str, runner: Any, ie: Any) -> None:
+    """First run: drive the app in CAPTURE mode and persist the baseline (offline)."""
+    if entry is None:
+        print(
+            "run: no baseline yet, and no driver to establish one — pass a driver as "
+            "'module:entrypoint' (e.g. myapp:generate_traffic) for the first run.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    ie._set_mode(ie.Mode.CAPTURE)
+    try:
+        result = entry()
+        if inspect.iscoroutine(result):
+            asyncio.run(result)
+    finally:
+        ie._set_mode(ie.Mode.OFF)
+    data = runner.save_baselines(out)
+    case_count = sum(len(v) for v in data.values())
+    print("recorded baseline: %d case(s) across %d subject(s) -> %s" % (case_count, len(data), os.path.abspath(out)))
+    print("edit your code, then `ddtrace-experiment run <module>` to compare against it.")
+
+
+def _run_compare_offline(args: Any, ie: Any, runner: Any, baseline_file: str) -> None:
+    """Rerun: replay the current code over the recorded baseline and report (offline).
+
+    Exits non-zero (CI gate) if any case errored, never reached its end, the default
+    comparison reported ``changed``, or (with ``--evaluate``) an attached evaluator
+    failed/errored.
+    """
+    baselines = runner.load_baselines(baseline_file)
+    ignore = [k for k in args.ignore.split(",") if k]
+    comparator = runner.comparator_from_spec(args.comparator, ignore)
+    ie._set_mode(ie.Mode.REPLAY)
+    total: dict[str, int] = {}
+    compared = False
+    try:
+        for name, cases in baselines.items():
+            if args.name and name != args.name:
+                continue
+            if name not in ie.registered_experiments():
+                print("  (skipping %r — not registered by %r)" % (name, args.target))
+                continue
+            compared = True
+            counts = _print_report(name, runner.replay(name, comparator, cases=cases, score_evaluators=args.evaluate))
+            for k, v in counts.items():
+                total[k] = total.get(k, 0) + v
+    finally:
+        ie._set_mode(ie.Mode.OFF)
+    if not compared:
+        which = "subject %r" % args.name if args.name else "any registered subject"
+        print("run: no baseline cases for %s in %s." % (which, baseline_file), file=sys.stderr)
+        sys.exit(2)
+    gate = ("CHANGED", "ERROR", "NO_END", "EVAL_FAIL", "EVAL_ERROR")
+    sys.exit(1 if any(total.get(k) for k in gate) else 0)
+
+
+def _cmd_run(args: Any, ie: Any, runner: Any) -> None:
+    """The unified ``run`` verb: auto-detect first-run (record) vs rerun (compare)."""
+    _, entry = _import_target(args.target)  # registers subjects
+    if not ie.registered_experiments():
+        print("run: no experiment subjects registered by %r (did you import the app module?)." % args.target)
+        sys.exit(2)
+    baseline_file = args.baseline_file or runner.DEFAULT_BASELINE_PATH
+    have_baseline = os.path.exists(baseline_file)
+    # First run when there is nothing to compare against, or when explicitly forced.
+    if args.record or not have_baseline:
+        reason = "--record: re-recording baseline" if have_baseline else "no baseline yet — first run"
+        print("run: %s -> %s" % (reason, baseline_file))
+        _run_record_offline(entry, baseline_file, runner, ie)
+        return
+    print("run: baseline found (%s) — comparing current code (use --record to re-establish)." % baseline_file)
+    _run_compare_offline(args, ie, runner, baseline_file)
+
+
 def _build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="ddtrace-experiment", description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
@@ -162,6 +243,36 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "directory if present); real environment variables take precedence",
     )
     sub = parser.add_subparsers(dest="command", required=True)
+
+    run = sub.add_parser(
+        "run",
+        parents=[common],
+        help="run the subject as an experiment; offline by default, auto-detecting first-run vs compare",
+    )
+    run.add_argument(
+        "target",
+        help="module to compare against the baseline, OR a driver 'module:entrypoint' to establish one",
+    )
+    run.add_argument("--name", default=None, help="operate on just this subject (default: all registered)")
+    run.add_argument(
+        "--record", action="store_true", help="force a first run: (re)record the baseline even if one exists"
+    )
+    run.add_argument(
+        "--baseline-file",
+        dest="baseline_file",
+        default=None,
+        help="local baseline JSON to read/write (default: .llmobs_experiments.json)",
+    )
+    run.add_argument(
+        "--comparator", default="structural", choices=["exact", "structural", "ignoring"], help="default: structural"
+    )
+    run.add_argument("--ignore", default="", help="comma-separated keys to ignore (implies the 'ignoring' comparator)")
+    run.add_argument(
+        "--evaluate",
+        action="store_true",
+        help="also score the boundary's attached `evaluators` locally and print verdicts "
+        "(may call provider APIs for LLM judges); a failing evaluator gates the exit code",
+    )
 
     cap = sub.add_parser("capture", parents=[common], help="run the entrypoint and persist a baseline")
     cap.add_argument("target", help="module:entrypoint that drives the app (e.g. myapp:generate_traffic)")
@@ -230,6 +341,10 @@ def main() -> None:
         print("registered experiment subjects:" if names else "no experiment subjects registered by %r" % args.target)
         for n in names:
             print("  - %s" % n)
+        return
+
+    if args.command == "run":
+        _cmd_run(args, ie, runner)
         return
 
     if args.command == "capture":

--- a/ddtrace/commands/ddtrace_experiment.py
+++ b/ddtrace/commands/ddtrace_experiment.py
@@ -191,7 +191,7 @@ def _run_compare_offline(args: Any, ie: Any, runner: Any, baseline_file: str) ->
     total: dict[str, int] = {}
     compared = False
     try:
-        for name, cases in baselines.items():
+        for name, cases in runner.subject_items(baselines):  # skips the reserved `_publish` block
             if args.name and name != args.name:
                 continue
             if name not in ie.registered_experiments():
@@ -211,13 +211,106 @@ def _run_compare_offline(args: Any, ie: Any, runner: Any, baseline_file: str) ->
     sys.exit(1 if any(total.get(k) for k in gate) else 0)
 
 
+def _resolve_subject(args: Any, ie: Any, mod: Any) -> str:
+    """The single subject a publish run operates on: --name, then module SUBJECT, then the
+    sole registered subject. Exits(2) if ambiguous or unregistered.
+    """
+    registered = ie.registered_experiments()
+    subject = args.name or getattr(mod, "SUBJECT", None) or (registered[0] if len(registered) == 1 else None)
+    if subject is None:
+        print("run --publish: several subjects registered; pass --name to choose: %s" % ", ".join(registered))
+        sys.exit(2)
+    if subject not in registered:
+        print("run --publish: subject %r is not registered by %r." % (subject, args.target), file=sys.stderr)
+        sys.exit(2)
+    return str(subject)
+
+
+def _publish_inputs(subject: str, mod: Any, baseline_file: str, runner: Any) -> list[Any]:
+    """Inputs for a first publish: prefer a prior offline baseline's inputs, else module INPUTS."""
+    if os.path.exists(baseline_file):
+        try:
+            cases = runner.load_baselines(baseline_file).get(subject) or []
+            from_baseline = [c["input"] for c in cases if isinstance(c, dict) and "input" in c]
+            if from_baseline:
+                return from_baseline
+        except Exception:
+            pass
+    module_inputs = getattr(mod, "INPUTS", None)
+    return list(module_inputs) if module_inputs else []
+
+
+def _cmd_run_publish(args: Any, ie: Any, runner: Any, baseline_file: str) -> None:
+    """`run --publish`: first publish creates the dataset + baseline experiment; a later publish
+    adds the current experiment + compare view. Correlation is the ``_publish`` block embedded
+    in the baseline file (no sidecar).
+    """
+    # Enable LLM Obs BEFORE importing the app so its LLM integrations are patched first.
+    _enable_llmobs(args.ml_app)
+    mod, _ = _import_target(args.target)
+    if not ie.registered_experiments():
+        print("run --publish: no experiment subjects registered by %r." % args.target, file=sys.stderr)
+        sys.exit(2)
+    subject = _resolve_subject(args, ie, mod)
+
+    from ddtrace.llmobs import _inline_experiment_sdk as sdk
+
+    ignore = [k for k in args.ignore.split(",") if k]
+    comparator = runner.comparator_from_spec(args.comparator, ignore)
+    meta = None if args.record else runner.load_publish_meta(baseline_file, subject)
+
+    if meta and meta.get("dataset_name") and meta.get("baseline_experiment_id"):
+        published = sdk.publish_current(
+            subject,
+            meta["dataset_name"],
+            comparator,
+            baseline_experiment_id=meta["baseline_experiment_id"],
+            project_name=args.project,
+            experiment_name=args.experiment_name,
+        )
+        print("published current experiment %r:" % subject)
+        print("  current -> %s" % (published.get("url") or "LLM Obs -> Experiments"))
+        if published.get("compare_url"):
+            print("  compare -> %s" % published["compare_url"])
+    else:
+        inputs = _publish_inputs(subject, mod, baseline_file, runner)
+        if not inputs:
+            print(
+                "run --publish (first publish): no inputs for %r — run offline `run %s` first to "
+                "capture a baseline, or define INPUTS in the module." % (subject, args.target),
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        published = sdk.publish_baseline(
+            subject, inputs, project_name=args.project, experiment_name=args.experiment_name
+        )
+        # Persist the local baseline + publish state INSIDE the baseline file (no sidecar).
+        runner.write_baseline_cases(baseline_file, subject, published["pairs"])
+        runner.save_publish_meta(
+            baseline_file,
+            subject,
+            dataset_name=published["dataset_name"],
+            baseline_experiment_id=published["experiment_id"],
+            project=args.project or "",
+        )
+        print("published baseline experiment %r:" % subject)
+        print("  baseline -> %s" % (published.get("url") or "LLM Obs -> Experiments"))
+        print("  dataset  -> %s  (%d case(s))" % (published["dataset_name"], len(published["pairs"])))
+        print("edit your code, then `ddtrace-experiment run %s --publish` to compare." % args.target)
+    _flush_llmobs()
+
+
 def _cmd_run(args: Any, ie: Any, runner: Any) -> None:
-    """The unified ``run`` verb: auto-detect first-run (record) vs rerun (compare)."""
+    """The unified ``run`` verb: offline by default; ``--publish`` routes to the backend."""
+    baseline_file = args.baseline_file or runner.DEFAULT_BASELINE_PATH
+    if args.publish:
+        _cmd_run_publish(args, ie, runner, baseline_file)
+        return
+
     _, entry = _import_target(args.target)  # registers subjects
     if not ie.registered_experiments():
         print("run: no experiment subjects registered by %r (did you import the app module?)." % args.target)
         sys.exit(2)
-    baseline_file = args.baseline_file or runner.DEFAULT_BASELINE_PATH
     have_baseline = os.path.exists(baseline_file)
     # First run when there is nothing to compare against, or when explicitly forced.
     if args.record or not have_baseline:
@@ -273,6 +366,16 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="also score the boundary's attached `evaluators` locally and print verdicts "
         "(may call provider APIs for LLM judges); a failing evaluator gates the exit code",
     )
+    run.add_argument(
+        "--publish",
+        action="store_true",
+        help="send the run to LLM Obs Experiments (needs DD_API_KEY): the first publish creates a "
+        "dataset + baseline experiment (with cost); a later publish adds the current experiment + a "
+        "compare view. Offline behavior is unchanged when omitted.",
+    )
+    run.add_argument("--project", default=None, help="project name for --publish")
+    run.add_argument("--experiment-name", default=None, help="experiment name for --publish (default: the subject)")
+    run.add_argument("--ml-app", default=None, help="ml_app for --publish (default: $DD_LLMOBS_ML_APP)")
 
     cap = sub.add_parser("capture", parents=[common], help="run the entrypoint and persist a baseline")
     cap.add_argument("target", help="module:entrypoint that drives the app (e.g. myapp:generate_traffic)")

--- a/ddtrace/llmobs/_inline_experiment.py
+++ b/ddtrace/llmobs/_inline_experiment.py
@@ -2,8 +2,9 @@
 
 This is the foundation layer for the "unit test for LLM apps" paradigm described in
 ``ddtrace/llmobs/_local_regression_experiments_design.md`` (RFC-002): a developer marks
-an input->output boundary inline in their already-instrumented app, and an explicit,
-out-of-band runner captures a baseline and replays the *current* code against it.
+an input->output boundary inline in their already-instrumented app, and the explicit,
+out-of-band ``ddtrace-experiment run`` command records a baseline and re-runs the
+*current* code against it (offline by default; ``--publish`` sends it to Experiments).
 
 This module provides ONLY the novel core:
   * ``experiment_start`` / ``experiment_end`` decorators (sync + async),

--- a/ddtrace/llmobs/_inline_experiment_runner.py
+++ b/ddtrace/llmobs/_inline_experiment_runner.py
@@ -54,6 +54,61 @@ def load_baselines(path: str = DEFAULT_BASELINE_PATH) -> dict[str, Any]:
     return data
 
 
+# Publish state (dataset name + baseline experiment id) lives INSIDE the baseline file under a
+# reserved ``_publish`` key — not a separate sidecar. This keeps it drift-free: ``save_baselines``
+# rewrites the file from the registry and drops ``_publish``, so re-recording a baseline (even a
+# different subject, or an offline capture) can never leave stale publish state behind for a
+# later ``run --publish`` to mis-correlate against. Subjects are real experiment names, so the
+# ``_``-prefixed reserved key never collides with one.
+PUBLISH_KEY = "_publish"
+
+
+def subject_items(baselines: dict[str, Any]) -> list[tuple[str, Any]]:
+    """(name, cases) pairs from a loaded baseline dict, skipping reserved (``_``-prefixed) keys."""
+    return [(k, v) for k, v in baselines.items() if not k.startswith("_")]
+
+
+def load_publish_meta(path: str, name: str) -> Optional[dict[str, Any]]:
+    """The persisted publish state for ``name`` (dataset_name, baseline_experiment_id), or None."""
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return None
+    value = data.get(PUBLISH_KEY, {}).get(name)
+    return value if isinstance(value, dict) else None
+
+
+def save_publish_meta(path: str, name: str, **fields: Any) -> None:
+    """Merge ``fields`` into ``_publish[name]`` in the baseline file (read-modify-write)."""
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        data = {}
+    pub = data.setdefault(PUBLISH_KEY, {})
+    pub[name] = {**pub.get(name, {}), **fields}
+    with open(path, "w") as f:
+        json.dump(data, f, default=str, indent=2)
+
+
+def write_baseline_cases(path: str, name: str, pairs: list[tuple[Any, Any]]) -> None:
+    """Persist ``(input, output)`` pairs as the local baseline for one subject.
+
+    Used after ``run --publish`` establishes a baseline through the engine (whose outputs
+    aren't captured via the decorator) so an offline ``run`` still has cases to compare. Other
+    subjects and the ``_publish`` block already in the file are preserved.
+    """
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        data = {}
+    data[name] = [{"input": i, "output": o} for i, o in pairs]
+    with open(path, "w") as f:
+        json.dump(data, f, default=str, indent=2)
+
+
 # --------------------------------------------------------------------------- #
 # Comparators — "is the new output equivalent to the recorded baseline?"
 # Real LLM output is non-deterministic, so `exact` reports CHANGED on every replay;

--- a/ddtrace/llmobs/_inline_experiment_sdk.py
+++ b/ddtrace/llmobs/_inline_experiment_sdk.py
@@ -174,7 +174,9 @@ def sync_dataset(dataset: Any, inputs: list[Any]) -> dict[str, int]:
     added = 0
     for key, value in want.items():
         if key not in seen:
-            dataset.append({"input_data": value})
+            # Carry an explicit expected_output key (empty) so the record shape matches what the
+            # engine reads; the regression signal is still the compare view, not this field.
+            dataset.append({"input_data": value, "expected_output": None})
             added += 1
     counts = {"added": added, "deleted": len(to_delete), "kept": len(seen)}
     if added or to_delete:

--- a/ddtrace/llmobs/_inline_experiment_sdk.py
+++ b/ddtrace/llmobs/_inline_experiment_sdk.py
@@ -59,6 +59,16 @@ def _experiment_id(experiment: Any) -> Optional[str]:
     return str(eid) if eid else None
 
 
+def dataset_url(dataset: Any) -> Optional[str]:
+    """The dataset's UI URL (``.../llm/datasets/<id>``), or None if not resolvable."""
+    try:
+        url = dataset.url
+        return str(url) if url else None
+    except Exception:
+        log.debug("inline experiment: could not resolve dataset url", exc_info=True)
+        return None
+
+
 # --------------------------------------------------------------------------- #
 # Unified `run --publish`: each run is a real Experiment (the "refresh" model).
 #
@@ -216,6 +226,7 @@ def publish_run(
         "url": experiment_url(experiment),
         "dataset": dataset,
         "dataset_name": ds_name,
+        "dataset_url": dataset_url(dataset),
         "sync": sync,
         "pairs": _rows_pairs(run),
     }

--- a/ddtrace/llmobs/_inline_experiment_sdk.py
+++ b/ddtrace/llmobs/_inline_experiment_sdk.py
@@ -1,12 +1,12 @@
-"""Bridge: run inline-experiment baselines through the real LLM Obs Experiments SDK.
+"""Bridge: run an inline-experiment subject through the real LLM Obs Experiments SDK.
 
-Turns captured baselines into a ``Dataset``, replays the decorated subject as the
-experiment *task*, and scores each case with the comparator (wrapped as an evaluator) —
-so the run appears in **LLM Observability -> Experiments** with eval metrics, instead of
-only a local terminal diff.
+Runs ``run --publish``: syncs the subject's auto-managed ``Dataset`` to the current inputs,
+runs the decorated subject as the experiment *task* scored by the subject's own evaluators,
+and links the compare view — so the run appears in **LLM Observability -> Experiments** with
+cost + eval metrics, instead of only a local terminal diff.
 
-This reuses the existing engine (``LLMObs.create_dataset`` / ``LLMObs.experiment`` /
-``_experiment.py``) rather than reimplementing it.
+This reuses the existing engine (``LLMObs.create_dataset`` / ``LLMObs.pull_dataset`` /
+``LLMObs.experiment`` / ``_experiment.py``) rather than reimplementing it.
 """
 
 from __future__ import annotations
@@ -24,7 +24,6 @@ from ddtrace.llmobs._inline_experiment import _ExperimentStop
 from ddtrace.llmobs._inline_experiment import _set_mode
 from ddtrace.llmobs._inline_experiment import _start_output
 from ddtrace.llmobs._inline_experiment_runner import _invoke
-from ddtrace.llmobs._inline_experiment_runner import as_evaluator
 from ddtrace.llmobs._inline_experiment_runner import resolve_evaluators
 
 
@@ -51,31 +50,6 @@ def _make_task(name: str) -> Callable[..., Any]:
     return task
 
 
-def _make_evaluator(comparator: Callable[[Any, Any], bool]) -> Callable[..., Any]:
-    """Wrap a comparator as the always-on ``regression_match`` guard evaluator.
-
-    Thin alias over the shared ``as_evaluator`` adapter so the guard and any
-    user-attached ``comparison(...)`` share one comparator->evaluator implementation.
-    """
-    return as_evaluator(comparator, name="regression_match")
-
-
-def _baseline_task(cases: list[dict[str, Any]]) -> Callable[..., Any]:
-    """A task that echoes the captured (recorded) output for each case.
-
-    This is the **baseline reference run**: it re-runs nothing and makes no model calls —
-    it just returns what capture recorded, keyed by the record's input. Publishing it as
-    its own experiment lets the Experiments *compare* view diff baseline vs the current
-    replay immediately, so a user sees value the moment they run ``--publish``.
-    """
-    by_input = {json.dumps(c["input"], sort_keys=True, default=str): c["output"] for c in cases}
-
-    def task(input_data: Any, config: Any) -> Any:
-        return by_input.get(json.dumps(input_data, sort_keys=True, default=str))
-
-    return task
-
-
 def experiment_url(experiment: Any) -> Optional[str]:
     return getattr(experiment, "url", None) or getattr(getattr(experiment, "_experiment", None), "url", None)
 
@@ -83,31 +57,6 @@ def experiment_url(experiment: Any) -> Optional[str]:
 def _experiment_id(experiment: Any) -> Optional[str]:
     eid = getattr(experiment, "_id", None) or getattr(getattr(experiment, "_experiment", None), "_id", None)
     return str(eid) if eid else None
-
-
-def dataset_url(dataset: Any) -> Optional[str]:
-    return getattr(dataset, "url", None)
-
-
-def compare_url(baseline: Any, current: Any, project_name: Optional[str] = None) -> Optional[str]:
-    """URL for the Experiments compare view: the ``baseline`` run with ``current`` as the target.
-
-    The baseline experiment is the page (first id); the current run is the compare target:
-    ``/llm/experiments/{baseline}?compareTargetExperimentId={current}&project=...``.
-    """
-    try:
-        from ddtrace.llmobs._experiment import _get_base_url
-
-        b, c = _experiment_id(baseline), _experiment_id(current)
-        if not (b and c):
-            return None
-        url = "%s/llm/experiments/%s?compareTargetExperimentId=%s" % (_get_base_url(), b, c)
-        if project_name:
-            url += "&project=%s" % quote(project_name, safe="")
-        return url
-    except Exception:
-        log.debug("inline experiment: could not build compare url", exc_info=True)
-        return None
 
 
 # --------------------------------------------------------------------------- #
@@ -270,70 +219,3 @@ def publish_run(
         "sync": sync,
         "pairs": _rows_pairs(run),
     }
-
-
-def run_as_experiment(
-    name: str,
-    cases: list[dict[str, Any]],
-    comparator: Callable[[Any, Any], bool],
-    experiment_name: Optional[str] = None,
-    project_name: Optional[str] = None,
-    dataset_name: Optional[str] = None,
-    publish_baseline: bool = True,
-) -> dict[str, Any]:
-    """Create a Dataset from ``cases`` and publish it as LLM Obs experiment(s).
-
-    Publishes two runs over the same dataset so the compare view has something to diff
-    immediately:
-      * ``baseline`` — echoes the captured outputs (no subject re-run, no model calls); the
-        known-good reference. Skipped when ``publish_baseline`` is False.
-      * ``current`` — replays the subject against the captured inputs (real re-execution).
-
-    Both are scored by the same evaluators (the always-on ``regression_match`` guard first,
-    then the subject's attached evaluators, resolved lazily here — never at import). Returns
-    ``{"current", "baseline", "dataset"}``. Requires ``LLMObs`` to be enabled.
-    """
-    from ddtrace.llmobs import LLMObs
-    from ddtrace.llmobs._experiment import DatasetRecordNew
-
-    records: list[DatasetRecordNew] = [{"input_data": c["input"], "expected_output": c["output"]} for c in cases]
-    dataset = LLMObs.create_dataset(
-        dataset_name or ("inline-experiment-%s" % name),
-        project_name=project_name,
-        description="Inline-experiment baseline for %r (captured locally)." % name,
-        records=records,
-    )
-    spec = _REGISTRY.get(name, {})
-    evaluators = [_make_evaluator(comparator), *resolve_evaluators(spec.get("evaluators"))]
-    base_name = experiment_name or ("inline-%s" % name)
-
-    # Baseline reference run first (mode stays OFF — the task only echoes stored outputs,
-    # the subject is never invoked), so the compare view can diff it against `current`.
-    baseline = None
-    if publish_baseline:
-        baseline = LLMObs.experiment(
-            base_name + "-baseline",
-            _baseline_task(cases),
-            dataset,
-            evaluators=evaluators,
-            project_name=project_name,
-            tags={"source": "ddtrace-experiment", "inline_role": "baseline"},
-        )
-        baseline.run()
-
-    # Current run: replay the subject. REPLAY so an emit-shape end marker unwinds (set once;
-    # the engine may run tasks concurrently, and a single-function subject is unaffected).
-    current = LLMObs.experiment(
-        base_name,
-        _make_task(name),
-        dataset,
-        evaluators=evaluators,
-        project_name=project_name,
-        tags={"source": "ddtrace-experiment", "inline_role": "current"},
-    )
-    _set_mode(Mode.REPLAY)
-    try:
-        current.run()
-    finally:
-        _set_mode(Mode.OFF)
-    return {"current": current, "baseline": baseline, "dataset": dataset}

--- a/ddtrace/llmobs/_inline_experiment_sdk.py
+++ b/ddtrace/llmobs/_inline_experiment_sdk.py
@@ -16,6 +16,7 @@ from typing import Any
 from typing import Callable
 from typing import Optional
 from urllib.parse import quote
+import uuid
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._inline_experiment import _REGISTRY
@@ -108,6 +109,184 @@ def compare_url(baseline: Any, current: Any, project_name: Optional[str] = None)
     except Exception:
         log.debug("inline experiment: could not build compare url", exc_info=True)
         return None
+
+
+# --------------------------------------------------------------------------- #
+# Unified `run --publish`: each run is a real Experiment.
+#
+# First publish -> `publish_baseline`: a fresh Dataset (unique name, no accumulation) + the
+# boundary run through the engine as the BASELINE experiment (real spans -> cost, scored by
+# the subject's own quality evaluators). Its produced outputs are backfilled as the dataset's
+# ``expected_output`` so a later rerun has something to regress against.
+# Rerun publish -> `publish_current`: the SAME dataset, the current code run as the CURRENT
+# experiment, scored by the regression guard + the subject's evaluators, linked to the
+# baseline via the compare view. Correlation is by explicit dataset name / experiment id
+# (persisted in the local baseline file by the caller) — there is no sidecar.
+# --------------------------------------------------------------------------- #
+def _unique_dataset_name(name: str) -> str:
+    """A fresh dataset name per capture so repeated publishes never accumulate records."""
+    return "inline-experiment-%s-%s" % (name, uuid.uuid4().hex[:8])
+
+
+def compare_url_from_ids(
+    baseline_id: Optional[str], current_id: Optional[str], project_name: Optional[str] = None
+) -> Optional[str]:
+    """Compare-view URL from two experiment ids: baseline is the page, current the target."""
+    if not (baseline_id and current_id):
+        return None
+    try:
+        from ddtrace.llmobs._experiment import _get_base_url
+
+        url = "%s/llm/experiments/%s?compareTargetExperimentId=%s" % (_get_base_url(), baseline_id, current_id)
+        if project_name:
+            url += "&project=%s" % quote(project_name, safe="")
+        return url
+    except Exception:
+        log.debug("inline experiment: could not build compare url", exc_info=True)
+        return None
+
+
+def _rows_pairs(run: Any) -> list[tuple[Any, Any]]:
+    """(input, output) for each non-errored row of an ExperimentRun."""
+    pairs: list[tuple[Any, Any]] = []
+    for row in getattr(run, "rows", None) or []:
+        if row.get("error"):
+            continue
+        pairs.append((row.get("input"), row.get("output")))
+    return pairs
+
+
+def _backfill_expected(dataset: Any, pairs: list[tuple[Any, Any]]) -> None:
+    """Set each dataset record's ``expected_output`` to the output the baseline produced.
+
+    Matches by input (json key) rather than position, then pushes once. Best-effort: a push
+    failure is logged, not raised (the experiment already ran).
+    """
+    by_input = {json.dumps(i, sort_keys=True, default=str): o for i, o in pairs}
+    changed = False
+    for idx in range(len(dataset)):
+        key = json.dumps(dataset[idx].get("input_data"), sort_keys=True, default=str)
+        if key in by_input:
+            dataset.update(idx, {"expected_output": by_input[key]})
+            changed = True
+    if not changed:
+        return
+    try:
+        dataset.push()
+    except Exception:
+        log.debug("inline experiment: could not push backfilled expected_output", exc_info=True)
+
+
+def _baseline_marker() -> Callable[..., Any]:
+    """A trivial evaluator for the baseline when the subject has no evaluators of its own.
+
+    The baseline has no prior run to regress against, so ``regression_match`` would be
+    meaningless there — but the engine requires at least one evaluator. This records that an
+    output was produced, nothing more.
+    """
+
+    def baseline_recorded(input_data: Any, output_data: Any, expected_output: Any) -> Any:
+        from ddtrace.llmobs._experiment import EvaluatorResult
+
+        return EvaluatorResult(value=output_data is not None, assessment="recorded")
+
+    return baseline_recorded
+
+
+def publish_baseline(
+    name: str,
+    inputs: list[Any],
+    project_name: Optional[str] = None,
+    experiment_name: Optional[str] = None,
+    dataset_name: Optional[str] = None,
+) -> dict[str, Any]:
+    """First publish: run the subject over ``inputs`` as the BASELINE experiment.
+
+    Creates a fresh dataset (input_data only), runs the real boundary through the engine
+    (spans -> cost) scored by the subject's own evaluators (no regression guard — nothing to
+    regress against yet), then backfills each record's ``expected_output`` with the produced
+    output. Returns ``{experiment, experiment_id, url, dataset, dataset_name, pairs}``.
+    Requires ``LLMObs`` to be enabled.
+    """
+    from ddtrace.llmobs import LLMObs
+    from ddtrace.llmobs._experiment import DatasetRecordNew
+
+    ds_name = dataset_name or _unique_dataset_name(name)
+    records: list[DatasetRecordNew] = [{"input_data": i} for i in inputs]
+    dataset = LLMObs.create_dataset(
+        ds_name,
+        project_name=project_name,
+        description="Inline-experiment baseline for %r." % name,
+        records=records,
+    )
+    spec = _REGISTRY.get(name, {})
+    evaluators = resolve_evaluators(spec.get("evaluators")) or [_baseline_marker()]
+    experiment = LLMObs.experiment(
+        experiment_name or ("%s-baseline" % name),
+        _make_task(name),
+        dataset,
+        evaluators=evaluators,
+        project_name=project_name,
+        tags={"source": "ddtrace-experiment", "inline_role": "baseline"},
+    )
+    _set_mode(Mode.REPLAY)  # so an emit-shape end marker unwinds; a single-function subject is unaffected
+    try:
+        run = experiment.run()
+    finally:
+        _set_mode(Mode.OFF)
+    pairs = _rows_pairs(run)
+    _backfill_expected(dataset, pairs)
+    return {
+        "experiment": experiment,
+        "experiment_id": _experiment_id(experiment),
+        "url": experiment_url(experiment),
+        "dataset": dataset,
+        "dataset_name": ds_name,
+        "pairs": pairs,
+    }
+
+
+def publish_current(
+    name: str,
+    dataset_name: str,
+    comparator: Callable[[Any, Any], bool],
+    baseline_experiment_id: Optional[str] = None,
+    project_name: Optional[str] = None,
+    experiment_name: Optional[str] = None,
+) -> dict[str, Any]:
+    """Rerun publish: run the current code over the baseline's dataset as the CURRENT experiment.
+
+    Pulls the shared dataset (so ``expected_output`` = the baseline's output), runs the
+    boundary through the engine scored by the regression guard + the subject's evaluators, and
+    builds the compare-view URL against ``baseline_experiment_id``. Returns
+    ``{experiment, experiment_id, url, dataset, compare_url}``.
+    """
+    from ddtrace.llmobs import LLMObs
+
+    dataset = LLMObs.pull_dataset(dataset_name, project_name=project_name)
+    spec = _REGISTRY.get(name, {})
+    evaluators = [_make_evaluator(comparator), *resolve_evaluators(spec.get("evaluators"))]
+    experiment = LLMObs.experiment(
+        experiment_name or name,
+        _make_task(name),
+        dataset,
+        evaluators=evaluators,
+        project_name=project_name,
+        tags={"source": "ddtrace-experiment", "inline_role": "current"},
+    )
+    _set_mode(Mode.REPLAY)
+    try:
+        experiment.run()
+    finally:
+        _set_mode(Mode.OFF)
+    current_id = _experiment_id(experiment)
+    return {
+        "experiment": experiment,
+        "experiment_id": current_id,
+        "url": experiment_url(experiment),
+        "dataset": dataset,
+        "compare_url": compare_url_from_ids(baseline_experiment_id, current_id, project_name),
+    }
 
 
 def run_as_experiment(

--- a/ddtrace/llmobs/_inline_experiment_sdk.py
+++ b/ddtrace/llmobs/_inline_experiment_sdk.py
@@ -16,7 +16,6 @@ from typing import Any
 from typing import Callable
 from typing import Optional
 from urllib.parse import quote
-import uuid
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.llmobs._inline_experiment import _REGISTRY
@@ -112,20 +111,27 @@ def compare_url(baseline: Any, current: Any, project_name: Optional[str] = None)
 
 
 # --------------------------------------------------------------------------- #
-# Unified `run --publish`: each run is a real Experiment.
+# Unified `run --publish`: each run is a real Experiment (the "refresh" model).
 #
-# First publish -> `publish_baseline`: a fresh Dataset (unique name, no accumulation) + the
-# boundary run through the engine as the BASELINE experiment (real spans -> cost, scored by
-# the subject's own quality evaluators). Its produced outputs are backfilled as the dataset's
-# ``expected_output`` so a later rerun has something to regress against.
-# Rerun publish -> `publish_current`: the SAME dataset, the current code run as the CURRENT
-# experiment, scored by the regression guard + the subject's evaluators, linked to the
-# baseline via the compare view. Correlation is by explicit dataset name / experiment id
-# (persisted in the local baseline file by the caller) — there is no sidecar.
+# One STABLE dataset per subject (``inline-experiment-<subject>``). Every publish run
+# ``sync_dataset``s it to EXACTLY this run's inputs (add missing / delete removed / keep
+# unchanged records with their ids, so the compare view lines up), then runs the boundary
+# through the engine as a timestamped experiment scored by the subject's OWN evaluators
+# (no regression guard — the regression signal is the compare view). The FIRST publish is
+# the frozen baseline; every later run compares current-vs-baseline. Correlation (dataset
+# name + baseline experiment id) is persisted in the local baseline file by the caller —
+# there is no sidecar.
 # --------------------------------------------------------------------------- #
-def _unique_dataset_name(name: str) -> str:
-    """A fresh dataset name per capture so repeated publishes never accumulate records."""
-    return "inline-experiment-%s-%s" % (name, uuid.uuid4().hex[:8])
+def _dataset_name(name: str) -> str:
+    """The one stable dataset for a subject (overwritten in place each publish run)."""
+    return "inline-experiment-%s" % name
+
+
+def _timestamp() -> str:
+    """A sortable run stamp so each run is a distinct experiment in the UI."""
+    from datetime import datetime
+
+    return datetime.now().strftime("%Y%m%d-%H%M%S")
 
 
 def compare_url_from_ids(
@@ -156,136 +162,113 @@ def _rows_pairs(run: Any) -> list[tuple[Any, Any]]:
     return pairs
 
 
-def _backfill_expected(dataset: Any, pairs: list[tuple[Any, Any]]) -> None:
-    """Set each dataset record's ``expected_output`` to the output the baseline produced.
-
-    Matches by input (json key) rather than position, then pushes once. Best-effort: a push
-    failure is logged, not raised (the experiment already ran).
-    """
-    by_input = {json.dumps(i, sort_keys=True, default=str): o for i, o in pairs}
-    changed = False
-    for idx in range(len(dataset)):
-        key = json.dumps(dataset[idx].get("input_data"), sort_keys=True, default=str)
-        if key in by_input:
-            dataset.update(idx, {"expected_output": by_input[key]})
-            changed = True
-    if not changed:
-        return
-    try:
-        dataset.push()
-    except Exception:
-        log.debug("inline experiment: could not push backfilled expected_output", exc_info=True)
-
-
 def _baseline_marker() -> Callable[..., Any]:
-    """A trivial evaluator for the baseline when the subject has no evaluators of its own.
+    """A trivial evaluator used when the subject declares none of its own.
 
-    The baseline has no prior run to regress against, so ``regression_match`` would be
-    meaningless there — but the engine requires at least one evaluator. This records that an
-    output was produced, nothing more.
+    The engine requires at least one evaluator; this just records that an output was
+    produced. Real regression signal comes from the compare view, not an in-experiment check.
     """
 
-    def baseline_recorded(input_data: Any, output_data: Any, expected_output: Any) -> Any:
+    def output_present(input_data: Any, output_data: Any, expected_output: Any) -> Any:
         from ddtrace.llmobs._experiment import EvaluatorResult
 
         return EvaluatorResult(value=output_data is not None, assessment="recorded")
 
-    return baseline_recorded
+    return output_present
 
 
-def publish_baseline(
+def _input_key(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, default=str)
+
+
+def _pull_or_create_dataset(dataset_name: str, project_name: Optional[str]) -> Any:
+    """The subject's stable dataset, created empty if it doesn't exist yet."""
+    from ddtrace.llmobs import LLMObs
+
+    try:
+        return LLMObs.pull_dataset(dataset_name, project_name=project_name)
+    except Exception:
+        log.debug("inline experiment: dataset %r not found, creating it", dataset_name, exc_info=True)
+        return LLMObs.create_dataset(
+            dataset_name, project_name=project_name, description="Inline-experiment set (auto-managed).", records=[]
+        )
+
+
+def sync_dataset(dataset: Any, inputs: list[Any]) -> dict[str, int]:
+    """Diff-sync ``dataset`` to hold EXACTLY ``inputs``: add missing, delete removed, keep the
+    rest (with their record ids, so the compare view matches unchanged cases across runs).
+
+    Deletes are applied high-index-first (``Dataset.delete`` pops the local list). Pushes once
+    as a new version. Returns ``{"added", "deleted", "kept"}``.
+    """
+    want = {_input_key(i): i for i in inputs}
+    have_keys = [_input_key(dataset[idx].get("input_data")) for idx in range(len(dataset))]
+    seen: set[str] = set()
+    to_delete: list[int] = []
+    for idx, key in enumerate(have_keys):
+        if key in want and key not in seen:
+            seen.add(key)  # keep the first record for each wanted input
+        else:
+            to_delete.append(idx)  # not wanted, or a duplicate of one we already kept
+    for idx in sorted(to_delete, reverse=True):
+        dataset.delete(idx)
+    added = 0
+    for key, value in want.items():
+        if key not in seen:
+            dataset.append({"input_data": value})
+            added += 1
+    counts = {"added": added, "deleted": len(to_delete), "kept": len(seen)}
+    if added or to_delete:
+        try:
+            dataset.push()
+        except Exception:
+            log.debug("inline experiment: could not push dataset sync", exc_info=True)
+    return counts
+
+
+def publish_run(
     name: str,
     inputs: list[Any],
     project_name: Optional[str] = None,
     experiment_name: Optional[str] = None,
-    dataset_name: Optional[str] = None,
 ) -> dict[str, Any]:
-    """First publish: run the subject over ``inputs`` as the BASELINE experiment.
+    """Run the subject over ``inputs`` as one Experiment (the refresh model).
 
-    Creates a fresh dataset (input_data only), runs the real boundary through the engine
-    (spans -> cost) scored by the subject's own evaluators (no regression guard — nothing to
-    regress against yet), then backfills each record's ``expected_output`` with the produced
-    output. Returns ``{experiment, experiment_id, url, dataset, dataset_name, pairs}``.
-    Requires ``LLMObs`` to be enabled.
+    Syncs the subject's stable dataset to exactly ``inputs``, then runs the real boundary
+    through the engine (spans -> cost) scored by the subject's OWN evaluators. Returns
+    ``{experiment, experiment_id, url, dataset, dataset_name, sync, pairs}``. The caller
+    decides baseline-vs-compare from its persisted state; this function treats every run the
+    same. Requires ``LLMObs`` to be enabled.
     """
-    from ddtrace.llmobs import LLMObs
-    from ddtrace.llmobs._experiment import DatasetRecordNew
-
-    ds_name = dataset_name or _unique_dataset_name(name)
-    records: list[DatasetRecordNew] = [{"input_data": i} for i in inputs]
-    dataset = LLMObs.create_dataset(
-        ds_name,
-        project_name=project_name,
-        description="Inline-experiment baseline for %r." % name,
-        records=records,
-    )
+    ds_name = _dataset_name(name)
+    dataset = _pull_or_create_dataset(ds_name, project_name)
+    sync = sync_dataset(dataset, inputs)
     spec = _REGISTRY.get(name, {})
     evaluators = resolve_evaluators(spec.get("evaluators")) or [_baseline_marker()]
+
+    from ddtrace.llmobs import LLMObs
+
     experiment = LLMObs.experiment(
-        experiment_name or ("%s-baseline" % name),
+        experiment_name or ("%s-%s" % (name, _timestamp())),
         _make_task(name),
         dataset,
         evaluators=evaluators,
         project_name=project_name,
-        tags={"source": "ddtrace-experiment", "inline_role": "baseline"},
+        tags={"source": "ddtrace-experiment"},
     )
     _set_mode(Mode.REPLAY)  # so an emit-shape end marker unwinds; a single-function subject is unaffected
     try:
         run = experiment.run()
     finally:
         _set_mode(Mode.OFF)
-    pairs = _rows_pairs(run)
-    _backfill_expected(dataset, pairs)
     return {
         "experiment": experiment,
         "experiment_id": _experiment_id(experiment),
         "url": experiment_url(experiment),
         "dataset": dataset,
         "dataset_name": ds_name,
-        "pairs": pairs,
-    }
-
-
-def publish_current(
-    name: str,
-    dataset_name: str,
-    comparator: Callable[[Any, Any], bool],
-    baseline_experiment_id: Optional[str] = None,
-    project_name: Optional[str] = None,
-    experiment_name: Optional[str] = None,
-) -> dict[str, Any]:
-    """Rerun publish: run the current code over the baseline's dataset as the CURRENT experiment.
-
-    Pulls the shared dataset (so ``expected_output`` = the baseline's output), runs the
-    boundary through the engine scored by the regression guard + the subject's evaluators, and
-    builds the compare-view URL against ``baseline_experiment_id``. Returns
-    ``{experiment, experiment_id, url, dataset, compare_url}``.
-    """
-    from ddtrace.llmobs import LLMObs
-
-    dataset = LLMObs.pull_dataset(dataset_name, project_name=project_name)
-    spec = _REGISTRY.get(name, {})
-    evaluators = [_make_evaluator(comparator), *resolve_evaluators(spec.get("evaluators"))]
-    experiment = LLMObs.experiment(
-        experiment_name or name,
-        _make_task(name),
-        dataset,
-        evaluators=evaluators,
-        project_name=project_name,
-        tags={"source": "ddtrace-experiment", "inline_role": "current"},
-    )
-    _set_mode(Mode.REPLAY)
-    try:
-        experiment.run()
-    finally:
-        _set_mode(Mode.OFF)
-    current_id = _experiment_id(experiment)
-    return {
-        "experiment": experiment,
-        "experiment_id": current_id,
-        "url": experiment_url(experiment),
-        "dataset": dataset,
-        "compare_url": compare_url_from_ids(baseline_experiment_id, current_id, project_name),
+        "sync": sync,
+        "pairs": _rows_pairs(run),
     }
 
 

--- a/releasenotes/notes/llmobs-inline-experiments-63f3e96b499c30ee.yaml
+++ b/releasenotes/notes/llmobs-inline-experiments-63f3e96b499c30ee.yaml
@@ -5,14 +5,14 @@ features:
     local regression mechanism ("unit test for LLM apps"). Mark an input/output boundary in an
     already-instrumented app with the new ``ddtrace.llmobs.experimental.experiment_start`` /
     ``experiment_end`` decorators (an inert no-op during normal execution), then run it out-of-band
-    with the new ``ddtrace-experiment`` command, which captures a baseline and replays the current
-    code against it, reporting per-case ``MATCH`` / ``CHANGED``. Pass ``ddtrace-experiment replay
-    --publish`` to run the replay through the LLM Obs Experiments SDK so results appear in the
-    Experiments UI with eval metrics; ``--publish`` also publishes a companion *baseline*
-    experiment (the captured outputs) over the same dataset and prints a compare-view link, so the
-    baseline-vs-current diff is viewable immediately. Or pass ``ddtrace-experiment capture --trace``
-    to also enable LLM Observability during the capture run so it is viewable as traces (each case
-    linked to its trace). All ``ddtrace-experiment`` subcommands accept ``--env-file`` (and auto-load
-    a ``.env`` in the current directory) to read ``DD_API_KEY`` / ``OPENAI_API_KEY`` / ``DD_LLMOBS_ML_APP``
-    etc. without exporting them; real environment variables take precedence. These APIs are
-    experimental and may change or be removed without notice.
+    with the new ``ddtrace-experiment run`` command. ``run`` is offline by default: the first run
+    records a baseline and each later run re-runs the current code against it, reporting per-case
+    ``MATCH`` / ``CHANGED`` with a CI-friendly exit code — no backend or credentials required.
+    Pass ``ddtrace-experiment run --publish`` to also send the run to the LLM Obs Experiments UI:
+    the first publish is a frozen *baseline* experiment (a real run, so it carries cost + eval
+    metrics) over the subject's auto-managed dataset, and every later publish is compared against
+    it via a printed compare-view link. The dataset is refreshed to exactly each run's inputs.
+    ``ddtrace-experiment`` also accepts ``--env-file`` (and auto-loads a ``.env`` in the current
+    directory) to read ``DD_API_KEY`` / ``OPENAI_API_KEY`` / ``DD_LLMOBS_ML_APP`` etc. without
+    exporting them; real environment variables take precedence. These APIs are experimental and
+    may change or be removed without notice.

--- a/tests/llmobs/test_inline_experiment_runner.py
+++ b/tests/llmobs/test_inline_experiment_runner.py
@@ -565,99 +565,45 @@ class _FakeDataset:
     def update(self, i, rec):
         self._records[i].update(rec)
 
+    def append(self, rec):
+        self._records.append(dict(rec))
+
+    def delete(self, i):
+        del self._records[i]
+
     def push(self):
         self.pushed += 1
 
-
-def test_publish_baseline_creates_input_only_dataset_and_backfills(monkeypatch):
-    events = {"created": [], "experiments": [], "dataset": None}
-
-    class _Exp:
-        _id = "base-1"
-        url = "http://exp/base-1"
-
-        def run(self):
-            return _FakeRun([{"input": {"x": 1}, "output": 11}, {"input": {"x": 2}, "output": 22}])
-
-    class _FakeLLMObs:
-        enabled = True
-
-        @staticmethod
-        def create_dataset(name, project_name=None, description="", records=None):
-            events["created"].append((name, records))
-            events["dataset"] = _FakeDataset(records)
-            return events["dataset"]
-
-        @staticmethod
-        def experiment(name, task, dataset, evaluators=None, **kw):
-            events["experiments"].append((name, evaluators))
-            return _Exp()
-
-    monkeypatch.setattr(llmobs_pkg, "LLMObs", _FakeLLMObs)
-
-    @experiment_start(name="e", inputs=["x"], output=lambda r: r)
-    def f(x):
-        return x
-
-    out = sdk.publish_baseline("e", [{"x": 1}, {"x": 2}], dataset_name="ds-fixed")
-    # dataset created with input_data only (no expected yet)
-    assert events["created"] == [("ds-fixed", [{"input_data": {"x": 1}}, {"input_data": {"x": 2}}])]
-    # baseline experiment named <subject>-baseline; no regression guard (subject has no evaluators)
-    ename, evs = events["experiments"][0]
-    assert ename == "e-baseline"
-    assert [getattr(ev, "__name__", None) for ev in evs] == ["baseline_recorded"]
-    # expected_output backfilled from the run's produced outputs, pushed once
-    assert events["dataset"]._records[0]["expected_output"] == 11
-    assert events["dataset"]._records[1]["expected_output"] == 22
-    assert events["dataset"].pushed == 1
-    assert out["experiment_id"] == "base-1" and out["dataset_name"] == "ds-fixed"
-    assert out["pairs"] == [({"x": 1}, 11), ({"x": 2}, 22)]
+    def inputs(self):
+        return [r["input_data"] for r in self._records]
 
 
-def test_publish_baseline_uses_subject_evaluators_not_the_guard(monkeypatch):
+def test_sync_dataset_diffs_to_current_inputs():
+    ds = _FakeDataset([{"input_data": {"t": "a"}}, {"input_data": {"t": "b"}}, {"input_data": {"t": "c"}}])
+    counts = sdk.sync_dataset(ds, [{"t": "c"}, {"t": "d"}, {"t": "e"}])
+    # end state = EXACTLY the current inputs; c kept (its record survives), a/b deleted, d/e added
+    assert ds.inputs() == [{"t": "c"}, {"t": "d"}, {"t": "e"}]
+    assert counts == {"added": 2, "deleted": 2, "kept": 1}
+    assert ds.pushed == 1
+
+
+def test_sync_dataset_noop_when_unchanged():
+    ds = _FakeDataset([{"input_data": {"t": "a"}}, {"input_data": {"t": "b"}}])
+    counts = sdk.sync_dataset(ds, [{"t": "a"}, {"t": "b"}])
+    assert counts == {"added": 0, "deleted": 0, "kept": 2}
+    assert ds.pushed == 0  # no diff -> no push -> new version not created
+
+
+def test_publish_run_syncs_stable_dataset_and_uses_subject_evaluators(monkeypatch):
     seen = {}
+    ds = _FakeDataset([])
 
     class _Exp:
-        _id = "b"
-        url = "u"
+        _id = "run-1"
+        url = "http://exp/run-1"
 
         def run(self):
-            return _FakeRun([])
-
-    class _FakeLLMObs:
-        enabled = True
-
-        @staticmethod
-        def create_dataset(name, **kw):
-            return _FakeDataset([])
-
-        @staticmethod
-        def experiment(name, task, dataset, evaluators=None, **kw):
-            seen["evaluators"] = evaluators
-            return _Exp()
-
-    monkeypatch.setattr(llmobs_pkg, "LLMObs", _FakeLLMObs)
-
-    def my_check(input_data, output_data, expected_output):
-        return True
-
-    @experiment_start(name="e", inputs=["x"], output=lambda r: r, evaluators=lambda: [my_check])
-    def f(x):
-        return x
-
-    sdk.publish_baseline("e", [{"x": 1}], dataset_name="d")
-    assert seen["evaluators"] == [my_check]  # the baseline is scored by the subject's own evaluators only
-
-
-def test_publish_current_pulls_dataset_stacks_guard_and_builds_compare(monkeypatch):
-    seen = {}
-
-    class _Exp:
-        _id = "cur-9"
-        url = "http://exp/cur-9"
-
-        def run(self):
-            pass
+            return _FakeRun([{"input": {"x": 1}, "output": 11}])
 
     class _FakeLLMObs:
         enabled = True
@@ -665,7 +611,7 @@ def test_publish_current_pulls_dataset_stacks_guard_and_builds_compare(monkeypat
         @staticmethod
         def pull_dataset(name, project_name=None):
             seen["pulled"] = name
-            return object()
+            return ds
 
         @staticmethod
         def experiment(name, task, dataset, evaluators=None, **kw):
@@ -678,17 +624,87 @@ def test_publish_current_pulls_dataset_stacks_guard_and_builds_compare(monkeypat
     def my_check(input_data, output_data, expected_output):
         return True
 
-    @experiment_start(name="e", inputs=["x"], output=lambda r: r, evaluators=lambda: [my_check])
+    @experiment_start(name="portfolio", inputs=["x"], output=lambda r: r, evaluators=lambda: [my_check])
     def f(x):
         return x
 
-    out = sdk.publish_current("e", "ds-1", runner.structural, baseline_experiment_id="base-1", project_name="p x")
-    assert seen["pulled"] == "ds-1" and seen["ename"] == "e"
-    assert seen["evaluators"][0].__name__ == "regression_match"  # guard first
-    assert seen["evaluators"][1] is my_check  # then the subject's evaluator
-    assert out["experiment_id"] == "cur-9"
-    assert "/llm/experiments/base-1?compareTargetExperimentId=cur-9" in out["compare_url"]
-    assert out["compare_url"].endswith("&project=p%20x")
+    out = sdk.publish_run("portfolio", [{"x": 1}])
+    assert seen["pulled"] == "inline-experiment-portfolio"  # one stable dataset per subject
+    assert seen["ename"].startswith("portfolio-")  # timestamped -> distinct run in the UI
+    assert seen["evaluators"] == [my_check]  # subject's OWN evaluators only; no regression guard
+    assert ds.inputs() == [{"x": 1}]  # dataset synced to this run's inputs
+    assert out["experiment_id"] == "run-1"
+    assert out["dataset_name"] == "inline-experiment-portfolio"
+    assert out["sync"] == {"added": 1, "deleted": 0, "kept": 0}
+    assert out["pairs"] == [({"x": 1}, 11)]
+
+
+def test_publish_run_falls_back_to_marker_without_subject_evaluators(monkeypatch):
+    seen = {}
+
+    class _Exp:
+        _id = "r"
+        url = "u"
+
+        def run(self):
+            return _FakeRun([])
+
+    class _FakeLLMObs:
+        enabled = True
+
+        @staticmethod
+        def pull_dataset(name, project_name=None):
+            return _FakeDataset([])
+
+        @staticmethod
+        def experiment(name, task, dataset, evaluators=None, **kw):
+            seen["evaluators"] = evaluators
+            return _Exp()
+
+    monkeypatch.setattr(llmobs_pkg, "LLMObs", _FakeLLMObs)
+
+    @experiment_start(name="e", inputs=["x"], output=lambda r: r)
+    def f(x):
+        return x
+
+    sdk.publish_run("e", [{"x": 1}])
+    assert [getattr(ev, "__name__", None) for ev in seen["evaluators"]] == ["output_present"]
+
+
+def test_publish_run_creates_dataset_when_absent(monkeypatch):
+    seen = {}
+
+    class _Exp:
+        _id = "r"
+        url = "u"
+
+        def run(self):
+            return _FakeRun([])
+
+    class _FakeLLMObs:
+        enabled = True
+
+        @staticmethod
+        def pull_dataset(name, project_name=None):
+            raise ValueError("dataset not found")
+
+        @staticmethod
+        def create_dataset(name, project_name=None, description="", records=None):
+            seen["created"] = name
+            return _FakeDataset(records)
+
+        @staticmethod
+        def experiment(name, task, dataset, evaluators=None, **kw):
+            return _Exp()
+
+    monkeypatch.setattr(llmobs_pkg, "LLMObs", _FakeLLMObs)
+
+    @experiment_start(name="e", inputs=["x"], output=lambda r: r)
+    def f(x):
+        return x
+
+    sdk.publish_run("e", [{"x": 1}])
+    assert seen["created"] == "inline-experiment-e"  # stable name, created empty then synced
 
 
 def test_compare_url_from_ids():
@@ -727,7 +743,7 @@ def test_write_baseline_cases_preserves_publish_block(tmp_path):
     assert runner.load_baselines(p)["e"] == [{"input": {"x": 1}, "output": 11}]
 
 
-def test_cli_run_publish_first_publish_persists_meta(tmp_path, monkeypatch):
+def test_cli_run_publish_first_publish_freezes_baseline(tmp_path, monkeypatch):
     p = str(tmp_path / "b.json")
     calls = {}
     monkeypatch.setattr(cli, "_enable_llmobs", lambda ml: "app")
@@ -743,32 +759,42 @@ def test_cli_run_publish_first_publish_persists_meta(tmp_path, monkeypatch):
 
     monkeypatch.setattr(cli, "_import_target", lambda t: (_Mod, None))
 
-    def fake_baseline(name, inputs, project_name=None, experiment_name=None, dataset_name=None):
-        calls["baseline"] = (name, inputs, project_name)
-        return {"experiment_id": "base-1", "url": "http://b", "dataset_name": "ds-1", "pairs": [({"x": 1}, 11)]}
+    def fake_run(name, inputs, project_name=None, experiment_name=None):
+        calls["run"] = (name, inputs, project_name)
+        return {
+            "experiment_id": "base-1",
+            "url": "http://b",
+            "dataset_name": "inline-experiment-e",
+            "sync": {"added": 1, "deleted": 0, "kept": 0},
+            "pairs": [({"x": 1}, 11)],
+        }
 
-    monkeypatch.setattr(sdk, "publish_baseline", fake_baseline)
+    monkeypatch.setattr(sdk, "publish_run", fake_run)
 
     args = cli._build_arg_parser().parse_args(["run", "mymod", "--publish", "--project", "proj", "--baseline-file", p])
     cli._cmd_run(args, ie, runner)
-    assert calls["baseline"] == ("e", [{"x": 1}], "proj")
+    assert calls["run"] == ("e", [{"x": 1}], "proj")
+    # first publish freezes the baseline id + dataset name and seeds the local baseline
     assert runner.load_publish_meta(p, "e") == {
-        "dataset_name": "ds-1",
+        "dataset_name": "inline-experiment-e",
         "baseline_experiment_id": "base-1",
         "project": "proj",
     }
     assert runner.load_baselines(p)["e"] == [{"input": {"x": 1}, "output": 11}]
 
 
-def test_cli_run_publish_rerun_uses_saved_meta(tmp_path, monkeypatch):
+def test_cli_run_publish_rerun_compares_to_frozen_baseline(tmp_path, monkeypatch):
     p = str(tmp_path / "b.json")
-    runner.save_publish_meta(p, "e", dataset_name="ds-1", baseline_experiment_id="base-1")
+    runner.save_publish_meta(p, "e", dataset_name="inline-experiment-e", baseline_experiment_id="base-1")
+    runner.write_baseline_cases(p, "e", [({"x": 1}, 11)])  # must stay frozen across the rerun
     calls = {}
     monkeypatch.setattr(cli, "_enable_llmobs", lambda ml: "app")
     monkeypatch.setattr(cli, "_flush_llmobs", lambda: None)
+    monkeypatch.setattr(sdk, "compare_url_from_ids", lambda b, c, proj=None: "cmp:%s->%s" % (b, c))
 
     class _Mod:
         SUBJECT = "e"
+        INPUTS = [{"x": 2}]  # the user changed the input this iteration
 
     @experiment_start(name="e", inputs=["x"], output=lambda r: r)
     def f(x):
@@ -776,14 +802,21 @@ def test_cli_run_publish_rerun_uses_saved_meta(tmp_path, monkeypatch):
 
     monkeypatch.setattr(cli, "_import_target", lambda t: (_Mod, None))
 
-    def fake_current(
-        name, dataset_name, comparator, baseline_experiment_id=None, project_name=None, experiment_name=None
-    ):
-        calls["current"] = (name, dataset_name, baseline_experiment_id, project_name)
-        return {"experiment_id": "cur-1", "url": "http://c", "compare_url": "http://compare"}
+    def fake_run(name, inputs, project_name=None, experiment_name=None):
+        calls["run"] = (name, inputs, project_name)
+        return {
+            "experiment_id": "cur-2",
+            "url": "http://c",
+            "dataset_name": "inline-experiment-e",
+            "sync": {"added": 1, "deleted": 1, "kept": 0},
+            "pairs": [({"x": 2}, 22)],
+        }
 
-    monkeypatch.setattr(sdk, "publish_current", fake_current)
+    monkeypatch.setattr(sdk, "publish_run", fake_run)
 
-    args = cli._build_arg_parser().parse_args(["run", "mymod", "--publish", "--project", "proj", "--baseline-file", p])
+    args = cli._build_arg_parser().parse_args(["run", "mymod", "--publish", "--baseline-file", p])
     cli._cmd_run(args, ie, runner)
-    assert calls["current"] == ("e", "ds-1", "base-1", "proj")
+    assert calls["run"] == ("e", [{"x": 2}], None)  # runs the CURRENT inputs (refresh)
+    # the frozen baseline id + local baseline are unchanged by the rerun
+    assert runner.load_publish_meta(p, "e")["baseline_experiment_id"] == "base-1"
+    assert runner.load_baselines(p)["e"] == [{"input": {"x": 1}, "output": 11}]

--- a/tests/llmobs/test_inline_experiment_runner.py
+++ b/tests/llmobs/test_inline_experiment_runner.py
@@ -4,6 +4,7 @@ import pytest
 
 from ddtrace.commands import ddtrace_experiment as cli
 import ddtrace.llmobs as llmobs_pkg
+from ddtrace.llmobs import _inline_experiment as ie
 from ddtrace.llmobs import _inline_experiment_runner as runner
 from ddtrace.llmobs import _inline_experiment_sdk as sdk
 from ddtrace.llmobs._experiment import BaseEvaluator
@@ -452,3 +453,90 @@ def test_cli_print_report_counts_eval_error(capsys):
     counts = cli._print_report("e", rows)
     # an evaluator that errored (the check didn't run) is counted so it can gate the exit code
     assert counts["OK"] == 1 and counts["EVAL_ERROR"] == 1
+
+
+# --- unified `run` verb (offline) ------------------------------------------ #
+def test_cli_run_arg_parser():
+    p = cli._build_arg_parser()
+    a = p.parse_args(["run", "myapp:gen"])
+    assert a.command == "run" and a.target == "myapp:gen"
+    assert a.record is False and a.name is None and a.comparator == "structural" and a.evaluate is False
+    a = p.parse_args(
+        ["run", "myapp", "--record", "--name", "greet", "--comparator", "exact", "--ignore", "ts", "--evaluate"]
+    )
+    assert a.record and a.name == "greet" and a.comparator == "exact" and a.ignore == "ts" and a.evaluate
+    assert p.parse_args(["run", "m", "--baseline-file", "b.json"]).baseline_file == "b.json"
+    assert p.parse_args(["run", "m", "--env-file", "x.env"]).env_file == "x.env"  # shared flag
+
+
+def test_cli_run_records_then_compares_offline(tmp_path):
+    out = str(tmp_path / "b.json")
+
+    @experiment_start(name="greet", inputs=["who"], output=lambda r: r)
+    def greet(who):
+        return {"msg": "hi " + who}
+
+    def driver():
+        greet(who="world")
+
+    # First run: record the baseline (CAPTURE), then restore mode to OFF.
+    cli._run_record_offline(driver, out, runner, ie)
+    assert ie._get_mode() is Mode.OFF
+    data = runner.load_baselines(out)
+    assert data["greet"][0]["input"] == {"who": "world"}
+    assert data["greet"][0]["output"] == {"msg": "hi world"}
+
+    # Rerun with unchanged code -> MATCH -> exit 0.
+    args = cli._build_arg_parser().parse_args(["run", "m", "--baseline-file", out])
+    with pytest.raises(SystemExit) as e:
+        cli._run_compare_offline(args, ie, runner, out)
+    assert e.value.code == 0
+    assert ie._get_mode() is Mode.OFF
+
+
+def test_cli_run_compare_gates_on_change(tmp_path):
+    out = str(tmp_path / "b.json")
+    state = {"v": 1}
+
+    @experiment_start(name="g", inputs=["x"], output=lambda r: r)
+    def g(x):
+        return {"v": state["v"], "x": x}
+
+    def driver():
+        g(x=1)
+
+    cli._run_record_offline(driver, out, runner, ie)
+    state["v"] = 2  # value drift; shape unchanged
+    # exact sees the change -> `changed` -> exit 1 (CI gate)
+    args = cli._build_arg_parser().parse_args(["run", "m", "--baseline-file", out, "--comparator", "exact"])
+    with pytest.raises(SystemExit) as e:
+        cli._run_compare_offline(args, ie, runner, out)
+    assert e.value.code == 1
+    # structural ignores value drift -> match -> exit 0
+    args = cli._build_arg_parser().parse_args(["run", "m", "--baseline-file", out, "--comparator", "structural"])
+    with pytest.raises(SystemExit) as e:
+        cli._run_compare_offline(args, ie, runner, out)
+    assert e.value.code == 0
+
+
+def test_cli_run_record_needs_driver_when_no_baseline():
+    with pytest.raises(SystemExit) as e:
+        cli._run_record_offline(None, "unused.json", runner, ie)
+    assert e.value.code == 2
+
+
+def test_cli_run_compare_no_matching_subject(tmp_path):
+    out = str(tmp_path / "b.json")
+
+    @experiment_start(name="greet", inputs=["who"], output=lambda r: r)
+    def greet(who):
+        return who
+
+    def driver():
+        greet(who="a")
+
+    cli._run_record_offline(driver, out, runner, ie)
+    args = cli._build_arg_parser().parse_args(["run", "m", "--baseline-file", out, "--name", "missing"])
+    with pytest.raises(SystemExit) as e:
+        cli._run_compare_offline(args, ie, runner, out)
+    assert e.value.code == 2

--- a/tests/llmobs/test_inline_experiment_runner.py
+++ b/tests/llmobs/test_inline_experiment_runner.py
@@ -467,6 +467,9 @@ def test_cli_run_arg_parser():
     assert a.record and a.name == "greet" and a.comparator == "exact" and a.ignore == "ts" and a.evaluate
     assert p.parse_args(["run", "m", "--baseline-file", "b.json"]).baseline_file == "b.json"
     assert p.parse_args(["run", "m", "--env-file", "x.env"]).env_file == "x.env"  # shared flag
+    a = p.parse_args(["run", "m", "--publish", "--project", "proj", "--experiment-name", "en", "--ml-app", "app"])
+    assert a.publish is True and a.project == "proj" and a.experiment_name == "en" and a.ml_app == "app"
+    assert p.parse_args(["run", "m"]).publish is False
 
 
 def test_cli_run_records_then_compares_offline(tmp_path):
@@ -540,3 +543,247 @@ def test_cli_run_compare_no_matching_subject(tmp_path):
     with pytest.raises(SystemExit) as e:
         cli._run_compare_offline(args, ie, runner, out)
     assert e.value.code == 2
+
+
+# --- `run --publish` (backend, mocked) ------------------------------------- #
+class _FakeRun:
+    def __init__(self, rows):
+        self.rows = rows
+
+
+class _FakeDataset:
+    def __init__(self, records):
+        self._records = [dict(r) for r in (records or [])]
+        self.pushed = 0
+
+    def __len__(self):
+        return len(self._records)
+
+    def __getitem__(self, i):
+        return self._records[i]
+
+    def update(self, i, rec):
+        self._records[i].update(rec)
+
+    def push(self):
+        self.pushed += 1
+
+
+def test_publish_baseline_creates_input_only_dataset_and_backfills(monkeypatch):
+    events = {"created": [], "experiments": [], "dataset": None}
+
+    class _Exp:
+        _id = "base-1"
+        url = "http://exp/base-1"
+
+        def run(self):
+            return _FakeRun([{"input": {"x": 1}, "output": 11}, {"input": {"x": 2}, "output": 22}])
+
+    class _FakeLLMObs:
+        enabled = True
+
+        @staticmethod
+        def create_dataset(name, project_name=None, description="", records=None):
+            events["created"].append((name, records))
+            events["dataset"] = _FakeDataset(records)
+            return events["dataset"]
+
+        @staticmethod
+        def experiment(name, task, dataset, evaluators=None, **kw):
+            events["experiments"].append((name, evaluators))
+            return _Exp()
+
+    monkeypatch.setattr(llmobs_pkg, "LLMObs", _FakeLLMObs)
+
+    @experiment_start(name="e", inputs=["x"], output=lambda r: r)
+    def f(x):
+        return x
+
+    out = sdk.publish_baseline("e", [{"x": 1}, {"x": 2}], dataset_name="ds-fixed")
+    # dataset created with input_data only (no expected yet)
+    assert events["created"] == [("ds-fixed", [{"input_data": {"x": 1}}, {"input_data": {"x": 2}}])]
+    # baseline experiment named <subject>-baseline; no regression guard (subject has no evaluators)
+    ename, evs = events["experiments"][0]
+    assert ename == "e-baseline"
+    assert [getattr(ev, "__name__", None) for ev in evs] == ["baseline_recorded"]
+    # expected_output backfilled from the run's produced outputs, pushed once
+    assert events["dataset"]._records[0]["expected_output"] == 11
+    assert events["dataset"]._records[1]["expected_output"] == 22
+    assert events["dataset"].pushed == 1
+    assert out["experiment_id"] == "base-1" and out["dataset_name"] == "ds-fixed"
+    assert out["pairs"] == [({"x": 1}, 11), ({"x": 2}, 22)]
+
+
+def test_publish_baseline_uses_subject_evaluators_not_the_guard(monkeypatch):
+    seen = {}
+
+    class _Exp:
+        _id = "b"
+        url = "u"
+
+        def run(self):
+            return _FakeRun([])
+
+    class _FakeLLMObs:
+        enabled = True
+
+        @staticmethod
+        def create_dataset(name, **kw):
+            return _FakeDataset([])
+
+        @staticmethod
+        def experiment(name, task, dataset, evaluators=None, **kw):
+            seen["evaluators"] = evaluators
+            return _Exp()
+
+    monkeypatch.setattr(llmobs_pkg, "LLMObs", _FakeLLMObs)
+
+    def my_check(input_data, output_data, expected_output):
+        return True
+
+    @experiment_start(name="e", inputs=["x"], output=lambda r: r, evaluators=lambda: [my_check])
+    def f(x):
+        return x
+
+    sdk.publish_baseline("e", [{"x": 1}], dataset_name="d")
+    assert seen["evaluators"] == [my_check]  # the baseline is scored by the subject's own evaluators only
+
+
+def test_publish_current_pulls_dataset_stacks_guard_and_builds_compare(monkeypatch):
+    seen = {}
+
+    class _Exp:
+        _id = "cur-9"
+        url = "http://exp/cur-9"
+
+        def run(self):
+            pass
+
+    class _FakeLLMObs:
+        enabled = True
+
+        @staticmethod
+        def pull_dataset(name, project_name=None):
+            seen["pulled"] = name
+            return object()
+
+        @staticmethod
+        def experiment(name, task, dataset, evaluators=None, **kw):
+            seen["ename"] = name
+            seen["evaluators"] = evaluators
+            return _Exp()
+
+    monkeypatch.setattr(llmobs_pkg, "LLMObs", _FakeLLMObs)
+
+    def my_check(input_data, output_data, expected_output):
+        return True
+
+    @experiment_start(name="e", inputs=["x"], output=lambda r: r, evaluators=lambda: [my_check])
+    def f(x):
+        return x
+
+    out = sdk.publish_current("e", "ds-1", runner.structural, baseline_experiment_id="base-1", project_name="p x")
+    assert seen["pulled"] == "ds-1" and seen["ename"] == "e"
+    assert seen["evaluators"][0].__name__ == "regression_match"  # guard first
+    assert seen["evaluators"][1] is my_check  # then the subject's evaluator
+    assert out["experiment_id"] == "cur-9"
+    assert "/llm/experiments/base-1?compareTargetExperimentId=cur-9" in out["compare_url"]
+    assert out["compare_url"].endswith("&project=p%20x")
+
+
+def test_compare_url_from_ids():
+    assert sdk.compare_url_from_ids(None, "c") is None
+    assert sdk.compare_url_from_ids("b", None) is None
+    u = sdk.compare_url_from_ids("b1", "c1", project_name="p x")
+    assert "/llm/experiments/b1?compareTargetExperimentId=c1" in u
+    assert u.endswith("&project=p%20x")
+
+
+def test_publish_meta_embedded_in_baseline_and_dropped_on_record(tmp_path):
+    p = str(tmp_path / "b.json")
+
+    @experiment_start(name="e", inputs=["x"], output=lambda r: r)
+    def f(x):
+        return x
+
+    _set_mode(Mode.CAPTURE)
+    f(x=1)
+    _set_mode(Mode.OFF)
+    runner.save_baselines(p)
+    runner.save_publish_meta(p, "e", dataset_name="ds-1", baseline_experiment_id="base-1")
+    assert runner.load_publish_meta(p, "e") == {"dataset_name": "ds-1", "baseline_experiment_id": "base-1"}
+    # the reserved _publish block is not iterated as a subject
+    assert [n for n, _ in runner.subject_items(runner.load_baselines(p))] == ["e"]
+    # re-recording rewrites the file from the registry and drops publish state (drift-free)
+    runner.save_baselines(p)
+    assert runner.load_publish_meta(p, "e") is None
+
+
+def test_write_baseline_cases_preserves_publish_block(tmp_path):
+    p = str(tmp_path / "b.json")
+    runner.save_publish_meta(p, "e", dataset_name="ds-1")
+    runner.write_baseline_cases(p, "e", [({"x": 1}, 11)])
+    assert runner.load_publish_meta(p, "e") == {"dataset_name": "ds-1"}  # meta survives
+    assert runner.load_baselines(p)["e"] == [{"input": {"x": 1}, "output": 11}]
+
+
+def test_cli_run_publish_first_publish_persists_meta(tmp_path, monkeypatch):
+    p = str(tmp_path / "b.json")
+    calls = {}
+    monkeypatch.setattr(cli, "_enable_llmobs", lambda ml: "app")
+    monkeypatch.setattr(cli, "_flush_llmobs", lambda: None)
+
+    class _Mod:
+        SUBJECT = "e"
+        INPUTS = [{"x": 1}]
+
+    @experiment_start(name="e", inputs=["x"], output=lambda r: r)
+    def f(x):
+        return x
+
+    monkeypatch.setattr(cli, "_import_target", lambda t: (_Mod, None))
+
+    def fake_baseline(name, inputs, project_name=None, experiment_name=None, dataset_name=None):
+        calls["baseline"] = (name, inputs, project_name)
+        return {"experiment_id": "base-1", "url": "http://b", "dataset_name": "ds-1", "pairs": [({"x": 1}, 11)]}
+
+    monkeypatch.setattr(sdk, "publish_baseline", fake_baseline)
+
+    args = cli._build_arg_parser().parse_args(["run", "mymod", "--publish", "--project", "proj", "--baseline-file", p])
+    cli._cmd_run(args, ie, runner)
+    assert calls["baseline"] == ("e", [{"x": 1}], "proj")
+    assert runner.load_publish_meta(p, "e") == {
+        "dataset_name": "ds-1",
+        "baseline_experiment_id": "base-1",
+        "project": "proj",
+    }
+    assert runner.load_baselines(p)["e"] == [{"input": {"x": 1}, "output": 11}]
+
+
+def test_cli_run_publish_rerun_uses_saved_meta(tmp_path, monkeypatch):
+    p = str(tmp_path / "b.json")
+    runner.save_publish_meta(p, "e", dataset_name="ds-1", baseline_experiment_id="base-1")
+    calls = {}
+    monkeypatch.setattr(cli, "_enable_llmobs", lambda ml: "app")
+    monkeypatch.setattr(cli, "_flush_llmobs", lambda: None)
+
+    class _Mod:
+        SUBJECT = "e"
+
+    @experiment_start(name="e", inputs=["x"], output=lambda r: r)
+    def f(x):
+        return x
+
+    monkeypatch.setattr(cli, "_import_target", lambda t: (_Mod, None))
+
+    def fake_current(
+        name, dataset_name, comparator, baseline_experiment_id=None, project_name=None, experiment_name=None
+    ):
+        calls["current"] = (name, dataset_name, baseline_experiment_id, project_name)
+        return {"experiment_id": "cur-1", "url": "http://c", "compare_url": "http://compare"}
+
+    monkeypatch.setattr(sdk, "publish_current", fake_current)
+
+    args = cli._build_arg_parser().parse_args(["run", "mymod", "--publish", "--project", "proj", "--baseline-file", p])
+    cli._cmd_run(args, ie, runner)
+    assert calls["current"] == ("e", "ds-1", "base-1", "proj")

--- a/tests/llmobs/test_inline_experiment_runner.py
+++ b/tests/llmobs/test_inline_experiment_runner.py
@@ -185,8 +185,8 @@ def test_replay_from_loaded_baseline_cases():
     assert runner.replay("e", runner.structural, cases=cases)[0]["evals"][0]["assessment"] == "changed"
 
 
-# --- SDK bridge (Slice C) -------------------------------------------------- #
-def test_sdk_bridge_task_replays_subject_and_evaluator_wraps_comparator():
+# --- SDK bridge ------------------------------------------------------------ #
+def test_sdk_bridge_task_replays_subject():
     @experiment_start(name="e", inputs=["x"], output=lambda r: r)
     def f(x):
         return {"v": x, "ts": "volatile"}
@@ -194,12 +194,6 @@ def test_sdk_bridge_task_replays_subject_and_evaluator_wraps_comparator():
     _set_mode(Mode.REPLAY)
     task = sdk._make_task("e")
     assert task({"x": 5}, None) == {"v": 5, "ts": "volatile"}  # task re-invokes the subject
-
-    ev = sdk._make_evaluator(runner.structural)
-    match = ev({}, {"v": 5, "ts": "a"}, {"v": 9, "ts": "b"})  # same shape
-    assert match.value is True and match.assessment == "match"
-    changed = ev({}, {"v": 5}, {"v": 9, "extra": 1})  # extra field
-    assert changed.value is False and changed.assessment == "changed"
 
 
 # --- evaluators ------------------------------------------------------------ #
@@ -276,135 +270,19 @@ def test_replay_scores_attached_evaluators_only_when_enabled():
     assert on["regression_match"] == "match" and on["at_least_as_long"] == "pass"
 
 
-def test_publish_stacks_user_evaluators_behind_guard(monkeypatch):
-    captured: dict = {}
-
-    class _Exp:
-        url = "http://exp"
-
-        def run(self):
-            pass
-
-    class _FakeLLMObs:
-        enabled = True
-
-        @staticmethod
-        def create_dataset(name, **kw):
-            return object()
-
-        @staticmethod
-        def experiment(name, task, dataset, evaluators=None, **kw):
-            captured["evaluators"] = evaluators
-            return _Exp()
-
-    monkeypatch.setattr(llmobs_pkg, "LLMObs", _FakeLLMObs)
-
-    def my_check(input_data, output_data, expected_output):
-        return output_data == expected_output
-
-    @experiment_start(name="e", inputs=["x"], output=lambda r: r, evaluators=lambda: [my_check])
-    def f(x):
-        return x
-
-    sdk.run_as_experiment("e", [{"input": {"x": 1}, "output": 1}], runner.structural)
-    evs = captured["evaluators"]
-    assert evs[0].__name__ == "regression_match"  # always-on guard first
-    assert evs[1] is my_check  # user evaluator stacked on top
-
-
-def test_publish_creates_baseline_and_current_over_same_dataset(monkeypatch):
-    created = []
-    datasets = []
-
-    class _Exp:
-        def __init__(self, name):
-            self.name = name
-            self._id = "id-" + name
-
-        def run(self):
-            pass
-
-    class _FakeLLMObs:
-        enabled = True
-
-        @staticmethod
-        def create_dataset(name, **kw):
-            datasets.append(name)
-            return object()
-
-        @staticmethod
-        def experiment(name, task, dataset, evaluators=None, **kw):
-            created.append((name, task))
-            return _Exp(name)
-
-    monkeypatch.setattr(llmobs_pkg, "LLMObs", _FakeLLMObs)
-
-    @experiment_start(name="e", inputs=["x"], output=lambda r: r)
-    def f(x):
-        return x
-
-    result = sdk.run_as_experiment("e", [{"input": {"x": 1}, "output": 11}], runner.structural)
-
-    names = [n for n, _ in created]
-    assert names == ["inline-e-baseline", "inline-e"]  # baseline reference first, then current
-    assert datasets == ["inline-experiment-e"]  # both runs share one dataset
-
-    baseline_task = created[0][1]  # the baseline task echoes the captured output (no re-run)
-    assert baseline_task({"x": 1}, None) == 11
-
-    # compare view = baseline experiment page (first id) with current as the compare target
-    cu = sdk.compare_url(result["baseline"], result["current"], project_name="proj x")
-    assert cu and "/llm/experiments/id-inline-e-baseline?compareTargetExperimentId=id-inline-e" in cu
-    assert cu.endswith("&project=proj%20x")  # project is url-encoded
-
-
-def test_publish_baseline_can_be_disabled(monkeypatch):
-    created = []
-
-    class _E:
-        _id = "x"
-
-        def run(self):
-            pass
-
-    class _FakeLLMObs:
-        enabled = True
-
-        @staticmethod
-        def create_dataset(name, **kw):
-            return object()
-
-        @staticmethod
-        def experiment(name, task, dataset, evaluators=None, **kw):
-            created.append(name)
-            return _E()
-
-    monkeypatch.setattr(llmobs_pkg, "LLMObs", _FakeLLMObs)
-
-    @experiment_start(name="e", inputs=["x"], output=lambda r: r)
-    def f(x):
-        return x
-
-    result = sdk.run_as_experiment("e", [{"input": {"x": 1}, "output": 1}], runner.structural, publish_baseline=False)
-    assert created == ["inline-e"]  # only the current run, no baseline
-    assert result["baseline"] is None
-
-
 # --- CLI helpers ----------------------------------------------------------- #
 def test_cli_arg_parser():
     p = cli._build_arg_parser()
-    a = p.parse_args(["capture", "myapp:gen", "--out", "b.json"])
-    assert a.command == "capture" and a.target == "myapp:gen" and a.out == "b.json"
-    a = p.parse_args(["replay", "myapp", "--ignore", "a,b"])
-    assert a.command == "replay" and a.ignore == "a,b" and a.comparator == "structural"
-    a = p.parse_args(["replay", "myapp", "--publish", "--project", "p", "--ml-app", "m"])
-    assert a.publish is True and a.project == "p" and a.ml_app == "m"
-    assert p.parse_args(["replay", "myapp", "--evaluate"]).evaluate is True
-    assert p.parse_args(["replay", "myapp"]).evaluate is False
+    # `run` and `list` are the only verbs; capture/replay were removed.
+    assert p.parse_args(["run", "myapp"]).command == "run"
     assert p.parse_args(["list", "myapp"]).command == "list"
-    # --env-file is shared across all subcommands (default None -> falls back to .env)
-    assert p.parse_args(["capture", "m:e", "--env-file", "x.env"]).env_file == "x.env"
-    assert p.parse_args(["replay", "myapp"]).env_file is None
+    with pytest.raises(SystemExit):
+        p.parse_args(["capture", "myapp:gen"])
+    with pytest.raises(SystemExit):
+        p.parse_args(["replay", "myapp"])
+    # --env-file is shared across subcommands (default None -> falls back to .env)
+    assert p.parse_args(["run", "m", "--env-file", "x.env"]).env_file == "x.env"
+    assert p.parse_args(["run", "myapp"]).env_file is None
     assert p.parse_args(["list", "myapp", "--env-file", "y.env"]).env_file == "y.env"
 
 

--- a/tests/llmobs/test_inline_experiment_runner.py
+++ b/tests/llmobs/test_inline_experiment_runner.py
@@ -430,6 +430,8 @@ class _FakeRun:
 
 
 class _FakeDataset:
+    url = "http://ds/inline-experiment-portfolio"
+
     def __init__(self, records):
         self._records = [dict(r) for r in (records or [])]
         self.pushed = 0
@@ -513,6 +515,7 @@ def test_publish_run_syncs_stable_dataset_and_uses_subject_evaluators(monkeypatc
     assert ds.inputs() == [{"x": 1}]  # dataset synced to this run's inputs
     assert out["experiment_id"] == "run-1"
     assert out["dataset_name"] == "inline-experiment-portfolio"
+    assert out["dataset_url"] == "http://ds/inline-experiment-portfolio"  # surfaced for the CLI
     assert out["sync"] == {"added": 1, "deleted": 0, "kept": 0}
     assert out["pairs"] == [({"x": 1}, 11)]
 


### PR DESCRIPTION
## What

Collapses the inline-experiments CLI into a single **`run`** verb and reworks `--publish` into the ergonomic "each run is an experiment" model. Stacked on `feat/llmobs-inline-experiments` (PR #18625).

### `run` — one verb, offline by default
- `ddtrace-experiment run <target>` auto-detects **first-run (record baseline)** vs **rerun (compare)** from whether a local baseline exists (`--record` forces re-record). Offline: records/compares against `.llmobs_experiments.json`, prints per-case `MATCH`/`CHANGED`, sets a CI-friendly exit code — no backend or credentials.
- The legacy `capture` / `replay` verbs are **removed** (verb set is now `{run, list}`), along with the SDK code only they used (`run_as_experiment`, the echo `_baseline_task`, `_make_evaluator`, the object-based `compare_url`/`dataset_url`).

### `--publish` — refresh model, frozen baseline (no sidecar)
- One **stable dataset per subject** (`inline-experiment-<subject>`), **diff-synced** to exactly each run's inputs (add missing / delete removed / keep unchanged record ids so the compare view lines up).
- Each run is a timestamped experiment scored by the subject's **own evaluators** (no in-experiment regression guard — the regression signal is the compare view).
- The **first** publish is the frozen **baseline** (a real run → cost + eval metrics); every later publish is compared against it. Correlation (dataset name + baseline experiment id) lives in a `_publish` block **inside the baseline file** — no sidecar, so re-recording can't strand stale state.
- Output prints **both** the experiment and dataset URLs, and the **compare** URL whenever a baseline exists.

### Fixes
- `sync_dataset` records now carry `expected_output` (empty) so `Experiment._merge_results` doesn't `KeyError` and runs finalize (experiment + per-record status populate).

## Testing
- `tests/llmobs/test_inline_experiment_runner.py` — unified `run` (offline record→compare, CHANGED gate, `--record`, subject filter), `sync_dataset` (diff-to-current, no-op), `publish_run` (stable dataset, subject-evaluators-only, timestamped name, marker fallback, create-when-absent, dataset URL), embedded `_publish` meta round-trip + drop-on-record, and CLI first-publish-freezes / rerun-compares orchestration. Backend paths are exercised via mocks; live validation is on the demo app.
- Full `llmobs::llmobs` suite green except the pre-existing `test_resolve_evaluators` failure (unrelated to this branch) and two environmental failures (no local `libddwaf.so` / DD app key).

## Notes
- Experimental, unmerged feature; APIs may change.
- Demo app updates (drivers/TESTING.md/guide → `run`) are in llm-observability `stock-watchlist-agent-run`.
- Backend record-matching in the compare view (does it match by input across dataset versions?) still needs a live check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)