### PR TITLE
feat(profiling): wire native heap gotter at profiler start (PR D)

### DIFF
--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -379,6 +379,22 @@ class _ProfilerInstance(service.Service):
 
     def _start_service(self) -> None:
         """Start the profiler."""
+        # Arm native (C/C++) heap allocation profiling, if requested and
+        # available. This installs process-global GOT overrides so Datadog's
+        # ddheap USDT probe sites fire on sampled allocations; the Full Host
+        # eBPF profiler collects them out-of-band. Installation is permanent and
+        # idempotent, so re-running it after a fork restart is a harmless no-op.
+        if profiling_config.native_heap.enabled:
+            from ddtrace.internal.datadog.profiling import heap_gotter
+
+            try:
+                if heap_gotter.install():
+                    LOG.debug("Native heap profiling armed (GOT overrides installed)")
+                else:
+                    LOG.debug("Native heap profiling requested but GOT overrides were not installed")
+            except Exception:
+                LOG.debug("Failed to arm native heap profiling", exc_info=True)
+
         collectors = []
         for col in self._collectors:
             try:

--- a/releasenotes/notes/native-heap-profiling-gotter-7f3a1c9d2e5b8a04.yaml
+++ b/releasenotes/notes/native-heap-profiling-gotter-7f3a1c9d2e5b8a04.yaml
@@ -1,0 +1,7 @@
+features:
+  - |
+    profiling: Add experimental, opt-in native (C/C++) heap allocation profiling that
+    integrates with the Datadog eBPF profiler, enabled via
+    ``DD_PROFILING_NATIVE_HEAP_ENABLED=true``. Profile collection and processing run
+    outside the application process. Allocation-only in this release, with live heap
+    tracking planned for the future. It is a no-op when disabled.

--- a/tests/profiling/test_native_heap_gotter.py
+++ b/tests/profiling/test_native_heap_gotter.py
@@ -42,3 +42,81 @@ def test_native_heap_gotter_smoke() -> None:
         for i in range(200):
             blobs.append(("x" * 4096, i))
         assert len(blobs) == 200
+
+
+@pytest.mark.subprocess(env=dict(DD_PROFILING_ENABLED="true"))
+def test_profiler_start_arms_native_heap_when_enabled() -> None:
+    """Starting the profiler with native heap enabled invokes the activator.
+
+    Cross-platform: we force the config flag on (the import-time availability
+    gate would otherwise disable it when the cdylib is absent) and patch the
+    activator, so this exercises only the profiler wiring, not the real library.
+    """
+    from unittest import mock
+
+    from ddtrace.internal.datadog.profiling import heap_gotter
+    from ddtrace.internal.settings.profiling import config as profiling_config
+
+    # Force on regardless of whether the cdylib shipped in this build.
+    profiling_config.native_heap.enabled = True  # pyright: ignore[reportAttributeAccessIssue]
+
+    with mock.patch.object(heap_gotter, "install", return_value=True) as install:
+        from ddtrace.profiling.profiler import Profiler
+
+        prof = Profiler()
+        prof.start()
+        try:
+            assert install.called, "profiler start should arm native heap profiling when enabled"
+        finally:
+            prof.stop(flush=False)
+
+
+@pytest.mark.subprocess(env=dict(DD_PROFILING_ENABLED="true"))
+def test_profiler_start_skips_native_heap_when_disabled() -> None:
+    """With native heap disabled, the profiler must not touch the activator.
+
+    This guards the zero-overhead promise of the disabled path: no install()
+    call (and therefore no dlopen of the gotter cdylib) when the feature is off.
+    """
+    from unittest import mock
+
+    from ddtrace.internal.datadog.profiling import heap_gotter
+    from ddtrace.internal.settings.profiling import config as profiling_config
+
+    profiling_config.native_heap.enabled = False  # pyright: ignore[reportAttributeAccessIssue]
+
+    with mock.patch.object(heap_gotter, "install", return_value=True) as install:
+        from ddtrace.profiling.profiler import Profiler
+
+        prof = Profiler()
+        prof.start()
+        try:
+            assert not install.called, "profiler must not arm native heap profiling when disabled"
+        finally:
+            prof.stop(flush=False)
+
+
+@pytest.mark.subprocess(env=dict(DD_PROFILING_ENABLED="true"))
+def test_profiler_start_survives_native_heap_install_error() -> None:
+    """A failure while arming native heap profiling must not break the profiler.
+
+    Arming is best-effort: if install() raises, profiler startup swallows it and
+    the profiler still comes up.
+    """
+    from unittest import mock
+
+    from ddtrace.internal.datadog.profiling import heap_gotter
+    from ddtrace.internal.settings.profiling import config as profiling_config
+
+    profiling_config.native_heap.enabled = True  # pyright: ignore[reportAttributeAccessIssue]
+
+    with mock.patch.object(heap_gotter, "install", side_effect=RuntimeError("boom")) as install:
+        from ddtrace.profiling.profiler import Profiler
+
+        prof = Profiler()
+        prof.start()  # must not raise
+        try:
+            assert install.called
+            assert prof.status.value == "running"
+        finally:
+            prof.stop(flush=False)


### PR DESCRIPTION
## Summary
- Call `heap_gotter.install()` once at profiler start when enabled
- Best-effort: install failure does not break profiler startup
- Release note + profiler wiring tests

Stack **4/4** — Phase 1 POC: arms `ddheap:alloc` USDTs for Full Host eBPF.

## Test plan
- [ ] `pytest tests/profiling/test_native_heap_gotter.py -v`
- [ ] Staging dogfood with FH profiler (see experimental `native_heap_gotter/PLAN.md`)