### PR TITLE
fix(tracing): guard against None version so ddtrace.auto import cannot crash

### DIFF
--- a/ddtrace/internal/utils/version.py
+++ b/ddtrace/internal/utils/version.py
@@ -69,7 +69,12 @@ def _pep440_to_semver(version: Optional[str] = None) -> str:
     #
     # e.g. 1.7.1-rc2.dev3+gf258c7d9 is valid
 
-    tracer_version = version or __version__
+    # ``__version__`` can be None if importlib.metadata.version() returned None
+    # (e.g. stale coexisting ddtrace-*.dist-info dirs), which would make the
+    # substring checks below raise ``TypeError: argument of type 'NoneType' is
+    # not iterable`` and crash ``import ddtrace.auto``. Fall back to a valid
+    # SemVer string instead. See issue #18804.
+    tracer_version = version or __version__ or "0.0.0"
     if "rc" in tracer_version and "-rc" not in tracer_version:
         tracer_version = tracer_version.replace("rc", "-rc", 1)
     elif ".dev" in tracer_version:

--- a/ddtrace/version.py
+++ b/ddtrace/version.py
@@ -13,6 +13,10 @@ except Exception:
     distributions = None
 
 try:
-    __version__ = importlib.metadata.version(distributions[0] if distributions else "ddtrace")
+    # ``version()`` can return None (not raise) when stale coexisting
+    # ddtrace-*.dist-info directories are present, which would leave
+    # ``__version__`` as None and crash consumers that expect a string.
+    # Coerce any falsy result to the same fallback the except-branch uses.
+    __version__ = importlib.metadata.version(distributions[0] if distributions else "ddtrace") or "0.0.0"
 except Exception:
     __version__ = "0.0.0"

--- a/releasenotes/notes/fix-version-none-crash-f8fb1de99b888ee5.yaml
+++ b/releasenotes/notes/fix-version-none-crash-f8fb1de99b888ee5.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    tracing: This fix resolves a crash on ``import ddtrace.auto`` (``TypeError:
+    argument of type 'NoneType' is not iterable``) that could occur when
+    ``importlib.metadata.version()`` returned ``None`` instead of a version
+    string, for example when stale coexisting ``ddtrace-*.dist-info``
+    directories were present. ``__version__`` and the internal SemVer helper now
+    fall back to ``0.0.0`` when the resolved version is missing.

--- a/releasenotes/notes/fix-version-none-crash-f8fb1de99b888ee5.yaml
+++ b/releasenotes/notes/fix-version-none-crash-f8fb1de99b888ee5.yaml
@@ -1,9 +1,6 @@
 ---
 fixes:
   - |
-    tracing: This fix resolves a crash on ``import ddtrace.auto`` (``TypeError:
-    argument of type 'NoneType' is not iterable``) that could occur when
+    tracing: This fix resolves a crash on ``import ddtrace.auto`` that could occur when
     ``importlib.metadata.version()`` returned ``None`` instead of a version
-    string, for example when stale coexisting ``ddtrace-*.dist-info``
-    directories were present. ``__version__`` and the internal SemVer helper now
-    fall back to ``0.0.0`` when the resolved version is missing.
+    string.

--- a/tests/internal/test_utils_version.py
+++ b/tests/internal/test_utils_version.py
@@ -61,3 +61,13 @@ def test_version_agent_format(version_str: str, expected: tuple[int, int, int]) 
     version_agent_format = _pep440_to_semver(version_str)
     assert version_agent_format == expected
     _assert_and_get_version_agent_format(version_agent_format)
+
+
+@pytest.mark.parametrize("version_arg", [None, ""])
+def test_pep440_to_semver_handles_missing_version(version_arg):
+    # __version__ can be None if importlib.metadata.version() returned None
+    # (e.g. stale coexisting ddtrace-*.dist-info dirs). _pep440_to_semver must
+    # not raise TypeError in that case, which used to crash import ddtrace.auto.
+    # See issue #18804.
+    version_agent_format = _pep440_to_semver(version_arg)
+    _assert_and_get_version_agent_format(version_agent_format)


### PR DESCRIPTION
## Description

Fixes #18804. On an Azure Function App, `import ddtrace.auto` crashed at import time with `TypeError: argument of type 'NoneType' is not iterable` in `_pep440_to_semver`.

Root cause: `importlib.metadata.version("ddtrace")` can return `None` (rather than raising) when stale coexisting `ddtrace-*.dist-info` directories are present in site-packages. In `ddtrace/version.py` that `None` slips past the `try/except` (which only catches exceptions), so `__version__` becomes `None`. `_pep440_to_semver()` then evaluates `"rc" in None` and raises, taking down the whole application.

This coerces a falsy `importlib.metadata.version()` result to `"0.0.0"` (the same fallback the `except` branch already uses), and makes `_pep440_to_semver` fall back to `"0.0.0"` when both its argument and `__version__` are falsy. Valid version strings are unaffected, since a real version string is truthy.

## Testing

Added a parametrized case to `tests/internal/test_utils_version.py` asserting `_pep440_to_semver(None)` and `_pep440_to_semver("")` return a valid SemVer string instead of raising `TypeError`. The existing `test_parse_version` / `test_version_agent_format` cases (valid version strings) continue to pass unchanged.

## Risks

None. The change only adds a fallback for a falsy/`None` version, which previously crashed. Behavior for valid version strings is identical (a truthy version short-circuits the `or "0.0.0"`).

## Additional Notes

Includes a release note under `releasenotes/notes/`.
