### PR TITLE
fix(dynamic-instrumentation): prevent SymDB reinstall/uninstall cycle in forked workers

### DIFF
--- a/ddtrace/internal/symbol_db/remoteconfig.py
+++ b/ddtrace/internal/symbol_db/remoteconfig.py
@@ -19,6 +19,7 @@ log = get_logger(__name__)
 shared_pid_file = SharedStringFile(f"{os.getppid()}-symdb-pids")
 
 MAX_CHILD_UPLOADERS = 1  # max one child
+_permanently_disabled: bool = False
 
 
 class SymbolDatabaseCallback(RCCallback):
@@ -30,6 +31,11 @@ class SymbolDatabaseCallback(RCCallback):
         Args:
             payloads: Sequence of configuration payloads to process
         """
+        global _permanently_disabled
+
+        if _permanently_disabled:
+            return
+
         with shared_pid_file.lock_exclusive() as f:
             if (pid := str(os.getpid())) not in (pids := set(shared_pid_file.peekall_unlocked(f))):
                 # Store the PID of the current process so that we know which processes
@@ -44,6 +50,7 @@ class SymbolDatabaseCallback(RCCallback):
                 # processes. Therefore, we avoid uploading the same symbols from each
                 # child process. We restrict the enablement of Symbol DB to just the
                 # parent process and the first fork child.
+                _permanently_disabled = True
                 remoteconfig_poller.unregister_callback("LIVE_DEBUGGING_SYMBOL_DB")
                 remoteconfig_poller.disable_product("LIVE_DEBUGGING_SYMBOL_DB")
 

--- a/releasenotes/notes/fix-symdb-fork-worker-reinstall-89878a9a704e4dd3.yaml
+++ b/releasenotes/notes/fix-symdb-fork-worker-reinstall-89878a9a704e4dd3.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: fixes Symbol Database reinstallation in forked worker
+    processes after the uploader is disabled, preventing repeated module scans that
+    could cause high memory usage or out-of-memory restarts.

--- a/tests/internal/symbol_db/test_symbols.py
+++ b/tests/internal/symbol_db/test_symbols.py
@@ -400,6 +400,50 @@ def test_symbols_fork_uploads():
         os.waitpid(pid, 0)
 
 
+def test_symbols_child_disable_is_permanent(monkeypatch):
+    """Regression test for a memory leak in forked workers (e.g. gunicorn/uvicorn).
+
+    Once SymDB has been disabled in a forked child process, subsequent periodic
+    remote-config callbacks must not reinstall the uploader, even if the fork
+    detection condition no longer holds and a fresh enablement payload is
+    received. Before the fix, install()/uninstall() could cycle indefinitely,
+    with each install() rescanning all loaded modules and leaking memory until
+    the process was OOM-killed.
+    """
+    from ddtrace.internal.remoteconfig import ConfigMetadata
+    from ddtrace.internal.remoteconfig import Payload
+    from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
+    from ddtrace.internal.symbol_db import remoteconfig as symdb_remoteconfig
+    from ddtrace.internal.symbol_db.symbols import SymbolDatabaseUploader
+
+    monkeypatch.setattr(symdb_remoteconfig, "_permanently_disabled", False)
+    monkeypatch.setattr(remoteconfig_poller, "unregister_callback", mock.Mock())
+    monkeypatch.setattr(remoteconfig_poller, "disable_product", mock.Mock())
+    monkeypatch.setattr(symdb_remoteconfig, "get_ancestor_runtime_id", lambda: "fake-runtime-id")
+    # Simulate the fork-detection condition firing once (triggering the disable
+    # branch) and then no longer holding on later periodic callbacks.
+    monkeypatch.setattr(symdb_remoteconfig, "has_forked", mock.Mock(side_effect=[True, False, False, False]))
+
+    callback = symdb_remoteconfig.SymbolDatabaseCallback()
+    rc_data = [Payload(ConfigMetadata("test", "symdb", "hash", 0, 0), {"upload_symbols": True}, None)]
+
+    with (
+        mock.patch.object(SymbolDatabaseUploader, "is_installed", side_effect=[True, False, False, False]),
+        mock.patch.object(SymbolDatabaseUploader, "uninstall") as mock_uninstall,
+        mock.patch.object(SymbolDatabaseUploader, "install") as mock_install,
+    ):
+        callback(rc_data)
+        mock_uninstall.assert_called_once()
+        assert symdb_remoteconfig._permanently_disabled is True
+
+        # Later callbacks would have re-triggered install() without the fix,
+        # since the fork condition no longer holds and is_installed() is False.
+        for _ in range(3):
+            callback(rc_data)
+
+        mock_install.assert_not_called()
+
+
 @pytest.mark.subprocess(run_module=True, err=None)
 def test_symbols_spawn_uploads():
     def spawn_target(results):


### PR DESCRIPTION
Identical to https://github.com/DataDog/dd-trace-py/pull/19017 which Brett opened from Bits because we were debugging my permissions :) 

## Summary
- Forked worker processes (e.g. gunicorn/uvicorn) that exceed the max child-uploader limit were being uninstalled and then reinstalled on every subsequent periodic remote-config callback, since `is_installed()` returns `False` right after `uninstall()`.
- Each `install()` call rescans all loaded modules via `_process_unseen_loaded_modules()`, leaking ~127 MiB/min and eventually OOM-killing the process.
- Adds a process-local `_permanently_disabled` flag in `SymbolDatabaseCallback.__call__` that short-circuits the callback once a child process has been disabled, breaking the cycle for good. The flag is process-local (inherited as `False` after fork, then set independently per child), so parent-process behavior is unchanged.

## Test plan
- [x] Added `test_symbols_child_disable_is_permanent` in `tests/internal/symbol_db/test_symbols.py`, which fails without the fix (proves `install()` is re-invoked on the next periodic callback) and passes with it
- [x] `scripts/lint style` and `scripts/lint spelling` pass on changed files
- [x] `py_compile` clean on Python 3.9
- [ ] Full riot test suite could not be run in this environment (native extension build failed due to a sandbox `sccache`/subprocess limitation) — needs to run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)