### PR TITLE
fix(iast): scope taint copy helpers to the active request slot [Backport 4.10]

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -28,8 +28,12 @@ from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import OriginTy
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import Source  # noqa: F401
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import TagMappingMode  # noqa: F401
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import VulnerabilityType  # noqa: F401
-from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import copy_and_shift_ranges_from_strings  # noqa: F401
-from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import copy_ranges_from_strings  # noqa: F401
+from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import (
+    copy_and_shift_ranges_from_strings as _native_copy_and_shift_ranges_from_strings,
+)
+from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import (
+    copy_ranges_from_strings as _native_copy_ranges_from_strings,
+)
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import get_range_by_hash  # noqa: F401
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import get_ranges as _native_get_ranges
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import is_tainted  # noqa: F401
@@ -51,6 +55,15 @@ log = get_logger(__name__)
 _CACHE_GET_IAST_CONTEXT_ID = None
 
 
+def _current_iast_context_id() -> Optional[int]:
+    global _CACHE_GET_IAST_CONTEXT_ID
+    if _CACHE_GET_IAST_CONTEXT_ID is None:
+        from ddtrace.appsec._iast._iast_request_context_base import _get_iast_context_id
+
+        _CACHE_GET_IAST_CONTEXT_ID = _get_iast_context_id
+    return _CACHE_GET_IAST_CONTEXT_ID()
+
+
 def get_ranges(string_input: Any, context_id: Optional[int] = None) -> Any:
     if context_id is None:
         global _CACHE_GET_IAST_CONTEXT_ID
@@ -60,6 +73,23 @@ def get_ranges(string_input: Any, context_id: Optional[int] = None) -> Any:
             _CACHE_GET_IAST_CONTEXT_ID = _get_iast_context_id
         context_id = _CACHE_GET_IAST_CONTEXT_ID()
     return _native_get_ranges(string_input, context_id)
+
+
+def copy_ranges_from_strings(str_1: Any, str_2: Any, context_id: Optional[int] = None) -> None:
+    # AIDEV-NOTE: scope the copy to the active request slot to match the scoped
+    # get_ranges() read path; otherwise the native multi-slot resolver may write
+    # the derived taint into a concurrent request's map and the scoped read misses it.
+    if context_id is None:
+        context_id = _current_iast_context_id()
+    _native_copy_ranges_from_strings(str_1, str_2, context_id)
+
+
+def copy_and_shift_ranges_from_strings(
+    str_1: Any, str_2: Any, offset: int, new_length: int = -1, context_id: Optional[int] = None
+) -> None:
+    if context_id is None:
+        context_id = _current_iast_context_id()
+    _native_copy_and_shift_ranges_from_strings(str_1, str_2, offset, new_length, context_id)
 
 
 __all__ = [

--- a/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/taint_range.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/taint_range.cpp
@@ -291,13 +291,18 @@ api_get_ranges(const py::handle& string_input, std::optional<size_t> context_id)
 }
 
 void
-api_copy_ranges_from_strings(py::handle& str_1, py::handle& str_2)
+api_copy_ranges_from_strings(py::handle& str_1, py::handle& str_2, std::optional<size_t> context_id)
 {
     if (!taint_engine_context) {
         return;
     }
 
-    const auto tx_map = safe_get_tainted_object_map(str_1.ptr());
+    // With a context_id both the source read and the derived write are pinned
+    // to the active request's slot, matching the scoped get_ranges() read path
+    // so a concurrent request's stale entry cannot capture the copy. Without a
+    // context_id the multi-slot resolver locates the map that owns the source.
+    const auto tx_map = context_id.has_value() ? safe_get_tainted_object_map_by_ctx_id(*context_id)
+                                               : safe_get_tainted_object_map(str_1.ptr());
 
     if (not tx_map) {
         py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
@@ -318,13 +323,17 @@ inline void
 api_copy_and_shift_ranges_from_strings(py::handle& str_1,
                                        py::handle& str_2,
                                        const int offset,
-                                       const int new_length = -1)
+                                       const int new_length,
+                                       std::optional<size_t> context_id)
 {
     if (!taint_engine_context) {
         return;
     }
 
-    const auto tx_map = safe_get_tainted_object_map(str_1.ptr());
+    // See api_copy_ranges_from_strings: context_id scopes both read and write to
+    // the active slot to keep parity with the scoped get_ranges() read path.
+    const auto tx_map = context_id.has_value() ? safe_get_tainted_object_map_by_ctx_id(*context_id)
+                                               : safe_get_tainted_object_map(str_1.ptr());
     if (not tx_map) {
         py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
         return;
@@ -452,13 +461,15 @@ pyexport_taintrange(py::module& m)
 
     // m.def("set_ranges", py::overload_cast<PyObject*, const TaintRangeRefs&>(&api_set_ranges), "str"_a, "ranges"_a);
     m.def("set_ranges", &api_set_ranges, "str"_a, "ranges"_a, "contextid"_a);
-    m.def("copy_ranges_from_strings", &api_copy_ranges_from_strings, "str_1"_a, "str_2"_a);
+    m.def(
+      "copy_ranges_from_strings", &api_copy_ranges_from_strings, "str_1"_a, "str_2"_a, "context_id"_a = std::nullopt);
     m.def("copy_and_shift_ranges_from_strings",
           &api_copy_and_shift_ranges_from_strings,
           "str_1"_a,
           "str_2"_a,
           "offset"_a,
-          "new_length"_a = -1);
+          "new_length"_a = -1,
+          "context_id"_a = std::nullopt);
 
     m.def("get_ranges",
           &api_get_ranges,

--- a/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/taint_range.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/taint_range.h
@@ -152,10 +152,14 @@ TaintRangeRefs
 api_get_ranges(const py::handle& string_input, std::optional<size_t> context_id = std::nullopt);
 
 void
-api_copy_ranges_from_strings(py::handle& str_1, py::handle& str_2);
+api_copy_ranges_from_strings(py::handle& str_1, py::handle& str_2, std::optional<size_t> context_id = std::nullopt);
 
 inline void
-api_copy_and_shift_ranges_from_strings(py::handle& str_1, py::handle& str_2, int offset, int new_length);
+api_copy_and_shift_ranges_from_strings(py::handle& str_1,
+                                       py::handle& str_2,
+                                       int offset,
+                                       int new_length = -1,
+                                       std::optional<size_t> context_id = std::nullopt);
 
 PyObject*
 api_taint_pyobject(PyObject* self, PyObject* const* args, const Py_ssize_t nargs);

--- a/releasenotes/notes/fix-iast-scope-copy-ranges-to-active-slot-a1b2c3d4e5f60789.yaml
+++ b/releasenotes/notes/fix-iast-scope-copy-ranges-to-active-slot-a1b2c3d4e5f60789.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Code Security (IAST): This fix scopes ``copy_ranges_from_strings`` and
+    ``copy_and_shift_ranges_from_strings`` to the active request slot, matching the
+    scoped taint read path. Previously these copy helpers resolved the taint map by
+    scanning all request slots, so a concurrent or still-open request could capture the
+    derived taint and the current request would miss the transformed tainted input.

--- a/tests/appsec/iast/taint_tracking/test_context.py
+++ b/tests/appsec/iast/taint_tracking/test_context.py
@@ -1,8 +1,11 @@
+import gc
+
 from ddtrace.appsec._iast._iast_request_context_base import IAST_CONTEXT
 from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request
 from ddtrace.appsec._iast._iast_request_context_base import _num_objects_tainted_in_request
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import TaintRange
+from ddtrace.appsec._iast._taint_tracking import get_ranges
 from ddtrace.appsec._iast._taint_tracking._context import clear_all_request_context_slots
 from ddtrace.appsec._iast._taint_tracking._context import debug_num_tainted_objects
 from ddtrace.appsec._iast._taint_tracking._context import finish_request_context

--- a/tests/appsec/iast/taint_tracking/test_context.py
+++ b/tests/appsec/iast/taint_tracking/test_context.py
@@ -229,3 +229,140 @@ def test_get_ranges_public_api_does_not_leak_across_request_slots():
     finish_request_context(ctx_a)
     finish_request_context(ctx_b)
     IAST_CONTEXT.set(None)
+
+
+def test_copy_ranges_from_strings_writes_to_active_slot_not_earlier_slot():
+    """copy_ranges_from_strings must write the derived taint into the active slot.
+
+    Regression: the native multi-slot resolver picks the first slot holding the
+    source id, so with a stale entry in an earlier slot the derived taint was
+    written there and the scoped get_ranges() read from the active slot missed it.
+    """
+    from ddtrace.appsec._iast._taint_tracking import copy_ranges_from_strings
+    from ddtrace.appsec._iast._taint_tracking import get_ranges
+    from ddtrace.appsec._iast._taint_tracking import set_ranges
+
+    clear_all_request_context_slots()
+    _end_iast_context_and_oce()
+
+    ctx_a = start_request_context()
+    ctx_b = start_request_context()
+    assert ctx_a is not None and ctx_b is not None and ctx_a != ctx_b
+
+    # The same source object lives in both slots, with ctx_a being the earlier slot.
+    shared = _taint_pyobject_base("SECRET", "p", "SECRET", OriginType.PARAMETER, contextid=ctx_a)
+    ranges_a = get_ranges(shared, ctx_a)
+    assert len(ranges_a) > 0
+    set_ranges(shared, ranges_a, ctx_b)
+    assert len(get_ranges(shared, ctx_b)) > 0
+
+    # Active request is the later slot ctx_b.
+    IAST_CONTEXT.set(ctx_b)
+    derived = "X" + shared  # a fresh, otherwise-untracked object
+    copy_ranges_from_strings(shared, derived)
+
+    # The derived taint must be visible from the active slot's scoped read.
+    assert len(get_ranges(derived, ctx_b)) > 0
+
+    finish_request_context(ctx_a)
+    finish_request_context(ctx_b)
+    IAST_CONTEXT.set(None)
+
+
+def test_copy_and_shift_ranges_from_strings_writes_to_active_slot_not_earlier_slot():
+    """copy_and_shift_ranges_from_strings must also be scoped to the active slot."""
+    from ddtrace.appsec._iast._taint_tracking import copy_and_shift_ranges_from_strings
+    from ddtrace.appsec._iast._taint_tracking import get_ranges
+    from ddtrace.appsec._iast._taint_tracking import set_ranges
+
+    clear_all_request_context_slots()
+    _end_iast_context_and_oce()
+
+    ctx_a = start_request_context()
+    ctx_b = start_request_context()
+    assert ctx_a is not None and ctx_b is not None and ctx_a != ctx_b
+
+    shared = _taint_pyobject_base("SECRET", "p", "SECRET", OriginType.PARAMETER, contextid=ctx_a)
+    ranges_a = get_ranges(shared, ctx_a)
+    assert len(ranges_a) > 0
+    set_ranges(shared, ranges_a, ctx_b)
+    assert len(get_ranges(shared, ctx_b)) > 0
+
+    IAST_CONTEXT.set(ctx_b)
+    derived = "X" + shared
+    copy_and_shift_ranges_from_strings(shared, derived, 1, len(derived))
+
+    assert len(get_ranges(derived, ctx_b)) > 0
+
+    finish_request_context(ctx_a)
+    finish_request_context(ctx_b)
+    IAST_CONTEXT.set(None)
+
+
+def test_is_pyobject_tainted_without_context_does_not_consult_native():
+    """Regression for a teardown/GC crash (#18996).
+
+    With no active request context the query must return False without
+    entering native code.
+    """
+    clear_all_request_context_slots()
+    _end_iast_context_and_oce()
+
+    ctx = start_request_context()
+    assert ctx is not None
+    tainted = _taint_pyobject_base(
+        "http://dummy.location.com",
+        "location",
+        "http://dummy.location.com",
+        OriginType.PARAMETER,
+        contextid=ctx,
+    )
+    IAST_CONTEXT.set(ctx)
+    assert is_pyobject_tainted(tainted) is True  # sanity: visible within its own slot
+
+    # Detach the context, as happens once the request finishes but the tainted
+    # object is still referenced by a soon-to-be-finalized structure.
+    IAST_CONTEXT.set(None)
+    assert is_pyobject_tainted(tainted) is False
+    assert get_tainted_ranges(tainted) == tuple()
+
+    finish_request_context(ctx)
+    IAST_CONTEXT.set(None)
+
+
+def test_taint_query_from_finalizer_without_context_is_safe():
+    clear_all_request_context_slots()
+    _end_iast_context_and_oce()
+    IAST_CONTEXT.set(None)
+
+    results = []
+
+    class _QueriesTaintOnDel:
+        def __init__(self, value):
+            self.value = value
+
+        def __del__(self):
+            results.append(is_pyobject_tainted(self.value))
+
+    obj = _QueriesTaintOnDel("some-tainted-looking-string")
+    del obj
+    gc.collect()
+
+    assert results == [False]
+
+
+def test_get_ranges_public_api_returns_empty_without_context():
+    clear_all_request_context_slots()
+    _end_iast_context_and_oce()
+
+    ctx = start_request_context()
+    assert ctx is not None
+    tainted = _taint_pyobject_base("secret", "p", "secret", OriginType.PARAMETER, contextid=ctx)
+
+    # The tainted object lives in a real slot, but with no active context the
+    # public wrapper must not consult the native multi-slot resolver.
+    IAST_CONTEXT.set(None)
+    assert list(get_ranges(tainted)) == []
+
+    finish_request_context(ctx)
+    IAST_CONTEXT.set(None)


### PR DESCRIPTION
backport #19033 to 4.10

<!-- Provide an overview of the change and motivation for the change -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
