### PR TITLE
refactor: decouple default service name from the versioned schematize_service_name function

### DIFF
--- a/ddtrace/internal/schema/__init__.py
+++ b/ddtrace/internal/schema/__init__.py
@@ -3,7 +3,7 @@ import logging
 from ddtrace.internal.settings import env
 from ddtrace.internal.utils.formats import asbool
 
-from .span_attribute_schema import _DEFAULT_SPAN_SERVICE_NAMES
+from .default import _get_schema_version
 from .span_attribute_schema import _SPAN_ATTRIBUTE_TO_FUNCTION
 from .span_attribute_schema import SpanDirection
 
@@ -11,35 +11,10 @@ from .span_attribute_schema import SpanDirection
 log = logging.getLogger(__name__)
 
 
-# Span attribute schema
-def _validate_schema(version):
-    error_message = (
-        "You have specified an invalid span attribute schema version: '{}'.".format(version),
-        "Valid options are: {}. You can change the specified value by updating".format(
-            _SPAN_ATTRIBUTE_TO_FUNCTION.keys()
-        ),
-        "the value exported in the 'DD_TRACE_SPAN_ATTRIBUTE_SCHEMA' environment variable.",
-    )
-
-    if version not in _SPAN_ATTRIBUTE_TO_FUNCTION.keys():
-        log.warning(" ".join(error_message))
-        return False
-
-    return True
-
-
-def _get_schema_version():
-    version = env.get("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", default="v0")
-    if not _validate_schema(version):
-        version = "v0"
-    return version
-
-
 SCHEMA_VERSION = _get_schema_version()
 _remove_client_service_names = asbool(env.get("DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED", default=False))
 _service_name_schema_version = "v0" if SCHEMA_VERSION == "v0" and not _remove_client_service_names else "v1"
 
-DEFAULT_SPAN_SERVICE_NAME = _DEFAULT_SPAN_SERVICE_NAMES[_service_name_schema_version]
 schematize_cache_operation = _SPAN_ATTRIBUTE_TO_FUNCTION[SCHEMA_VERSION]["cache_operation"]
 schematize_cloud_api_operation = _SPAN_ATTRIBUTE_TO_FUNCTION[SCHEMA_VERSION]["cloud_api_operation"]
 schematize_cloud_faas_operation = _SPAN_ATTRIBUTE_TO_FUNCTION[SCHEMA_VERSION]["cloud_faas_operation"]
@@ -50,7 +25,6 @@ schematize_service_name = _SPAN_ATTRIBUTE_TO_FUNCTION[_service_name_schema_versi
 schematize_url_operation = _SPAN_ATTRIBUTE_TO_FUNCTION[SCHEMA_VERSION]["url_operation"]
 
 __all__ = [
-    "DEFAULT_SPAN_SERVICE_NAME",
     "SCHEMA_VERSION",
     "SpanDirection",
     "schematize_cache_operation",

--- a/ddtrace/internal/schema/default.py
+++ b/ddtrace/internal/schema/default.py
@@ -1,0 +1,50 @@
+import logging
+import sys
+import typing as t
+
+from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
+from ddtrace.internal.settings import env
+from ddtrace.internal.settings._inferred_base_service import detect_service
+from ddtrace.internal.utils.formats import asbool
+
+
+VALID_VERSIONS = ["v0", "v1"]
+
+
+log = logging.getLogger(__name__)
+
+
+def _validate_schema(version: str) -> bool:
+    error_message = (
+        "You have specified an invalid span attribute schema version: '{}'.".format(version),
+        "Valid options are: {}. You can change the specified value by updating".format(VALID_VERSIONS),
+        "the value exported in the 'DD_TRACE_SPAN_ATTRIBUTE_SCHEMA' environment variable.",
+    )
+
+    if version not in VALID_VERSIONS:
+        log.warning(" ".join(error_message))
+        return False
+
+    return True
+
+
+def _get_schema_version() -> t.Any:
+    version = env.get("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", default="v0")
+    if not _validate_schema(version):
+        version = "v0"
+    return version
+
+
+SCHEMA_VERSION = _get_schema_version()
+_remove_client_service_names = asbool(env.get("DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED", default=False))
+_service_name_schema_version = "v0" if SCHEMA_VERSION == "v0" and not _remove_client_service_names else "v1"
+
+_inferred_base_service: t.Optional[str] = detect_service(sys.argv)
+
+
+_DEFAULT_SPAN_SERVICE_NAMES: dict[str, t.Optional[str]] = {
+    "v0": _inferred_base_service or None,
+    "v1": _inferred_base_service or DEFAULT_SERVICE_NAME,
+}
+
+DEFAULT_SPAN_SERVICE_NAME = _DEFAULT_SPAN_SERVICE_NAMES[_service_name_schema_version]

--- a/ddtrace/internal/schema/span_attribute_schema.py
+++ b/ddtrace/internal/schema/span_attribute_schema.py
@@ -1,9 +1,4 @@
 from enum import Enum
-import sys
-from typing import Optional
-
-from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
-from ddtrace.internal.settings._inferred_base_service import detect_service
 
 
 class SpanDirection(Enum):
@@ -112,11 +107,4 @@ _SPAN_ATTRIBUTE_TO_FUNCTION = {
         "service_name": service_name_v1,
         "url_operation": url_operation_v1,
     },
-}
-
-_inferred_base_service: Optional[str] = detect_service(sys.argv)
-
-_DEFAULT_SPAN_SERVICE_NAMES: dict[str, Optional[str]] = {
-    "v0": _inferred_base_service or None,
-    "v1": _inferred_base_service or DEFAULT_SERVICE_NAME,
 }

--- a/ddtrace/internal/settings/_config.py
+++ b/ddtrace/internal/settings/_config.py
@@ -26,7 +26,7 @@ from ddtrace.internal.evp_proxy.constants import DEFAULT_EVP_PAYLOAD_SIZE_LIMIT
 from ddtrace.internal.logger import get_log_injection_state
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.native import config as _native_config
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.serverless import in_aws_lambda
 from ddtrace.internal.serverless import in_azure_function
 from ddtrace.internal.serverless import in_gcp_function

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -72,7 +72,7 @@ import pytest
 import asyncio
 from tests.conftest import *
 from tests.contrib.aiohttp.conftest import *
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 
 def test(app, loop, aiohttp_client, test_spans):
     async def async_test(app, aiohttp_client, test_spans):

--- a/tests/contrib/aiomysql/test_aiomysql.py
+++ b/tests/contrib/aiomysql/test_aiomysql.py
@@ -7,7 +7,7 @@ import pytest
 
 from ddtrace.contrib.internal.aiomysql.patch import patch
 from ddtrace.contrib.internal.aiomysql.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib import shared_tests_async as shared_tests
 from tests.contrib.asyncio.utils import AsyncioTestCase
 from tests.contrib.asyncio.utils import mark_asyncio

--- a/tests/contrib/aiopg/test.py
+++ b/tests/contrib/aiopg/test.py
@@ -7,7 +7,7 @@ import pytest
 # project
 from ddtrace.contrib.internal.aiopg.patch import patch
 from ddtrace.contrib.internal.aiopg.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib.asyncio.utils import AsyncioTestCase
 from tests.contrib.config import POSTGRES_CONFIG
 from tests.subprocesstest import run_in_subprocess

--- a/tests/contrib/boto/test.py
+++ b/tests/contrib/boto/test.py
@@ -18,7 +18,7 @@ from moto import mock_sts
 from ddtrace.contrib.internal.boto.patch import patch
 from ddtrace.contrib.internal.boto.patch import unpatch
 from ddtrace.ext import http
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 from tests.utils import assert_span_http_status_code

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -41,7 +41,7 @@ from ddtrace.contrib.internal.botocore.patch import patch
 from ddtrace.contrib.internal.botocore.patch import patch_submodules
 from ddtrace.contrib.internal.botocore.patch import unpatch
 from ddtrace.internal.compat import PYTHON_VERSION_INFO
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from tests.utils import TracerTestCase

--- a/tests/contrib/bottle/test.py
+++ b/tests/contrib/bottle/test.py
@@ -6,7 +6,7 @@ from ddtrace import config
 from ddtrace.constants import USER_KEEP
 from ddtrace.contrib.internal.bottle.patch import TracePlugin
 from ddtrace.ext import http
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured

--- a/tests/contrib/consul/test.py
+++ b/tests/contrib/consul/test.py
@@ -6,7 +6,7 @@ from wrapt import BoundFunctionWrapper
 from ddtrace.contrib.internal.consul.patch import patch
 from ddtrace.contrib.internal.consul.patch import unpatch
 from ddtrace.ext import consul as consulx
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 

--- a/tests/contrib/elasticsearch/test_elasticsearch.py
+++ b/tests/contrib/elasticsearch/test_elasticsearch.py
@@ -15,7 +15,7 @@ from ddtrace.contrib.internal.elasticsearch.patch import get_versions
 from ddtrace.contrib.internal.elasticsearch.patch import patch
 from ddtrace.contrib.internal.elasticsearch.patch import unpatch
 from ddtrace.ext import http
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib.patch import emit_integration_and_version_to_test_agent
 from tests.utils import TracerTestCase
 

--- a/tests/contrib/flask_cache/test.py
+++ b/tests/contrib/flask_cache/test.py
@@ -4,7 +4,7 @@ from flask import Flask
 from ddtrace.contrib.internal.flask_cache.patch import CACHE_BACKEND
 from ddtrace.contrib.internal.flask_cache.patch import get_traced_cache
 from ddtrace.ext import net
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_dict_issuperset
 from tests.utils import assert_is_measured

--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -12,7 +12,7 @@ from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.internal.grpc.patch import _unpatch_server
 from ddtrace.contrib.internal.grpc.patch import patch
 from ddtrace.contrib.internal.grpc.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import snapshot
 

--- a/tests/contrib/httplib/test_httplib.py
+++ b/tests/contrib/httplib/test_httplib.py
@@ -15,7 +15,7 @@ from ddtrace.contrib.internal.httplib.patch import patch
 from ddtrace.contrib.internal.httplib.patch import unpatch
 from ddtrace.ext import http
 from ddtrace.internal.constants import _HTTPLIB_NO_TRACE_REQUEST
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_span_http_status_code
 from tests.utils import override_global_tracer

--- a/tests/contrib/kombu/test.py
+++ b/tests/contrib/kombu/test.py
@@ -10,7 +10,7 @@ from ddtrace.contrib.internal.kombu.patch import unpatch
 from ddtrace.ext import kombu as kombux
 from ddtrace.internal.datastreams.processor import PROPAGATION_KEY_BASE_64
 from ddtrace.internal.native import DDSketch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 

--- a/tests/contrib/mako/test_mako.py
+++ b/tests/contrib/mako/test_mako.py
@@ -8,7 +8,7 @@ from mako.template import Template
 from ddtrace.contrib.internal.mako.constants import DEFAULT_TEMPLATE_NAME
 from ddtrace.contrib.internal.mako.patch import patch
 from ddtrace.contrib.internal.mako.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 

--- a/tests/contrib/molten/test_molten.py
+++ b/tests/contrib/molten/test_molten.py
@@ -8,7 +8,7 @@ from ddtrace.constants import USER_KEEP
 from ddtrace.contrib.internal.molten.patch import patch
 from ddtrace.contrib.internal.molten.patch import unpatch
 from ddtrace.ext import http
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID

--- a/tests/contrib/mysqldb/test_mysqldb.py
+++ b/tests/contrib/mysqldb/test_mysqldb.py
@@ -4,7 +4,7 @@ import pytest
 
 from ddtrace.contrib.internal.mysqldb.patch import patch
 from ddtrace.contrib.internal.mysqldb.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib import shared_tests
 from tests.utils import TracerTestCase
 from tests.utils import assert_dict_issuperset

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -10,7 +10,7 @@ from psycopg.sql import Literal
 
 from ddtrace.contrib.internal.psycopg.patch import patch
 from ddtrace.contrib.internal.psycopg.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.utils.version import parse_version
 from tests.contrib.config import POSTGRES_CONFIG
 from tests.utils import TracerTestCase

--- a/tests/contrib/psycopg2/test_psycopg.py
+++ b/tests/contrib/psycopg2/test_psycopg.py
@@ -9,7 +9,7 @@ from psycopg2 import extras
 
 from ddtrace.contrib.internal.psycopg.patch import patch
 from ddtrace.contrib.internal.psycopg.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.utils.version import parse_version
 from tests.contrib.config import POSTGRES_CONFIG
 from tests.utils import TracerTestCase

--- a/tests/contrib/pymemcache/test_client.py
+++ b/tests/contrib/pymemcache/test_client.py
@@ -14,7 +14,7 @@ from ddtrace.contrib.internal.pymemcache.client import WrappedClient
 from ddtrace.contrib.internal.pymemcache.patch import patch
 from ddtrace.contrib.internal.pymemcache.patch import unpatch
 from ddtrace.internal.compat import is_wrapted
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import override_config
 

--- a/tests/contrib/pymysql/test_pymysql.py
+++ b/tests/contrib/pymysql/test_pymysql.py
@@ -3,7 +3,7 @@ import pymysql
 
 from ddtrace.contrib.internal.pymysql.patch import patch
 from ddtrace.contrib.internal.pymysql.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib import shared_tests
 from tests.utils import TracerTestCase
 from tests.utils import assert_dict_issuperset

--- a/tests/contrib/pynamodb/test_pynamodb.py
+++ b/tests/contrib/pynamodb/test_pynamodb.py
@@ -6,7 +6,7 @@ import pytest
 
 from ddtrace.contrib.internal.pynamodb.patch import patch
 from ddtrace.contrib.internal.pynamodb.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 

--- a/tests/contrib/pyodbc/test_pyodbc.py
+++ b/tests/contrib/pyodbc/test_pyodbc.py
@@ -2,7 +2,7 @@ import pyodbc
 
 from ddtrace.contrib.internal.pyodbc.patch import patch
 from ddtrace.contrib.internal.pyodbc.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -8,7 +8,7 @@ import pytest
 from ddtrace import config
 from ddtrace.constants import _ORIGIN_KEY
 from ddtrace.constants import _SAMPLING_PRIORITY_KEY
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
 from tests.utils import TracerTestCase
 from tests.webclient import Client

--- a/tests/contrib/redis/test_redis_cluster.py
+++ b/tests/contrib/redis/test_redis_cluster.py
@@ -9,7 +9,7 @@ from ddtrace.contrib.internal.redis.patch import unpatch
 from ddtrace.contrib.internal.redis_utils import _build_tags
 from ddtrace.ext import net
 from ddtrace.internal.compat import PYTHON_VERSION_INFO
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib.config import REDISCLUSTER_CONFIG
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured

--- a/tests/contrib/redis/test_redis_cluster_asyncio.py
+++ b/tests/contrib/redis/test_redis_cluster_asyncio.py
@@ -246,7 +246,7 @@ def test_default_service_name_v1():
     import redis
 
     from ddtrace.contrib.internal.redis.patch import patch
-    from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+    from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
     from tests.contrib.config import REDISCLUSTER_CONFIG
     from tests.utils import TracerSpanContainer
     from tests.utils import scoped_tracer

--- a/tests/contrib/rediscluster/test.py
+++ b/tests/contrib/rediscluster/test.py
@@ -5,7 +5,7 @@ import rediscluster
 from ddtrace.contrib.internal.rediscluster.patch import REDISCLUSTER_VERSION
 from ddtrace.contrib.internal.rediscluster.patch import patch
 from ddtrace.contrib.internal.rediscluster.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib.config import REDISCLUSTER_CONFIG
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured

--- a/tests/contrib/requests/test_requests.py
+++ b/tests/contrib/requests/test_requests.py
@@ -16,7 +16,7 @@ from ddtrace.contrib.internal.requests.connection import _extract_query_string
 from ddtrace.contrib.internal.requests.patch import patch
 from ddtrace.contrib.internal.requests.patch import unpatch
 from ddtrace.ext import http
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 from tests.utils import assert_span_http_status_code

--- a/tests/contrib/sqlalchemy/test_mysql.py
+++ b/tests/contrib/sqlalchemy/test_mysql.py
@@ -3,7 +3,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import ProgrammingError
 
 from ddtrace.constants import ERROR_MSG
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 

--- a/tests/contrib/sqlite3/test_sqlite3.py
+++ b/tests/contrib/sqlite3/test_sqlite3.py
@@ -19,7 +19,7 @@ from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.internal.sqlite3.patch import TracedSQLiteCursor
 from ddtrace.contrib.internal.sqlite3.patch import patch
 from ddtrace.contrib.internal.sqlite3.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 from tests.utils import assert_is_not_measured

--- a/tests/contrib/tornado/test_tornado_web.py
+++ b/tests/contrib/tornado/test_tornado_web.py
@@ -4,7 +4,7 @@ from ddtrace.constants import _SAMPLING_PRIORITY_KEY
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import USER_KEEP
 from ddtrace.ext import http
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
 from tests.utils import assert_is_measured
 from tests.utils import assert_span_http_status_code

--- a/tests/contrib/urllib3/test_urllib3.py
+++ b/tests/contrib/urllib3/test_urllib3.py
@@ -10,7 +10,7 @@ from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.internal.urllib3.patch import patch
 from ddtrace.contrib.internal.urllib3.patch import unpatch
 from ddtrace.ext import http
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib.config import HTTPBIN_CONFIG
 from tests.utils import TracerTestCase
 from tests.utils import snapshot

--- a/tests/contrib/valkey/test_valkey.py
+++ b/tests/contrib/valkey/test_valkey.py
@@ -6,7 +6,7 @@ import valkey
 
 from ddtrace.contrib.internal.valkey.patch import patch
 from ddtrace.contrib.internal.valkey.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import snapshot
 

--- a/tests/contrib/valkey/test_valkey_cluster.py
+++ b/tests/contrib/valkey/test_valkey_cluster.py
@@ -3,7 +3,7 @@ import valkey
 
 from ddtrace.contrib.internal.valkey.patch import patch
 from ddtrace.contrib.internal.valkey.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib.config import VALKEY_CLUSTER_CONFIG
 from tests.contrib.redis.utils import find_redis_span
 from tests.utils import TracerTestCase

--- a/tests/contrib/valkey/test_valkey_cluster_asyncio.py
+++ b/tests/contrib/valkey/test_valkey_cluster_asyncio.py
@@ -175,7 +175,7 @@ def test_default_service_name_v1():
     import valkey
 
     from ddtrace.contrib.internal.valkey.patch import patch
-    from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+    from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
     from tests.contrib.config import VALKEY_CLUSTER_CONFIG
     from tests.utils import TracerSpanContainer
     from tests.utils import scoped_tracer

--- a/tests/contrib/vertica/test_vertica.py
+++ b/tests/contrib/vertica/test_vertica.py
@@ -7,7 +7,7 @@ from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.internal.vertica.patch import patch
 from ddtrace.contrib.internal.vertica.patch import unpatch
 from ddtrace.internal.compat import is_wrapted
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.settings._config import _deepmerge
 from tests.contrib.config import VERTICA_CONFIG
 from tests.utils import TracerSpanContainer

--- a/tests/internal/service_name/test_imports.py
+++ b/tests/internal/service_name/test_imports.py
@@ -3,12 +3,12 @@ import pytest
 
 @pytest.mark.subprocess(env=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
 def test_service_names_import_default():
-    from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
     from ddtrace.internal.schema import schematize_cache_operation
     from ddtrace.internal.schema import schematize_cloud_api_operation
     from ddtrace.internal.schema import schematize_database_operation
     from ddtrace.internal.schema import schematize_service_name
     from ddtrace.internal.schema import schematize_url_operation
+    from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
     from ddtrace.internal.schema.span_attribute_schema import cache_operation_v0
     from ddtrace.internal.schema.span_attribute_schema import cloud_api_operation_v0
     from ddtrace.internal.schema.span_attribute_schema import database_operation_v0
@@ -26,12 +26,12 @@ def test_service_names_import_default():
 
 @pytest.mark.subprocess(env=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
 def test_service_names_import_and_v0():
-    from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
     from ddtrace.internal.schema import schematize_cache_operation
     from ddtrace.internal.schema import schematize_cloud_api_operation
     from ddtrace.internal.schema import schematize_database_operation
     from ddtrace.internal.schema import schematize_service_name
     from ddtrace.internal.schema import schematize_url_operation
+    from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
     from ddtrace.internal.schema.span_attribute_schema import cache_operation_v0
     from ddtrace.internal.schema.span_attribute_schema import cloud_api_operation_v0
     from ddtrace.internal.schema.span_attribute_schema import database_operation_v0
@@ -52,12 +52,12 @@ def test_service_names_import_and_v0():
     parametrize={"DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED": ["False", "True"]},
 )
 def test_service_name_imports_v1():
-    from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
     from ddtrace.internal.schema import schematize_cache_operation
     from ddtrace.internal.schema import schematize_cloud_api_operation
     from ddtrace.internal.schema import schematize_database_operation
     from ddtrace.internal.schema import schematize_service_name
     from ddtrace.internal.schema import schematize_url_operation
+    from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
     from ddtrace.internal.schema.span_attribute_schema import cache_operation_v1
     from ddtrace.internal.schema.span_attribute_schema import cloud_api_operation_v1
     from ddtrace.internal.schema.span_attribute_schema import database_operation_v1
@@ -80,12 +80,12 @@ def test_service_name_import_with_client_service_names_enabled_v0():
     """
     Service name parameters are flipped when DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED is True for v0
     """
-    from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
     from ddtrace.internal.schema import schematize_cache_operation
     from ddtrace.internal.schema import schematize_cloud_api_operation
     from ddtrace.internal.schema import schematize_database_operation
     from ddtrace.internal.schema import schematize_service_name
     from ddtrace.internal.schema import schematize_url_operation
+    from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
     from ddtrace.internal.schema.span_attribute_schema import cache_operation_v0
     from ddtrace.internal.schema.span_attribute_schema import cloud_api_operation_v0
     from ddtrace.internal.schema.span_attribute_schema import database_operation_v0


### PR DESCRIPTION
This change eliminates 2500 import cycles by decoupling the default service named relied on by `ddtrace.settings` from the versioned `schematize_service_name` function definition relied on by most contribs.