### PR TITLE
feat(profiler): make native frames appear as third party code

### DIFF
--- a/ddtrace/internal/datadog/profiling/code_provenance.py
+++ b/ddtrace/internal/datadog/profiling/code_provenance.py
@@ -70,6 +70,17 @@ class CodeProvenance:
 
         self.libraries.append(python_stdlib)
 
+        # Native frames pushed by the profiler use a synthetic "<native>" filename.
+        # Register it as a "library" so those frames are attributed to third-party code.
+        self.libraries.append(
+            Library(
+                kind="library",
+                name="native",
+                version="",
+                paths={"<native>"},
+            )
+        )
+
         module_to_distribution: dict[str, Distribution] = _package_for_root_module_mapping() or {}
 
         libraries: dict[str, Library] = {}

--- a/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
@@ -187,13 +187,18 @@ StackRenderer::render_native_frame(const std::string& name, const std::string& m
         return;
     }
 
-    auto maybe_name_id = Datadog::intern_string(name);
+    std::string display_name = module.empty() ? name : module + "." + name;
+    auto maybe_name_id = Datadog::intern_string(display_name);
     if (!maybe_name_id) {
         return;
     }
     auto name_id = *maybe_name_id;
 
-    auto maybe_filename_id = Datadog::intern_string(module);
+    // Native frames have no source file. Use a synthetic filename so the backend
+    // attributes them to third-party ("library") code via the code-provenance
+    // manifest. This sentinel must match the entry added in code_provenance.py.
+    static constexpr std::string_view native_filename = "<native>";
+    auto maybe_filename_id = Datadog::intern_string(native_filename);
     if (!maybe_filename_id) {
         return;
     }

--- a/releasenotes/notes/profiling-native-frames-third-party-provenance-6b1d2f3a4c5e7d8f.yaml
+++ b/releasenotes/notes/profiling-native-frames-third-party-provenance-6b1d2f3a4c5e7d8f.yaml
@@ -1,0 +1,5 @@
+features:
+  - |
+    profiling: Native frames collected by the profiler are now attributed to
+    third-party code in the code provenance view, rather than appearing as
+    application code.

--- a/tests/profiling/test_code_provenance.py
+++ b/tests/profiling/test_code_provenance.py
@@ -107,6 +107,11 @@ class TestCodeProvenance:
             if item["name"] == "stdlib":
                 # See below test_stdlib_paths
                 continue
+
+            if item["name"] == "native":
+                # Synthetic entry for profiler native frames, path is "<native>"
+                continue
+
             for path in item["paths"]:
                 assert path.startswith("/") and path.startswith(site_packages_path)
 
@@ -128,6 +133,16 @@ class TestCodeProvenance:
 
         for path in stdlib_paths:
             assert path.startswith("<frozen") or path == sysconfig.get_path("stdlib")
+
+    def test_native_frames_are_third_party(self) -> None:
+        file_path = get_code_provenance_file()
+        assert file_path is not None
+        json_obj = _read_json(file_path)
+
+        native = [item for item in json_obj["v1"] if item["name"] == "native"]
+        assert len(native) == 1
+        assert native[0]["kind"] == "library"
+        assert native[0]["paths"] == ["<native>"]
 
     @pytest.mark.subprocess(
         env=dict(DD_MAIN_PACKAGE="ddtrace"),


### PR DESCRIPTION
## Description

This PR updates the Python Profiler to make native frames (obtained through `sys.monitoring` probe) as coming from the `<native>` module. 

The rationale for doing this is that, currently, native frames called by third party libraries appear as their own group in the UI (because they're not from the same package as far as Code Provenance can tell).  
The change is to make native frames appear as coming from a synthetic `<native>` module, and make Code Provenance know about `<native>` as a third party module.

Making this work will also require a change on the frontend (cc @lea-margery who I've already talked to about this) where any group that ends with a call to a function coming from the `<native>` package should "absorb" that frame.  
It will not _always_ be correct, but it'll be in most cases, which is much better than what we have today.

**Before** (notice how the `epoll.poll` is blue, not gray)

<img width="527" height="311" alt="image" src="https://github.com/user-attachments/assets/30fe0574-2349-4788-81f6-885bb3884381" />


**After** (although grouping needs to be fixed on the frontend)

<img width="188" height="180" alt="image" src="https://github.com/user-attachments/assets/cd8688e3-7276-4421-9781-50d6b53a9368" />

<img width="261" height="290" alt="image" src="https://github.com/user-attachments/assets/e954e0f0-5e72-4c34-bb71-13d355979101" />
