### PR TITLE
chore(rc): full state reset after fork

### DIFF
--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -397,11 +397,19 @@ class RemoteConfigClient:
             applied.apply_state = apply_state
             applied.apply_error = apply_error
 
-    def renew_id(self):
-        # called after the process is forked to declare a new id
+    def reset_at_fork(self):
+        """Reset all state scoped to the client id after the process forks.
+
+        A fork starts a new client identity, so nothing tied to the old id
+        (applied configs, cached_target_files) may carry over. In particular,
+        cached_target_files declares to the agent/backend which target files
+        this client already has; if it survived under a new id, the backend
+        would skip resending files this "new" client never actually applied.
+        """
         self.id = str(uuid.uuid4())
         self._client_tracer["runtime_id"] = runtime.get_runtime_id()
         self._applied_configs.clear()
+        self.cached_target_files.clear()
 
     def register_callback(
         self,

--- a/ddtrace/internal/remoteconfig/worker.py
+++ b/ddtrace/internal/remoteconfig/worker.py
@@ -99,7 +99,7 @@ class RemoteConfigPoller(periodic.PeriodicService):
         """Client Id needs to be refreshed when application forks"""
         self._enable = False
         log.debug("[%d][P: %d] Remote Config Poller fork. Refreshing state", os.getpid(), os.getppid())
-        self._client.renew_id()
+        self._client.reset_at_fork()
 
         # Restart the global subscriber if needed and if there are registered products
         if self._client._product_callbacks:

--- a/tests/internal/remoteconfig/test_remoteconfig.py
+++ b/tests/internal/remoteconfig/test_remoteconfig.py
@@ -962,6 +962,26 @@ def test_send_request_retries_once_on_oserror():
     assert result == {"ok": True}
 
 
+def test_reset_at_fork_clears_cached_target_files():
+    """A fresh client id must not carry over cache claims from the pre-fork identity.
+
+    Otherwise the backend, trusting the client's own cached_target_files declaration, skips
+    resending target_files for configs this "new" client never actually applied.
+    """
+    client = RemoteConfigClient()
+    client.cached_target_files = [
+        {
+            "path": "datadog/2/LIVE_DEBUGGING_SYMBOL_DB/symDb/config",
+            "length": 1,
+            "hashes": [{"algorithm": "sha256", "hash": "x"}],
+        }
+    ]
+
+    client.reset_at_fork()
+
+    assert client.cached_target_files == []
+
+
 def test_online_tolerates_transient_failures_before_bouncing(remote_config_worker):
     """_online should stay in _online for N-1 consecutive failures, and bounce on the Nth."""
     worker = RemoteConfigPoller()


### PR DESCRIPTION
## Description

We make sure that the RC client is fully reset after a fork to prevent it from ending up in an inconsistent state. In particular, we clear the applied configs and the cached target files so that the two collections are in a consistent state after a fork.

Refs: [DEBUG-5474](https://datadoghq.atlassian.net/browse/DEBUG-5474)

[DEBUG-5474]: https://datadoghq.atlassian.net/browse/DEBUG-5474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ