### PR TITLE
ci(hooks): clang-format re-stage and pre-push clang-tidy for profiling

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -388,12 +388,8 @@ detect_circular_imports:
     - cp dd-trace-py/.gitlab/scripts/post-pr-comment.sh post-pr-comment.sh
     - uv run --script cycles.py analyze --root dd-trace-py/ddtrace cycles-pr.json
     - cat cycles-pr.json
-  # Compare against the PR target branch (e.g. 4.12 backports), not always main.
-    - |
-      CYCLES_BASE_REF="${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-${GITHUB_BASE_REF:-main}}"
-      echo "Circular-import baseline: origin/${CYCLES_BASE_REF}"
-    - cd dd-trace-py && git fetch origin "${CYCLES_BASE_REF}" && git checkout "origin/${CYCLES_BASE_REF}" && cd ..
-    # Analyse the target branch ddtrace using the PR version of cycles.py (has uv metadata)
+    - cd dd-trace-py && git checkout main && cd ..
+    # Analyse main branch ddtrace using the PR version of cycles.py (has uv metadata)
     - uv run --script cycles.py analyze --root dd-trace-py/ddtrace cycles-base.json
     - cat cycles-base.json
     - |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -388,8 +388,12 @@ detect_circular_imports:
     - cp dd-trace-py/.gitlab/scripts/post-pr-comment.sh post-pr-comment.sh
     - uv run --script cycles.py analyze --root dd-trace-py/ddtrace cycles-pr.json
     - cat cycles-pr.json
-    - cd dd-trace-py && git checkout main && cd ..
-    # Analyse main branch ddtrace using the PR version of cycles.py (has uv metadata)
+  # Compare against the PR target branch (e.g. 4.12 backports), not always main.
+    - |
+      CYCLES_BASE_REF="${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-${GITHUB_BASE_REF:-main}}"
+      echo "Circular-import baseline: origin/${CYCLES_BASE_REF}"
+    - cd dd-trace-py && git fetch origin "${CYCLES_BASE_REF}" && git checkout "origin/${CYCLES_BASE_REF}" && cd ..
+    # Analyse the target branch ddtrace using the PR version of cycles.py (has uv metadata)
     - uv run --script cycles.py analyze --root dd-trace-py/ddtrace cycles-base.json
     - cat cycles-base.json
     - |

--- a/ddtrace/internal/datadog/profiling/run_clang_tidy.sh
+++ b/ddtrace/internal/datadog/profiling/run_clang_tidy.sh
@@ -10,65 +10,74 @@ BUILD_DIR="${SCRIPT_DIR}/build"
 echo "Script dir: ${SCRIPT_DIR}"
 echo "Repo root: ${REPO_ROOT}"
 
-# Build the rust native library first (required for cmake to find it)
-echo "Building rust native library..."
-pushd "${REPO_ROOT}"
-pip install setuptools_rust
-python3 setup.py build_rust --inplace
-popd
-
-# Configure cmake for dd_wrapper to generate compile_commands.json
-echo "Configuring cmake for dd_wrapper..."
-mkdir -p "${BUILD_DIR}/dd_wrapper"
-pushd "${BUILD_DIR}/dd_wrapper"
-cmake \
-    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-    -DCMAKE_BUILD_TYPE=Debug \
-    -DPython3_ROOT_DIR=$(python3 -c "import sys; print(sys.prefix)") \
-    -DEXTENSION_SUFFIX=$(python3 -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))") \
-    -DNATIVE_EXTENSION_LOCATION="${REPO_ROOT}/ddtrace/internal/native" \
-    "${SCRIPT_DIR}/dd_wrapper"
-popd
-
-# Configure cmake for stack (including fuzz harnesses so they are covered by clang-tidy)
-echo "Configuring cmake for stack..."
-mkdir -p "${BUILD_DIR}/stack"
-pushd "${BUILD_DIR}/stack"
-cmake \
-    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-    -DCMAKE_BUILD_TYPE=Debug \
-    -DPython3_ROOT_DIR=$(python3 -c "import sys; print(sys.prefix)") \
-    -DEXTENSION_SUFFIX=$(python3 -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))") \
-    -DNATIVE_EXTENSION_LOCATION="${REPO_ROOT}/ddtrace/internal/native" \
-    -DDD_WRAPPER_DIR="${BUILD_DIR}/dd_wrapper" \
-    -DBUILD_FUZZING=ON \
-    -DSTACK_USE_LIBFUZZER=OFF \
-    "${SCRIPT_DIR}/stack"
-popd
-
-# Merge compile_commands.json from all build directories
-MERGED_COMPILE_COMMANDS="${BUILD_DIR}/compile_commands.json"
-echo "Merging compile_commands.json files..."
-COMPILE_COMMANDS_FILES=()
-for subdir in dd_wrapper stack ddup; do
-    if [[ -f "${BUILD_DIR}/${subdir}/compile_commands.json" ]]; then
-        COMPILE_COMMANDS_FILES+=("${BUILD_DIR}/${subdir}/compile_commands.json")
+if [[ "${DDTRACE_CLANG_TIDY_SKIP_BUILD:-0}" == "1" ]]; then
+    if [[ ! -f "${BUILD_DIR}/compile_commands.json" ]]; then
+        echo "Error: DDTRACE_CLANG_TIDY_SKIP_BUILD=1 but ${BUILD_DIR}/compile_commands.json is missing."
+        echo "Bootstrap once with: bash ${SCRIPT_DIR}/run_clang_tidy.sh"
+        exit 1
     fi
-done
-
-if [[ ${#COMPILE_COMMANDS_FILES[@]} -eq 0 ]]; then
-    echo "Error: No compile_commands.json files found after cmake configure"
-    exit 1
-fi
-
-# Merge JSON arrays using jq
-if [[ ${#COMPILE_COMMANDS_FILES[@]} -eq 1 ]]; then
-    cp "${COMPILE_COMMANDS_FILES[0]}" "${MERGED_COMPILE_COMMANDS}"
+    echo "Skipping rust/cmake bootstrap (DDTRACE_CLANG_TIDY_SKIP_BUILD=1)"
 else
-    jq -s 'add' "${COMPILE_COMMANDS_FILES[@]}" > "${MERGED_COMPILE_COMMANDS}"
-fi
+    # Build the rust native library first (required for cmake to find it)
+    echo "Building rust native library..."
+    pushd "${REPO_ROOT}"
+    pip install setuptools_rust
+    python3 setup.py build_rust --inplace
+    popd
 
-echo "Using merged compile_commands.json from: ${BUILD_DIR}"
+    # Configure cmake for dd_wrapper to generate compile_commands.json
+    echo "Configuring cmake for dd_wrapper..."
+    mkdir -p "${BUILD_DIR}/dd_wrapper"
+    pushd "${BUILD_DIR}/dd_wrapper"
+    cmake \
+        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DPython3_ROOT_DIR=$(python3 -c "import sys; print(sys.prefix)") \
+        -DEXTENSION_SUFFIX=$(python3 -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))") \
+        -DNATIVE_EXTENSION_LOCATION="${REPO_ROOT}/ddtrace/internal/native" \
+        "${SCRIPT_DIR}/dd_wrapper"
+    popd
+
+    # Configure cmake for stack (including fuzz harnesses so they are covered by clang-tidy)
+    echo "Configuring cmake for stack..."
+    mkdir -p "${BUILD_DIR}/stack"
+    pushd "${BUILD_DIR}/stack"
+    cmake \
+        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DPython3_ROOT_DIR=$(python3 -c "import sys; print(sys.prefix)") \
+        -DEXTENSION_SUFFIX=$(python3 -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))") \
+        -DNATIVE_EXTENSION_LOCATION="${REPO_ROOT}/ddtrace/internal/native" \
+        -DDD_WRAPPER_DIR="${BUILD_DIR}/dd_wrapper" \
+        -DBUILD_FUZZING=ON \
+        -DSTACK_USE_LIBFUZZER=OFF \
+        "${SCRIPT_DIR}/stack"
+    popd
+
+    # Merge compile_commands.json from all build directories
+    MERGED_COMPILE_COMMANDS="${BUILD_DIR}/compile_commands.json"
+    echo "Merging compile_commands.json files..."
+    COMPILE_COMMANDS_FILES=()
+    for subdir in dd_wrapper stack ddup; do
+        if [[ -f "${BUILD_DIR}/${subdir}/compile_commands.json" ]]; then
+            COMPILE_COMMANDS_FILES+=("${BUILD_DIR}/${subdir}/compile_commands.json")
+        fi
+    done
+
+    if [[ ${#COMPILE_COMMANDS_FILES[@]} -eq 0 ]]; then
+        echo "Error: No compile_commands.json files found after cmake configure"
+        exit 1
+    fi
+
+    # Merge JSON arrays using jq
+    if [[ ${#COMPILE_COMMANDS_FILES[@]} -eq 1 ]]; then
+        cp "${COMPILE_COMMANDS_FILES[0]}" "${MERGED_COMPILE_COMMANDS}"
+    else
+        jq -s 'add' "${COMPILE_COMMANDS_FILES[@]}" > "${MERGED_COMPILE_COMMANDS}"
+    fi
+
+    echo "Using merged compile_commands.json from: ${BUILD_DIR}"
+fi
 
 # Collect all profiling source files, except for  headers, source files, build artifacts.
 # Fuzz sources are included so clang-tidy catches compilation regressions in the harnesses

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -38,9 +38,9 @@ Runs before `git push`. A non-zero exit code **aborts the push**. Contains:
 
 | Hook | Description |
 |------|-------------|
-| `01-clang-tidy-profiling` | When the push includes changes to the profiling native extension's C/C++ sources or headers, runs the same clang-tidy analysis as the CI `clang-tidy profiling` job (`-warnings-as-errors='*'`, via `ddtrace/internal/datadog/profiling/run_clang_tidy.sh`). Catches issues plain clang-format cannot, e.g. `clang-analyzer-optin.performance.Padding` (excessive struct padding). No-op when no profiling native files changed. |
+| `01-clang-tidy-profiling` | When the push includes changes to the profiling native extension's C/C++ sources or headers, runs the same clang-tidy analysis as the CI `clang-tidy profiling` job (`-warnings-as-errors='*'`, via `ddtrace/internal/datadog/profiling/run_clang_tidy.sh`). Catches issues plain clang-format cannot, e.g. `clang-analyzer-optin.performance.Padding` (excessive struct padding). No-op when no profiling native files changed. Requires LLVM 18+ and an existing `build/compile_commands.json` (bootstrap once with `run_clang_tidy.sh`); the hook never pip-installs or builds into your active Python env. |
 
-The clang-tidy hook is heavier than a format check (it needs `clang-tidy` 18+, `cmake`, and `jq`), so it only runs on push, only when relevant files changed, and reuses a cached build dir. clang-tidy has no auto-fix for these diagnostics, so the hook only **detects** — it never edits files.
+The clang-tidy hook is heavier than a format check (it needs `clang-tidy` 18+, `cmake`, `jq`, and cached compile commands), so it only runs on push, only when relevant files changed, and reuses the cached build dir. clang-tidy has no auto-fix for these diagnostics, so the hook only **detects** — it never edits files.
 
 Escape hatches:
 ```bash

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -33,6 +33,24 @@ Individual pre-commit hooks (run in numeric order):
 | `08-run-sg` | Runs `ast-grep scan` on staged Python files using rules in `.sg/rules/`. Catches anti-patterns and deprecated API usage. Skipped when no Python files are staged. |
 | `09-run-error-log-check` | Checks that `log.error()`, `add_error_log`, and `iast_error` calls use constant string literals as their first argument (LOG001) |
 
+### pre-push (blocking)
+Runs before `git push`. A non-zero exit code **aborts the push**. Contains:
+
+| Hook | Description |
+|------|-------------|
+| `01-clang-tidy-profiling` | When the push includes changes to the profiling native extension's C/C++ sources or headers, runs the same clang-tidy analysis as the CI `clang-tidy profiling` job (`-warnings-as-errors='*'`, via `ddtrace/internal/datadog/profiling/run_clang_tidy.sh`). Catches issues plain clang-format cannot, e.g. `clang-analyzer-optin.performance.Padding` (excessive struct padding). No-op when no profiling native files changed. |
+
+The clang-tidy hook is heavier than a format check (it needs `clang-tidy` 18+, `cmake`, and `jq`), so it only runs on push, only when relevant files changed, and reuses a cached build dir. clang-tidy has no auto-fix for these diagnostics, so the hook only **detects** — it never edits files.
+
+Escape hatches:
+```bash
+git push --no-verify                          # skip all pre-push hooks
+SKIP_CLANG_TIDY_PROFILING=1 git push          # skip only this check
+DDTRACE_PREPUSH_CLANG_TIDY_STRICT=1 git push  # fail (not skip) if the toolchain is missing
+```
+
+When the toolchain is not installed the hook prints a note and lets the push through (relying on CI), unless strict mode is set.
+
 ### post-merge (non-blocking)
 Runs after `git pull` or `git merge`. Non-zero exit codes are logged but **do not block** the operation (the merge has already completed). Contains:
 - **check-native-changes**: Detects changes to native code files (C, C++, Rust, Cython) and Python dependency files, and alerts you to rebuild or reinstall
@@ -214,6 +232,8 @@ hooks/
 ├── pre-commit/              # Pre-commit hooks
 │   ├── ...
 │   └── 08-run-sg            # ast-grep scan on staged Python files
+├── pre-push/                # Pre-push hooks
+│   └── 01-clang-tidy-profiling # clang-tidy on profiling native changes
 ├── post-merge/              # Post-merge hooks
 │   └── check-native-changes # Detects native code and dependency changes
 ├── post-checkout/           # Post-checkout hooks

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -26,7 +26,7 @@ Individual pre-commit hooks (run in numeric order):
 | `01-format-and-lint` | Formats and lints staged Python files |
 | `02-run-mypy` | Type-checks staged Python files |
 | `03-run-codespell` | Spell-checks staged files |
-| `04-run-clang-format` | Formats staged C/C++ files with clang-format |
+| `04-run-clang-format` | Formats staged C/C++ files with clang-format and re-stages the fixes |
 | `05-run-bandit` | Security-scans staged production Python files |
 | `06-check-cython-stubs` | Validates Cython stub files |
 | `07-run-cmake-format` | Formats staged CMake files (`*.cmake`, `CMakeLists.txt`) |

--- a/hooks/autohook.sh
+++ b/hooks/autohook.sh
@@ -36,6 +36,7 @@ echo() {
 install() {
     hook_types=(
         "pre-commit"
+        "pre-push"
         "post-merge"
         "post-checkout"
     )
@@ -96,10 +97,10 @@ main() {
             done
             if [[ $hook_exit_code != 0 ]]
             then
-              if [[ $hook_type == "pre-commit" || $hook_type == "commit-msg" ]]
+              if [[ $hook_type == "pre-commit" || $hook_type == "commit-msg" || $hook_type == "pre-push" ]]
               then
                 echo ""
-                echo "The following $hook_type hooks failed — aborting commit:"
+                echo "The following $hook_type hooks failed — aborting $hook_type:"
                 for s in "${failed_scripts[@]}"; do
                     echo "  x $s"
                 done

--- a/hooks/autohook.sh
+++ b/hooks/autohook.sh
@@ -99,8 +99,13 @@ main() {
             then
               if [[ $hook_type == "pre-commit" || $hook_type == "commit-msg" || $hook_type == "pre-push" ]]
               then
+                abort_action="$hook_type"
+                case "$hook_type" in
+                    pre-commit|commit-msg) abort_action="commit" ;;
+                    pre-push) abort_action="push" ;;
+                esac
                 echo ""
-                echo "The following $hook_type hooks failed — aborting $hook_type:"
+                echo "The following $hook_type hooks failed — aborting $abort_action:"
                 for s in "${failed_scripts[@]}"; do
                     echo "  x $s"
                 done

--- a/hooks/pre-push/01-clang-tidy-profiling
+++ b/hooks/pre-push/01-clang-tidy-profiling
@@ -75,28 +75,34 @@ have_clang_tidy_18_plus() {
     return 1
 }
 
+# Set when the push range cannot be determined; conservatively run clang-tidy.
+FORCE_CLANG_TIDY=0
+_changed_list="$(mktemp)"
+trap 'rm -f "${_changed_list}"' EXIT
+
 # Collect the set of files this push would add relative to origin/main. Reads the
 # standard pre-push stdin format: "<local_ref> <local_sha> <remote_ref> <remote_sha>".
-collect_changed_files() {
-    local local_ref local_sha remote_ref remote_sha base
-    while read -r local_ref local_sha remote_ref remote_sha; do
-        [[ "${local_sha}" == "${ZERO}" ]] && continue # branch deletion
-        if [[ "${remote_sha}" == "${ZERO}" ]]; then
-            # New branch on the remote: diff against the merge-base with main.
-            base="$(git merge-base "${local_sha}" origin/main 2>/dev/null || true)"
-        else
-            base="${remote_sha}"
+while read -r local_ref local_sha remote_ref remote_sha; do
+    [[ "${local_sha}" == "${ZERO}" ]] && continue # branch deletion
+    if [[ "${remote_sha}" == "${ZERO}" ]]; then
+        # New branch on the remote: diff against the merge-base with main.
+        base="$(git merge-base "${local_sha}" origin/main 2>/dev/null || true)"
+        if [[ -z "${base}" ]]; then
+            # merge-base unavailable (e.g. origin/main not fetched): run clang-tidy
+            # rather than diff only the tip commit and miss earlier profiling edits.
+            FORCE_CLANG_TIDY=1
+            continue
         fi
-        if [[ -n "${base}" ]]; then
-            git diff --name-only "${base}" "${local_sha}" 2>/dev/null || true
-        else
-            git show --pretty="" --name-only "${local_sha}" 2>/dev/null || true
-        fi
-    done | sort -u
-}
+    else
+        base="${remote_sha}"
+    fi
+    git diff --name-only "${base}" "${local_sha}" 2>/dev/null >> "${_changed_list}" || true
+done
 
-CHANGED_FILES="$(collect_changed_files || true)"
-if ! printf '%s\n' "${CHANGED_FILES}" | grep -qE "${PROFILING_CPP_RE}"; then
+CHANGED_FILES="$(sort -u "${_changed_list}" 2>/dev/null || true)"
+rm -f "${_changed_list}"
+trap - EXIT
+if [[ "${FORCE_CLANG_TIDY}" != "1" ]] && ! printf '%s\n' "${CHANGED_FILES}" | grep -qE "${PROFILING_CPP_RE}"; then
     exit 0 # no profiling native changes in this push
 fi
 

--- a/hooks/pre-push/01-clang-tidy-profiling
+++ b/hooks/pre-push/01-clang-tidy-profiling
@@ -96,7 +96,7 @@ collect_changed_files() {
 }
 
 CHANGED_FILES="$(collect_changed_files || true)"
-if ! grep -qE "${PROFILING_CPP_RE}" <<<"${CHANGED_FILES}"; then
+if ! printf '%s\n' "${CHANGED_FILES}" | grep -qE "${PROFILING_CPP_RE}"; then
     exit 0 # no profiling native changes in this push
 fi
 

--- a/hooks/pre-push/01-clang-tidy-profiling
+++ b/hooks/pre-push/01-clang-tidy-profiling
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Pre-push hook: run clang-tidy on the profiling native extension when a push
+# includes changes to its C/C++ sources or headers.
+#
+# Motivation: the "clang-tidy profiling" GitLab job runs with
+# `-warnings-as-errors='*'` and catches issues that plain clang-format cannot,
+# e.g. clang-analyzer-optin.performance.Padding (excessive struct padding). These
+# only surface in CI today, costing a full round-trip. Running the same analysis
+# locally before push catches them early. clang-tidy has no auto-fix for most of
+# these diagnostics, so this hook only *detects* — it does not modify files.
+#
+# It is gated on profiling native changes and is a no-op otherwise. Because the
+# analysis needs a full toolchain (clang-tidy 18+, cmake, jq) it is skipped with
+# a friendly note when the toolchain is missing, unless strict mode is enabled.
+#
+# Escape hatches:
+#   git push --no-verify                       # skip all pre-push hooks
+#   SKIP_CLANG_TIDY_PROFILING=1 git push       # skip just this check
+#   DDTRACE_PREPUSH_CLANG_TIDY_STRICT=1 git push  # fail (not skip) if toolchain missing
+
+set -euo pipefail
+
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log() { printf "%b\n" "$@"; }
+
+if [[ "${SKIP_CLANG_TIDY_PROFILING:-0}" == "1" ]]; then
+    log "${YELLOW}clang-tidy profiling pre-push check skipped (SKIP_CLANG_TIDY_PROFILING=1).${NC}"
+    exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PROFILING_DIR="${REPO_ROOT}/ddtrace/internal/datadog/profiling"
+RUN_SCRIPT="${PROFILING_DIR}/run_clang_tidy.sh"
+ZERO="0000000000000000000000000000000000000000"
+
+# Only C/C++ under the profiling tree matter for this analysis.
+PROFILING_CPP_RE='^ddtrace/internal/datadog/profiling/.*\.(c|cc|cpp|h|hpp)$'
+
+# Collect the set of files this push would add relative to origin/main. Reads the
+# standard pre-push stdin format: "<local_ref> <local_sha> <remote_ref> <remote_sha>".
+collect_changed_files() {
+    local local_ref local_sha remote_ref remote_sha base
+    while read -r local_ref local_sha remote_ref remote_sha; do
+        [[ "${local_sha}" == "${ZERO}" ]] && continue # branch deletion
+        if [[ "${remote_sha}" == "${ZERO}" ]]; then
+            # New branch on the remote: diff against the merge-base with main.
+            base="$(git merge-base "${local_sha}" origin/main 2>/dev/null || true)"
+        else
+            base="${remote_sha}"
+        fi
+        if [[ -n "${base}" ]]; then
+            git diff --name-only "${base}" "${local_sha}" 2>/dev/null || true
+        else
+            git show --pretty="" --name-only "${local_sha}" 2>/dev/null || true
+        fi
+    done | sort -u
+}
+
+CHANGED_FILES="$(collect_changed_files || true)"
+if ! grep -qE "${PROFILING_CPP_RE}" <<<"${CHANGED_FILES}"; then
+    exit 0 # no profiling native changes in this push
+fi
+
+log "${BLUE}Profiling native changes detected in this push — running clang-tidy...${NC}"
+
+# Verify the toolchain is present before attempting the (heavy) analysis.
+missing=()
+have_run_clang_tidy=0
+for cmd in run-clang-tidy run-clang-tidy-20 run-clang-tidy-19 run-clang-tidy-18; do
+    if command -v "${cmd}" >/dev/null 2>&1; then
+        have_run_clang_tidy=1
+        break
+    fi
+done
+[[ "${have_run_clang_tidy}" == "0" ]] && ! command -v clang-tidy >/dev/null 2>&1 && missing+=("clang-tidy / run-clang-tidy (v18+)")
+command -v cmake >/dev/null 2>&1 || missing+=("cmake")
+command -v jq >/dev/null 2>&1 || missing+=("jq")
+[[ -f "${RUN_SCRIPT}" ]] || missing+=("${RUN_SCRIPT}")
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+    log "${YELLOW}clang-tidy profiling check skipped — missing:${NC}"
+    for m in "${missing[@]}"; do log "  ${YELLOW}•${NC} ${m}"; done
+    if [[ "${DDTRACE_PREPUSH_CLANG_TIDY_STRICT:-0}" == "1" ]]; then
+        log "${RED}Strict mode (DDTRACE_PREPUSH_CLANG_TIDY_STRICT=1): failing.${NC}"
+        exit 1
+    fi
+    log "${YELLOW}Install the toolchain (clang-tidy 18+, cmake, jq) to enable this check,${NC}"
+    log "${YELLOW}or rely on the CI 'clang-tidy profiling' job. Continuing push.${NC}"
+    exit 0
+fi
+
+# run_clang_tidy.sh caches its build dir, so repeat runs only re-analyze deltas.
+if ! bash "${RUN_SCRIPT}"; then
+    log ""
+    log "${RED}clang-tidy found issues in the profiling native code (see above).${NC}"
+    log "${YELLOW}This is the same analysis as the CI 'clang-tidy profiling' job.${NC}"
+    log "${YELLOW}Fix the reported diagnostics, or bypass with one of:${NC}"
+    log "  ${GREEN}SKIP_CLANG_TIDY_PROFILING=1 git push${NC}"
+    log "  ${GREEN}git push --no-verify${NC}"
+    exit 1
+fi
+
+log "${GREEN}clang-tidy profiling check passed.${NC}"
+exit 0

--- a/hooks/pre-push/01-clang-tidy-profiling
+++ b/hooks/pre-push/01-clang-tidy-profiling
@@ -11,8 +11,10 @@
 # these diagnostics, so this hook only *detects* — it does not modify files.
 #
 # It is gated on profiling native changes and is a no-op otherwise. Because the
-# analysis needs a full toolchain (clang-tidy 18+, cmake, jq) it is skipped with
-# a friendly note when the toolchain is missing, unless strict mode is enabled.
+# analysis needs a full toolchain (clang-tidy 18+, cmake, jq) and a cached
+# compile_commands.json from a prior bootstrap it is skipped with a friendly note
+# when prerequisites are missing, unless strict mode is enabled. The hook never
+# pip-installs or builds into the active Python environment.
 #
 # Escape hatches:
 #   git push --no-verify                       # skip all pre-push hooks
@@ -37,10 +39,41 @@ fi
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 PROFILING_DIR="${REPO_ROOT}/ddtrace/internal/datadog/profiling"
 RUN_SCRIPT="${PROFILING_DIR}/run_clang_tidy.sh"
+COMPILE_COMMANDS="${PROFILING_DIR}/build/compile_commands.json"
 ZERO="0000000000000000000000000000000000000000"
 
 # Only C/C++ under the profiling tree matter for this analysis.
 PROFILING_CPP_RE='^ddtrace/internal/datadog/profiling/.*\.(c|cc|cpp|h|hpp)$'
+
+clang_tidy_major_version() {
+    if ! command -v clang-tidy >/dev/null 2>&1; then
+        return 1
+    fi
+    local major
+    major="$(clang-tidy --version 2>/dev/null | sed -nE 's/.*clang-tidy version ([0-9]+).*/\1/p' | head -1)"
+    [[ -n "${major}" ]] || return 1
+    printf '%s' "${major}"
+}
+
+have_clang_tidy_18_plus() {
+    local cmd major
+    for cmd in run-clang-tidy-20 run-clang-tidy-19 run-clang-tidy-18; do
+        if command -v "${cmd}" >/dev/null 2>&1; then
+            return 0
+        fi
+    done
+    if command -v run-clang-tidy >/dev/null 2>&1; then
+        major="$(clang_tidy_major_version)" || return 1
+        [[ "${major}" -ge 18 ]]
+        return
+    fi
+    if command -v clang-tidy >/dev/null 2>&1; then
+        major="$(clang_tidy_major_version)" || return 1
+        [[ "${major}" -ge 18 ]]
+        return
+    fi
+    return 1
+}
 
 # Collect the set of files this push would add relative to origin/main. Reads the
 # standard pre-push stdin format: "<local_ref> <local_sha> <remote_ref> <remote_sha>".
@@ -69,19 +102,17 @@ fi
 
 log "${BLUE}Profiling native changes detected in this push — running clang-tidy...${NC}"
 
-# Verify the toolchain is present before attempting the (heavy) analysis.
+# Verify prerequisites before attempting analysis.
 missing=()
-have_run_clang_tidy=0
-for cmd in run-clang-tidy run-clang-tidy-20 run-clang-tidy-19 run-clang-tidy-18; do
-    if command -v "${cmd}" >/dev/null 2>&1; then
-        have_run_clang_tidy=1
-        break
-    fi
-done
-[[ "${have_run_clang_tidy}" == "0" ]] && ! command -v clang-tidy >/dev/null 2>&1 && missing+=("clang-tidy / run-clang-tidy (v18+)")
+if ! have_clang_tidy_18_plus; then
+    missing+=("clang-tidy / run-clang-tidy (LLVM 18+, matching CI)")
+fi
 command -v cmake >/dev/null 2>&1 || missing+=("cmake")
 command -v jq >/dev/null 2>&1 || missing+=("jq")
 [[ -f "${RUN_SCRIPT}" ]] || missing+=("${RUN_SCRIPT}")
+[[ -f "${COMPILE_COMMANDS}" ]] || missing+=(
+    "profiling build/compile_commands.json (bootstrap once: bash ddtrace/internal/datadog/profiling/run_clang_tidy.sh)"
+)
 
 if [[ ${#missing[@]} -gt 0 ]]; then
     log "${YELLOW}clang-tidy profiling check skipped — missing:${NC}"
@@ -90,13 +121,13 @@ if [[ ${#missing[@]} -gt 0 ]]; then
         log "${RED}Strict mode (DDTRACE_PREPUSH_CLANG_TIDY_STRICT=1): failing.${NC}"
         exit 1
     fi
-    log "${YELLOW}Install the toolchain (clang-tidy 18+, cmake, jq) to enable this check,${NC}"
+    log "${YELLOW}Install the toolchain (clang-tidy 18+, cmake, jq) and bootstrap compile_commands,${NC}"
     log "${YELLOW}or rely on the CI 'clang-tidy profiling' job. Continuing push.${NC}"
     exit 0
 fi
 
-# run_clang_tidy.sh caches its build dir, so repeat runs only re-analyze deltas.
-if ! bash "${RUN_SCRIPT}"; then
+# Analysis only — reuse cached compile_commands; do not pip-install or build in-place.
+if ! DDTRACE_CLANG_TIDY_SKIP_BUILD=1 bash "${RUN_SCRIPT}"; then
     log ""
     log "${RED}clang-tidy found issues in the profiling native code (see above).${NC}"
     log "${YELLOW}This is the same analysis as the CI 'clang-tidy profiling' job.${NC}"

--- a/hooks/scripts/run-clang-format.sh
+++ b/hooks/scripts/run-clang-format.sh
@@ -34,9 +34,12 @@ if [ -n "$(printf '%s' "$staged_files" | tr -d ' \t\n')" ]; then
 
     "$clang_format" -i $staged_files || exit $?
 
-    echo "$staged_files" | tr ' ' '\n' | while read -r f; do
+    for f in $staged_files; do
         [ -n "$f" ] || continue
-        echo "$unstaged_before" | grep -qFx "$f" || git add "$f"
+        if echo "$unstaged_before" | grep -qFx "$f"; then
+            continue
+        fi
+        git add "$f" || exit $?
     done
 else
     echo 'Run clang-format skipped: No C/C++ files were found in `git diff --staged`'

--- a/hooks/scripts/run-clang-format.sh
+++ b/hooks/scripts/run-clang-format.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env sh
 # clang-format version CI pins via the lint dependency group (clang-format==18.1.5).
 CFORMAT_VERSION=18.1.5
-staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR | grep -E '\.(c|h|cc|cpp|hpp)$')
-if [ -n "$staged_files" ]; then
+staged_files=$(git diff --staged --name-only HEAD --diff-filter=ACMR | grep -E '\.(c|h|cc|cpp|hpp)$' | tr '\n' ' ')
+if [ -n "$(printf '%s' "$staged_files" | tr -d ' \t\n')" ]; then
+    file_count=$(echo "$staged_files" | wc -w | tr -d ' ')
+    echo "Formatting $file_count staged C/C++ file(s)..."
     # Resolve a clang-format binary, preferring the version pinned in the lint
     # dependency group (clang-format==18.1.5) so local formatting matches CI, which
     # runs `scripts/lint cformat`. An unpinned PATH binary reformats differently
@@ -26,7 +28,16 @@ if [ -n "$staged_files" ]; then
             exit 1
         fi
     fi
-    "$clang_format" -i $staged_files
+
+    # Skip re-adding files that already had unstaged changes to preserve partial staging.
+    unstaged_before=$(git diff --name-only)
+
+    "$clang_format" -i $staged_files || exit $?
+
+    echo "$staged_files" | tr ' ' '\n' | while read -r f; do
+        [ -n "$f" ] || continue
+        echo "$unstaged_before" | grep -qFx "$f" || git add "$f"
+    done
 else
     echo 'Run clang-format skipped: No C/C++ files were found in `git diff --staged`'
 fi

--- a/hooks/tests/test-clang-tidy-pre-push.sh
+++ b/hooks/tests/test-clang-tidy-pre-push.sh
@@ -80,12 +80,13 @@ EOF
 
 run_hook() {
     push_input="$1"
-    env -i \
+    # Use a pipe, not <<< (bash-only); invoke the hook via its bash shebang.
+    printf '%s\n' "${push_input}" | env -i \
         PATH="${TMPDIR_TEST}:${PATH}" \
         HOME="${TMPDIR_TEST}" \
         SKIP_CLANG_TIDY_PROFILING="${SKIP_CLANG_TIDY_PROFILING:-}" \
         DDTRACE_PREPUSH_CLANG_TIDY_STRICT="${DDTRACE_PREPUSH_CLANG_TIDY_STRICT:-}" \
-        sh "${HOOK}" <<< "${push_input}"
+        bash "${HOOK}"
 }
 
 PUSH_INPUT="refs/heads/x $(git rev-parse HEAD) refs/heads/main $(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)"

--- a/hooks/tests/test-clang-tidy-pre-push.sh
+++ b/hooks/tests/test-clang-tidy-pre-push.sh
@@ -80,16 +80,18 @@ EOF
 
 run_hook() {
     push_input="$1"
+    skip_flag="${2:-}"
     # Use a pipe, not <<< (bash-only); invoke the hook via its bash shebang.
     printf '%s\n' "${push_input}" | env -i \
         PATH="${TMPDIR_TEST}:${PATH}" \
         HOME="${TMPDIR_TEST}" \
-        SKIP_CLANG_TIDY_PROFILING="${SKIP_CLANG_TIDY_PROFILING:-}" \
+        SKIP_CLANG_TIDY_PROFILING="${skip_flag}" \
         DDTRACE_PREPUSH_CLANG_TIDY_STRICT="${DDTRACE_PREPUSH_CLANG_TIDY_STRICT:-}" \
         bash "${HOOK}"
 }
 
 PUSH_INPUT="refs/heads/x $(git rev-parse HEAD) refs/heads/main $(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)"
+ZERO_SHA="0000000000000000000000000000000000000000"
 
 # No profiling native changes: hook is a no-op.
 setup_toolchain 18
@@ -129,8 +131,30 @@ setup_toolchain 18
 setup_repo_layout
 setup_git_mock "ddtrace/internal/datadog/profiling/stack/src/sampler.cpp"
 : > "${TMPDIR_TEST}/clang-tidy-calls.txt"
-SKIP_CLANG_TIDY_PROFILING=1 run_hook "${PUSH_INPUT}" > /dev/null
+run_hook "${PUSH_INPUT}" 1 > /dev/null
 check "SKIP_CLANG_TIDY_PROFILING bypasses clang-tidy" "! [ -s '${TMPDIR_TEST}/clang-tidy-calls.txt' ]"
+
+# merge-base failure on a new branch forces clang-tidy even without profiling paths in the diff.
+setup_toolchain 18
+setup_repo_layout
+cat > "${TMPDIR_TEST}/git" << EOF
+#!/usr/bin/env sh
+case "\$*" in
+    "rev-parse --show-toplevel")
+        printf '%s\n' "${TMPDIR_TEST}" ;;
+    "merge-base "*)
+        exit 1 ;;
+    "diff --name-only "*)
+        printf 'README.md\n' ;;
+    *)
+        exec "$(command -v git)" "\$@" ;;
+esac
+EOF
+chmod +x "${TMPDIR_TEST}/git"
+: > "${TMPDIR_TEST}/clang-tidy-calls.txt"
+# New remote branch: remote_sha is ZERO
+run_hook "refs/heads/x $(git rev-parse HEAD) refs/heads/main ${ZERO_SHA}" > /dev/null
+check "merge-base failure forces clang-tidy" "[ -s '${TMPDIR_TEST}/clang-tidy-calls.txt' ]"
 
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"

--- a/hooks/tests/test-clang-tidy-pre-push.sh
+++ b/hooks/tests/test-clang-tidy-pre-push.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env sh
+# Tests for hooks/pre-push/01-clang-tidy-profiling
+#
+# Stubs git and run_clang_tidy.sh so no real toolchain is needed.
+# Run with:  sh hooks/tests/test-clang-tidy-pre-push.sh
+
+set -eu
+
+HOOK="$(cd "$(dirname "$0")/../pre-push" && pwd)/01-clang-tidy-profiling"
+PASS=0
+FAIL=0
+
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+RUN_SCRIPT="${TMPDIR_TEST}/run_clang_tidy.sh"
+PROFILING_DIR="${TMPDIR_TEST}/ddtrace/internal/datadog/profiling"
+mkdir -p "${PROFILING_DIR}"
+printf '#!/usr/bin/env sh\necho run_clang_tidy >> "%s"\n' "${TMPDIR_TEST}/clang-tidy-calls.txt" > "${RUN_SCRIPT}"
+chmod +x "${RUN_SCRIPT}"
+
+check() {
+    name="$1"
+    condition="$2"
+    if eval "$condition"; then
+        echo "PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Mock git: rev-parse returns TMPDIR_TEST as repo root; pre-push stdin drives diff output.
+setup_git_mock() {
+    changed_files="$1"
+    cat > "${TMPDIR_TEST}/git" << EOF
+#!/usr/bin/env sh
+case "\$*" in
+    "rev-parse --show-toplevel")
+        printf '%s\n' "${TMPDIR_TEST}" ;;
+    "diff --name-only "*)
+        printf '%s\n' ${changed_files} ;;
+    "show --pretty=\"\" --name-only "*)
+        printf '%s\n' ${changed_files} ;;
+    "merge-base "*)
+        printf 'base\n' ;;
+    *)
+        exec "$(command -v git)" "\$@" ;;
+esac
+EOF
+    chmod +x "${TMPDIR_TEST}/git"
+}
+
+run_hook() {
+  push_input="$1"
+  env -i \
+      PATH="${TMPDIR_TEST}:${PATH}" \
+      HOME="${TMPDIR_TEST}" \
+      SKIP_CLANG_TIDY_PROFILING="${SKIP_CLANG_TIDY_PROFILING:-}" \
+      DDTRACE_PREPUSH_CLANG_TIDY_STRICT="${DDTRACE_PREPUSH_CLANG_TIDY_STRICT:-}" \
+      sh "${HOOK}" <<< "${push_input}"
+}
+
+# Provide fake toolchain binaries on PATH.
+for cmd in cmake jq clang-tidy run-clang-tidy; do
+    printf '#!/usr/bin/env sh\nexit 0\n' > "${TMPDIR_TEST}/${cmd}"
+    chmod +x "${TMPDIR_TEST}/${cmd}"
+done
+
+# Point the hook at our stub run_clang_tidy.sh via repo layout under TMPDIR_TEST.
+cat > "${TMPDIR_TEST}/ddtrace/internal/datadog/profiling/run_clang_tidy.sh" << EOF
+#!/usr/bin/env sh
+echo run_clang_tidy >> "${TMPDIR_TEST}/clang-tidy-calls.txt"
+exit 0
+EOF
+chmod +x "${TMPDIR_TEST}/ddtrace/internal/datadog/profiling/run_clang_tidy.sh"
+
+# No profiling native changes: hook is a no-op.
+setup_git_mock "README.md"
+: > "${TMPDIR_TEST}/clang-tidy-calls.txt"
+run_hook "refs/heads/x $(git rev-parse HEAD) refs/heads/main $(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)" > /dev/null
+check "no profiling changes skips clang-tidy" "! [ -s '${TMPDIR_TEST}/clang-tidy-calls.txt' ]"
+
+# Profiling C++ change: hook runs clang-tidy script.
+setup_git_mock "ddtrace/internal/datadog/profiling/stack/src/sampler.cpp"
+: > "${TMPDIR_TEST}/clang-tidy-calls.txt"
+run_hook "refs/heads/x $(git rev-parse HEAD) refs/heads/main $(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)" > /dev/null
+check "profiling native changes run clang-tidy" "[ -s '${TMPDIR_TEST}/clang-tidy-calls.txt' ]"
+
+# SKIP_CLANG_TIDY_PROFILING=1 bypasses the check.
+setup_git_mock "ddtrace/internal/datadog/profiling/stack/src/sampler.cpp"
+: > "${TMPDIR_TEST}/clang-tidy-calls.txt"
+SKIP_CLANG_TIDY_PROFILING=1 run_hook "refs/heads/x $(git rev-parse HEAD) refs/heads/main $(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)" > /dev/null
+check "SKIP_CLANG_TIDY_PROFILING bypasses clang-tidy" "! [ -s '${TMPDIR_TEST}/clang-tidy-calls.txt' ]"
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" = "0" ]

--- a/hooks/tests/test-clang-tidy-pre-push.sh
+++ b/hooks/tests/test-clang-tidy-pre-push.sh
@@ -13,12 +13,6 @@ FAIL=0
 TMPDIR_TEST=$(mktemp -d)
 trap 'rm -rf "$TMPDIR_TEST"' EXIT
 
-RUN_SCRIPT="${TMPDIR_TEST}/run_clang_tidy.sh"
-PROFILING_DIR="${TMPDIR_TEST}/ddtrace/internal/datadog/profiling"
-mkdir -p "${PROFILING_DIR}"
-printf '#!/usr/bin/env sh\necho run_clang_tidy >> "%s"\n' "${TMPDIR_TEST}/clang-tidy-calls.txt" > "${RUN_SCRIPT}"
-chmod +x "${RUN_SCRIPT}"
-
 check() {
     name="$1"
     condition="$2"
@@ -29,6 +23,38 @@ check() {
         echo "FAIL: $name"
         FAIL=$((FAIL + 1))
     fi
+}
+
+setup_toolchain() {
+    clang_major="${1:-18}"
+    for cmd in cmake jq run-clang-tidy; do
+        printf '#!/usr/bin/env sh\nexit 0\n' > "${TMPDIR_TEST}/${cmd}"
+        chmod +x "${TMPDIR_TEST}/${cmd}"
+    done
+    cat > "${TMPDIR_TEST}/clang-tidy" << EOF
+#!/usr/bin/env sh
+if [ "\$1" = "--version" ]; then
+    echo "clang-tidy version ${clang_major}.1.0"
+    exit 0
+fi
+exit 0
+EOF
+    chmod +x "${TMPDIR_TEST}/clang-tidy"
+}
+
+setup_repo_layout() {
+    mkdir -p "${TMPDIR_TEST}/ddtrace/internal/datadog/profiling/build"
+    printf '[]\n' > "${TMPDIR_TEST}/ddtrace/internal/datadog/profiling/build/compile_commands.json"
+    cat > "${TMPDIR_TEST}/ddtrace/internal/datadog/profiling/run_clang_tidy.sh" << EOF
+#!/usr/bin/env sh
+if [ "\${DDTRACE_CLANG_TIDY_SKIP_BUILD:-0}" != "1" ]; then
+    echo "expected DDTRACE_CLANG_TIDY_SKIP_BUILD=1" >&2
+    exit 2
+fi
+echo run_clang_tidy >> "${TMPDIR_TEST}/clang-tidy-calls.txt"
+exit 0
+EOF
+    chmod +x "${TMPDIR_TEST}/ddtrace/internal/datadog/profiling/run_clang_tidy.sh"
 }
 
 # Mock git: rev-parse returns TMPDIR_TEST as repo root; pre-push stdin drives diff output.
@@ -53,45 +79,56 @@ EOF
 }
 
 run_hook() {
-  push_input="$1"
-  env -i \
-      PATH="${TMPDIR_TEST}:${PATH}" \
-      HOME="${TMPDIR_TEST}" \
-      SKIP_CLANG_TIDY_PROFILING="${SKIP_CLANG_TIDY_PROFILING:-}" \
-      DDTRACE_PREPUSH_CLANG_TIDY_STRICT="${DDTRACE_PREPUSH_CLANG_TIDY_STRICT:-}" \
-      sh "${HOOK}" <<< "${push_input}"
+    push_input="$1"
+    env -i \
+        PATH="${TMPDIR_TEST}:${PATH}" \
+        HOME="${TMPDIR_TEST}" \
+        SKIP_CLANG_TIDY_PROFILING="${SKIP_CLANG_TIDY_PROFILING:-}" \
+        DDTRACE_PREPUSH_CLANG_TIDY_STRICT="${DDTRACE_PREPUSH_CLANG_TIDY_STRICT:-}" \
+        sh "${HOOK}" <<< "${push_input}"
 }
 
-# Provide fake toolchain binaries on PATH.
-for cmd in cmake jq clang-tidy run-clang-tidy; do
-    printf '#!/usr/bin/env sh\nexit 0\n' > "${TMPDIR_TEST}/${cmd}"
-    chmod +x "${TMPDIR_TEST}/${cmd}"
-done
-
-# Point the hook at our stub run_clang_tidy.sh via repo layout under TMPDIR_TEST.
-cat > "${TMPDIR_TEST}/ddtrace/internal/datadog/profiling/run_clang_tidy.sh" << EOF
-#!/usr/bin/env sh
-echo run_clang_tidy >> "${TMPDIR_TEST}/clang-tidy-calls.txt"
-exit 0
-EOF
-chmod +x "${TMPDIR_TEST}/ddtrace/internal/datadog/profiling/run_clang_tidy.sh"
+PUSH_INPUT="refs/heads/x $(git rev-parse HEAD) refs/heads/main $(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)"
 
 # No profiling native changes: hook is a no-op.
+setup_toolchain 18
+setup_repo_layout
 setup_git_mock "README.md"
 : > "${TMPDIR_TEST}/clang-tidy-calls.txt"
-run_hook "refs/heads/x $(git rev-parse HEAD) refs/heads/main $(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)" > /dev/null
+run_hook "${PUSH_INPUT}" > /dev/null
 check "no profiling changes skips clang-tidy" "! [ -s '${TMPDIR_TEST}/clang-tidy-calls.txt' ]"
 
-# Profiling C++ change: hook runs clang-tidy script.
+# Profiling C++ change with prerequisites: hook runs analysis in skip-build mode.
+setup_toolchain 18
+setup_repo_layout
 setup_git_mock "ddtrace/internal/datadog/profiling/stack/src/sampler.cpp"
 : > "${TMPDIR_TEST}/clang-tidy-calls.txt"
-run_hook "refs/heads/x $(git rev-parse HEAD) refs/heads/main $(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)" > /dev/null
+run_hook "${PUSH_INPUT}" > /dev/null
 check "profiling native changes run clang-tidy" "[ -s '${TMPDIR_TEST}/clang-tidy-calls.txt' ]"
 
-# SKIP_CLANG_TIDY_PROFILING=1 bypasses the check.
+# LLVM <18 is rejected (skip, not run).
+setup_toolchain 14
+setup_repo_layout
 setup_git_mock "ddtrace/internal/datadog/profiling/stack/src/sampler.cpp"
 : > "${TMPDIR_TEST}/clang-tidy-calls.txt"
-SKIP_CLANG_TIDY_PROFILING=1 run_hook "refs/heads/x $(git rev-parse HEAD) refs/heads/main $(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)" > /dev/null
+run_hook "${PUSH_INPUT}" > /dev/null
+check "clang-tidy older than 18 is skipped" "! [ -s '${TMPDIR_TEST}/clang-tidy-calls.txt' ]"
+
+# Missing compile_commands.json skips without running analysis.
+setup_toolchain 18
+setup_repo_layout
+rm -f "${TMPDIR_TEST}/ddtrace/internal/datadog/profiling/build/compile_commands.json"
+setup_git_mock "ddtrace/internal/datadog/profiling/stack/src/sampler.cpp"
+: > "${TMPDIR_TEST}/clang-tidy-calls.txt"
+run_hook "${PUSH_INPUT}" > /dev/null
+check "missing compile_commands skips clang-tidy" "! [ -s '${TMPDIR_TEST}/clang-tidy-calls.txt' ]"
+
+# SKIP_CLANG_TIDY_PROFILING=1 bypasses the check.
+setup_toolchain 18
+setup_repo_layout
+setup_git_mock "ddtrace/internal/datadog/profiling/stack/src/sampler.cpp"
+: > "${TMPDIR_TEST}/clang-tidy-calls.txt"
+SKIP_CLANG_TIDY_PROFILING=1 run_hook "${PUSH_INPUT}" > /dev/null
 check "SKIP_CLANG_TIDY_PROFILING bypasses clang-tidy" "! [ -s '${TMPDIR_TEST}/clang-tidy-calls.txt' ]"
 
 echo ""

--- a/hooks/tests/test-run-clang-format.sh
+++ b/hooks/tests/test-run-clang-format.sh
@@ -19,14 +19,16 @@ TMPDIR_TEST=$(mktemp -d)
 trap 'rm -rf "$TMPDIR_TEST"' EXIT
 
 CALLS_FILE="$TMPDIR_TEST/clang-format-calls.txt"
+GIT_ADD_CALLS_FILE="$TMPDIR_TEST/git-add-calls.txt"
 
 # Writes a mock git that emits $1 (newline-separated filenames) for the
 # staged-files query, answers `rev-parse --show-toplevel` with $2 (default
-# $TMPDIR_TEST, which has no .venv-lint), and delegates everything else to the
-# real git.
+# $TMPDIR_TEST, which has no .venv-lint), optional unstaged names in $3, and
+# delegates everything else to the real git.
 mock_staged() {
     files="$1"
     root="${2:-$TMPDIR_TEST}"
+    unstaged="${3:-}"
     cat > "$TMPDIR_TEST/git" << EOF
 #!/usr/bin/env sh
 case "\$*" in
@@ -34,6 +36,10 @@ case "\$*" in
         printf '%s\n' $files ;;
     "rev-parse --show-toplevel")
         printf '%s\n' "$root" ;;
+    "diff --name-only")
+        printf '%s\n' $unstaged ;;
+    "add "*)
+        echo "\$*" >> "$GIT_ADD_CALLS_FILE" ;;
     *)
         exec "$(command -v git)" "\$@" ;;
 esac
@@ -74,6 +80,7 @@ echo "\$*" >> "$CALLS_FILE"
 EOF
     chmod +x "$dest"
     : > "$CALLS_FILE"
+    : > "$GIT_ADD_CALLS_FILE"
 }
 
 # Writes a mock clang-format on PATH (in $TMPDIR_TEST) that records its arguments.
@@ -106,6 +113,20 @@ mock_staged "clock.hpp"
 : > "$CALLS_FILE"
 run_hook > /dev/null
 check ".hpp files are formatted" "grep -qF 'clock.hpp' '$CALLS_FILE'"
+
+# clang-format fixes are re-staged so the commit includes formatted content
+mock_staged "sampler.hpp"
+: > "$CALLS_FILE"
+: > "$GIT_ADD_CALLS_FILE"
+run_hook > /dev/null
+check "formatted .hpp files are re-staged" "grep -qF 'sampler.hpp' '$GIT_ADD_CALLS_FILE'"
+
+# Partially staged files are not re-added
+mock_staged "sampler.hpp" "$TMPDIR_TEST" "sampler.hpp"
+: > "$CALLS_FILE"
+: > "$GIT_ADD_CALLS_FILE"
+run_hook > /dev/null
+check "partially staged files are not re-added" "! grep -qF 'sampler.hpp' '$GIT_ADD_CALLS_FILE'"
 
 # .cpp is processed
 mock_staged "sample.cpp"


### PR DESCRIPTION
## Description

Two local guardrails for profiling native code (replaces misconfigured #19024):

1. **Pre-commit clang-format re-stage** — formatted C/C++ files are re-staged after clang-format so commits include the formatted content (fixes index/worktree mismatch that let headers fail CI prechecks). Keeps main pinned clang-format 18.1.5 resolution.

2. **Pre-push clang-tidy** — blocking hook runs the same analysis as the GitLab clang-tidy profiling job when a push touches profiling native C/C++. Requires LLVM 18+, cached compile_commands.json, and never pip-installs or build_rust on push (bootstrap once via run_clang_tidy.sh).

Adds DDTRACE_CLANG_TIDY_SKIP_BUILD=1 to run_clang_tidy.sh for detect-only pre-push runs.

## Testing

Automated (no toolchain):
```bash
sh hooks/tests/test-run-clang-format.sh      # 23 tests
sh hooks/tests/test-clang-tidy-pre-push.sh   # 5 tests (POSIX sh / dash)
```

Manual — clang-format re-stage:
```bash
hooks/autohook.sh install
# stage a mis-formatted .hpp, commit; hook should format + re-stage
```

Manual — pre-push clang-tidy:
```bash
hooks/autohook.sh install
bash ddtrace/internal/datadog/profiling/run_clang_tidy.sh   # one-time bootstrap
git push   # runs when push includes profiling C++ changes
SKIP_CLANG_TIDY_PROFILING=1 git push   # bypass
```

## Additional Notes

- Circular-import CI baseline: #19042 (not in this PR).
- Escape hatches documented in hooks/README.md.
