### PR TITLE
docs(dramatiq): clarify that the integration traces task enqueuing

### DIFF
--- a/ddtrace/contrib/internal/dramatiq/__init__.py
+++ b/ddtrace/contrib/internal/dramatiq/__init__.py
@@ -1,8 +1,12 @@
 """
 Enabling
 ~~~~~~~~
-The dramatiq integration will trace background tasks as marked by the @dramatiq.actor
-decorator. To trace your dramatiq app, call the patch method::
+The dramatiq integration traces the enqueuing of background tasks. It creates a
+span each time a task is sent to the broker via the ``send()`` or
+``send_with_options()`` methods on an actor. The span measures the duration of the
+enqueue call itself, not the execution time of the background task.
+
+Use :func:`patch()<ddtrace.patch>` to manually enable the integration::
 
     import dramatiq
     from ddtrace import patch


### PR DESCRIPTION
## Summary

The dramatiq integration docs said it 
> will trace background tasks as marked by the @dramatiq.actor decorator"

This reads like it traces the execution of the task. In reality the patch only wraps `Actor.send_with_options`, so it traces the enqueue call (`send`/`send_with_options`), not the task running.

This reworks the docstring to say what actually gets traced. The generated docs come from this `__init__.py`, so this corrects them too.

## Changes

- Reword the dramatiq `__init__.py` docstring to describe tracing the enqueue call and its duration, not task execution.
- Switch the enable wording to match the psycopg convention using `:func:\`patch()<ddtrace.patch>\``.

## Testing

Docs only change, no behavior change. Ran the lint format and spelling checks on the file.