### PR TITLE
chore(profiling): add CPU timer sample ring

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/include/cpu_sample_ring.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/cpu_sample_ring.hpp
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <type_traits>
+
+namespace Datadog {
+namespace CpuTimer {
+
+// Keep this intentionally below echion's 2048-frame wall-sampler cap. RawSample
+// is embedded in every preallocated ring slot, so high frame caps multiply into
+// large per-thread resident memory and can destabilize thread-heavy processes.
+constexpr uint16_t kMaxCpuTimerFrames = 512;
+
+struct RawFrame
+{
+    uintptr_t code_object = 0;
+    int lasti = -1;
+    int first_lineno = 0;
+};
+
+struct RawSample
+{
+    uint64_t cpu_delta_ns = 0;
+    uint64_t python_thread_id = 0;
+    uint64_t native_tid = 0;
+    uint16_t depth = 0;
+    std::array<RawFrame, kMaxCpuTimerFrames> frames{};
+};
+
+static_assert(std::is_trivially_copyable<RawSample>::value, "ring slots must be safe to copy without allocation");
+static_assert(std::atomic<uint32_t>::is_always_lock_free,
+              "CPU timer signal handler requires lock-free ring index atomics");
+
+// Single-producer, single-consumer ring. Each CaptureState owns one ring, so
+// its SIGEV_THREAD_ID target is the sole producer and the sampler thread is the
+// sole consumer. The producer must either publish a reserved slot or abandon it
+// before its next reservation. An abandoned slot remains invisible and can be
+// overwritten by the next reservation.
+class CpuSampleRing
+{
+    static constexpr uint32_t kMinimumCapacity = 2;
+
+    const uint32_t capacity_;
+    std::unique_ptr<RawSample[]> samples_;
+    std::atomic<uint32_t> head_{ 0 };
+    std::atomic<uint32_t> tail_{ 0 };
+
+    uint32_t advance(uint32_t index) const noexcept
+    {
+        const uint32_t next = index + 1;
+        return next == capacity_ ? 0 : next;
+    }
+
+  public:
+    explicit CpuSampleRing(uint32_t capacity)
+      : capacity_(capacity < kMinimumCapacity ? kMinimumCapacity : capacity)
+      , samples_(std::make_unique<RawSample[]>(capacity_))
+    {
+    }
+
+    CpuSampleRing(const CpuSampleRing&) = delete;
+    CpuSampleRing& operator=(const CpuSampleRing&) = delete;
+
+    [[nodiscard]] uint32_t capacity() const noexcept { return capacity_; }
+
+    // The acquire load pairs with the consumer's release store after it has
+    // finished copying a slot, so the producer never overwrites an in-use slot.
+    [[nodiscard]] RawSample* reserve_for_producer() noexcept
+    {
+        const uint32_t head = head_.load(std::memory_order_relaxed);
+        const uint32_t next = advance(head);
+        const uint32_t tail = tail_.load(std::memory_order_acquire);
+        if (next == tail) {
+            return nullptr;
+        }
+        return &samples_[head];
+    }
+
+    // The release store publishes all slot writes to the consumer.
+    void publish_for_producer() noexcept
+    {
+        const uint32_t head = head_.load(std::memory_order_relaxed);
+        head_.store(advance(head), std::memory_order_release);
+    }
+
+    // The acquire load pairs with publish_for_producer(), so the consumer sees
+    // a complete RawSample before copying it.
+    [[nodiscard]] bool pop_for_consumer(RawSample& out) noexcept
+    {
+        const uint32_t tail = tail_.load(std::memory_order_relaxed);
+        const uint32_t head = head_.load(std::memory_order_acquire);
+        if (tail == head) {
+            return false;
+        }
+        out = samples_[tail];
+        tail_.store(advance(tail), std::memory_order_release);
+        return true;
+    }
+
+    // This is a best-effort snapshot. It must not be used to coordinate work.
+    [[nodiscard]] bool empty() const noexcept
+    {
+        return tail_.load(std::memory_order_acquire) == head_.load(std::memory_order_acquire);
+    }
+};
+
+} // namespace CpuTimer
+} // namespace Datadog

--- a/ddtrace/internal/datadog/profiling/stack/test/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/stack/test/CMakeLists.txt
@@ -77,6 +77,7 @@ function(dd_wrapper_add_test name)
 endfunction()
 
 # Add the tests
+dd_wrapper_add_test(test_cpu_sample_ring test_cpu_sample_ring.cpp)
 dd_wrapper_add_test(test_thread_span_links test_thread_span_links.cpp)
 
 dd_wrapper_add_test(test_alt_stack_ownership test_alt_stack_ownership.cpp)

--- a/ddtrace/internal/datadog/profiling/stack/test/test_cpu_sample_ring.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/test/test_cpu_sample_ring.cpp
@@ -1,0 +1,179 @@
+#include "cpu_sample_ring.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <thread>
+
+using Datadog::CpuTimer::CpuSampleRing;
+using Datadog::CpuTimer::RawSample;
+
+namespace {
+
+RawSample
+make_sample(uint64_t id)
+{
+    RawSample sample{};
+    sample.cpu_delta_ns = 1'000 + id;
+    sample.python_thread_id = 2'000 + id;
+    sample.native_tid = 3'000 + id;
+    sample.depth = 2;
+    sample.frames[0].code_object = static_cast<uintptr_t>(4'000 + id);
+    sample.frames[0].lasti = static_cast<int>(5'000 + id);
+    sample.frames[0].first_lineno = static_cast<int>(6'000 + id);
+    sample.frames[1].code_object = static_cast<uintptr_t>(7'000 + id);
+    sample.frames[1].lasti = static_cast<int>(8'000 + id);
+    sample.frames[1].first_lineno = static_cast<int>(9'000 + id);
+    return sample;
+}
+
+void
+expect_sample_eq(const RawSample& actual, const RawSample& expected)
+{
+    EXPECT_EQ(actual.cpu_delta_ns, expected.cpu_delta_ns);
+    EXPECT_EQ(actual.python_thread_id, expected.python_thread_id);
+    EXPECT_EQ(actual.native_tid, expected.native_tid);
+    EXPECT_EQ(actual.depth, expected.depth);
+    for (uint16_t i = 0; i < expected.depth; i++) {
+        EXPECT_EQ(actual.frames[i].code_object, expected.frames[i].code_object);
+        EXPECT_EQ(actual.frames[i].lasti, expected.frames[i].lasti);
+        EXPECT_EQ(actual.frames[i].first_lineno, expected.frames[i].first_lineno);
+    }
+}
+
+} // namespace
+
+TEST(CpuSampleRing, StartsEmpty)
+{
+    CpuSampleRing ring(4);
+    RawSample out{};
+
+    EXPECT_EQ(ring.capacity(), 4u);
+    EXPECT_TRUE(ring.empty());
+    EXPECT_FALSE(ring.pop_for_consumer(out));
+}
+
+TEST(CpuSampleRing, ClampsCapacityToKeepOneUsableSlot)
+{
+    CpuSampleRing ring(0);
+    RawSample out{};
+
+    EXPECT_EQ(ring.capacity(), 2u);
+
+    RawSample* reserved = ring.reserve_for_producer();
+    ASSERT_NE(reserved, nullptr);
+    *reserved = make_sample(1);
+    ring.publish_for_producer();
+
+    EXPECT_EQ(ring.reserve_for_producer(), nullptr);
+    ASSERT_TRUE(ring.pop_for_consumer(out));
+    expect_sample_eq(out, make_sample(1));
+}
+
+TEST(CpuSampleRing, ProducerReserveDoesNotPublish)
+{
+    CpuSampleRing ring(4);
+    RawSample out{};
+    RawSample sample = make_sample(1);
+
+    RawSample* reserved = ring.reserve_for_producer();
+    ASSERT_NE(reserved, nullptr);
+    *reserved = sample;
+
+    EXPECT_TRUE(ring.empty());
+    EXPECT_FALSE(ring.pop_for_consumer(out));
+
+    ring.publish_for_producer();
+
+    EXPECT_FALSE(ring.empty());
+    ASSERT_TRUE(ring.pop_for_consumer(out));
+    expect_sample_eq(out, sample);
+    EXPECT_TRUE(ring.empty());
+}
+
+TEST(CpuSampleRing, CapacityKeepsOneSlotOpenToDistinguishFullFromEmpty)
+{
+    CpuSampleRing ring(4);
+    RawSample samples[] = { make_sample(1), make_sample(2), make_sample(3) };
+
+    for (const auto& sample : samples) {
+        RawSample* reserved = ring.reserve_for_producer();
+        ASSERT_NE(reserved, nullptr);
+        *reserved = sample;
+        ring.publish_for_producer();
+    }
+
+    EXPECT_EQ(ring.reserve_for_producer(), nullptr);
+
+    for (const auto& expected : samples) {
+        RawSample out{};
+        ASSERT_TRUE(ring.pop_for_consumer(out));
+        expect_sample_eq(out, expected);
+    }
+
+    RawSample out{};
+    EXPECT_TRUE(ring.empty());
+    EXPECT_FALSE(ring.pop_for_consumer(out));
+}
+
+TEST(CpuSampleRing, WraparoundPreservesFifoOrder)
+{
+    CpuSampleRing ring(4);
+
+    RawSample first = make_sample(1);
+    RawSample second = make_sample(2);
+    RawSample third = make_sample(3);
+
+    RawSample* reserved = ring.reserve_for_producer();
+    ASSERT_NE(reserved, nullptr);
+    *reserved = first;
+    ring.publish_for_producer();
+
+    reserved = ring.reserve_for_producer();
+    ASSERT_NE(reserved, nullptr);
+    *reserved = second;
+    ring.publish_for_producer();
+
+    RawSample out{};
+    ASSERT_TRUE(ring.pop_for_consumer(out));
+    expect_sample_eq(out, first);
+
+    reserved = ring.reserve_for_producer();
+    ASSERT_NE(reserved, nullptr);
+    *reserved = third;
+    ring.publish_for_producer();
+
+    ASSERT_TRUE(ring.pop_for_consumer(out));
+    expect_sample_eq(out, second);
+    ASSERT_TRUE(ring.pop_for_consumer(out));
+    expect_sample_eq(out, third);
+    EXPECT_TRUE(ring.empty());
+}
+
+TEST(CpuSampleRing, ConcurrentProducerAndConsumerPreserveWholeFifoSamples)
+{
+    constexpr uint64_t sample_count = 20'000;
+    CpuSampleRing ring(64);
+
+    std::thread producer([&] {
+        for (uint64_t id = 1; id <= sample_count; id++) {
+            RawSample* reserved;
+            while ((reserved = ring.reserve_for_producer()) == nullptr) {
+                std::this_thread::yield();
+            }
+            *reserved = make_sample(id);
+            ring.publish_for_producer();
+        }
+    });
+
+    for (uint64_t expected_id = 1; expected_id <= sample_count; expected_id++) {
+        RawSample actual{};
+        while (!ring.pop_for_consumer(actual)) {
+            std::this_thread::yield();
+        }
+        expect_sample_eq(actual, make_sample(expected_id));
+    }
+
+    producer.join();
+    EXPECT_TRUE(ring.empty());
+}


### PR DESCRIPTION
## Description

Adds an internal, fixed-capacity SPSC ring for CPU timer raw samples. The ring is preallocated at construction and uses lock-free atomic indices, so its producer path does not allocate or lock. It is intentionally only scaffolding: this PR does not enable timers, install signal handlers, add configuration, or change profiler runtime behavior.

The ring documents its single-producer and single-consumer ownership plus its acquire/release publication pairs. Tests cover capacity clamping, unpublished reservations, full/empty behavior, FIFO wraparound, and concurrent producer/consumer ordering.

## Testing

- `scripts/lint cformat ddtrace/internal/datadog/profiling/stack/include/cpu_sample_ring.hpp ddtrace/internal/datadog/profiling/stack/test/test_cpu_sample_ring.cpp`
- `git diff --check`
- Built `test_cpu_sample_ring` with CMake and ran `/tmp/ddtrace-cpu-sample-ring-worktree-build/test/test_cpu_sample_ring`, 6 passed.

## Risks

None. The new ring is not wired into runtime code in this PR.

## Additional Notes

This is a stacked PR on `taegyunkim/prof-14213-safe-copy-altstack-teardown-guard` and is intended as a small prerequisite for the CPU timer implementation. No release note is needed because this is internal scaffolding.
