### PR TITLE
fix(llmobs): coerce None tool-call arguments in openai streamed chunk reconstruction

### DIFF
--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -1143,7 +1143,9 @@ def openai_construct_tool_call_from_streamed_chunk(stored_tool_calls, tool_call_
     if function_call_chunk:
         if not stored_tool_calls:
             stored_tool_calls.append({"name": getattr(function_call_chunk, "name", ""), "arguments": ""})
-        stored_tool_calls[0]["arguments"] += getattr(function_call_chunk, "arguments", "")
+        # ``arguments`` may be present but None on OpenAI-compatible backends (e.g. DashScope),
+        # so coerce to "" — getattr's default only applies when the attribute is absent.
+        stored_tool_calls[0]["arguments"] += getattr(function_call_chunk, "arguments", "") or ""
         return
     if not tool_call_chunk:
         return
@@ -1171,9 +1173,9 @@ def openai_construct_tool_call_from_streamed_chunk(stored_tool_calls, tool_call_
         stored_tool_calls.append(call_dict)
         list_idx = -1
     if function_call:
-        stored_tool_calls[list_idx]["function"]["arguments"] += getattr(function_call, "arguments", "")
+        stored_tool_calls[list_idx]["function"]["arguments"] += getattr(function_call, "arguments", "") or ""
     elif custom_call:
-        stored_tool_calls[list_idx]["custom"]["input"] += getattr(custom_call, "input", "")
+        stored_tool_calls[list_idx]["custom"]["input"] += getattr(custom_call, "input", "") or ""
 
 
 def openai_construct_message_from_streamed_chunks(streamed_chunks: list[Any]) -> dict[str, Any]:

--- a/releasenotes/notes/fix-llmobs-openai-stream-none-tool-args-202bba261dd24460.yaml
+++ b/releasenotes/notes/fix-llmobs-openai-stream-none-tool-args-202bba261dd24460.yaml
@@ -3,5 +3,4 @@ fixes:
   - |
     LLM Observability: Resolves a ``TypeError`` raised during streamed tool-call reconstruction
     when an OpenAI-compatible backend (e.g. DashScope/Qwen) emits a tool-call delta with
-    ``function.arguments`` or ``custom.input`` set to ``None`` instead of ``""``. The ``None``
-    is now coerced to an empty string, so the span is no longer dropped for those responses.
+    ``function.arguments`` or ``custom.input`` set to ``None`` instead of ``""``.

--- a/releasenotes/notes/fix-llmobs-openai-stream-none-tool-args-202bba261dd24460.yaml
+++ b/releasenotes/notes/fix-llmobs-openai-stream-none-tool-args-202bba261dd24460.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    LLM Observability: Resolves a ``TypeError`` raised during streamed tool-call reconstruction
+    when an OpenAI-compatible backend (e.g. DashScope/Qwen) emits a tool-call delta with
+    ``function.arguments`` or ``custom.input`` set to ``None`` instead of ``""``. The ``None``
+    is now coerced to an empty string, so the span is no longer dropped for those responses.

--- a/tests/llmobs/test_integrations_utils.py
+++ b/tests/llmobs/test_integrations_utils.py
@@ -9,6 +9,7 @@ from ddtrace.llmobs._integrations.utils import _openai_parse_input_response_mess
 from ddtrace.llmobs._integrations.utils import audio_mime_type_from_format
 from ddtrace.llmobs._integrations.utils import format_audio_part
 from ddtrace.llmobs._integrations.utils import openai_construct_message_from_streamed_chunks
+from ddtrace.llmobs._integrations.utils import openai_construct_tool_call_from_streamed_chunk
 from ddtrace.llmobs._integrations.utils import openai_set_meta_tags_from_chat
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import get_llmobs_input_messages
@@ -492,3 +493,44 @@ class TestOpenAIConstructMessageFromStreamedChunks:
         message = openai_construct_message_from_streamed_chunks(chunks)
         assert message["reasoning_content"] == "r"
         assert message["content"] == "c"
+
+
+class TestOpenAIConstructToolCallFromStreamedChunk:
+    """OpenAI-compatible backends (e.g. DashScope/Qwen) may stream a tool-call delta with
+    ``function.arguments`` / ``custom.input`` set to ``None`` rather than ``""``. ``getattr``
+    returns that ``None`` (the default only applies when the attribute is absent), so the
+    ``str += None`` accumulation used to raise TypeError and drop the whole LLMObs span.
+    """
+
+    def test_function_call_chunk_with_none_arguments(self):
+        function_call = SimpleNamespace(name="get_weather", arguments=None)
+        stored = []
+        openai_construct_tool_call_from_streamed_chunk(stored, function_call_chunk=function_call)
+        assert stored[0]["arguments"] == ""
+
+    def test_tool_call_chunk_with_none_function_arguments(self):
+        function = SimpleNamespace(name="get_weather", arguments=None)
+        tool_call = SimpleNamespace(index=0, id="call_1", type="function", function=function, custom=None)
+        stored = []
+        openai_construct_tool_call_from_streamed_chunk(stored, tool_call_chunk=tool_call)
+        assert stored[0]["function"]["arguments"] == ""
+
+    def test_tool_call_chunk_with_none_custom_input(self):
+        custom = SimpleNamespace(name="my_tool", input=None)
+        tool_call = SimpleNamespace(index=0, id="call_2", type="custom", function=None, custom=custom)
+        stored = []
+        openai_construct_tool_call_from_streamed_chunk(stored, tool_call_chunk=tool_call)
+        assert stored[0]["custom"]["input"] == ""
+
+    def test_none_then_value_arguments_accumulate(self):
+        # DashScope emits arguments=None in the first tool-call delta, then the JSON in later deltas.
+        first = SimpleNamespace(name="get_weather", arguments=None)
+        later = SimpleNamespace(name=None, arguments='{"city": "NYC"}')
+        stored = []
+        openai_construct_tool_call_from_streamed_chunk(
+            stored, tool_call_chunk=SimpleNamespace(index=0, id="call_1", type="function", function=first, custom=None)
+        )
+        openai_construct_tool_call_from_streamed_chunk(
+            stored, tool_call_chunk=SimpleNamespace(index=0, id=None, type=None, function=later, custom=None)
+        )
+        assert stored[0]["function"]["arguments"] == '{"city": "NYC"}'


### PR DESCRIPTION
## Description

`openai_construct_tool_call_from_streamed_chunk` in `ddtrace/llmobs/_integrations/utils.py` raises `TypeError: can only concatenate str (not "NoneType") to str` when a streamed tool-call chunk has `function.arguments = None`.

`getattr(function_call, "arguments", "")` only returns the `""` default when the attribute is *absent*. OpenAI-compatible backends such as Alibaba DashScope (Qwen) stream the field *present but `null`*, so `getattr` returns `None` and `str += None` raises. This aborts stream reconstruction, the LLMObs span never gets its `kind` tag, and `_submit_llmobs_span` then raises `KeyError: 'Span kind not found in span context'` — the span is dropped for every streamed tool-call response.

Fix coerces `None` → `""` at the three concatenation sites in the function: the legacy `function_call` branch, the tool-call `function.arguments` branch, and the `custom.input` branch. Legitimate streamed values are strings, and the only falsey string (`""`) is already a no-op, so the coercion changes nothing for well-behaved backends.

Fixes #19031.

## Testing

Added `TestOpenAIConstructToolCallFromStreamedChunk` in `tests/llmobs/test_integrations_utils.py` covering the three `None` paths plus a `None`-then-value sequence (DashScope emits `arguments=null` in the first delta, then the JSON in later deltas) to confirm arguments still accumulate.

## Risks

None. The change only affects the `None` case that previously crashed.

## Additional Notes

None.

<!-- oss-radar:idempotency=auto-20260714-222233.w1.DataDog_dd-trace-py.19031 -->
