### PR TITLE
chore(ray): fix ray tests concurrency

### DIFF
--- a/ddtrace/contrib/internal/ray/core/utils.py
+++ b/ddtrace/contrib/internal/ray/core/utils.py
@@ -53,8 +53,10 @@ JOB_NAME_REGEX = re.compile(r"^job\:([A-Za-z0-9_\.\-]+),run:([A-Za-z0-9_\.\-]+)$
 # then the job name will be woof
 ENTRY_POINT_REGEX = re.compile(r"([^\s\/\\]+)\.py")
 
-# Per-thread cache. Thread locals are naturally fork-safe: after os.fork() only the
-# calling thread survives, so every other thread's cached values vanish automatically.
+# Per-thread cache.
+# TODO(dubloom): Register _reset_thread_local_state with forksafe and validate cached runtime
+# invariants by job identity. The forking thread's local values survive in the child, and
+# a new Ray job can run on the same node while the cached job and worker IDs are stale.
 _local = threading.local()
 
 

--- a/ddtrace/contrib/internal/ray/patch.py
+++ b/ddtrace/contrib/internal/ray/patch.py
@@ -158,6 +158,8 @@ def traced_submit_job(wrapped, instance, args, kwargs):
     # This prevents inferred services (for example "ray.dashboard") from being
     # attached as _dd.base_service on worker spans.
     env_vars.setdefault("DD_SERVICE", job_name)
+    # TODO(dubloom): Overwrite the internal submission ID and job name instead of using setdefault.
+    # Reusing a runtime_env across submissions can otherwise propagate stale correlation values.
     # Ray doesn't propagate submission_id / job_name as env vars; workers need them for span tags.
     env_vars.setdefault(RAY_SUBMISSION_ID, submission_id)
     env_vars.setdefault(RAY_JOB_NAME, job_name)

--- a/tests/contrib/ray/test_actor_method_tags.py
+++ b/tests/contrib/ray/test_actor_method_tags.py
@@ -2,15 +2,13 @@
 
 from ddtrace import config
 import ddtrace._trace.subscribers.ray  # noqa: F401 — registers Ray subscribers
-from ddtrace._trace.subscribers.ray import RayExecutionSubscriber
-from ddtrace._trace.subscribers.ray import RaySubmissionSubscriber
 from ddtrace.contrib._events.ray import RayExecutionEvent
 from ddtrace.contrib._events.ray import RaySubmissionEvent
 from ddtrace.contrib.internal.ray.constants import RAY_ACTOR_CLASS_NAME
 from ddtrace.contrib.internal.ray.constants import RAY_ACTOR_METHOD_NAME
 from ddtrace.contrib.internal.ray.constants import RAY_ACTOR_MODULE_NAME
 import ddtrace.contrib.internal.ray.patch  # noqa: F401 — triggers config._add("ray", ...) registration
-from ddtrace.trace import tracer
+from ddtrace.internal import core
 
 
 # ---------------------------------------------------------------------------
@@ -43,18 +41,6 @@ def _make_actor_execution_event(**extra):
         method_kwargs={},
         **extra,
     )
-
-
-def _make_ctx_with_span(event):
-    """Create a minimal mock context holding the event and a live span."""
-
-    class _Ctx:
-        pass
-
-    ctx = _Ctx()
-    ctx.event = event
-    ctx.span = tracer.start_span(event.operation_name, service=event.service, resource=event.resource)
-    return ctx
 
 
 # ---------------------------------------------------------------------------
@@ -116,32 +102,24 @@ def test_submission_span_carries_actor_metadata_tags():
         actor_method_name="train_step",
     )
 
-    ctx = _make_ctx_with_span(event)
-    try:
-        RaySubmissionSubscriber.on_started(ctx)
+    with core.context_with_event(event) as ctx:
         span = ctx.span
 
         assert span.get_tag(RAY_ACTOR_CLASS_NAME) == "MyActor"
         assert span.get_tag(RAY_ACTOR_MODULE_NAME) == "my.module"
         assert span.get_tag(RAY_ACTOR_METHOD_NAME) == "train_step"
-    finally:
-        ctx.span.finish()
 
 
 def test_submission_span_omits_none_actor_metadata_tags():
     """When actor metadata fields are None, no actor identity tags are stamped."""
     event = _make_actor_submission_event()  # all actor fields default to None
 
-    ctx = _make_ctx_with_span(event)
-    try:
-        RaySubmissionSubscriber.on_started(ctx)
+    with core.context_with_event(event) as ctx:
         span = ctx.span
 
         assert span.get_tag(RAY_ACTOR_CLASS_NAME) is None
         assert span.get_tag(RAY_ACTOR_MODULE_NAME) is None
         assert span.get_tag(RAY_ACTOR_METHOD_NAME) is None
-    finally:
-        ctx.span.finish()
 
 
 def test_task_submission_does_not_get_actor_metadata_tags():
@@ -159,17 +137,13 @@ def test_task_submission_does_not_get_actor_metadata_tags():
         actor_method_name="should_not_appear",
     )
 
-    ctx = _make_ctx_with_span(event)
-    try:
-        RaySubmissionSubscriber.on_started(ctx)
+    with core.context_with_event(event) as ctx:
         span = ctx.span
 
         # The subscriber must gate actor tags on is_actor_method
         assert span.get_tag(RAY_ACTOR_CLASS_NAME) is None
         assert span.get_tag(RAY_ACTOR_MODULE_NAME) is None
         assert span.get_tag(RAY_ACTOR_METHOD_NAME) is None
-    finally:
-        ctx.span.finish()
 
 
 # ---------------------------------------------------------------------------
@@ -185,32 +159,24 @@ def test_execution_span_carries_actor_metadata_tags():
         actor_method_name="train_step",
     )
 
-    ctx = _make_ctx_with_span(event)
-    try:
-        RayExecutionSubscriber.on_started(ctx)
+    with core.context_with_event(event) as ctx:
         span = ctx.span
 
         assert span.get_tag(RAY_ACTOR_CLASS_NAME) == "MyActor"
         assert span.get_tag(RAY_ACTOR_MODULE_NAME) == "my.module"
         assert span.get_tag(RAY_ACTOR_METHOD_NAME) == "train_step"
-    finally:
-        ctx.span.finish()
 
 
 def test_execution_span_omits_none_actor_metadata_tags():
     """When actor metadata fields are None, no actor identity tags are stamped."""
     event = _make_actor_execution_event()  # all actor fields default to None
 
-    ctx = _make_ctx_with_span(event)
-    try:
-        RayExecutionSubscriber.on_started(ctx)
+    with core.context_with_event(event) as ctx:
         span = ctx.span
 
         assert span.get_tag(RAY_ACTOR_CLASS_NAME) is None
         assert span.get_tag(RAY_ACTOR_MODULE_NAME) is None
         assert span.get_tag(RAY_ACTOR_METHOD_NAME) is None
-    finally:
-        ctx.span.finish()
 
 
 def test_remote_task_execution_does_not_get_actor_metadata_tags():
@@ -230,14 +196,10 @@ def test_remote_task_execution_does_not_get_actor_metadata_tags():
         actor_method_name="should_not_appear",
     )
 
-    ctx = _make_ctx_with_span(event)
-    try:
-        RayExecutionSubscriber.on_started(ctx)
+    with core.context_with_event(event) as ctx:
         span = ctx.span
 
         # The subscriber must gate actor tags on is_actor_method
         assert span.get_tag(RAY_ACTOR_CLASS_NAME) is None
         assert span.get_tag(RAY_ACTOR_MODULE_NAME) is None
         assert span.get_tag(RAY_ACTOR_METHOD_NAME) is None
-    finally:
-        ctx.span.finish()

--- a/tests/contrib/ray/test_job_close_tags.py
+++ b/tests/contrib/ray/test_job_close_tags.py
@@ -1,5 +1,9 @@
 """Tests for ray.job close-time tags stamped from JobInfo."""
 
+import atexit
+
+import pytest
+
 from ddtrace.contrib.internal.ray.constants import RAY_JOB_DRIVER_AGENT_HTTP_ADDRESS
 from ddtrace.contrib.internal.ray.constants import RAY_JOB_DRIVER_NODE_ID
 from ddtrace.contrib.internal.ray.constants import RAY_JOB_END_TIME_MS
@@ -34,61 +38,62 @@ def _make_span(submission_id="sub-1"):
     return span
 
 
+@pytest.fixture(scope="module")
+def span_manager():
+    manager = RaySpanManager()
+    yield manager
+    atexit.unregister(manager.cleanup_on_exit)
+
+
 # ---------------------------------------------------------------------------
 # Tests: full JobInfo with all fields present
 # ---------------------------------------------------------------------------
 
 
-def test_finish_span_stamps_start_time():
+def test_finish_span_stamps_start_time(span_manager):
     """start_time from JobInfo lands as a numeric span attribute."""
     span = _make_span()
-    manager = RaySpanManager()
-    manager._finish_span(span, job_info=_FakeJobInfo())
+    span_manager._finish_span(span, job_info=_FakeJobInfo())
 
     assert span.get_metric(RAY_JOB_START_TIME_MS) == 1_700_000_000_000
 
 
-def test_finish_span_stamps_end_time():
+def test_finish_span_stamps_end_time(span_manager):
     """end_time from JobInfo lands as a numeric span attribute."""
     span = _make_span()
-    manager = RaySpanManager()
-    manager._finish_span(span, job_info=_FakeJobInfo())
+    span_manager._finish_span(span, job_info=_FakeJobInfo())
 
     assert span.get_metric(RAY_JOB_END_TIME_MS) == 1_700_001_000_000
 
 
-def test_finish_span_stamps_driver_node_id():
+def test_finish_span_stamps_driver_node_id(span_manager):
     """driver_node_id from JobInfo lands as a string span tag."""
     span = _make_span()
-    manager = RaySpanManager()
-    manager._finish_span(span, job_info=_FakeJobInfo())
+    span_manager._finish_span(span, job_info=_FakeJobInfo())
 
     assert span.get_tag(RAY_JOB_DRIVER_NODE_ID) == "node-abc123"
 
 
-def test_finish_span_stamps_driver_agent_http_address():
+def test_finish_span_stamps_driver_agent_http_address(span_manager):
     """driver_agent_http_address from JobInfo lands as a string span tag."""
     span = _make_span()
-    manager = RaySpanManager()
-    manager._finish_span(span, job_info=_FakeJobInfo())
+    span_manager._finish_span(span, job_info=_FakeJobInfo())
 
     assert span.get_tag(RAY_JOB_DRIVER_AGENT_HTTP_ADDRESS) == "http://10.0.0.1:52365"
 
 
-def test_finish_span_stamps_has_runtime_env_true_when_present():
+def test_finish_span_stamps_has_runtime_env_true_when_present(span_manager):
     """has_runtime_env is 'true' when runtime_env is a non-empty dict."""
     span = _make_span()
-    manager = RaySpanManager()
-    manager._finish_span(span, job_info=_FakeJobInfo())
+    span_manager._finish_span(span, job_info=_FakeJobInfo())
 
     assert span.get_tag(RAY_JOB_HAS_RUNTIME_ENV) == "true"
 
 
-def test_finish_span_also_sets_status_and_message():
+def test_finish_span_also_sets_status_and_message(span_manager):
     """Existing status and message tags are still set alongside the new ones."""
     span = _make_span()
-    manager = RaySpanManager()
-    manager._finish_span(span, job_info=_FakeJobInfo())
+    span_manager._finish_span(span, job_info=_FakeJobInfo())
 
     assert span.get_tag(RAY_JOB_STATUS) == "SUCCEEDED"
     assert span.get_tag(RAY_JOB_MESSAGE) == "Job finished successfully."
@@ -108,47 +113,42 @@ class _FakeJobInfoMinimal:
     # are intentionally absent.
 
 
-def test_finish_span_tolerates_missing_start_time():
+def test_finish_span_tolerates_missing_start_time(span_manager):
     """Missing start_time does not raise and no tag is emitted."""
     span = _make_span()
-    manager = RaySpanManager()
-    manager._finish_span(span, job_info=_FakeJobInfoMinimal())
+    span_manager._finish_span(span, job_info=_FakeJobInfoMinimal())
 
     assert span.get_metric(RAY_JOB_START_TIME_MS) is None
 
 
-def test_finish_span_tolerates_missing_end_time():
+def test_finish_span_tolerates_missing_end_time(span_manager):
     """Missing end_time does not raise and no tag is emitted."""
     span = _make_span()
-    manager = RaySpanManager()
-    manager._finish_span(span, job_info=_FakeJobInfoMinimal())
+    span_manager._finish_span(span, job_info=_FakeJobInfoMinimal())
 
     assert span.get_metric(RAY_JOB_END_TIME_MS) is None
 
 
-def test_finish_span_tolerates_missing_driver_node_id():
+def test_finish_span_tolerates_missing_driver_node_id(span_manager):
     """Missing driver_node_id does not raise and no tag is emitted."""
     span = _make_span()
-    manager = RaySpanManager()
-    manager._finish_span(span, job_info=_FakeJobInfoMinimal())
+    span_manager._finish_span(span, job_info=_FakeJobInfoMinimal())
 
     assert span.get_tag(RAY_JOB_DRIVER_NODE_ID) is None
 
 
-def test_finish_span_tolerates_missing_driver_agent_http_address():
+def test_finish_span_tolerates_missing_driver_agent_http_address(span_manager):
     """Missing driver_agent_http_address does not raise and no tag is emitted."""
     span = _make_span()
-    manager = RaySpanManager()
-    manager._finish_span(span, job_info=_FakeJobInfoMinimal())
+    span_manager._finish_span(span, job_info=_FakeJobInfoMinimal())
 
     assert span.get_tag(RAY_JOB_DRIVER_AGENT_HTTP_ADDRESS) is None
 
 
-def test_finish_span_stamps_has_runtime_env_false_when_missing():
+def test_finish_span_stamps_has_runtime_env_false_when_missing(span_manager):
     """has_runtime_env is not emitted when runtime_env field is absent (older Ray versions)."""
     span = _make_span()
-    manager = RaySpanManager()
-    manager._finish_span(span, job_info=_FakeJobInfoMinimal())
+    span_manager._finish_span(span, job_info=_FakeJobInfoMinimal())
 
     assert span.get_tag(RAY_JOB_HAS_RUNTIME_ENV) is None
 
@@ -158,11 +158,10 @@ def test_finish_span_stamps_has_runtime_env_false_when_missing():
 # ---------------------------------------------------------------------------
 
 
-def test_finish_span_no_job_info_does_not_stamp_new_tags():
+def test_finish_span_no_job_info_does_not_stamp_new_tags(span_manager):
     """When job_info is None (non-job spans), none of the new tags appear."""
     span = _make_span()
-    manager = RaySpanManager()
-    manager._finish_span(span, job_info=None)
+    span_manager._finish_span(span, job_info=None)
 
     assert span.get_metric(RAY_JOB_START_TIME_MS) is None
     assert span.get_metric(RAY_JOB_END_TIME_MS) is None
@@ -171,7 +170,7 @@ def test_finish_span_no_job_info_does_not_stamp_new_tags():
     assert span.get_tag(RAY_JOB_HAS_RUNTIME_ENV) is None
 
 
-def test_finish_span_has_runtime_env_false_for_empty_dict():
+def test_finish_span_has_runtime_env_false_for_empty_dict(span_manager):
     """has_runtime_env is 'false' when runtime_env is an empty dict (falsy)."""
 
     class _FakeJobInfoEmptyEnv:
@@ -184,13 +183,12 @@ def test_finish_span_has_runtime_env_false_for_empty_dict():
         runtime_env = {}
 
     span = _make_span()
-    manager = RaySpanManager()
-    manager._finish_span(span, job_info=_FakeJobInfoEmptyEnv())
+    span_manager._finish_span(span, job_info=_FakeJobInfoEmptyEnv())
 
     assert span.get_tag(RAY_JOB_HAS_RUNTIME_ENV) == "false"
 
 
-def test_finish_span_start_end_time_as_strings():
+def test_finish_span_start_end_time_as_strings(span_manager):
     """start_time / end_time provided as strings are coerced to int."""
 
     class _FakeJobInfoStringTimes:
@@ -203,8 +201,7 @@ def test_finish_span_start_end_time_as_strings():
         runtime_env = None
 
     span = _make_span()
-    manager = RaySpanManager()
-    manager._finish_span(span, job_info=_FakeJobInfoStringTimes())
+    span_manager._finish_span(span, job_info=_FakeJobInfoStringTimes())
 
     assert span.get_metric(RAY_JOB_START_TIME_MS) == 1_700_000_000_000
     assert span.get_metric(RAY_JOB_END_TIME_MS) == 1_700_001_000_000

--- a/tests/contrib/ray/test_long_running_span.py
+++ b/tests/contrib/ray/test_long_running_span.py
@@ -16,7 +16,7 @@ class TestLongRunningSpan(TracerTestCase):
     def setUp(self):
         super().setUp()
         # Override timing values to make tests run quickly
-        self.original_long_running_flush_interval = getattr(config, "_long_running_span_submission_interval", 120.0)
+        self.original_long_running_flush_interval = config._long_running_flush_interval
         self.original_long_running_initial_flush_interval = getattr(
             config, "_long_running_initial_flush_interval", 10.0
         )
@@ -27,6 +27,8 @@ class TestLongRunningSpan(TracerTestCase):
 
         # Clear any existing spans from the job manager
         with _ray_span_manager._lock:
+            for timer in _ray_span_manager._timers.values():
+                timer.cancel()
             _ray_span_manager._job_spans.clear()
             _ray_span_manager._root_spans.clear()
             _ray_span_manager._timers.clear()

--- a/tests/contrib/ray/test_task_submit_tags.py
+++ b/tests/contrib/ray/test_task_submit_tags.py
@@ -2,7 +2,6 @@
 
 from ddtrace import config
 import ddtrace._trace.subscribers.ray  # noqa: F401 — registers RaySubmissionSubscriber
-from ddtrace._trace.subscribers.ray import RaySubmissionSubscriber
 from ddtrace.contrib._events.ray import RaySubmissionEvent
 from ddtrace.contrib.internal.ray.constants import RAY_TASK_ACCELERATOR_TYPE
 from ddtrace.contrib.internal.ray.constants import RAY_TASK_FUNCTION_MODULE
@@ -18,7 +17,7 @@ from ddtrace.contrib.internal.ray.core.remote_function import _as_float
 from ddtrace.contrib.internal.ray.core.remote_function import _as_int
 from ddtrace.contrib.internal.ray.core.remote_function import _as_str
 import ddtrace.contrib.internal.ray.patch  # noqa: F401 — triggers config._add("ray", ...) registration
-from ddtrace.trace import tracer
+from ddtrace.internal import core
 
 
 # ---------------------------------------------------------------------------
@@ -36,18 +35,6 @@ def _make_submission_event(**extra):
         is_task_submission=True,
         **extra,
     )
-
-
-def _make_ctx_with_span(event):
-    """Create a minimal mock context holding the event and a live span."""
-
-    class _Ctx:
-        pass
-
-    ctx = _Ctx()
-    ctx.event = event
-    ctx.span = tracer.start_span(event.operation_name, service=event.service, resource=event.resource)
-    return ctx
 
 
 # ---------------------------------------------------------------------------
@@ -164,9 +151,7 @@ def test_submission_span_carries_scheduling_tags():
         task_function_qualname="compute_task",
     )
 
-    ctx = _make_ctx_with_span(event)
-    try:
-        RaySubmissionSubscriber.on_started(ctx)
+    with core.context_with_event(event) as ctx:
         span = ctx.span
 
         assert span.get_metric(RAY_TASK_NUM_CPUS) == 4.0
@@ -179,17 +164,13 @@ def test_submission_span_carries_scheduling_tags():
         assert span.get_tag(RAY_TASK_FUNCTION_QUALNAME) == "compute_task"
         # Resource tag: ray.task.resources.my_custom_gpu
         assert span.get_metric(f"{RAY_TASK_RESOURCES_PREFIX}my_custom_gpu") == 1.0
-    finally:
-        ctx.span.finish()
 
 
 def test_submission_span_omits_none_scheduling_tags():
     """When optional fields are None, no extra tags are stamped."""
     event = _make_submission_event()  # all scheduling fields default to None
 
-    ctx = _make_ctx_with_span(event)
-    try:
-        RaySubmissionSubscriber.on_started(ctx)
+    with core.context_with_event(event) as ctx:
         span = ctx.span
 
         assert span.get_metric(RAY_TASK_NUM_CPUS) is None
@@ -200,8 +181,6 @@ def test_submission_span_omits_none_scheduling_tags():
         assert span.get_tag(RAY_TASK_SCHEDULING_STRATEGY) is None
         assert span.get_tag(RAY_TASK_FUNCTION_MODULE) is None
         assert span.get_tag(RAY_TASK_FUNCTION_QUALNAME) is None
-    finally:
-        ctx.span.finish()
 
 
 def test_actor_method_submission_does_not_get_task_tags():
@@ -218,16 +197,12 @@ def test_actor_method_submission_does_not_get_task_tags():
         task_num_gpus=4.0,
     )
 
-    ctx = _make_ctx_with_span(event)
-    try:
-        RaySubmissionSubscriber.on_started(ctx)
+    with core.context_with_event(event) as ctx:
         span = ctx.span
 
         # The subscriber must gate task tags on is_task_submission
         assert span.get_metric(RAY_TASK_NUM_CPUS) is None
         assert span.get_metric(RAY_TASK_NUM_GPUS) is None
-    finally:
-        ctx.span.finish()
 
 
 def test_submission_span_resources_multiple_keys():
@@ -236,12 +211,8 @@ def test_submission_span_resources_multiple_keys():
         task_resources={"accelerator_v100": 2.0, "custom_memory": 4.0},
     )
 
-    ctx = _make_ctx_with_span(event)
-    try:
-        RaySubmissionSubscriber.on_started(ctx)
+    with core.context_with_event(event) as ctx:
         span = ctx.span
 
         assert span.get_metric(f"{RAY_TASK_RESOURCES_PREFIX}accelerator_v100") == 2.0
         assert span.get_metric(f"{RAY_TASK_RESOURCES_PREFIX}custom_memory") == 4.0
-    finally:
-        ctx.span.finish()


### PR DESCRIPTION
The ray tests added in https://github.com/DataDog/dd-trace-py/commit/2521a39786bbf654ded0417760a225b7b092bc33 were doing weird things such as:
- Reinstantiating a `RaySpanManager` every tests
- Reimplementing the Events AI subscriber manager in the tests directly.

It probably caused leakage between tests causing flakiness in a ray test.


This PR refactors these tests. It also adds two TODO that were spotted by codex and that should be addressed  in a follow up PR