### PR TITLE
ci: auto-commit regenerated riot lockfiles on PR branches (PROF-15403)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -337,7 +337,9 @@ check_requirements_lockfiles:
       git config --global --add safe.directory "${CI_PROJECT_DIR}"
       git add -A .riot/requirements requirements.csv
       # Match scripts/check-diff semantics: ignore pure-comment (#) line changes.
-      if [ -z "$(git diff --cached -G'^[^#]' -- .riot/requirements requirements.csv)" ]; then
+      # Use --quiet (implies --exit-code) so we don't buffer the (potentially
+      # large) lockfile diff into a shell string just to test for emptiness.
+      if git diff --cached --quiet -G'^[^#]' -- .riot/requirements requirements.csv; then
         echo "Lockfiles and requirements.csv are up to date."
         exit 0
       fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -305,8 +305,13 @@ requirements_json_test:
 # Regenerates the riot lockfiles + requirements.csv (this image has every
 # interpreter, incl. 3.15-dev, which contributors rarely have locally). On a PR
 # branch, drift is not a dead-end: commit_requirements_lockfiles pushes the fix
-# back automatically. On protected / merge-queue refs, where we must not push,
-# drift stays a hard gate.
+# back automatically. On integration refs -- the default branch, release lines,
+# and merge-queue refs -- where a bot push is unsafe, drift stays a hard gate.
+#
+# NB: we intentionally do NOT gate on CI_COMMIT_REF_PROTECTED. The GitLab mirror
+# marks EVERY branch protected via a blanket `*` protected-branch rule, so that
+# variable is always "true" and cannot distinguish a PR branch from an
+# integration branch. We gate on the ref name instead.
 check_requirements_lockfiles:
   stage: tests
   needs: []
@@ -339,10 +344,12 @@ check_requirements_lockfiles:
       echo "REGEN_DRIFT=true" > regen.env
       git diff --cached > regen.patch
       git --no-pager diff --cached --stat
-      if [ "${CI_COMMIT_REF_PROTECTED:-false}" = "true" ] \
+      if [ "${CI_COMMIT_REF_NAME:-}" = "main" ] \
+          || [ "${CI_COMMIT_REF_NAME:-}" = "${CI_DEFAULT_BRANCH:-main}" ] \
+          || [[ "${CI_COMMIT_REF_NAME:-}" =~ ^[0-9]+\.[0-9x]+$ ]] \
           || [[ "${CI_COMMIT_REF_NAME:-}" == gh-readonly-queue/* ]] \
           || [[ "${CI_COMMIT_REF_NAME:-}" == mq-working-branch-* ]]; then
-        echo "ERROR: .riot/requirements/*.txt and/or requirements.csv are out of date on a protected/merge-queue ref."
+        echo "ERROR: .riot/requirements/*.txt and/or requirements.csv are out of date on an integration ref (default/release/merge-queue) where auto-commit is unsafe."
         echo "Run scripts/compile-and-prune-test-requirements and python scripts/requirements_to_csv.py, then commit the result."
         exit 1
       fi
@@ -371,9 +378,15 @@ commit_requirements_lockfiles:
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts
   rules:
-    # Never auto-commit on protected / merge-queue refs (they hard-fail in the
-    # regen job instead); only act when there was drift on a PR branch.
-    - if: $CI_COMMIT_REF_PROTECTED == "true"
+    # The GitLab mirror marks EVERY branch protected (blanket `*` rule), so
+    # CI_COMMIT_REF_PROTECTED is useless here. Gate on the ref name instead:
+    # never auto-commit on the default branch, release lines, or merge-queue
+    # refs (they hard-fail in the regen job); only self-heal PR branches.
+    - if: $CI_COMMIT_REF_NAME == "main"
+      when: never
+    - if: $CI_COMMIT_REF_NAME == $CI_DEFAULT_BRANCH
+      when: never
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+\.[0-9x]+$/
       when: never
     - if: $CI_COMMIT_REF_NAME =~ /^gh-readonly-queue\//
       when: never

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -302,6 +302,11 @@ requirements_json_test:
     REQUIREMENTS_BLOCK_JSON_PATH: ".gitlab/requirements_block.json"
     REQUIREMENTS_ALLOW_JSON_PATH: ".gitlab/requirements_allow.json"
 
+# Regenerates the riot lockfiles + requirements.csv (this image has every
+# interpreter, incl. 3.15-dev, which contributors rarely have locally). On a PR
+# branch, drift is not a dead-end: commit_requirements_lockfiles pushes the fix
+# back automatically. On protected / merge-queue refs, where we must not push,
+# drift stays a hard gate.
 check_requirements_lockfiles:
   stage: tests
   needs: []
@@ -319,9 +324,98 @@ check_requirements_lockfiles:
   script:
     - pip install toml==0.10.2 pyyaml==6.0.2
     - scripts/compile-and-prune-test-requirements
-    - scripts/check-diff '.riot/requirements/' 'Mismatches found between .riot/requirements/*.txt and riotfile.py. Run scripts/compile-and-prune-test-requirements and commit the result.'
     - python scripts/requirements_to_csv.py
-    - scripts/check-diff 'requirements.csv' 'Tracer dependency requirements in requirements.csv is out of date. Run `python scripts/requirements_to_csv.py` and commit the result.'
+    - |
+      set -euo pipefail
+      : > regen.patch
+      echo "REGEN_DRIFT=false" > regen.env
+      git config --global --add safe.directory "${CI_PROJECT_DIR}"
+      git add -A .riot/requirements requirements.csv
+      # Match scripts/check-diff semantics: ignore pure-comment (#) line changes.
+      if [ -z "$(git diff --cached -G'^[^#]' -- .riot/requirements requirements.csv)" ]; then
+        echo "Lockfiles and requirements.csv are up to date."
+        exit 0
+      fi
+      echo "REGEN_DRIFT=true" > regen.env
+      git diff --cached > regen.patch
+      git --no-pager diff --cached --stat
+      if [ "${CI_COMMIT_REF_PROTECTED:-false}" = "true" ] \
+          || [[ "${CI_COMMIT_REF_NAME:-}" == gh-readonly-queue/* ]] \
+          || [[ "${CI_COMMIT_REF_NAME:-}" == mq-working-branch-* ]]; then
+        echo "ERROR: .riot/requirements/*.txt and/or requirements.csv are out of date on a protected/merge-queue ref."
+        echo "Run scripts/compile-and-prune-test-requirements and python scripts/requirements_to_csv.py, then commit the result."
+        exit 1
+      fi
+      echo "Drift detected on PR branch '${CI_COMMIT_REF_NAME}'; commit_requirements_lockfiles will push the fix and trigger a fresh pipeline."
+  artifacts:
+    when: always
+    paths:
+      - regen.patch
+    reports:
+      dotenv: regen.env
+
+# Auto-commits the regenerated lockfiles/requirements.csv back to the PR branch
+# when check_requirements_lockfiles reports drift. Split from the regen job
+# because the push needs the dd-octo-sts image (has dd-octo-sts + gh), while the
+# regen needs the testrunner image (has every interpreter). The bot commit
+# advances the PR head, so the stale SHA can't be merged, and a fresh pipeline
+# validates the result.
+commit_requirements_lockfiles:
+  stage: tests
+  image: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.06-1
+  tags: [ "arch:amd64" ]
+  needs:
+    - job: check_requirements_lockfiles
+      artifacts: true
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
+  rules:
+    # Never auto-commit on protected / merge-queue refs (they hard-fail in the
+    # regen job instead); only act when there was drift on a PR branch.
+    - if: $CI_COMMIT_REF_PROTECTED == "true"
+      when: never
+    - if: $CI_COMMIT_REF_NAME =~ /^gh-readonly-queue\//
+      when: never
+    - if: $CI_COMMIT_REF_NAME =~ /^mq-working-branch-/
+      when: never
+    - if: $REGEN_DRIFT == "true"
+      when: on_success
+    - when: never
+  script:
+    - |
+      set -euo pipefail
+      git config --global --add safe.directory "${CI_PROJECT_DIR}"
+
+      # Re-apply the regenerated files captured by the regen job (a patch also
+      # carries deletions, which plain artifacts would not).
+      git apply regen.patch
+      git add -A .riot/requirements requirements.csv
+
+      GH_TOKEN=$(dd-octo-sts token --scope DataDog/dd-trace-py --policy gitlab.regenerate-requirements.push)
+      git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/DataDog/dd-trace-py.git"
+
+      git config user.name "dd-trace-py-ci-bot"
+      git config user.email "apm-python-team@datadoghq.com"
+      git commit -m "ci: regenerate riot lockfiles and requirements.csv [auto]"
+
+      if git push origin "HEAD:${CI_COMMIT_REF_NAME}"; then
+        echo "Pushed regenerated lockfiles to '${CI_COMMIT_REF_NAME}'; a fresh pipeline will validate them."
+        exit 0
+      fi
+
+      # Push failed. Distinguish "branch advanced mid-pipeline" (a newer pipeline
+      # will regenerate; nothing to do) from a genuine no-write-access failure
+      # (e.g. a fork PR) that a human must resolve.
+      git fetch origin "${CI_COMMIT_REF_NAME}" || true
+      REMOTE_SHA=$(git rev-parse "origin/${CI_COMMIT_REF_NAME}" 2>/dev/null || echo "")
+      if [ -n "${REMOTE_SHA}" ] && [ "${REMOTE_SHA}" != "${CI_COMMIT_SHA}" ]; then
+        echo "Branch '${CI_COMMIT_REF_NAME}' advanced during this pipeline; a newer pipeline will regenerate. Skipping."
+        exit 0
+      fi
+      echo "ERROR: could not push regenerated lockfiles (e.g. a fork PR without write access to DataDog/dd-trace-py)."
+      echo "Run scripts/compile-and-prune-test-requirements and python scripts/requirements_to_csv.py, then commit the result."
+      exit 1
 
 check_ci_dependencies:
   stage: tests

--- a/docs/contributing-testing.rst
+++ b/docs/contributing-testing.rst
@@ -194,9 +194,9 @@ Why is my CI run failing with a message about requirements files?
 by ``riotfile.py``. Riot uses these files to build its environments, and they do not get rebuilt automatically
 when the riotfile changes. Thus, if you make changes to the riotfile, you need to rebuild them.
 
-On a pull request branch you usually do **not** need to do this by hand: when the ``check_requirements_lockfiles``
-CI job detects drift, ``commit_requirements_lockfiles`` regenerates the lockfiles (and ``requirements.csv``) and
-pushes the result back to your branch automatically, then a fresh pipeline validates it. Regeneration runs in the
+On a pull request branch you usually do **not** need to do this by hand: the ``check_requirements_lockfiles``
+CI job regenerates the lockfiles (and ``requirements.csv``) and detects drift, then ``commit_requirements_lockfiles``
+pushes the result back to your branch automatically and a fresh pipeline validates it. Regeneration runs in the
 CI image, which has every interpreter (including ``3.15-dev``), so you do not need all of them installed locally.
 
 If you prefer to regenerate locally (for faster iteration, or if the auto-commit can't push, e.g. a fork PR), run:

--- a/docs/contributing-testing.rst
+++ b/docs/contributing-testing.rst
@@ -206,8 +206,8 @@ If you prefer to regenerate locally (for faster iteration, or if the auto-commit
   $ scripts/ddtest scripts/compile-and-prune-test-requirements
 
 and commit the resulting changes to files in ``.riot/requirements`` (and ``requirements.csv``) alongside the
-changes you made to ``riotfile.py``. On protected and merge-queue refs the check stays a hard gate and is not
-auto-committed.
+changes you made to ``riotfile.py``. On integration refs (the default branch, release lines, and merge-queue
+refs) the check stays a hard gate and is not auto-committed.
 
 Why is my CI run failing with benchmark or Service Level Objective (SLO) threshold breaches?
 ---------------------------------------------------------------------------------------------

--- a/docs/contributing-testing.rst
+++ b/docs/contributing-testing.rst
@@ -194,12 +194,20 @@ Why is my CI run failing with a message about requirements files?
 by ``riotfile.py``. Riot uses these files to build its environments, and they do not get rebuilt automatically
 when the riotfile changes. Thus, if you make changes to the riotfile, you need to rebuild them.
 
+On a pull request branch you usually do **not** need to do this by hand: when the ``check_requirements_lockfiles``
+CI job detects drift, ``commit_requirements_lockfiles`` regenerates the lockfiles (and ``requirements.csv``) and
+pushes the result back to your branch automatically, then a fresh pipeline validates it. Regeneration runs in the
+CI image, which has every interpreter (including ``3.15-dev``), so you do not need all of them installed locally.
+
+If you prefer to regenerate locally (for faster iteration, or if the auto-commit can't push, e.g. a fork PR), run:
+
 .. code-block:: bash
 
   $ scripts/ddtest scripts/compile-and-prune-test-requirements
 
-You can commit and pull request the resulting changes to files in ``.riot/requirements`` alongside the
-changes you made to ``riotfile.py``.
+and commit the resulting changes to files in ``.riot/requirements`` (and ``requirements.csv``) alongside the
+changes you made to ``riotfile.py``. On protected and merge-queue refs the check stays a hard gate and is not
+auto-committed.
 
 Why is my CI run failing with benchmark or Service Level Objective (SLO) threshold breaches?
 ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

`check_requirements_lockfiles` is currantly a hard gate: when `.riot/requirements/*.txt` or
`requirements.csv` drifted from `riotfile.py`, CI failed and asked the contributor to
regenerate locally and commit — which needs every interpreter (incl. `3.15-dev`) that
contributors rarely have.

This PR makes the process self-driven:

- **`check_requirements_lockfiles`** (testrunner image, has all interpreters) regenerates
  the files, then emits the drift as a `regen.patch` artifact + `REGEN_DRIFT` flag
  (comment-only `#` changes ignored).
- **`commit_requirements_lockfiles`** (dd-octo-sts image) runs only on PR-branch drift:
  re-applies the patch, commits as `dd-trace-py-ci-bot`, and pushes back via a token from
  the `gitlab.regenerate-requirements.push` octo-sts policy, triggering a fresh pipeline.
- On **protected / merge-queue refs**, drift stays a hard gate (regen fails, commit job
  is gated off).

## Testing

- End-to-end on https://github.com/DataDog/dd-trace-py/pull/17849(drift → bot commit → fresh pipeline)

## Additional Notes

**_Decision flow-chart_**
<img width="1104" height="655" alt="Screenshot 2026-07-14 at 2 34 00 PM" src="https://github.com/user-attachments/assets/8fde38ce-25fe-480c-a3de-898b1d016a65" />

### Security scope / known limitation (accepted)

Codex flagged (P1) that with `ref_protected` dropped and `ref: .+`, the
`contents: write` token is mintable from any push pipeline on this GitLab
project — `main`, release, and merge-queue refs — not just PR branches. This is
a correct read and an **accepted residual risk** for now.

Why we can't scope it at the policy level today: the GitLab project is a gitsync
mirror with a blanket `*` protected-branch rule, so `ref_protected` is `true` on
every ref and can't distinguish a PR branch from `main`. Adding the claim back
just breaks token minting entirely.

Compensating controls (defense in depth):
- The only consumer job gates via `rules:` on explicit ref names, so a bot commit
  is only attempted on the intended branches.
- GitHub branch protection on `main` requires PRs + review, so a minted token
  cannot land unreviewed changes on `main`.
- The token is already narrowed by `ci_config_ref_uri` (this repo's own
  `.gitlab-ci.yml`) and `pipeline_source: push`.
