### PR TITLE
ci: bump flaky iastaspects noaspect SLOs

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -413,7 +413,7 @@ experiments:
               - max_rss_usage < 48.00 MB
           - name: iastaspects-bytes_noaspect
             thresholds:
-              - execution_time < 0.20 ms
+              - execution_time < 0.25 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-bytesio_aspect
             thresholds:
@@ -537,7 +537,7 @@ experiments:
               - max_rss_usage < 48.00 MB
           - name: iastaspects-replace_noaspect
             thresholds:
-              - execution_time < 0.50 ms
+              - execution_time < 0.60 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-repr_aspect
             thresholds:


### PR DESCRIPTION
## Description

Two microbenchmark SLO gates are breaching on `main`:

```
FAIL! iastaspects-bytes_noaspect    execution_time 0.22 ms < 0.20 ms  (90% CI crosses SLO)
FAIL! iastaspects-replace_noaspect  execution_time 0.52 ms < 0.50 ms  (90% CI crosses SLO)
```

Both scenarios are configured with `iast_enabled: false`, so their timed
loop runs **pure-Python builtins** — `bytes(s, "utf-8")` and
`str.replace()` — with no dd-trace-py code on the hot path. Their gates
sat too close to baseline jitter, so the 90% CI straddles the threshold.

This surfaced on the CI run around #18996, but that PR's changes are
confined to `is_pyobject_tainted` / `get_ranges` no-context guards —
code paths these `*_noaspect` baseline scenarios never exercise. So this
is a flaky-gate calibration, not a real regression.

## Changes

Give both baseline gates headroom over observed values:

| scenario | old | new |
|---|---|---|
| `iastaspects-bytes_noaspect` | `< 0.20 ms` | `< 0.25 ms` |
| `iastaspects-replace_noaspect` | `< 0.50 ms` | `< 0.60 ms` |

Refs: https://github.com/DataDog/dd-trace-py/pull/18996

## Testing

CI-only change to `.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml`
(threshold scalars only; YAML validated). No runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
