### PR TITLE
refactor: factor out is_user_provided_service to break cyclic import between config and process_tags

### DIFF
--- a/ddtrace/internal/core/__init__.py
+++ b/ddtrace/internal/core/__init__.py
@@ -119,6 +119,7 @@ after the ``with`` block exits. For example::
         return future
 """
 
+import contextvars
 import logging
 import types
 import typing
@@ -135,12 +136,6 @@ from .event_hub import has_listeners  # noqa:F401
 from .event_hub import on  # noqa:F401
 from .event_hub import reset as reset_listeners  # noqa:F401
 from .events import EventType
-
-
-if typing.TYPE_CHECKING:
-    from ddtrace._trace.span import Span  # noqa:F401
-
-import contextvars
 
 
 _MISSING = object()
@@ -180,7 +175,7 @@ class ExecutionContext(Generic[EventType]):
         self._suppress_exceptions: list[type] = []
         self._data.update(kwargs)
         self._parent: Optional["ExecutionContext"] = parent
-        self._inner_span: Optional["Span"] = None
+        self._inner_span: Optional[Any] = None
         self._token: Optional[contextvars.Token["ExecutionContext"]] = None
         self._dispatch_end_event: bool = dispatch_end_event
         self._end_event_dispatched: bool = False
@@ -324,7 +319,7 @@ class ExecutionContext(Generic[EventType]):
         return current
 
     @property
-    def span(self) -> "Span":
+    def span(self) -> Any:
         if self._inner_span is None:
             log.warning(
                 "No span found in %s. "
@@ -336,7 +331,7 @@ class ExecutionContext(Generic[EventType]):
         return self._inner_span
 
     @span.setter
-    def span(self, value: "Span") -> None:
+    def span(self, value: Any) -> None:
         self._inner_span = value
         if "span_key" in self._data:
             self._data[self._data["span_key"]] = value
@@ -428,7 +423,7 @@ def discard_local_item(data_key: str) -> None:
     _CURRENT_CONTEXT.get().discard_local_item(data_key)
 
 
-def get_span() -> Optional["Span"]:
+def get_span() -> Optional[Any]:
     current: Optional[ExecutionContext] = _CURRENT_CONTEXT.get()
     while current is not None:
         if current._inner_span is not None:
@@ -437,7 +432,7 @@ def get_span() -> Optional["Span"]:
     return None
 
 
-def get_root_span() -> Optional["Span"]:
+def get_root_span() -> Optional[Any]:
     span = get_span()
     if span is None:
         return None if tracer is None else tracer.current_root_span()

--- a/ddtrace/internal/core/__init__.py
+++ b/ddtrace/internal/core/__init__.py
@@ -122,7 +122,6 @@ after the ``with`` block exits. For example::
 import contextvars
 import logging
 import types
-import typing
 from typing import Any  # noqa:F401
 from typing import Generic
 from typing import Optional  # noqa:F401

--- a/ddtrace/internal/getconfig.py
+++ b/ddtrace/internal/getconfig.py
@@ -20,7 +20,7 @@ def get_config(
     default: t.Any = None,
     modifier: t.Optional[t.Callable[[t.Any], t.Any]] = None,
     otel_env: t.Optional[str] = None,
-    report_telemetry=True,
+    report_telemetry: bool = True,
 ) -> t.Any:
     """Retrieve a configuration value in order of precedence:
     1. Fleet stable config (highest)
@@ -105,7 +105,7 @@ def get_config(
     return effective_val
 
 
-def _invalid_otel_config(otel_env):
+def _invalid_otel_config(otel_env: str) -> None:
     log.warning(
         "Setting %s to %s is not supported by ddtrace, this configuration will be ignored.",
         otel_env,
@@ -122,7 +122,7 @@ def _invalid_otel_config(otel_env):
     )
 
 
-def _hiding_otel_config(otel_env, dd_env):
+def _hiding_otel_config(otel_env: str, dd_env: str) -> None:
     log.debug(
         "Datadog configuration %s is already set. OpenTelemetry configuration will be ignored: %s=%s",
         dd_env,

--- a/ddtrace/internal/getconfig.py
+++ b/ddtrace/internal/getconfig.py
@@ -1,0 +1,140 @@
+import typing as t
+
+from ddtrace.internal import core
+from ddtrace.internal.logger import get_logger
+from ddtrace.internal.settings import env
+from ddtrace.internal.settings._core import FLEET_CONFIG
+from ddtrace.internal.settings._core import FLEET_CONFIG_IDS
+from ddtrace.internal.settings._core import LOCAL_CONFIG
+from ddtrace.internal.settings._otel_remapper import parse_otel_env
+from ddtrace.internal.settings._supported_configurations import CONFIGURATION_ALIASES
+from ddtrace.internal.settings._supported_configurations import SENSITIVE_CONFIGURATIONS
+from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
+
+
+log = get_logger(__name__)
+
+
+def get_config(
+    envs: t.Union[str, list[str]],
+    default: t.Any = None,
+    modifier: t.Optional[t.Callable[[t.Any], t.Any]] = None,
+    otel_env: t.Optional[str] = None,
+    report_telemetry=True,
+) -> t.Any:
+    """Retrieve a configuration value in order of precedence:
+    1. Fleet stable config (highest)
+    2. Datadog env vars
+    3. OpenTelemetry env vars
+    4. Local stable config
+    5. Default value (lowest)
+
+    Reports telemetry for every detected configuration source.
+    """
+    if isinstance(envs, str):
+        envs = [envs]
+
+    # Expand with registered aliases of the canonical name (envs[0]) so all
+    # config sources (LOCAL_CONFIG, env, FLEET_CONFIG) honor legacy renames.
+    canonical = envs[0]
+    aliases = CONFIGURATION_ALIASES.get(canonical, [])
+    if aliases:
+        envs += [a for a in aliases if a not in envs]
+
+    effective_val = default
+    telemetry_name = envs[0]
+    # Configurations marked ``sensitive: true`` in the registry are excluded from
+    # configuration telemetry, regardless of which source supplies the value.
+    if telemetry_name in SENSITIVE_CONFIGURATIONS:
+        report_telemetry = False
+    if report_telemetry:
+        core.dispatch("telemetry.add_configuration", (telemetry_name, default, "default"))
+
+    for env_name in envs:
+        if env_name in LOCAL_CONFIG:
+            val = LOCAL_CONFIG[env_name]
+            if modifier:
+                val = modifier(val)
+
+            if report_telemetry:
+                core.dispatch("telemetry.add_configuration", (telemetry_name, val, "local_stable_config"))
+            effective_val = val
+            break
+
+    if otel_env is not None and otel_env in env:
+        raw_val, parsed_val = parse_otel_env(otel_env)
+        if parsed_val is not None:
+            val = parsed_val
+            if modifier:
+                val = modifier(val)
+
+            if report_telemetry:
+                # OpenTelemetry configurations always report the raw value
+                core.dispatch("telemetry.add_configuration", (telemetry_name, raw_val, "otel_env_var"))
+            effective_val = val
+        else:
+            _invalid_otel_config(otel_env)
+
+    for env_name in envs:
+        if env_name in env:
+            val = env[env_name]
+            if modifier:
+                val = modifier(val)
+
+            if report_telemetry:
+                core.dispatch("telemetry.add_configuration", (telemetry_name, val, "env_var"))
+                if otel_env is not None and otel_env in env:
+                    _hiding_otel_config(otel_env, env_name)
+            effective_val = val
+            break
+
+    for env_name in envs:
+        if env_name in FLEET_CONFIG:
+            val = FLEET_CONFIG[env_name]
+            config_id = FLEET_CONFIG_IDS.get(env_name)
+            if modifier:
+                val = modifier(val)
+
+            if report_telemetry:
+                core.dispatch("telemetry.add_configuration", (telemetry_name, val, "fleet_stable_config", config_id))
+                if otel_env is not None and otel_env in env:
+                    _hiding_otel_config(otel_env, env_name)
+            effective_val = val
+            break
+
+    return effective_val
+
+
+def _invalid_otel_config(otel_env):
+    log.warning(
+        "Setting %s to %s is not supported by ddtrace, this configuration will be ignored.",
+        otel_env,
+        env.get(otel_env, ""),
+    )
+    core.dispatch(
+        "telemetry.add_count_metric",
+        (
+            TELEMETRY_NAMESPACE.TRACERS,
+            "otel.env.invalid",
+            1,
+            (("config_opentelemetry", otel_env.lower()),),
+        ),
+    )
+
+
+def _hiding_otel_config(otel_env, dd_env):
+    log.debug(
+        "Datadog configuration %s is already set. OpenTelemetry configuration will be ignored: %s=%s",
+        dd_env,
+        otel_env,
+        env[otel_env],
+    )
+    core.dispatch(
+        "telemetry.add_count_metric",
+        (
+            TELEMETRY_NAMESPACE.TRACERS,
+            "otel.env.hiding",
+            1,
+            (("config_opentelemetry", otel_env.lower()), ("config_datadog", dd_env.lower())),
+        ),
+    )

--- a/ddtrace/internal/process_tags/__init__.py
+++ b/ddtrace/internal/process_tags/__init__.py
@@ -109,7 +109,6 @@ def generate_process_tags() -> tuple[Optional[str], Optional[list[str]]]:
     if not process_tags_config.enabled:
         return None, None
 
-    # from ddtrace import config as ddtrace_config
     from ddtrace.internal.settings._inferred_base_service import detect_service
 
     tag_definitions = [
@@ -117,12 +116,12 @@ def generate_process_tags() -> tuple[Optional[str], Optional[list[str]]]:
         (ENTRYPOINT_BASEDIR_TAG, lambda: Path(sys.argv[0]).resolve().parent.name),
         (ENTRYPOINT_NAME_TAG, _get_entrypoint_name),
         (ENTRYPOINT_TYPE_TAG, _get_entrypoint_type),
-        (SVC_USER_TAG, lambda: "true" if user_service.is_user_provided_service else None),
+        (SVC_USER_TAG, lambda: "true" if user_service.is_user_provided_service() else None),
         (
             SVC_AUTO_TAG,
             lambda: (
                 (detect_service(sys.argv) or _get_entrypoint_name())
-                if not user_service.is_user_provided_service
+                if not user_service.is_user_provided_service()
                 else None
             ),
         ),

--- a/ddtrace/internal/process_tags/__init__.py
+++ b/ddtrace/internal/process_tags/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 from typing import Callable
 from typing import Optional
 
+from ddtrace.internal import user_service
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings.process_tags import process_tags_config
 from ddtrace.internal.utils.fnv import fnv1_64
@@ -108,7 +109,7 @@ def generate_process_tags() -> tuple[Optional[str], Optional[list[str]]]:
     if not process_tags_config.enabled:
         return None, None
 
-    from ddtrace import config as ddtrace_config
+    # from ddtrace import config as ddtrace_config
     from ddtrace.internal.settings._inferred_base_service import detect_service
 
     tag_definitions = [
@@ -116,12 +117,14 @@ def generate_process_tags() -> tuple[Optional[str], Optional[list[str]]]:
         (ENTRYPOINT_BASEDIR_TAG, lambda: Path(sys.argv[0]).resolve().parent.name),
         (ENTRYPOINT_NAME_TAG, _get_entrypoint_name),
         (ENTRYPOINT_TYPE_TAG, _get_entrypoint_type),
-        (SVC_USER_TAG, lambda: "true" if ddtrace_config._is_user_provided_service else None),
+        (SVC_USER_TAG, lambda: "true" if user_service.is_user_provided_service else None),
         (
             SVC_AUTO_TAG,
-            lambda: (detect_service(sys.argv) or _get_entrypoint_name())
-            if not ddtrace_config._is_user_provided_service
-            else None,
+            lambda: (
+                (detect_service(sys.argv) or _get_entrypoint_name())
+                if not user_service.is_user_provided_service
+                else None
+            ),
         ),
     ]
 

--- a/ddtrace/internal/settings/_config.py
+++ b/ddtrace/internal/settings/_config.py
@@ -523,7 +523,7 @@ class Config(object):
         self.env = _get_config("DD_ENV", self.tags.get("env"))
         self.service = _get_config("DD_SERVICE", self.tags.get("service", None), otel_env="OTEL_SERVICE_NAME")
 
-        self._is_user_provided_service = user_service.is_user_provided_service
+        self._is_user_provided_service = user_service.is_user_provided_service()
 
         self._inferred_base_service = detect_service(sys.argv)
 

--- a/ddtrace/internal/settings/_config.py
+++ b/ddtrace/internal/settings/_config.py
@@ -10,6 +10,7 @@ from typing import Optional  # noqa:F401
 from typing import Union  # noqa:F401
 
 from ddtrace.internal import gitmetadata
+from ddtrace.internal import user_service
 from ddtrace.internal.constants import _PROPAGATION_BEHAVIOR_DEFAULT
 from ddtrace.internal.constants import _PROPAGATION_BEHAVIOR_IGNORE
 from ddtrace.internal.constants import _PROPAGATION_STYLE_DEFAULT
@@ -522,7 +523,7 @@ class Config(object):
         self.env = _get_config("DD_ENV", self.tags.get("env"))
         self.service = _get_config("DD_SERVICE", self.tags.get("service", None), otel_env="OTEL_SERVICE_NAME")
 
-        self._is_user_provided_service = self.service is not None
+        self._is_user_provided_service = user_service.is_user_provided_service
 
         self._inferred_base_service = detect_service(sys.argv)
 

--- a/ddtrace/internal/settings/_config.py
+++ b/ddtrace/internal/settings/_config.py
@@ -24,6 +24,7 @@ from ddtrace.internal.constants import DEFAULT_TIMEOUT
 from ddtrace.internal.constants import PROPAGATION_STYLE_ALL
 from ddtrace.internal.evp_proxy.constants import DEFAULT_EVP_EVENT_SIZE_LIMIT
 from ddtrace.internal.evp_proxy.constants import DEFAULT_EVP_PAYLOAD_SIZE_LIMIT
+from ddtrace.internal.getconfig import get_config as _get_config
 from ddtrace.internal.logger import get_log_injection_state
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.native import config as _native_config
@@ -32,7 +33,6 @@ from ddtrace.internal.serverless import in_aws_lambda
 from ddtrace.internal.serverless import in_azure_function
 from ddtrace.internal.serverless import in_gcp_function
 from ddtrace.internal.settings import env
-from ddtrace.internal.telemetry import get_config as _get_config
 from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry import validate_and_report_otel_metrics_exporter_enabled
 from ddtrace.internal.telemetry import validate_otel_envs

--- a/ddtrace/internal/telemetry/__init__.py
+++ b/ddtrace/internal/telemetry/__init__.py
@@ -4,19 +4,15 @@ This is normally started automatically when ``ddtrace`` is imported. It can be d
 ``DD_INSTRUMENTATION_TELEMETRY_ENABLED`` variable to ``False``.
 """
 
-import typing as t
-
+from ddtrace.internal import core
+from ddtrace.internal.getconfig import _invalid_otel_config
+from ddtrace.internal.getconfig import get_config
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings import env
 from ddtrace.internal.settings._agent import config as agent_config
-from ddtrace.internal.settings._core import FLEET_CONFIG
-from ddtrace.internal.settings._core import FLEET_CONFIG_IDS
-from ddtrace.internal.settings._core import LOCAL_CONFIG
 from ddtrace.internal.settings._core import DDConfig
 from ddtrace.internal.settings._otel_remapper import ENV_VAR_MAPPINGS
 from ddtrace.internal.settings._otel_remapper import SUPPORTED_OTEL_ENV_VARS
-from ddtrace.internal.settings._otel_remapper import parse_otel_env
-from ddtrace.internal.settings._supported_configurations import CONFIGURATION_ALIASES
 from ddtrace.internal.settings._supported_configurations import SENSITIVE_CONFIGURATIONS
 from ddtrace.internal.settings.process_tags import process_tags_config
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
@@ -28,94 +24,16 @@ log = get_logger(__name__)
 __all__ = ["telemetry_writer"]
 
 
-def get_config(
-    envs: t.Union[str, list[str]],
-    default: t.Any = None,
-    modifier: t.Optional[t.Callable[[t.Any], t.Any]] = None,
-    otel_env: t.Optional[str] = None,
-    report_telemetry=True,
-) -> t.Any:
-    """Retrieve a configuration value in order of precedence:
-    1. Fleet stable config (highest)
-    2. Datadog env vars
-    3. OpenTelemetry env vars
-    4. Local stable config
-    5. Default value (lowest)
+def _add_conf(*args):
+    telemetry_writer.add_configuration(*args)
 
-    Reports telemetry for every detected configuration source.
-    """
-    if isinstance(envs, str):
-        envs = [envs]
 
-    # Expand with registered aliases of the canonical name (envs[0]) so all
-    # config sources (LOCAL_CONFIG, env, FLEET_CONFIG) honor legacy renames.
-    canonical = envs[0]
-    aliases = CONFIGURATION_ALIASES.get(canonical, [])
-    if aliases:
-        envs += [a for a in aliases if a not in envs]
+def _add_count(*args):
+    telemetry_writer.add_count_metric(*args)
 
-    effective_val = default
-    telemetry_name = envs[0]
-    # Configurations marked ``sensitive: true`` in the registry are excluded from
-    # configuration telemetry, regardless of which source supplies the value.
-    if telemetry_name in SENSITIVE_CONFIGURATIONS:
-        report_telemetry = False
-    if report_telemetry:
-        telemetry_writer.add_configuration(telemetry_name, default, "default")
 
-    for env_name in envs:
-        if env_name in LOCAL_CONFIG:
-            val = LOCAL_CONFIG[env_name]
-            if modifier:
-                val = modifier(val)
-
-            if report_telemetry:
-                telemetry_writer.add_configuration(telemetry_name, val, "local_stable_config")
-            effective_val = val
-            break
-
-    if otel_env is not None and otel_env in env:
-        raw_val, parsed_val = parse_otel_env(otel_env)
-        if parsed_val is not None:
-            val = parsed_val
-            if modifier:
-                val = modifier(val)
-
-            if report_telemetry:
-                # OpenTelemetry configurations always report the raw value
-                telemetry_writer.add_configuration(telemetry_name, raw_val, "otel_env_var")
-            effective_val = val
-        else:
-            _invalid_otel_config(otel_env)
-
-    for env_name in envs:
-        if env_name in env:
-            val = env[env_name]
-            if modifier:
-                val = modifier(val)
-
-            if report_telemetry:
-                telemetry_writer.add_configuration(telemetry_name, val, "env_var")
-                if otel_env is not None and otel_env in env:
-                    _hiding_otel_config(otel_env, env_name)
-            effective_val = val
-            break
-
-    for env_name in envs:
-        if env_name in FLEET_CONFIG:
-            val = FLEET_CONFIG[env_name]
-            config_id = FLEET_CONFIG_IDS.get(env_name)
-            if modifier:
-                val = modifier(val)
-
-            if report_telemetry:
-                telemetry_writer.add_configuration(telemetry_name, val, "fleet_stable_config", config_id)
-                if otel_env is not None and otel_env in env:
-                    _hiding_otel_config(otel_env, env_name)
-            effective_val = val
-            break
-
-    return effective_val
+core.on("telemetry.add_configuration", _add_conf)
+core.on("telemetry.add_count_metric", _add_count)
 
 
 telemetry_enabled = get_config("DD_INSTRUMENTATION_TELEMETRY_ENABLED", True, asbool, report_telemetry=False)
@@ -144,30 +62,21 @@ def report_configuration(config: DDConfig) -> None:
         for p in name.split("."):
             env_val = getattr(env_val, p)
 
-        telemetry_writer.add_configuration(env_name, env_val, config.value_source(env_name), config.config_id)
-
-
-def _invalid_otel_config(otel_env):
-    log.warning(
-        "Setting %s to %s is not supported by ddtrace, this configuration will be ignored.",
-        otel_env,
-        env.get(otel_env, ""),
-    )
-    telemetry_writer.add_count_metric(
-        TELEMETRY_NAMESPACE.TRACERS,
-        "otel.env.invalid",
-        1,
-        (("config_opentelemetry", otel_env.lower()),),
-    )
+        core.dispatch(
+            "telemetry.add_configuration", (env_name, env_val, config.value_source(env_name), config.config_id)
+        )
 
 
 def _unsupported_otel_config(otel_env):
     log.warning("OpenTelemetry configuration %s is not supported by Datadog.", otel_env)
-    telemetry_writer.add_count_metric(
-        TELEMETRY_NAMESPACE.TRACERS,
-        "otel.env.unsupported",
-        1,
-        (("config_opentelemetry", otel_env.lower()),),
+    core.dispatch(
+        "telemetry.add_count_metric",
+        (
+            TELEMETRY_NAMESPACE.TRACERS,
+            "otel.env.unsupported",
+            1,
+            (("config_opentelemetry", otel_env.lower()),),
+        ),
     )
 
 
@@ -185,8 +94,7 @@ def validate_otel_envs():
             otel_value = env.get(otel_env, "none").lower()
             if otel_value != "none":
                 _invalid_otel_config(otel_env)
-            # TODO: Separate from validation
-            telemetry_writer.add_configuration(otel_env, otel_value, "env_var")
+            core.dispatch("telemetry.add_configuration", (otel_env, otel_value, "env_var"))
         elif otel_env == "OTEL_METRICS_EXPORTER":
             # defer validation to validate_and_report_otel_metrics_exporter_enabled
             pass
@@ -202,25 +110,9 @@ def validate_and_report_otel_metrics_exporter_enabled():
         elif otel_value != "otlp":
             _invalid_otel_config("OTEL_METRICS_EXPORTER")
 
-        # Report to configuration telemetry
-        telemetry_writer.add_configuration("OTEL_METRICS_EXPORTER", otel_value, "env_var")
+        core.dispatch("telemetry.add_configuration", ("OTEL_METRICS_EXPORTER", otel_value, "env_var"))
 
     return metrics_exporter_enabled
-
-
-def _hiding_otel_config(otel_env, dd_env):
-    log.debug(
-        "Datadog configuration %s is already set. OpenTelemetry configuration will be ignored: %s=%s",
-        dd_env,
-        otel_env,
-        env[otel_env],
-    )
-    telemetry_writer.add_count_metric(
-        TELEMETRY_NAMESPACE.TRACERS,
-        "otel.env.hiding",
-        1,
-        (("config_opentelemetry", otel_env.lower()), ("config_datadog", dd_env.lower())),
-    )
 
 
 # TODO: Remove this once the telemetry feature is refactored to a better design

--- a/ddtrace/internal/user_service.py
+++ b/ddtrace/internal/user_service.py
@@ -2,9 +2,10 @@ from ddtrace.internal.telemetry import get_config as _get_config
 from ddtrace.internal.utils.formats import parse_tags_str
 
 
-service = _get_config("DD_SERVICE")
-if not service:
-    service = parse_tags_str(_get_config("DD_TAGS"))["service"]
-if not service:
-    service = _get_config("OTEL_SERVICE_NAME")
-is_user_provided_service = service is not None
+def is_user_provided_service() -> bool:
+    service = _get_config("DD_SERVICE")
+    if not service:
+        service = parse_tags_str(_get_config("DD_TAGS"))["service"]
+    if not service:
+        service = _get_config("OTEL_SERVICE_NAME")
+    return service is not None

--- a/ddtrace/internal/user_service.py
+++ b/ddtrace/internal/user_service.py
@@ -1,0 +1,10 @@
+from ddtrace.internal.telemetry import get_config as _get_config
+from ddtrace.internal.utils.formats import parse_tags_str
+
+
+service = _get_config("DD_SERVICE")
+if not service:
+    service = parse_tags_str(_get_config("DD_TAGS"))["service"]
+if not service:
+    service = _get_config("OTEL_SERVICE_NAME")
+is_user_provided_service = service is not None

--- a/ddtrace/internal/user_service.py
+++ b/ddtrace/internal/user_service.py
@@ -1,11 +1,15 @@
 from ddtrace.internal.getconfig import get_config
+from ddtrace.internal.utils.cache import cached
 from ddtrace.internal.utils.formats import parse_tags_str
 
 
+@cached()
 def is_user_provided_service() -> bool:
-    service = get_config(
-        "DD_SERVICE",
-        parse_tags_str(get_config("DD_TAGS", otel_env="OTEL_RESOURCE_ATTRIBUTES")).get("service"),
-        otel_env="OTEL_SERVICE_NAME",
+    return (
+        get_config(
+            "DD_SERVICE",
+            parse_tags_str(get_config("DD_TAGS", otel_env="OTEL_RESOURCE_ATTRIBUTES")).get("service"),
+            otel_env="OTEL_SERVICE_NAME",
+        )
+        is not None
     )
-    return service is not None

--- a/ddtrace/internal/user_service.py
+++ b/ddtrace/internal/user_service.py
@@ -1,11 +1,11 @@
-from ddtrace.internal.telemetry import get_config as _get_config
+from ddtrace.internal.getconfig import get_config
 from ddtrace.internal.utils.formats import parse_tags_str
 
 
 def is_user_provided_service() -> bool:
-    service = _get_config("DD_SERVICE")
+    service = get_config("DD_SERVICE")
     if not service:
-        service = parse_tags_str(_get_config("DD_TAGS")).get("service")
+        service = parse_tags_str(get_config("DD_TAGS")).get("service")
     if not service:
-        service = _get_config("OTEL_SERVICE_NAME")
+        service = get_config("OTEL_SERVICE_NAME")
     return service is not None

--- a/ddtrace/internal/user_service.py
+++ b/ddtrace/internal/user_service.py
@@ -5,7 +5,7 @@ from ddtrace.internal.utils.formats import parse_tags_str
 def is_user_provided_service() -> bool:
     service = _get_config("DD_SERVICE")
     if not service:
-        service = parse_tags_str(_get_config("DD_TAGS"))["service"]
+        service = parse_tags_str(_get_config("DD_TAGS")).get("service")
     if not service:
         service = _get_config("OTEL_SERVICE_NAME")
     return service is not None

--- a/ddtrace/internal/user_service.py
+++ b/ddtrace/internal/user_service.py
@@ -3,9 +3,9 @@ from ddtrace.internal.utils.formats import parse_tags_str
 
 
 def is_user_provided_service() -> bool:
-    service = get_config("DD_SERVICE")
-    if not service:
-        service = parse_tags_str(get_config("DD_TAGS")).get("service")
-    if not service:
-        service = get_config("OTEL_SERVICE_NAME")
+    service = get_config(
+        "DD_SERVICE",
+        parse_tags_str(get_config("DD_TAGS", otel_env="OTEL_RESOURCE_ATTRIBUTES")).get("service"),
+        otel_env="OTEL_SERVICE_NAME",
+    )
     return service is not None

--- a/tests/internal/test_env.py
+++ b/tests/internal/test_env.py
@@ -184,27 +184,27 @@ def test_contains_false_when_neither_canonical_nor_alias_set(monkeypatch):
 
 
 def test_get_config_falls_back_to_alias_in_local_config(monkeypatch):
-    from ddtrace.internal import telemetry as telemetry_mod
+    from ddtrace.internal import getconfig as config_mod
 
     canonical, legacy = _pick_alias_pair()
     monkeypatch.delenv(canonical, raising=False)
     monkeypatch.delenv(legacy, raising=False)
-    monkeypatch.setattr(telemetry_mod, "LOCAL_CONFIG", {legacy: "from-local"})
-    monkeypatch.setattr(telemetry_mod, "FLEET_CONFIG", {})
+    monkeypatch.setattr(config_mod, "LOCAL_CONFIG", {legacy: "from-local"})
+    monkeypatch.setattr(config_mod, "FLEET_CONFIG", {})
 
-    val = telemetry_mod.get_config(canonical, default=None, report_telemetry=False)
+    val = config_mod.get_config(canonical, default=None, report_telemetry=False)
     assert val == "from-local"
 
 
 def test_get_config_falls_back_to_alias_in_fleet_config(monkeypatch):
-    from ddtrace.internal import telemetry as telemetry_mod
+    from ddtrace.internal import getconfig as config_mod
 
     canonical, legacy = _pick_alias_pair()
     monkeypatch.delenv(canonical, raising=False)
     monkeypatch.delenv(legacy, raising=False)
-    monkeypatch.setattr(telemetry_mod, "LOCAL_CONFIG", {})
-    monkeypatch.setattr(telemetry_mod, "FLEET_CONFIG", {legacy: "from-fleet"})
-    monkeypatch.setattr(telemetry_mod, "FLEET_CONFIG_IDS", {})
+    monkeypatch.setattr(config_mod, "LOCAL_CONFIG", {})
+    monkeypatch.setattr(config_mod, "FLEET_CONFIG", {legacy: "from-fleet"})
+    monkeypatch.setattr(config_mod, "FLEET_CONFIG_IDS", {})
 
-    val = telemetry_mod.get_config(canonical, default=None, report_telemetry=False)
+    val = config_mod.get_config(canonical, default=None, report_telemetry=False)
     assert val == "from-fleet"


### PR DESCRIPTION
This change moves `is_user_provided_service` to its own loosely-coupled module, allowing both `process_tags` and `settings._config` to depend on it instead of each other. This reduces the number of import cycles in the library by about 2400.

Making this change required separating the concerns of resolving configurations and reporting them via the TelemetryWriter, which was accomplished using the API at `ddtrace.internal.core`.

Making **that** change required removing the import cycle present between `ddtrace.internal.core` and `ddtrace._trace.Span` by deleting the import of the `Span` name, which was used only in type checking.