### PR TITLE
chore(ci): use exposed PR/MR target branch int the circular imports job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -401,12 +401,13 @@ detect_circular_imports:
     - cat cycles-pr.json
     - |
       cd dd-trace-py
-      if [ -z "${GH_TOKEN:-}" ]; then
-        export GH_TOKEN=$(dd-octo-sts token --scope DataDog/dd-trace-py --policy gitlab.github-access.read)
-      fi
+      # resolve-base-branch.sh only needs a GitHub token for its API-fallback
+      # path and mints one itself (via dd-octo-sts) when required, so we no
+      # longer acquire a token unconditionally here -- that would fail the job
+      # even when the base is resolved without any API call.
       BASE_BRANCH=$(.gitlab/scripts/resolve-base-branch.sh)
       git fetch origin "${BASE_BRANCH}"
-      git checkout FETCH_HEAD
+      git checkout --detach FETCH_HEAD
       cd ..
     # Analyse the base branch ddtrace using the PR version of cycles.py (has uv metadata)
     - uv run --script cycles.py analyze --root dd-trace-py/ddtrace cycles-base.json
@@ -419,6 +420,21 @@ detect_circular_imports:
     - cat cycles_report.txt
     - ./post-pr-comment.sh "Circular import analysis" cycles_report.txt
     - exit $COMPARE_EXIT
+
+# Unit tests for resolve-base-branch.sh (used above to pick the comparison
+# baseline). Reuses the testrunner image only for its bash + jq; the tests stub
+# git/curl and need no network, so we skip the heavier .testrunner setup.
+test_resolve_base_branch:
+  stage: tests
+  needs: []
+  image:
+    name: ${TESTRUNNER_IMAGE}
+    docker:
+      user: bits
+  tags: [ "arch:amd64" ]
+  timeout: 5m
+  script:
+    - .gitlab/scripts/resolve-base-branch.test.sh
 
 
 "summarize failures":

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -401,10 +401,8 @@ detect_circular_imports:
     - cat cycles-pr.json
     - |
       cd dd-trace-py
-      # resolve-base-branch.sh only needs a GitHub token for its API-fallback
-      # path and mints one itself (via dd-octo-sts) when required, so we no
-      # longer acquire a token unconditionally here -- that would fail the job
-      # even when the base is resolved without any API call.
+      # resolve-base-branch.sh mints its own token only if it hits the API,
+      # so don't acquire one unconditionally here.
       BASE_BRANCH=$(.gitlab/scripts/resolve-base-branch.sh)
       git fetch origin "${BASE_BRANCH}"
       git checkout --detach FETCH_HEAD
@@ -421,9 +419,8 @@ detect_circular_imports:
     - ./post-pr-comment.sh "Circular import analysis" cycles_report.txt
     - exit $COMPARE_EXIT
 
-# Unit tests for resolve-base-branch.sh (used above to pick the comparison
-# baseline). Reuses the testrunner image only for its bash + jq; the tests stub
-# git/curl and need no network, so we skip the heavier .testrunner setup.
+# Unit tests for resolve-base-branch.sh. Reuses the testrunner image for bash+jq;
+# tests stub git/curl (no network), so we skip the heavier .testrunner setup.
 test_resolve_base_branch:
   stage: tests
   needs: []

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -426,9 +426,10 @@ detect_circular_imports:
     - cat cycles-pr.json
     - |
       cd dd-trace-py
-      if [ -z "${GH_TOKEN:-}" ]; then
-        export GH_TOKEN=$(dd-octo-sts token --scope DataDog/dd-trace-py --policy gitlab.github-access.read)
-      fi
+      # resolve-base-branch.sh only needs a GitHub token for its API-fallback
+      # path and mints one itself (via dd-octo-sts) when required, so we no
+      # longer acquire a token unconditionally here -- that would fail the job
+      # even when the base is resolved without any API call.
       BASE_BRANCH=$(.gitlab/scripts/resolve-base-branch.sh)
       git fetch origin "${BASE_BRANCH}"
       MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
@@ -520,6 +521,21 @@ check_added_file_size:
       BASE_BRANCH=$(.gitlab/scripts/resolve-base-branch.sh)
       git fetch origin "${BASE_BRANCH}"
     - python3 scripts/check_added_file_size.py --base-ref FETCH_HEAD
+
+# Unit tests for resolve-base-branch.sh (used above to pick the comparison
+# baseline). Reuses the testrunner image only for its bash + jq; the tests stub
+# git/curl and need no network, so we skip the heavier .testrunner setup.
+test_resolve_base_branch:
+  stage: tests
+  needs: []
+  image:
+    name: ${TESTRUNNER_IMAGE}
+    docker:
+      user: bits
+  tags: [ "arch:amd64" ]
+  timeout: 5m
+  script:
+    - .gitlab/scripts/resolve-base-branch.test.sh
 
 
 "summarize failures":

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -426,10 +426,8 @@ detect_circular_imports:
     - cat cycles-pr.json
     - |
       cd dd-trace-py
-      # resolve-base-branch.sh only needs a GitHub token for its API-fallback
-      # path and mints one itself (via dd-octo-sts) when required, so we no
-      # longer acquire a token unconditionally here -- that would fail the job
-      # even when the base is resolved without any API call.
+      # resolve-base-branch.sh mints its own token only if it hits the API,
+      # so don't acquire one unconditionally here.
       BASE_BRANCH=$(.gitlab/scripts/resolve-base-branch.sh)
       git fetch origin "${BASE_BRANCH}"
       MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
@@ -522,9 +520,8 @@ check_added_file_size:
       git fetch origin "${BASE_BRANCH}"
     - python3 scripts/check_added_file_size.py --base-ref FETCH_HEAD
 
-# Unit tests for resolve-base-branch.sh (used above to pick the comparison
-# baseline). Reuses the testrunner image only for its bash + jq; the tests stub
-# git/curl and need no network, so we skip the heavier .testrunner setup.
+# Unit tests for resolve-base-branch.sh. Reuses the testrunner image for bash+jq;
+# tests stub git/curl (no network), so we skip the heavier .testrunner setup.
 test_resolve_base_branch:
   stage: tests
   needs: []

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -429,7 +429,7 @@ detect_circular_imports:
       # resolve-base-branch.sh mints its own token only if it hits the API,
       # so don't acquire one unconditionally here.
       BASE_BRANCH=$(.gitlab/scripts/resolve-base-branch.sh)
-      git fetch origin "${BASE_BRANCH}"
+      git fetch origin -- "${BASE_BRANCH}"
       MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
       git checkout "${MERGE_BASE}"
       cd ..

--- a/.gitlab/scripts/resolve-base-branch.sh
+++ b/.gitlab/scripts/resolve-base-branch.sh
@@ -18,12 +18,23 @@
 # Falls back to "main" whenever the branch can't be determined (e.g. no open
 # PR for the ref, or the GitHub lookup fails), rather than erroring out.
 #
-# Requires `git`, `curl` and `jq`. For the feature/PR-branch fallback it
-# queries the GitHub REST API directly (rather than shelling out to the `gh`
-# CLI, which isn't installed in every image this script runs in) against
-# GH_REPO (defaults to DataDog/dd-trace-py) — independent of whatever the
-# local `origin` remote happens to point at (e.g. a GitLab mirror). Set
-# GH_TOKEN to avoid unauthenticated GitHub API rate limits.
+# For a feature/PR branch the target is resolved in two steps:
+#   1. If the CI system already exposes the PR/MR target branch
+#      (CI_MERGE_REQUEST_TARGET_BRANCH_NAME on GitLab merge-request pipelines,
+#      GITHUB_BASE_REF on GitHub pull_request events), use it directly. This is
+#      the cheapest, most authoritative source and needs no token or network.
+#   2. Otherwise (e.g. this repo's GitLab branch pipelines, where neither var is
+#      set) query the GitHub REST API for the ref's open PR base branch.
+#
+# Requires `git`, `curl` and `jq`. The API fallback queries GitHub directly
+# (rather than shelling out to the `gh` CLI, which isn't installed in every
+# image this script runs in) against GH_REPO (defaults to DataDog/dd-trace-py) —
+# independent of whatever the local `origin` remote happens to point at (e.g. a
+# GitLab mirror). Authentication for that call is resolved lazily, only when the
+# API path is taken: pre-set GH_TOKEN to use it directly, else a read-scoped
+# token is minted via `dd-octo-sts` when that binary is available, else the
+# request is made unauthenticated (subject to GitHub rate limits). The fast
+# paths above never touch the token, so token issuance can't break them.
 
 set -euo pipefail
 
@@ -61,10 +72,26 @@ elif [[ "${REF}" =~ ^gh-readonly-queue/([^/]+)/ ]]; then
   BASE_BRANCH="${BASH_REMATCH[1]}"
   log "Ref is a GitHub merge-queue branch; extracted target branch '${BASE_BRANCH}'"
 
+elif [ -n "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-${GITHUB_BASE_REF:-}}" ]; then
+  # Fast path: the CI system already told us the PR/MR target branch, so trust
+  # it and skip the GitHub API round-trip (and its token requirement).
+  BASE_BRANCH="${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-${GITHUB_BASE_REF}}"
+  log "CI provided the PR target branch: '${BASE_BRANCH}'; using it directly"
+
 else
   GITHUB_REPO="${GH_REPO:-DataDog/dd-trace-py}"
   GITHUB_OWNER="${GITHUB_REPO%%/*}"
   log "Ref looks like a feature/PR branch; querying the GitHub API for its PR base branch (repo: ${GITHUB_REPO})"
+
+  # Acquire a GitHub token lazily -- only now that we know the API lookup is
+  # actually needed, so token issuance can never break the fast paths above.
+  # Callers may pre-set GH_TOKEN; otherwise mint a read-scoped one via
+  # dd-octo-sts when it's available, and fall back to an unauthenticated
+  # (rate-limited) request when it isn't.
+  if [ -z "${GH_TOKEN:-}" ] && command -v dd-octo-sts > /dev/null 2>&1; then
+    log "Minting a GitHub token via dd-octo-sts for the API lookup"
+    GH_TOKEN="$(dd-octo-sts token --scope "${GITHUB_REPO}" --policy gitlab.github-access.read 2> /dev/null || true)"
+  fi
 
   AUTH_HEADER=()
   if [ -n "${GH_TOKEN:-}" ]; then

--- a/.gitlab/scripts/resolve-base-branch.sh
+++ b/.gitlab/scripts/resolve-base-branch.sh
@@ -1,40 +1,17 @@
 #!/usr/bin/env bash
-# Resolve the branch that a CI ref should be compared against (its "base" or
-# "baseline" branch), so jobs that diff a PR/branch against upstream (e.g.
-# circular import analysis, benchmark baselines) don't hardcode `main` and
-# get the wrong answer for PRs targeting a release branch.
+# Resolve the base branch a CI ref should be compared against, so jobs
+# (circular-import analysis, benchmark baselines) don't hardcode `main` and get
+# the wrong answer for PRs targeting a release branch.
 #
-# Usage:
-#   resolve-base-branch.sh [ref]
+# Usage: resolve-base-branch.sh [ref]   (ref defaults to $CI_COMMIT_REF_NAME)
+# Prints only the resolved branch to stdout; trace goes to stderr. Falls back to
+# `main` when undeterminable.
 #
-#   ref   Git ref/branch/tag to resolve from. Defaults to $CI_COMMIT_REF_NAME.
-#
-# Prints ONLY the resolved base branch name to stdout, so callers can do:
-#   BASE_BRANCH=$(.gitlab/scripts/resolve-base-branch.sh)
-#
-# All debug/trace output goes to stderr and is visible in the job log, so if
-# the wrong branch gets resolved it's clear which rule fired and why.
-#
-# Falls back to "main" whenever the branch can't be determined (e.g. no open
-# PR for the ref, or the GitHub lookup fails), rather than erroring out.
-#
-# For a feature/PR branch the target is resolved in two steps:
-#   1. If the CI system already exposes the PR/MR target branch
-#      (CI_MERGE_REQUEST_TARGET_BRANCH_NAME on GitLab merge-request pipelines,
-#      GITHUB_BASE_REF on GitHub pull_request events), use it directly. This is
-#      the cheapest, most authoritative source and needs no token or network.
-#   2. Otherwise (e.g. this repo's GitLab branch pipelines, where neither var is
-#      set) query the GitHub REST API for the ref's open PR base branch.
-#
-# Requires `git`, `curl` and `jq`. The API fallback queries GitHub directly
-# (rather than shelling out to the `gh` CLI, which isn't installed in every
-# image this script runs in) against GH_REPO (defaults to DataDog/dd-trace-py) —
-# independent of whatever the local `origin` remote happens to point at (e.g. a
-# GitLab mirror). Authentication for that call is resolved lazily, only when the
-# API path is taken: pre-set GH_TOKEN to use it directly, else a read-scoped
-# token is minted via `dd-octo-sts` when that binary is available, else the
-# request is made unauthenticated (subject to GitHub rate limits). The fast
-# paths above never touch the token, so token issuance can't break them.
+# For a feature/PR branch: use the CI-provided target
+# (CI_MERGE_REQUEST_TARGET_BRANCH_NAME / GITHUB_BASE_REF) if set, else query the
+# GitHub API (GH_REPO, default DataDog/dd-trace-py; needs git/curl/jq). The API
+# call auths lazily: GH_TOKEN if set, else a token minted via dd-octo-sts if
+# present, else unauthenticated.
 
 set -euo pipefail
 
@@ -73,8 +50,7 @@ elif [[ "${REF}" =~ ^gh-readonly-queue/([^/]+)/ ]]; then
   log "Ref is a GitHub merge-queue branch; extracted target branch '${BASE_BRANCH}'"
 
 elif [ -n "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-${GITHUB_BASE_REF:-}}" ]; then
-  # Fast path: the CI system already told us the PR/MR target branch, so trust
-  # it and skip the GitHub API round-trip (and its token requirement).
+  # Fast path: CI already told us the target; skip the API round-trip.
   BASE_BRANCH="${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-${GITHUB_BASE_REF}}"
   log "CI provided the PR target branch: '${BASE_BRANCH}'; using it directly"
 
@@ -83,11 +59,7 @@ else
   GITHUB_OWNER="${GITHUB_REPO%%/*}"
   log "Ref looks like a feature/PR branch; querying the GitHub API for its PR base branch (repo: ${GITHUB_REPO})"
 
-  # Acquire a GitHub token lazily -- only now that we know the API lookup is
-  # actually needed, so token issuance can never break the fast paths above.
-  # Callers may pre-set GH_TOKEN; otherwise mint a read-scoped one via
-  # dd-octo-sts when it's available, and fall back to an unauthenticated
-  # (rate-limited) request when it isn't.
+  # Auth lazily, only on the API path, so token issues can't break the fast paths.
   if [ -z "${GH_TOKEN:-}" ] && command -v dd-octo-sts > /dev/null 2>&1; then
     log "Minting a GitHub token via dd-octo-sts for the API lookup"
     GH_TOKEN="$(dd-octo-sts token --scope "${GITHUB_REPO}" --policy gitlab.github-access.read 2> /dev/null || true)"

--- a/.gitlab/scripts/resolve-base-branch.sh
+++ b/.gitlab/scripts/resolve-base-branch.sh
@@ -20,12 +20,23 @@
 #
 # Merge-queue runs use devflow's `mq-working-branch-<target>-<sha>` naming.
 #
-# Requires `git`, `curl` and `jq`. For the feature/PR-branch fallback it
-# queries the GitHub REST API directly (rather than shelling out to the `gh`
-# CLI, which isn't installed in every image this script runs in) against
-# GH_REPO (defaults to DataDog/dd-trace-py) — independent of whatever the
-# local `origin` remote happens to point at (e.g. a GitLab mirror). Set
-# GH_TOKEN to avoid unauthenticated GitHub API rate limits.
+# For a feature/PR branch the target is resolved in two steps:
+#   1. If the CI system already exposes the PR/MR target branch
+#      (CI_MERGE_REQUEST_TARGET_BRANCH_NAME on GitLab merge-request pipelines,
+#      GITHUB_BASE_REF on GitHub pull_request events), use it directly. This is
+#      the cheapest, most authoritative source and needs no token or network.
+#   2. Otherwise (e.g. this repo's GitLab branch pipelines, where neither var is
+#      set) query the GitHub REST API for the ref's open PR base branch.
+#
+# Requires `git`, `curl` and `jq`. The API fallback queries GitHub directly
+# (rather than shelling out to the `gh` CLI, which isn't installed in every
+# image this script runs in) against GH_REPO (defaults to DataDog/dd-trace-py) —
+# independent of whatever the local `origin` remote happens to point at (e.g. a
+# GitLab mirror). Authentication for that call is resolved lazily, only when the
+# API path is taken: pre-set GH_TOKEN to use it directly, else a read-scoped
+# token is minted via `dd-octo-sts` when that binary is available, else the
+# request is made unauthenticated (subject to GitHub rate limits). The fast
+# paths above never touch the token, so token issuance can't break them.
 
 set -euo pipefail
 
@@ -63,10 +74,26 @@ elif [[ "${REF}" =~ ^mq-working-branch-(.+)-[0-9a-f]{7,40}$ ]]; then
   BASE_BRANCH="${BASH_REMATCH[1]}"
   log "Ref is a devflow merge-queue working branch; extracted target branch '${BASE_BRANCH}'"
 
+elif [ -n "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-${GITHUB_BASE_REF:-}}" ]; then
+  # Fast path: the CI system already told us the PR/MR target branch, so trust
+  # it and skip the GitHub API round-trip (and its token requirement).
+  BASE_BRANCH="${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-${GITHUB_BASE_REF}}"
+  log "CI provided the PR target branch: '${BASE_BRANCH}'; using it directly"
+
 else
   GITHUB_REPO="${GH_REPO:-DataDog/dd-trace-py}"
   GITHUB_OWNER="${GITHUB_REPO%%/*}"
   log "Ref looks like a feature/PR branch; querying the GitHub API for its PR base branch (repo: ${GITHUB_REPO})"
+
+  # Acquire a GitHub token lazily -- only now that we know the API lookup is
+  # actually needed, so token issuance can never break the fast paths above.
+  # Callers may pre-set GH_TOKEN; otherwise mint a read-scoped one via
+  # dd-octo-sts when it's available, and fall back to an unauthenticated
+  # (rate-limited) request when it isn't.
+  if [ -z "${GH_TOKEN:-}" ] && command -v dd-octo-sts > /dev/null 2>&1; then
+    log "Minting a GitHub token via dd-octo-sts for the API lookup"
+    GH_TOKEN="$(dd-octo-sts token --scope "${GITHUB_REPO}" --policy gitlab.github-access.read 2> /dev/null || true)"
+  fi
 
   AUTH_HEADER=()
   if [ -n "${GH_TOKEN:-}" ]; then

--- a/.gitlab/scripts/resolve-base-branch.sh
+++ b/.gitlab/scripts/resolve-base-branch.sh
@@ -1,42 +1,18 @@
 #!/usr/bin/env bash
-# Resolve the branch that a CI ref should be compared against (its "base" or
-# "baseline" branch), so jobs that diff a PR/branch against upstream (e.g.
-# circular import analysis, benchmark baselines) don't hardcode `main` and
-# get the wrong answer for PRs targeting a release branch.
+# Resolve the base branch a CI ref should be compared against, so jobs
+# (circular-import analysis, benchmark baselines) don't hardcode `main` and get
+# the wrong answer for PRs targeting a release branch.
 #
-# Usage:
-#   resolve-base-branch.sh [ref]
-#
-#   ref   Git ref/branch/tag to resolve from. Defaults to $CI_COMMIT_REF_NAME.
-#
-# Prints ONLY the resolved base branch name to stdout, so callers can do:
-#   BASE_BRANCH=$(.gitlab/scripts/resolve-base-branch.sh)
-#
-# All debug/trace output goes to stderr and is visible in the job log, so if
-# the wrong branch gets resolved it's clear which rule fired and why.
-#
-# Falls back to "main" whenever the branch can't be determined (e.g. no open
-# PR for the ref, or the GitHub lookup fails), rather than erroring out.
+# Usage: resolve-base-branch.sh [ref]   (ref defaults to $CI_COMMIT_REF_NAME)
+# Prints only the resolved branch to stdout; trace goes to stderr. Falls back to
+# `main` when undeterminable.
 #
 # Merge-queue runs use devflow's `mq-working-branch-<target>-<sha>` naming.
-#
-# For a feature/PR branch the target is resolved in two steps:
-#   1. If the CI system already exposes the PR/MR target branch
-#      (CI_MERGE_REQUEST_TARGET_BRANCH_NAME on GitLab merge-request pipelines,
-#      GITHUB_BASE_REF on GitHub pull_request events), use it directly. This is
-#      the cheapest, most authoritative source and needs no token or network.
-#   2. Otherwise (e.g. this repo's GitLab branch pipelines, where neither var is
-#      set) query the GitHub REST API for the ref's open PR base branch.
-#
-# Requires `git`, `curl` and `jq`. The API fallback queries GitHub directly
-# (rather than shelling out to the `gh` CLI, which isn't installed in every
-# image this script runs in) against GH_REPO (defaults to DataDog/dd-trace-py) —
-# independent of whatever the local `origin` remote happens to point at (e.g. a
-# GitLab mirror). Authentication for that call is resolved lazily, only when the
-# API path is taken: pre-set GH_TOKEN to use it directly, else a read-scoped
-# token is minted via `dd-octo-sts` when that binary is available, else the
-# request is made unauthenticated (subject to GitHub rate limits). The fast
-# paths above never touch the token, so token issuance can't break them.
+# For a feature/PR branch: use the CI-provided target
+# (CI_MERGE_REQUEST_TARGET_BRANCH_NAME / GITHUB_BASE_REF) if set, else query the
+# GitHub API (GH_REPO, default DataDog/dd-trace-py; needs git/curl/jq). The API
+# call auths lazily: GH_TOKEN if set, else a token minted via dd-octo-sts if
+# present, else unauthenticated.
 
 set -euo pipefail
 
@@ -75,8 +51,7 @@ elif [[ "${REF}" =~ ^mq-working-branch-(.+)-[0-9a-f]{7,40}$ ]]; then
   log "Ref is a devflow merge-queue working branch; extracted target branch '${BASE_BRANCH}'"
 
 elif [ -n "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-${GITHUB_BASE_REF:-}}" ]; then
-  # Fast path: the CI system already told us the PR/MR target branch, so trust
-  # it and skip the GitHub API round-trip (and its token requirement).
+  # Fast path: CI already told us the target; skip the API round-trip.
   BASE_BRANCH="${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-${GITHUB_BASE_REF}}"
   log "CI provided the PR target branch: '${BASE_BRANCH}'; using it directly"
 
@@ -85,11 +60,7 @@ else
   GITHUB_OWNER="${GITHUB_REPO%%/*}"
   log "Ref looks like a feature/PR branch; querying the GitHub API for its PR base branch (repo: ${GITHUB_REPO})"
 
-  # Acquire a GitHub token lazily -- only now that we know the API lookup is
-  # actually needed, so token issuance can never break the fast paths above.
-  # Callers may pre-set GH_TOKEN; otherwise mint a read-scoped one via
-  # dd-octo-sts when it's available, and fall back to an unauthenticated
-  # (rate-limited) request when it isn't.
+  # Auth lazily, only on the API path, so token issues can't break the fast paths.
   if [ -z "${GH_TOKEN:-}" ] && command -v dd-octo-sts > /dev/null 2>&1; then
     log "Minting a GitHub token via dd-octo-sts for the API lookup"
     GH_TOKEN="$(dd-octo-sts token --scope "${GITHUB_REPO}" --policy gitlab.github-access.read 2> /dev/null || true)"

--- a/.gitlab/scripts/resolve-base-branch.test.sh
+++ b/.gitlab/scripts/resolve-base-branch.test.sh
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
-# Unit tests for resolve-base-branch.sh.
-#
-# Self-contained: stubs `git` and `curl` on PATH so the tests are hermetic (no
-# network, no real repo state) and need no extra tooling beyond bash + jq. Run:
-#
-#   .gitlab/scripts/resolve-base-branch.test.sh
-#
-# Exits non-zero if any case fails, so it can be wired straight into CI.
+# Hermetic unit tests for resolve-base-branch.sh: stubs git/curl/dd-octo-sts on
+# PATH (no network), needs only bash + jq. Exits non-zero if any case fails.
 
 set -uo pipefail
 
@@ -23,9 +17,7 @@ BIN="${TMPROOT}/bin"
 mkdir -p "${BIN}"
 trap 'rm -rf "${TMPROOT}"' EXIT
 
-# --- stub: git -------------------------------------------------------------
-# Only `git ls-remote --exit-code --heads origin refs/heads/<b>` is used.
-# Succeed iff <b> is listed in FAKE_EXISTING_BRANCHES (colon-separated).
+# git stub: ls-remote succeeds iff <branch> is in FAKE_EXISTING_BRANCHES (colon-sep).
 cat > "${BIN}/git" <<'STUB'
 #!/usr/bin/env bash
 if [ "${1:-}" = "ls-remote" ]; then
@@ -44,9 +36,7 @@ exit 0
 STUB
 chmod +x "${BIN}/git"
 
-# --- stub: curl ------------------------------------------------------------
-# Records that it was invoked (so we can assert the fast path skips it) and
-# emits FAKE_CURL_BODY as the GitHub API response.
+# curl stub: touches FAKE_CURL_MARKER if called, emits FAKE_CURL_BODY.
 cat > "${BIN}/curl" <<'STUB'
 #!/usr/bin/env bash
 if [ -n "${FAKE_CURL_MARKER:-}" ]; then : > "${FAKE_CURL_MARKER}"; fi
@@ -55,9 +45,7 @@ exit 0
 STUB
 chmod +x "${BIN}/curl"
 
-# --- stub: dd-octo-sts -----------------------------------------------------
-# Records that it was invoked (to assert lazy minting happens only on the API
-# path) and prints a fake token on `dd-octo-sts token ...`.
+# dd-octo-sts stub: touches FAKE_OCTOSTS_MARKER if called, prints a fake token.
 cat > "${BIN}/dd-octo-sts" <<'STUB'
 #!/usr/bin/env bash
 if [ -n "${FAKE_OCTOSTS_MARKER:-}" ]; then : > "${FAKE_OCTOSTS_MARKER}"; fi
@@ -68,15 +56,13 @@ chmod +x "${BIN}/dd-octo-sts"
 
 export PATH="${BIN}:${PATH}"
 
-# Make sure the real environment doesn't leak into cases that expect these
-# unset; each case sets what it needs via an inline env prefix.
+# Prevent the real env from leaking in; each case sets what it needs inline.
 unset CI_COMMIT_REF_NAME CI_MERGE_REQUEST_TARGET_BRANCH_NAME GITHUB_BASE_REF GH_TOKEN 2>/dev/null || true
 
 pass=0
 fail=0
 
 check() {
-  # check <got> <expected> <description>
   local got="$1" expected="$2" desc="$3"
   if [ "${got}" = "${expected}" ]; then
     printf 'ok   - %s (=> %s)\n' "${desc}" "${got}"
@@ -88,7 +74,6 @@ check() {
 }
 
 assert_present() {
-  # assert_present <path> <description>
   if [ -e "$1" ]; then
     printf 'ok   - %s\n' "$2"
     pass=$((pass + 1))
@@ -99,7 +84,6 @@ assert_present() {
 }
 
 assert_absent() {
-  # assert_absent <path> <description>
   if [ ! -e "$1" ]; then
     printf 'ok   - %s\n' "$2"
     pass=$((pass + 1))
@@ -109,25 +93,19 @@ assert_absent() {
   fi
 }
 
-# 1. main compares against itself.
 check "$(bash "${TARGET}" main 2>/dev/null)" "main" "ref=main -> main"
 
-# 2. release tag -> derived release branch (branch exists).
 check "$(FAKE_EXISTING_BRANCHES="4.12" bash "${TARGET}" v4.12.3 2>/dev/null)" \
   "4.12" "release tag v4.12.3 -> 4.12"
 
-# 3. release tag whose release branch does not exist -> main.
 check "$(FAKE_EXISTING_BRANCHES="" bash "${TARGET}" v9.9.9 2>/dev/null)" \
   "main" "release tag with missing branch -> main"
 
-# 4. release branch compares against itself.
 check "$(bash "${TARGET}" 4.12 2>/dev/null)" "4.12" "ref=4.12 -> 4.12"
 
-# 5. merge-queue ref -> extracted target branch.
 check "$(bash "${TARGET}" "gh-readonly-queue/4.12/pr-123-abc" 2>/dev/null)" \
   "4.12" "merge-queue ref -> 4.12"
 
-# 6. feature branch with GitLab MR target var -> fast path, no curl, no token.
 marker="${TMPROOT}/curl_called_6"; rm -f "${marker}"
 octo="${TMPROOT}/octo_called_6"; rm -f "${octo}"
 got="$(CI_MERGE_REQUEST_TARGET_BRANCH_NAME="4.12" FAKE_CURL_MARKER="${marker}" \
@@ -136,14 +114,13 @@ check "${got}" "4.12" "feature branch + CI_MERGE_REQUEST_TARGET_BRANCH_NAME -> 4
 assert_absent "${marker}" "fast path (MR var) skips the curl call"
 assert_absent "${octo}" "fast path (MR var) skips dd-octo-sts token minting"
 
-# 7. feature branch with GitHub Actions base ref -> fast path.
 marker="${TMPROOT}/curl_called_7"; rm -f "${marker}"
 got="$(GITHUB_BASE_REF="4.11" FAKE_CURL_MARKER="${marker}" \
   bash "${TARGET}" my-feature 2>/dev/null)"
 check "${got}" "4.11" "feature branch + GITHUB_BASE_REF -> 4.11"
 assert_absent "${marker}" "fast path (GITHUB_BASE_REF) skips the curl call"
 
-# 8. feature branch, no CI target vars -> GitHub API lookup, token minted lazily.
+# API-lookup cases need jq to parse the stubbed response.
 if command -v jq > /dev/null 2>&1; then
   body='[{"base":{"ref":"4.10"}}]'
   octo="${TMPROOT}/octo_called_8"; rm -f "${octo}"
@@ -152,21 +129,18 @@ if command -v jq > /dev/null 2>&1; then
     "4.10" "feature branch, API returns base.ref -> 4.10"
   assert_present "${octo}" "API path mints a token via dd-octo-sts when GH_TOKEN unset"
 
-  # 8b. GH_TOKEN pre-set -> API path must NOT mint a token.
   octo="${TMPROOT}/octo_called_8b"; rm -f "${octo}"
   check "$(GH_TOKEN="preset" FAKE_CURL_BODY="${body}" FAKE_OCTOSTS_MARKER="${octo}" \
     bash "${TARGET}" backport-x-to-4.10 2>/dev/null)" \
     "4.10" "feature branch, pre-set GH_TOKEN, API returns base.ref -> 4.10"
   assert_absent "${octo}" "pre-set GH_TOKEN skips dd-octo-sts token minting"
 
-  # 9. feature branch, API returns no open PR -> main.
   check "$(FAKE_CURL_BODY="[]" bash "${TARGET}" orphan-branch 2>/dev/null)" \
     "main" "feature branch, no open PR -> main"
 else
   printf 'skip - API-lookup cases (jq not installed)\n'
 fi
 
-# 10. no ref and CI_COMMIT_REF_NAME unset -> main.
 check "$(bash "${TARGET}" 2>/dev/null)" "main" "no ref -> main"
 
 echo

--- a/.gitlab/scripts/resolve-base-branch.test.sh
+++ b/.gitlab/scripts/resolve-base-branch.test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Unit tests for resolve-base-branch.sh.
+#
+# Self-contained: stubs `git` and `curl` on PATH so the tests are hermetic (no
+# network, no real repo state) and need no extra tooling beyond bash + jq. Run:
+#
+#   .gitlab/scripts/resolve-base-branch.test.sh
+#
+# Exits non-zero if any case fails, so it can be wired straight into CI.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="${SCRIPT_DIR}/resolve-base-branch.sh"
+
+if [ ! -x "${TARGET}" ]; then
+  echo "cannot find executable script under test: ${TARGET}" >&2
+  exit 1
+fi
+
+TMPROOT="$(mktemp -d)"
+BIN="${TMPROOT}/bin"
+mkdir -p "${BIN}"
+trap 'rm -rf "${TMPROOT}"' EXIT
+
+# --- stub: git -------------------------------------------------------------
+# Only `git ls-remote --exit-code --heads origin refs/heads/<b>` is used.
+# Succeed iff <b> is listed in FAKE_EXISTING_BRANCHES (colon-separated).
+cat > "${BIN}/git" <<'STUB'
+#!/usr/bin/env bash
+if [ "${1:-}" = "ls-remote" ]; then
+  ref="${!#}"                       # last arg: refs/heads/<branch>
+  branch="${ref#refs/heads/}"
+  IFS=':' read -ra existing <<< "${FAKE_EXISTING_BRANCHES:-}"
+  for b in "${existing[@]}"; do
+    if [ "${b}" = "${branch}" ]; then
+      echo "deadbeef	refs/heads/${branch}"
+      exit 0
+    fi
+  done
+  exit 2
+fi
+exit 0
+STUB
+chmod +x "${BIN}/git"
+
+# --- stub: curl ------------------------------------------------------------
+# Records that it was invoked (so we can assert the fast path skips it) and
+# emits FAKE_CURL_BODY as the GitHub API response.
+cat > "${BIN}/curl" <<'STUB'
+#!/usr/bin/env bash
+if [ -n "${FAKE_CURL_MARKER:-}" ]; then : > "${FAKE_CURL_MARKER}"; fi
+printf '%s' "${FAKE_CURL_BODY:-[]}"
+exit 0
+STUB
+chmod +x "${BIN}/curl"
+
+# --- stub: dd-octo-sts -----------------------------------------------------
+# Records that it was invoked (to assert lazy minting happens only on the API
+# path) and prints a fake token on `dd-octo-sts token ...`.
+cat > "${BIN}/dd-octo-sts" <<'STUB'
+#!/usr/bin/env bash
+if [ -n "${FAKE_OCTOSTS_MARKER:-}" ]; then : > "${FAKE_OCTOSTS_MARKER}"; fi
+if [ "${1:-}" = "token" ]; then echo "fake-token"; fi
+exit 0
+STUB
+chmod +x "${BIN}/dd-octo-sts"
+
+export PATH="${BIN}:${PATH}"
+
+# Make sure the real environment doesn't leak into cases that expect these
+# unset; each case sets what it needs via an inline env prefix.
+unset CI_COMMIT_REF_NAME CI_MERGE_REQUEST_TARGET_BRANCH_NAME GITHUB_BASE_REF GH_TOKEN 2>/dev/null || true
+
+pass=0
+fail=0
+
+check() {
+  # check <got> <expected> <description>
+  local got="$1" expected="$2" desc="$3"
+  if [ "${got}" = "${expected}" ]; then
+    printf 'ok   - %s (=> %s)\n' "${desc}" "${got}"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL - %s: expected %q, got %q\n' "${desc}" "${expected}" "${got}"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_present() {
+  # assert_present <path> <description>
+  if [ -e "$1" ]; then
+    printf 'ok   - %s\n' "$2"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL - %s (%s missing)\n' "$2" "$1"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_absent() {
+  # assert_absent <path> <description>
+  if [ ! -e "$1" ]; then
+    printf 'ok   - %s\n' "$2"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL - %s (%s exists)\n' "$2" "$1"
+    fail=$((fail + 1))
+  fi
+}
+
+# 1. main compares against itself.
+check "$(bash "${TARGET}" main 2>/dev/null)" "main" "ref=main -> main"
+
+# 2. release tag -> derived release branch (branch exists).
+check "$(FAKE_EXISTING_BRANCHES="4.12" bash "${TARGET}" v4.12.3 2>/dev/null)" \
+  "4.12" "release tag v4.12.3 -> 4.12"
+
+# 3. release tag whose release branch does not exist -> main.
+check "$(FAKE_EXISTING_BRANCHES="" bash "${TARGET}" v9.9.9 2>/dev/null)" \
+  "main" "release tag with missing branch -> main"
+
+# 4. release branch compares against itself.
+check "$(bash "${TARGET}" 4.12 2>/dev/null)" "4.12" "ref=4.12 -> 4.12"
+
+# 5. merge-queue ref -> extracted target branch.
+check "$(bash "${TARGET}" "gh-readonly-queue/4.12/pr-123-abc" 2>/dev/null)" \
+  "4.12" "merge-queue ref -> 4.12"
+
+# 6. feature branch with GitLab MR target var -> fast path, no curl, no token.
+marker="${TMPROOT}/curl_called_6"; rm -f "${marker}"
+octo="${TMPROOT}/octo_called_6"; rm -f "${octo}"
+got="$(CI_MERGE_REQUEST_TARGET_BRANCH_NAME="4.12" FAKE_CURL_MARKER="${marker}" \
+  FAKE_OCTOSTS_MARKER="${octo}" bash "${TARGET}" my-feature 2>/dev/null)"
+check "${got}" "4.12" "feature branch + CI_MERGE_REQUEST_TARGET_BRANCH_NAME -> 4.12"
+assert_absent "${marker}" "fast path (MR var) skips the curl call"
+assert_absent "${octo}" "fast path (MR var) skips dd-octo-sts token minting"
+
+# 7. feature branch with GitHub Actions base ref -> fast path.
+marker="${TMPROOT}/curl_called_7"; rm -f "${marker}"
+got="$(GITHUB_BASE_REF="4.11" FAKE_CURL_MARKER="${marker}" \
+  bash "${TARGET}" my-feature 2>/dev/null)"
+check "${got}" "4.11" "feature branch + GITHUB_BASE_REF -> 4.11"
+assert_absent "${marker}" "fast path (GITHUB_BASE_REF) skips the curl call"
+
+# 8. feature branch, no CI target vars -> GitHub API lookup, token minted lazily.
+if command -v jq > /dev/null 2>&1; then
+  body='[{"base":{"ref":"4.10"}}]'
+  octo="${TMPROOT}/octo_called_8"; rm -f "${octo}"
+  check "$(FAKE_CURL_BODY="${body}" FAKE_OCTOSTS_MARKER="${octo}" \
+    bash "${TARGET}" backport-x-to-4.10 2>/dev/null)" \
+    "4.10" "feature branch, API returns base.ref -> 4.10"
+  assert_present "${octo}" "API path mints a token via dd-octo-sts when GH_TOKEN unset"
+
+  # 8b. GH_TOKEN pre-set -> API path must NOT mint a token.
+  octo="${TMPROOT}/octo_called_8b"; rm -f "${octo}"
+  check "$(GH_TOKEN="preset" FAKE_CURL_BODY="${body}" FAKE_OCTOSTS_MARKER="${octo}" \
+    bash "${TARGET}" backport-x-to-4.10 2>/dev/null)" \
+    "4.10" "feature branch, pre-set GH_TOKEN, API returns base.ref -> 4.10"
+  assert_absent "${octo}" "pre-set GH_TOKEN skips dd-octo-sts token minting"
+
+  # 9. feature branch, API returns no open PR -> main.
+  check "$(FAKE_CURL_BODY="[]" bash "${TARGET}" orphan-branch 2>/dev/null)" \
+    "main" "feature branch, no open PR -> main"
+else
+  printf 'skip - API-lookup cases (jq not installed)\n'
+fi
+
+# 10. no ref and CI_COMMIT_REF_NAME unset -> main.
+check "$(bash "${TARGET}" 2>/dev/null)" "main" "no ref -> main"
+
+echo
+echo "passed: ${pass}, failed: ${fail}"
+[ "${fail}" -eq 0 ]

--- a/.gitlab/scripts/resolve-base-branch.test.sh
+++ b/.gitlab/scripts/resolve-base-branch.test.sh
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
-# Unit tests for resolve-base-branch.sh.
-#
-# Self-contained: stubs `git` and `curl` on PATH so the tests are hermetic (no
-# network, no real repo state) and need no extra tooling beyond bash + jq. Run:
-#
-#   .gitlab/scripts/resolve-base-branch.test.sh
-#
-# Exits non-zero if any case fails, so it can be wired straight into CI.
+# Hermetic unit tests for resolve-base-branch.sh: stubs git/curl/dd-octo-sts on
+# PATH (no network), needs only bash + jq. Exits non-zero if any case fails.
 
 set -uo pipefail
 
@@ -23,9 +17,7 @@ BIN="${TMPROOT}/bin"
 mkdir -p "${BIN}"
 trap 'rm -rf "${TMPROOT}"' EXIT
 
-# --- stub: git -------------------------------------------------------------
-# Only `git ls-remote --exit-code --heads origin refs/heads/<b>` is used.
-# Succeed iff <b> is listed in FAKE_EXISTING_BRANCHES (colon-separated).
+# git stub: ls-remote succeeds iff <branch> is in FAKE_EXISTING_BRANCHES (colon-sep).
 cat > "${BIN}/git" <<'STUB'
 #!/usr/bin/env bash
 if [ "${1:-}" = "ls-remote" ]; then
@@ -44,9 +36,7 @@ exit 0
 STUB
 chmod +x "${BIN}/git"
 
-# --- stub: curl ------------------------------------------------------------
-# Records that it was invoked (so we can assert the fast path skips it) and
-# emits FAKE_CURL_BODY as the GitHub API response.
+# curl stub: touches FAKE_CURL_MARKER if called, emits FAKE_CURL_BODY.
 cat > "${BIN}/curl" <<'STUB'
 #!/usr/bin/env bash
 if [ -n "${FAKE_CURL_MARKER:-}" ]; then : > "${FAKE_CURL_MARKER}"; fi
@@ -55,9 +45,7 @@ exit 0
 STUB
 chmod +x "${BIN}/curl"
 
-# --- stub: dd-octo-sts -----------------------------------------------------
-# Records that it was invoked (to assert lazy minting happens only on the API
-# path) and prints a fake token on `dd-octo-sts token ...`.
+# dd-octo-sts stub: touches FAKE_OCTOSTS_MARKER if called, prints a fake token.
 cat > "${BIN}/dd-octo-sts" <<'STUB'
 #!/usr/bin/env bash
 if [ -n "${FAKE_OCTOSTS_MARKER:-}" ]; then : > "${FAKE_OCTOSTS_MARKER}"; fi
@@ -68,15 +56,13 @@ chmod +x "${BIN}/dd-octo-sts"
 
 export PATH="${BIN}:${PATH}"
 
-# Make sure the real environment doesn't leak into cases that expect these
-# unset; each case sets what it needs via an inline env prefix.
+# Prevent the real env from leaking in; each case sets what it needs inline.
 unset CI_COMMIT_REF_NAME CI_MERGE_REQUEST_TARGET_BRANCH_NAME GITHUB_BASE_REF GH_TOKEN 2>/dev/null || true
 
 pass=0
 fail=0
 
 check() {
-  # check <got> <expected> <description>
   local got="$1" expected="$2" desc="$3"
   if [ "${got}" = "${expected}" ]; then
     printf 'ok   - %s (=> %s)\n' "${desc}" "${got}"
@@ -88,7 +74,6 @@ check() {
 }
 
 assert_present() {
-  # assert_present <path> <description>
   if [ -e "$1" ]; then
     printf 'ok   - %s\n' "$2"
     pass=$((pass + 1))
@@ -99,7 +84,6 @@ assert_present() {
 }
 
 assert_absent() {
-  # assert_absent <path> <description>
   if [ ! -e "$1" ]; then
     printf 'ok   - %s\n' "$2"
     pass=$((pass + 1))
@@ -109,25 +93,19 @@ assert_absent() {
   fi
 }
 
-# 1. main compares against itself.
 check "$(bash "${TARGET}" main 2>/dev/null)" "main" "ref=main -> main"
 
-# 2. release tag -> derived release branch (branch exists).
 check "$(FAKE_EXISTING_BRANCHES="4.12" bash "${TARGET}" v4.12.3 2>/dev/null)" \
   "4.12" "release tag v4.12.3 -> 4.12"
 
-# 3. release tag whose release branch does not exist -> main.
 check "$(FAKE_EXISTING_BRANCHES="" bash "${TARGET}" v9.9.9 2>/dev/null)" \
   "main" "release tag with missing branch -> main"
 
-# 4. release branch compares against itself.
 check "$(bash "${TARGET}" 4.12 2>/dev/null)" "4.12" "ref=4.12 -> 4.12"
 
-# 5. merge-queue ref -> extracted target branch.
 check "$(bash "${TARGET}" "mq-working-branch-4.12-abc1234" 2>/dev/null)" \
   "4.12" "merge-queue ref -> 4.12"
 
-# 6. feature branch with GitLab MR target var -> fast path, no curl, no token.
 marker="${TMPROOT}/curl_called_6"; rm -f "${marker}"
 octo="${TMPROOT}/octo_called_6"; rm -f "${octo}"
 got="$(CI_MERGE_REQUEST_TARGET_BRANCH_NAME="4.12" FAKE_CURL_MARKER="${marker}" \
@@ -136,14 +114,13 @@ check "${got}" "4.12" "feature branch + CI_MERGE_REQUEST_TARGET_BRANCH_NAME -> 4
 assert_absent "${marker}" "fast path (MR var) skips the curl call"
 assert_absent "${octo}" "fast path (MR var) skips dd-octo-sts token minting"
 
-# 7. feature branch with GitHub Actions base ref -> fast path.
 marker="${TMPROOT}/curl_called_7"; rm -f "${marker}"
 got="$(GITHUB_BASE_REF="4.11" FAKE_CURL_MARKER="${marker}" \
   bash "${TARGET}" my-feature 2>/dev/null)"
 check "${got}" "4.11" "feature branch + GITHUB_BASE_REF -> 4.11"
 assert_absent "${marker}" "fast path (GITHUB_BASE_REF) skips the curl call"
 
-# 8. feature branch, no CI target vars -> GitHub API lookup, token minted lazily.
+# API-lookup cases need jq to parse the stubbed response.
 if command -v jq > /dev/null 2>&1; then
   body='[{"base":{"ref":"4.10"}}]'
   octo="${TMPROOT}/octo_called_8"; rm -f "${octo}"
@@ -152,21 +129,18 @@ if command -v jq > /dev/null 2>&1; then
     "4.10" "feature branch, API returns base.ref -> 4.10"
   assert_present "${octo}" "API path mints a token via dd-octo-sts when GH_TOKEN unset"
 
-  # 8b. GH_TOKEN pre-set -> API path must NOT mint a token.
   octo="${TMPROOT}/octo_called_8b"; rm -f "${octo}"
   check "$(GH_TOKEN="preset" FAKE_CURL_BODY="${body}" FAKE_OCTOSTS_MARKER="${octo}" \
     bash "${TARGET}" backport-x-to-4.10 2>/dev/null)" \
     "4.10" "feature branch, pre-set GH_TOKEN, API returns base.ref -> 4.10"
   assert_absent "${octo}" "pre-set GH_TOKEN skips dd-octo-sts token minting"
 
-  # 9. feature branch, API returns no open PR -> main.
   check "$(FAKE_CURL_BODY="[]" bash "${TARGET}" orphan-branch 2>/dev/null)" \
     "main" "feature branch, no open PR -> main"
 else
   printf 'skip - API-lookup cases (jq not installed)\n'
 fi
 
-# 10. no ref and CI_COMMIT_REF_NAME unset -> main.
 check "$(bash "${TARGET}" 2>/dev/null)" "main" "no ref -> main"
 
 echo

--- a/.gitlab/scripts/resolve-base-branch.test.sh
+++ b/.gitlab/scripts/resolve-base-branch.test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Unit tests for resolve-base-branch.sh.
+#
+# Self-contained: stubs `git` and `curl` on PATH so the tests are hermetic (no
+# network, no real repo state) and need no extra tooling beyond bash + jq. Run:
+#
+#   .gitlab/scripts/resolve-base-branch.test.sh
+#
+# Exits non-zero if any case fails, so it can be wired straight into CI.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="${SCRIPT_DIR}/resolve-base-branch.sh"
+
+if [ ! -x "${TARGET}" ]; then
+  echo "cannot find executable script under test: ${TARGET}" >&2
+  exit 1
+fi
+
+TMPROOT="$(mktemp -d)"
+BIN="${TMPROOT}/bin"
+mkdir -p "${BIN}"
+trap 'rm -rf "${TMPROOT}"' EXIT
+
+# --- stub: git -------------------------------------------------------------
+# Only `git ls-remote --exit-code --heads origin refs/heads/<b>` is used.
+# Succeed iff <b> is listed in FAKE_EXISTING_BRANCHES (colon-separated).
+cat > "${BIN}/git" <<'STUB'
+#!/usr/bin/env bash
+if [ "${1:-}" = "ls-remote" ]; then
+  ref="${!#}"                       # last arg: refs/heads/<branch>
+  branch="${ref#refs/heads/}"
+  IFS=':' read -ra existing <<< "${FAKE_EXISTING_BRANCHES:-}"
+  for b in "${existing[@]}"; do
+    if [ "${b}" = "${branch}" ]; then
+      echo "deadbeef	refs/heads/${branch}"
+      exit 0
+    fi
+  done
+  exit 2
+fi
+exit 0
+STUB
+chmod +x "${BIN}/git"
+
+# --- stub: curl ------------------------------------------------------------
+# Records that it was invoked (so we can assert the fast path skips it) and
+# emits FAKE_CURL_BODY as the GitHub API response.
+cat > "${BIN}/curl" <<'STUB'
+#!/usr/bin/env bash
+if [ -n "${FAKE_CURL_MARKER:-}" ]; then : > "${FAKE_CURL_MARKER}"; fi
+printf '%s' "${FAKE_CURL_BODY:-[]}"
+exit 0
+STUB
+chmod +x "${BIN}/curl"
+
+# --- stub: dd-octo-sts -----------------------------------------------------
+# Records that it was invoked (to assert lazy minting happens only on the API
+# path) and prints a fake token on `dd-octo-sts token ...`.
+cat > "${BIN}/dd-octo-sts" <<'STUB'
+#!/usr/bin/env bash
+if [ -n "${FAKE_OCTOSTS_MARKER:-}" ]; then : > "${FAKE_OCTOSTS_MARKER}"; fi
+if [ "${1:-}" = "token" ]; then echo "fake-token"; fi
+exit 0
+STUB
+chmod +x "${BIN}/dd-octo-sts"
+
+export PATH="${BIN}:${PATH}"
+
+# Make sure the real environment doesn't leak into cases that expect these
+# unset; each case sets what it needs via an inline env prefix.
+unset CI_COMMIT_REF_NAME CI_MERGE_REQUEST_TARGET_BRANCH_NAME GITHUB_BASE_REF GH_TOKEN 2>/dev/null || true
+
+pass=0
+fail=0
+
+check() {
+  # check <got> <expected> <description>
+  local got="$1" expected="$2" desc="$3"
+  if [ "${got}" = "${expected}" ]; then
+    printf 'ok   - %s (=> %s)\n' "${desc}" "${got}"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL - %s: expected %q, got %q\n' "${desc}" "${expected}" "${got}"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_present() {
+  # assert_present <path> <description>
+  if [ -e "$1" ]; then
+    printf 'ok   - %s\n' "$2"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL - %s (%s missing)\n' "$2" "$1"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_absent() {
+  # assert_absent <path> <description>
+  if [ ! -e "$1" ]; then
+    printf 'ok   - %s\n' "$2"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL - %s (%s exists)\n' "$2" "$1"
+    fail=$((fail + 1))
+  fi
+}
+
+# 1. main compares against itself.
+check "$(bash "${TARGET}" main 2>/dev/null)" "main" "ref=main -> main"
+
+# 2. release tag -> derived release branch (branch exists).
+check "$(FAKE_EXISTING_BRANCHES="4.12" bash "${TARGET}" v4.12.3 2>/dev/null)" \
+  "4.12" "release tag v4.12.3 -> 4.12"
+
+# 3. release tag whose release branch does not exist -> main.
+check "$(FAKE_EXISTING_BRANCHES="" bash "${TARGET}" v9.9.9 2>/dev/null)" \
+  "main" "release tag with missing branch -> main"
+
+# 4. release branch compares against itself.
+check "$(bash "${TARGET}" 4.12 2>/dev/null)" "4.12" "ref=4.12 -> 4.12"
+
+# 5. merge-queue ref -> extracted target branch.
+check "$(bash "${TARGET}" "mq-working-branch-4.12-abc1234" 2>/dev/null)" \
+  "4.12" "merge-queue ref -> 4.12"
+
+# 6. feature branch with GitLab MR target var -> fast path, no curl, no token.
+marker="${TMPROOT}/curl_called_6"; rm -f "${marker}"
+octo="${TMPROOT}/octo_called_6"; rm -f "${octo}"
+got="$(CI_MERGE_REQUEST_TARGET_BRANCH_NAME="4.12" FAKE_CURL_MARKER="${marker}" \
+  FAKE_OCTOSTS_MARKER="${octo}" bash "${TARGET}" my-feature 2>/dev/null)"
+check "${got}" "4.12" "feature branch + CI_MERGE_REQUEST_TARGET_BRANCH_NAME -> 4.12"
+assert_absent "${marker}" "fast path (MR var) skips the curl call"
+assert_absent "${octo}" "fast path (MR var) skips dd-octo-sts token minting"
+
+# 7. feature branch with GitHub Actions base ref -> fast path.
+marker="${TMPROOT}/curl_called_7"; rm -f "${marker}"
+got="$(GITHUB_BASE_REF="4.11" FAKE_CURL_MARKER="${marker}" \
+  bash "${TARGET}" my-feature 2>/dev/null)"
+check "${got}" "4.11" "feature branch + GITHUB_BASE_REF -> 4.11"
+assert_absent "${marker}" "fast path (GITHUB_BASE_REF) skips the curl call"
+
+# 8. feature branch, no CI target vars -> GitHub API lookup, token minted lazily.
+if command -v jq > /dev/null 2>&1; then
+  body='[{"base":{"ref":"4.10"}}]'
+  octo="${TMPROOT}/octo_called_8"; rm -f "${octo}"
+  check "$(FAKE_CURL_BODY="${body}" FAKE_OCTOSTS_MARKER="${octo}" \
+    bash "${TARGET}" backport-x-to-4.10 2>/dev/null)" \
+    "4.10" "feature branch, API returns base.ref -> 4.10"
+  assert_present "${octo}" "API path mints a token via dd-octo-sts when GH_TOKEN unset"
+
+  # 8b. GH_TOKEN pre-set -> API path must NOT mint a token.
+  octo="${TMPROOT}/octo_called_8b"; rm -f "${octo}"
+  check "$(GH_TOKEN="preset" FAKE_CURL_BODY="${body}" FAKE_OCTOSTS_MARKER="${octo}" \
+    bash "${TARGET}" backport-x-to-4.10 2>/dev/null)" \
+    "4.10" "feature branch, pre-set GH_TOKEN, API returns base.ref -> 4.10"
+  assert_absent "${octo}" "pre-set GH_TOKEN skips dd-octo-sts token minting"
+
+  # 9. feature branch, API returns no open PR -> main.
+  check "$(FAKE_CURL_BODY="[]" bash "${TARGET}" orphan-branch 2>/dev/null)" \
+    "main" "feature branch, no open PR -> main"
+else
+  printf 'skip - API-lookup cases (jq not installed)\n'
+fi
+
+# 10. no ref and CI_COMMIT_REF_NAME unset -> main.
+check "$(bash "${TARGET}" 2>/dev/null)" "main" "no ref -> main"
+
+echo
+echo "passed: ${pass}, failed: ${fail}"
+[ "${fail}" -eq 0 ]


### PR DESCRIPTION
[< Prev PR](https://github.com/DataDog/dd-trace-py/pull/18907)

## Description

#18907 introduced `.gitlab/scripts/resolve-base-branch.sh` script 
so that CI jobs (circular-import analysis, benchmark baselines) stop hardcoding `main`
as the comparison baseline and instead compare against a PR's real target branch.

For a feature/PR branch, #18907 resolves the base by querying the GitHub REST API
for the ref's open PR. That works but needs a token (dd-octo-sts
`gitlab.github-access.read`) and a network round-trip.

This PR adds a **fast path**: when the CI system already exposes the PR/MR target
branch, use it directly and skip the API call:

- `CI_MERGE_REQUEST_TARGET_BRANCH_NAME` — GitLab merge-request pipelines
- `GITHUB_BASE_REF` — GitHub Actions `pull_request` events

When neither is set (the case on this repo's GitLab **branch** pipelines), it falls
back to the existing GitHub API lookup. The fast path avoids a token + API round-trip 
whenever the information is already present.

## Testing

- New tests in `.gitlab/scripts/resolve-base-branch.test.sh`: 12 cases covering `main`, release tags, release branches, merge-queue refs, fast-path env vars, the API lookup (hit/miss), and the no-ref default. Ran by the new `test_resolve_base_branch` CI job.