### PR TITLE
refactor(llmobs): remove label metadata from managed prompts

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -1931,7 +1931,7 @@ class LLMObs(Service):
         Retrieve a prompt template from the Datadog Prompt Registry.
 
         :param prompt_id: The unique identifier of the prompt in the registry
-        :param label: Deprecated; set ``DD_ENV`` instead. Deployment label selecting a version.
+        :param label: Deprecated; set ``DD_ENV`` instead. Must be ``production`` or ``development``.
         :param fallback: Fallback to use if prompt cannot be fetched (cold start + API failure).
                          Can be a template string, message list, Prompt dict, or a callable that
                          returns any of those.
@@ -2012,7 +2012,7 @@ class LLMObs(Service):
 
         Args:
             prompt_id: The prompt identifier.
-            label: Deprecated; set DD_ENV instead. Deployment label selecting a version.
+            label: Deprecated; set DD_ENV instead. Must be ``production`` or ``development``.
 
         Returns:
             The refreshed prompt, or None if fetch failed.
@@ -2041,7 +2041,7 @@ class LLMObs(Service):
             title: Optional human-readable title.
             description: Optional description of the prompt.
             user_version: Optional user-defined version string.
-            labels: Optional list of deployment labels (arbitrary strings, typically DD_ENV values).
+            labels: Optional list containing ``production`` and/or ``development``.
 
         Returns:
             The created prompt.
@@ -2074,7 +2074,7 @@ class LLMObs(Service):
             template: List of chat messages defining the new version's template.
             description: Optional description of this version.
             user_version: Optional user-defined version string.
-            labels: Optional list of deployment labels (arbitrary strings, typically DD_ENV values).
+            labels: Optional list containing ``production`` and/or ``development``.
 
         Returns:
             The created prompt version.
@@ -2131,7 +2131,7 @@ class LLMObs(Service):
         Args:
             prompt_id: The prompt identifier.
             version: The numeric version number (auto-incremented by the API, e.g. 1, 2, 3).
-            labels: New labels for the version.
+            labels: New labels for the version. Values must be ``production`` and/or ``development``.
             description: New description for the version.
 
         Returns:

--- a/ddtrace/llmobs/_prompts/manager.py
+++ b/ddtrace/llmobs/_prompts/manager.py
@@ -482,15 +482,9 @@ class PromptManager:
             if not version:
                 log.warning("Failed to parse prompt response: missing version")
                 return None
-            raw_labels = data.get("labels")
-            if isinstance(raw_labels, list):
-                labels = [value for value in raw_labels if isinstance(value, str)]
-            else:
-                labels = []
             return ManagedPrompt(
                 id=prompt_id,
                 version=version,
-                labels=labels,
                 source=source,
                 template=extract_template(data, default=[]),
                 _uuid=data.get("prompt_uuid"),

--- a/ddtrace/llmobs/_prompts/manager.py
+++ b/ddtrace/llmobs/_prompts/manager.py
@@ -434,7 +434,7 @@ class PromptManager:
 
             if status == 200:
                 source: Literal["registry", "resolve"] = "resolve" if req.use_resolve else "registry"
-                prompt = self._parse_prompt(body, source=source, label=req.label)
+                prompt = self._parse_prompt(body, source=source)
                 return prompt, False, ""
 
             not_found = status == 404
@@ -465,7 +465,6 @@ class PromptManager:
     def _parse_prompt(
         raw: Union[str, dict[str, Any]],
         source: Literal["registry", "ff", "resolve"],
-        label: Optional[str] = None,
     ) -> Optional[ManagedPrompt]:
         try:
             if isinstance(raw, str):
@@ -483,10 +482,15 @@ class PromptManager:
             if not version:
                 log.warning("Failed to parse prompt response: missing version")
                 return None
+            raw_labels = data.get("labels")
+            if isinstance(raw_labels, list):
+                labels = [value for value in raw_labels if isinstance(value, str)]
+            else:
+                labels = []
             return ManagedPrompt(
                 id=prompt_id,
                 version=version,
-                label=data.get("label", label),
+                labels=labels,
                 source=source,
                 template=extract_template(data, default=[]),
                 _uuid=data.get("prompt_uuid"),

--- a/ddtrace/llmobs/_prompts/prompt.py
+++ b/ddtrace/llmobs/_prompts/prompt.py
@@ -24,12 +24,11 @@ class ManagedPrompt:
         - to_annotation_dict(**vars) -> dict[str, Any]
 
     INTERNAL (may change):
-        - All fields (id, version, labels, source, template)
+        - All fields (id, version, source, template)
     """
 
     id: str
     version: str
-    labels: list[str]
     source: Literal["registry", "cache", "fallback", "ff", "resolve"]
     template: Union[str, list[Message]]
     _uuid: Optional[str] = None
@@ -87,16 +86,13 @@ class ManagedPrompt:
         return result
 
     def __repr__(self) -> str:
-        return (
-            f"ManagedPrompt(id={self.id!r}, version={self.version!r}, labels={self.labels!r}, source={self.source!r})"
-        )
+        return f"ManagedPrompt(id={self.id!r}, version={self.version!r}, source={self.source!r})"
 
     def _serialize(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dict for cache storage."""
         return {
             "id": self.id,
             "version": self.version,
-            "labels": self.labels,
             "source": self.source,
             "template": self.template,
             "_uuid": self._uuid,
@@ -109,7 +105,6 @@ class ManagedPrompt:
         return cls(
             id=data["id"],
             version=data["version"],
-            labels=data["labels"],
             source=data.get("source", "cache"),
             template=data["template"],
             _uuid=data.get("_uuid"),
@@ -135,7 +130,7 @@ class ManagedPrompt:
             fallback: A string, message list, Prompt dict, or callable returning any of those.
 
         Returns:
-            A ManagedPrompt with source="fallback" and no labels.
+            A ManagedPrompt with source="fallback".
         """
         template: Union[str, list[Message]] = ""
         version = "fallback"
@@ -151,7 +146,6 @@ class ManagedPrompt:
         return cls(
             id=prompt_id,
             version=version,
-            labels=[],
             source="fallback",
             template=template,
         )

--- a/ddtrace/llmobs/_prompts/prompt.py
+++ b/ddtrace/llmobs/_prompts/prompt.py
@@ -24,12 +24,12 @@ class ManagedPrompt:
         - to_annotation_dict(**vars) -> dict[str, Any]
 
     INTERNAL (may change):
-        - All fields (id, version, label, source, template)
+        - All fields (id, version, labels, source, template)
     """
 
     id: str
     version: str
-    label: Optional[str]
+    labels: list[str]
     source: Literal["registry", "cache", "fallback", "ff", "resolve"]
     template: Union[str, list[Message]]
     _uuid: Optional[str] = None
@@ -74,8 +74,6 @@ class ManagedPrompt:
         }
         if variables:
             result["variables"] = variables
-        if self.label:
-            result["label"] = self.label
         if self._uuid:
             result["prompt_uuid"] = self._uuid
         if self._version_uuid:
@@ -89,14 +87,16 @@ class ManagedPrompt:
         return result
 
     def __repr__(self) -> str:
-        return f"ManagedPrompt(id={self.id!r}, version={self.version!r}, label={self.label!r}, source={self.source!r})"
+        return (
+            f"ManagedPrompt(id={self.id!r}, version={self.version!r}, labels={self.labels!r}, source={self.source!r})"
+        )
 
     def _serialize(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dict for cache storage."""
         return {
             "id": self.id,
             "version": self.version,
-            "label": self.label,
+            "labels": self.labels,
             "source": self.source,
             "template": self.template,
             "_uuid": self._uuid,
@@ -109,7 +109,7 @@ class ManagedPrompt:
         return cls(
             id=data["id"],
             version=data["version"],
-            label=data["label"],
+            labels=data["labels"],
             source=data.get("source", "cache"),
             template=data["template"],
             _uuid=data.get("_uuid"),
@@ -135,7 +135,7 @@ class ManagedPrompt:
             fallback: A string, message list, Prompt dict, or callable returning any of those.
 
         Returns:
-            A ManagedPrompt with source="fallback" and label=None.
+            A ManagedPrompt with source="fallback" and no labels.
         """
         template: Union[str, list[Message]] = ""
         version = "fallback"
@@ -151,7 +151,7 @@ class ManagedPrompt:
         return cls(
             id=prompt_id,
             version=version,
-            label=None,
+            labels=[],
             source="fallback",
             template=template,
         )

--- a/releasenotes/notes/llmobs-prompt-labels-ce04882fdbe05721.yaml
+++ b/releasenotes/notes/llmobs-prompt-labels-ce04882fdbe05721.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    LLM Observability: Managed prompts no longer expose deprecated deployment label metadata.

--- a/releasenotes/notes/llmobs-prompt-labels-ce04882fdbe05721.yaml
+++ b/releasenotes/notes/llmobs-prompt-labels-ce04882fdbe05721.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    LLM Observability: Managed prompts now expose all labels associated with the selected version through ``ManagedPrompt.labels``.
+    LLM Observability: Managed prompts no longer expose deprecated deployment label metadata.

--- a/releasenotes/notes/llmobs-prompt-labels-ce04882fdbe05721.yaml
+++ b/releasenotes/notes/llmobs-prompt-labels-ce04882fdbe05721.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: Managed prompts no longer expose deprecated deployment label metadata.

--- a/releasenotes/notes/llmobs-prompt-labels-ce04882fdbe05721.yaml
+++ b/releasenotes/notes/llmobs-prompt-labels-ce04882fdbe05721.yaml
@@ -1,4 +1,4 @@
 ---
-fixes:
+deprecations:
   - |
     LLM Observability: Managed prompts no longer expose deprecated deployment label metadata. #19047

--- a/releasenotes/notes/llmobs-prompt-labels-ce04882fdbe05721.yaml
+++ b/releasenotes/notes/llmobs-prompt-labels-ce04882fdbe05721.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    LLM Observability: Managed prompts no longer expose deprecated deployment label metadata.
+    LLM Observability: Managed prompts no longer expose deprecated deployment label metadata. #19047

--- a/releasenotes/notes/llmobs-prompt-labels-ce04882fdbe05721.yaml
+++ b/releasenotes/notes/llmobs-prompt-labels-ce04882fdbe05721.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: Managed prompts now expose all labels associated with the selected version through ``ManagedPrompt.labels``.

--- a/tests/llmobs/test_prompts.py
+++ b/tests/llmobs/test_prompts.py
@@ -119,7 +119,6 @@ def assert_prompt_matches_response(prompt, response, expected_source):
     """Assert prompt fields match the API response."""
     assert prompt.id == response["prompt_id"]
     assert prompt.version == response["version"]
-    assert prompt.labels == response.get("labels", [])
     assert prompt.source == expected_source
     assert prompt._uuid == response.get("prompt_uuid")
     assert prompt._version_uuid == response.get("prompt_version_uuid")
@@ -191,7 +190,7 @@ class TestPrompts:
             with pytest.warns(DDTraceDeprecationWarning):
                 prod_prompt = LLMObs.get_prompt("greeting", label="production")
         assert prod_prompt.version == "v1"
-        assert prod_prompt.labels == ["development", "production"]
+        assert all(not hasattr(prod_prompt, field) for field in ("label", "labels"))
 
         LLMObs.clear_prompt_cache(hot=True, warm=True)
 
@@ -199,7 +198,6 @@ class TestPrompts:
             with pytest.warns(DDTraceDeprecationWarning):
                 dev_prompt = LLMObs.get_prompt("greeting", label="development")
         assert dev_prompt.version == "dev-v1"
-        assert dev_prompt.labels == ["development"]
         assert "DEBUG" in dev_prompt.format(name="Test")
 
     def test_string_fallback_on_error(self):
@@ -473,24 +471,18 @@ class TestPrompts:
         with _ffe_enabled():
             _deliver_prompt_flag(
                 "greeting",
-                {
-                    "prompt_id": "greeting",
-                    "version": "ff-v1",
-                    "labels": ["development", "production"],
-                    "template": "FF Hello!",
-                },
+                {"prompt_id": "greeting", "version": "ff-v1", "template": "FF Hello!"},
             )
             with patch.object(manager, "_get_prompt_http") as http_mock:
                 prompt = manager.get_prompt("greeting")
         http_mock.assert_not_called()
         assert prompt.source == "ff"
         assert prompt.version == "ff-v1"
-        assert prompt.labels == ["development", "production"]
         assert prompt.template == "FF Hello!"
 
     def test_route_env_agentless_to_http_resolve(self):
         manager = _make_manager(agentless=True)
-        sentinel = ManagedPrompt(id="greeting", version="v1", labels=["production"], source="resolve", template="Hi")
+        sentinel = ManagedPrompt(id="greeting", version="v1", source="resolve", template="Hi")
         with patch.object(manager, "_fetch_from_ff") as ff_mock:
             with patch.object(manager, "_get_prompt_http", return_value=sentinel) as http_mock:
                 with patch("ddtrace.llmobs._prompts.manager.config") as cfg:
@@ -507,7 +499,6 @@ class TestPrompts:
         ff_prompt = ManagedPrompt(
             id="greeting",
             version="ff-v1",
-            labels=[],
             source="ff",
             template="Hello!",
         )
@@ -531,7 +522,7 @@ class TestPrompts:
     # which resolves the same env-scoped variant server-side.
     def test_route_not_ready_to_http_resolve(self):
         manager = _make_manager()
-        sentinel = ManagedPrompt(id="greeting", version="v1", labels=["development"], source="resolve", template="Hi")
+        sentinel = ManagedPrompt(id="greeting", version="v1", source="resolve", template="Hi")
         with _ffe_enabled():
             with patch.object(manager, "_get_prompt_http", return_value=sentinel) as http_mock:
                 prompt = manager.get_prompt("greeting")
@@ -542,7 +533,7 @@ class TestPrompts:
 
     def test_route_no_flag_to_http_resolve(self):
         manager = _make_manager()
-        sentinel = ManagedPrompt(id="greeting", version="v1", labels=["development"], source="resolve", template="Hi")
+        sentinel = ManagedPrompt(id="greeting", version="v1", source="resolve", template="Hi")
         with _ffe_enabled():
             _deliver_prompt_flag("other-prompt", {"prompt_id": "other-prompt", "version": "1", "template": "x"})
             with patch.object(manager, "_get_prompt_http", return_value=sentinel) as http_mock:
@@ -713,7 +704,7 @@ class TestPromptManagement:
         manager = _make_manager()
         manager._hot_cache.set(
             "my-prompt:production",
-            ManagedPrompt(id="my-prompt", version="v1", labels=["production"], source="registry", template=[]),
+            ManagedPrompt(id="my-prompt", version="v1", source="registry", template=[]),
         )
         assert len(manager._hot_cache) == 1
 
@@ -811,11 +802,11 @@ class TestPromptManagement:
         manager = _make_manager()
         manager._hot_cache.set(
             "foo:production",
-            ManagedPrompt(id="foo", version="v1", labels=["production"], source="registry", template=[]),
+            ManagedPrompt(id="foo", version="v1", source="registry", template=[]),
         )
         manager._hot_cache.set(
             "foo:bar:production",
-            ManagedPrompt(id="foo:bar", version="v1", labels=["production"], source="registry", template=[]),
+            ManagedPrompt(id="foo:bar", version="v1", source="registry", template=[]),
         )
         assert len(manager._hot_cache) == 2
 
@@ -827,8 +818,8 @@ class TestPromptManagement:
     def test_warm_cache_distinct_ids_do_not_collide_on_path(self, tmp_path):
         """Regression: 'a/b' and 'a_b' must not share a cache file (lossy sanitization served wrong prompts)."""
         cache = WarmCache(cache_dir=str(tmp_path), ttl_seconds=60)
-        cache.set("a/b:", ManagedPrompt(id="a/b", version="v1", labels=[], source="registry", template=[]))
-        cache.set("a_b:", ManagedPrompt(id="a_b", version="v2", labels=[], source="registry", template=[]))
+        cache.set("a/b:", ManagedPrompt(id="a/b", version="v1", source="registry", template=[]))
+        cache.set("a_b:", ManagedPrompt(id="a_b", version="v2", source="registry", template=[]))
 
         assert cache.get("a/b:")[0].id == "a/b"
         assert cache.get("a_b:")[0].id == "a_b"
@@ -860,7 +851,7 @@ def test_hot_cache_lru_eviction():
     cache = HotCache(ttl_seconds=60, maxsize=2)
 
     def mk(v):
-        return ManagedPrompt(id=v, version="1", labels=[], source="resolve", template="x")
+        return ManagedPrompt(id=v, version="1", source="resolve", template="x")
 
     cache.set("a", mk("a"))
     cache.set("b", mk("b"))

--- a/tests/llmobs/test_prompts.py
+++ b/tests/llmobs/test_prompts.py
@@ -531,7 +531,7 @@ class TestPrompts:
     # which resolves the same env-scoped variant server-side.
     def test_route_not_ready_to_http_resolve(self):
         manager = _make_manager()
-        sentinel = ManagedPrompt(id="greeting", version="v1", labels=["staging"], source="resolve", template="Hi")
+        sentinel = ManagedPrompt(id="greeting", version="v1", labels=["development"], source="resolve", template="Hi")
         with _ffe_enabled():
             with patch.object(manager, "_get_prompt_http", return_value=sentinel) as http_mock:
                 prompt = manager.get_prompt("greeting")
@@ -542,7 +542,7 @@ class TestPrompts:
 
     def test_route_no_flag_to_http_resolve(self):
         manager = _make_manager()
-        sentinel = ManagedPrompt(id="greeting", version="v1", labels=["staging"], source="resolve", template="Hi")
+        sentinel = ManagedPrompt(id="greeting", version="v1", labels=["development"], source="resolve", template="Hi")
         with _ffe_enabled():
             _deliver_prompt_flag("other-prompt", {"prompt_id": "other-prompt", "version": "1", "template": "x"})
             with patch.object(manager, "_get_prompt_http", return_value=sentinel) as http_mock:

--- a/tests/llmobs/test_prompts.py
+++ b/tests/llmobs/test_prompts.py
@@ -33,7 +33,7 @@ TEXT_PROMPT_RESPONSE = {
     "prompt_uuid": "prompt-uuid-123",
     "prompt_version_uuid": "version-uuid-456",
     "version": "v1",
-    "label": "production",
+    "labels": ["development", "production"],
     "template": "Hello {name}!",
 }
 
@@ -42,7 +42,7 @@ CHAT_PROMPT_RESPONSE = {
     "prompt_uuid": "chat-uuid-123",
     "prompt_version_uuid": "chat-version-uuid-456",
     "version": "v2",
-    "label": "production",
+    "labels": ["production"],
     "template": [
         {"role": "system", "content": "You are {{persona}}."},
         {"role": "user", "content": "{{question}}"},
@@ -54,7 +54,7 @@ DEV_PROMPT_RESPONSE = {
     "prompt_uuid": "dev-prompt-uuid-789",
     "prompt_version_uuid": "dev-version-uuid-012",
     "version": "dev-v1",
-    "label": "development",
+    "labels": ["development"],
     "template": "DEBUG: Hello {name}!",
 }
 
@@ -119,6 +119,7 @@ def assert_prompt_matches_response(prompt, response, expected_source):
     """Assert prompt fields match the API response."""
     assert prompt.id == response["prompt_id"]
     assert prompt.version == response["version"]
+    assert prompt.labels == response.get("labels", [])
     assert prompt.source == expected_source
     assert prompt._uuid == response.get("prompt_uuid")
     assert prompt._version_uuid == response.get("prompt_version_uuid")
@@ -190,7 +191,7 @@ class TestPrompts:
             with pytest.warns(DDTraceDeprecationWarning):
                 prod_prompt = LLMObs.get_prompt("greeting", label="production")
         assert prod_prompt.version == "v1"
-        assert prod_prompt.label == "production"
+        assert prod_prompt.labels == ["development", "production"]
 
         LLMObs.clear_prompt_cache(hot=True, warm=True)
 
@@ -198,7 +199,7 @@ class TestPrompts:
             with pytest.warns(DDTraceDeprecationWarning):
                 dev_prompt = LLMObs.get_prompt("greeting", label="development")
         assert dev_prompt.version == "dev-v1"
-        assert dev_prompt.label == "development"
+        assert dev_prompt.labels == ["development"]
         assert "DEBUG" in dev_prompt.format(name="Test")
 
     def test_string_fallback_on_error(self):
@@ -330,7 +331,7 @@ class TestPrompts:
                 prompt_data = get_llmobs_input_prompt(span)
                 assert prompt_data["id"] == "greeting"
                 assert prompt_data["version"] == "v1"
-                assert prompt_data["label"] == "production"
+                assert "label" not in prompt_data
                 assert prompt_data["variables"] == {"name": "Alice"}
                 assert prompt_data["prompt_uuid"] == "prompt-uuid-123"
                 assert prompt_data["prompt_version_uuid"] == "version-uuid-456"
@@ -472,18 +473,24 @@ class TestPrompts:
         with _ffe_enabled():
             _deliver_prompt_flag(
                 "greeting",
-                {"prompt_id": "greeting", "version": "ff-v1", "template": "FF Hello!"},
+                {
+                    "prompt_id": "greeting",
+                    "version": "ff-v1",
+                    "labels": ["development", "production"],
+                    "template": "FF Hello!",
+                },
             )
             with patch.object(manager, "_get_prompt_http") as http_mock:
                 prompt = manager.get_prompt("greeting")
         http_mock.assert_not_called()
         assert prompt.source == "ff"
         assert prompt.version == "ff-v1"
+        assert prompt.labels == ["development", "production"]
         assert prompt.template == "FF Hello!"
 
     def test_route_env_agentless_to_http_resolve(self):
         manager = _make_manager(agentless=True)
-        sentinel = ManagedPrompt(id="greeting", version="v1", label="production", source="resolve", template="Hi")
+        sentinel = ManagedPrompt(id="greeting", version="v1", labels=["production"], source="resolve", template="Hi")
         with patch.object(manager, "_fetch_from_ff") as ff_mock:
             with patch.object(manager, "_get_prompt_http", return_value=sentinel) as http_mock:
                 with patch("ddtrace.llmobs._prompts.manager.config") as cfg:
@@ -500,7 +507,7 @@ class TestPrompts:
         ff_prompt = ManagedPrompt(
             id="greeting",
             version="ff-v1",
-            label=None,
+            labels=[],
             source="ff",
             template="Hello!",
         )
@@ -524,7 +531,7 @@ class TestPrompts:
     # which resolves the same env-scoped variant server-side.
     def test_route_not_ready_to_http_resolve(self):
         manager = _make_manager()
-        sentinel = ManagedPrompt(id="greeting", version="v1", label="staging", source="resolve", template="Hi")
+        sentinel = ManagedPrompt(id="greeting", version="v1", labels=["staging"], source="resolve", template="Hi")
         with _ffe_enabled():
             with patch.object(manager, "_get_prompt_http", return_value=sentinel) as http_mock:
                 prompt = manager.get_prompt("greeting")
@@ -535,7 +542,7 @@ class TestPrompts:
 
     def test_route_no_flag_to_http_resolve(self):
         manager = _make_manager()
-        sentinel = ManagedPrompt(id="greeting", version="v1", label="staging", source="resolve", template="Hi")
+        sentinel = ManagedPrompt(id="greeting", version="v1", labels=["staging"], source="resolve", template="Hi")
         with _ffe_enabled():
             _deliver_prompt_flag("other-prompt", {"prompt_id": "other-prompt", "version": "1", "template": "x"})
             with patch.object(manager, "_get_prompt_http", return_value=sentinel) as http_mock:
@@ -706,7 +713,7 @@ class TestPromptManagement:
         manager = _make_manager()
         manager._hot_cache.set(
             "my-prompt:production",
-            ManagedPrompt(id="my-prompt", version="v1", label="production", source="registry", template=[]),
+            ManagedPrompt(id="my-prompt", version="v1", labels=["production"], source="registry", template=[]),
         )
         assert len(manager._hot_cache) == 1
 
@@ -804,11 +811,11 @@ class TestPromptManagement:
         manager = _make_manager()
         manager._hot_cache.set(
             "foo:production",
-            ManagedPrompt(id="foo", version="v1", label="production", source="registry", template=[]),
+            ManagedPrompt(id="foo", version="v1", labels=["production"], source="registry", template=[]),
         )
         manager._hot_cache.set(
             "foo:bar:production",
-            ManagedPrompt(id="foo:bar", version="v1", label="production", source="registry", template=[]),
+            ManagedPrompt(id="foo:bar", version="v1", labels=["production"], source="registry", template=[]),
         )
         assert len(manager._hot_cache) == 2
 
@@ -820,8 +827,8 @@ class TestPromptManagement:
     def test_warm_cache_distinct_ids_do_not_collide_on_path(self, tmp_path):
         """Regression: 'a/b' and 'a_b' must not share a cache file (lossy sanitization served wrong prompts)."""
         cache = WarmCache(cache_dir=str(tmp_path), ttl_seconds=60)
-        cache.set("a/b:", ManagedPrompt(id="a/b", version="v1", label=None, source="registry", template=[]))
-        cache.set("a_b:", ManagedPrompt(id="a_b", version="v2", label=None, source="registry", template=[]))
+        cache.set("a/b:", ManagedPrompt(id="a/b", version="v1", labels=[], source="registry", template=[]))
+        cache.set("a_b:", ManagedPrompt(id="a_b", version="v2", labels=[], source="registry", template=[]))
 
         assert cache.get("a/b:")[0].id == "a/b"
         assert cache.get("a_b:")[0].id == "a_b"
@@ -853,7 +860,7 @@ def test_hot_cache_lru_eviction():
     cache = HotCache(ttl_seconds=60, maxsize=2)
 
     def mk(v):
-        return ManagedPrompt(id=v, version="1", label=None, source="resolve", template="x")
+        return ManagedPrompt(id=v, version="1", labels=[], source="resolve", template="x")
 
     cache.set("a", mk("a"))
     cache.set("b", mk("b"))


### PR DESCRIPTION
## Description

Remove deployment label metadata from the runtime `ManagedPrompt` model. Managed prompts now contain their identifier, version, source, template, and backend UUIDs, but neither a singular `label` nor a plural `labels` field.

The deprecated `label=` argument remains available only as a prompt-selection input. The supported selector values remain `production` and `development`.

Labels are mutable management and routing metadata rather than part of a runtime prompt version. The backend uses them to configure which numeric FFE variant each environment serves, while FFE prompt values and SDK prompt objects remain independent of labels.

Companion backend change: https://github.com/ddoghq/dd-source/pull/20314

## Testing

Changed tests fixtures to match what the backend returns (See companion PR above)

## Risks

Prompt selection by `label=` and `DD_ENV` is unchanged. This removes an internal field before the prompt-management feature reaches GA and avoids source-dependent metadata between registry and FFE responses.
