### PR TITLE
chore(iast): preserve propagation during source suppression

### DIFF
--- a/ddtrace/appsec/_iast/_iast_request_context_base.py
+++ b/ddtrace/appsec/_iast/_iast_request_context_base.py
@@ -22,7 +22,7 @@ log = get_logger(__name__)
 
 IAST_CONTEXT: contextvars.ContextVar[Optional[int]] = contextvars.ContextVar("iast_var", default=None)
 
-# AIDEV-NOTE: Keep source suppression separate from IAST_CONTEXT. Clearing the
+# Keep source suppression separate from IAST_CONTEXT. Clearing the
 # request context id disables request-scoped taint queries and propagation and
 # can send no-context queries through unsafe native fallback paths.
 _IAST_TAINT_SOURCES_SUPPRESSED: contextvars.ContextVar[bool] = contextvars.ContextVar(

--- a/ddtrace/appsec/_iast/_iast_request_context_base.py
+++ b/ddtrace/appsec/_iast/_iast_request_context_base.py
@@ -22,15 +22,26 @@ log = get_logger(__name__)
 
 IAST_CONTEXT: contextvars.ContextVar[Optional[int]] = contextvars.ContextVar("iast_var", default=None)
 
+# AIDEV-NOTE: Keep source suppression separate from IAST_CONTEXT. Clearing the
+# request context id disables request-scoped taint queries and propagation and
+# can send no-context queries through unsafe native fallback paths.
+_IAST_TAINT_SOURCES_SUPPRESSED: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "iast_taint_sources_suppressed", default=False
+)
+
 
 @contextlib.contextmanager
 def iast_suppress_context():
     """Temporarily disable IAST taint *source* generation for the current context."""
-    token = IAST_CONTEXT.set(None)
+    token = _IAST_TAINT_SOURCES_SUPPRESSED.set(True)
     try:
         yield
     finally:
-        IAST_CONTEXT.reset(token)
+        _IAST_TAINT_SOURCES_SUPPRESSED.reset(token)
+
+
+def _is_iast_taint_source_enabled() -> bool:
+    return not _IAST_TAINT_SOURCES_SUPPRESSED.get()
 
 
 def _set_span_tag_iast_request_tainted(span):

--- a/ddtrace/appsec/_iast/_taint_tracking/_taint_objects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/_taint_objects.py
@@ -5,6 +5,7 @@ from typing import Sequence
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.appsec._iast._iast_request_context_base import _get_iast_context_id
+from ddtrace.appsec._iast._iast_request_context_base import _is_iast_taint_source_enabled
 from ddtrace.appsec._iast._logs import iast_propagation_debug_log
 from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_source
 from ddtrace.appsec._iast._span_metrics import increment_iast_span_metric
@@ -20,7 +21,7 @@ log = get_logger(__name__)
 
 def taint_pyobject(pyobject: Any, source_name: Any, source_value: Any, source_origin=None) -> Any:
     try:
-        if (contextid := _get_iast_context_id()) is not None:
+        if (contextid := _get_iast_context_id()) is not None and _is_iast_taint_source_enabled():
             if source_origin is None:
                 source_origin = OriginType.PARAMETER
             res = _taint_pyobject_base(pyobject, source_name, source_value, source_origin, contextid)

--- a/ddtrace/appsec/_iast/_taint_tracking/_taint_objects_base.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/_taint_objects_base.py
@@ -1,9 +1,7 @@
 from typing import Any
 
 from ddtrace.appsec._constants import IAST
-from ddtrace.appsec._iast._iast_env import in_iast_env
 from ddtrace.appsec._iast._iast_request_context_base import _get_iast_context_id
-from ddtrace.appsec._iast._iast_request_context_base import is_iast_request_enabled
 from ddtrace.appsec._iast._logs import iast_propagation_debug_log
 from ddtrace.appsec._iast._logs import iast_propagation_error_log
 from ddtrace.appsec._iast._taint_tracking import OriginType
@@ -66,26 +64,28 @@ def _taint_pyobject_base(pyobject: Any, source_name: Any, source_value: Any, sou
 
 
 def get_tainted_ranges(pyobject: Any) -> tuple:
-    if not is_iast_request_enabled():
+    context_id = _get_iast_context_id()
+    if context_id is None:
         return tuple()
     if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
         return tuple()
     try:
-        return get_ranges(pyobject, _get_iast_context_id())
+        return get_ranges(pyobject, context_id)
     except ValueError as e:
         iast_propagation_error_log(f"get_tainted_ranges error (pyobject type {type(pyobject)})", exc=e)
     return tuple()
 
 
 def is_pyobject_tainted(pyobject: Any) -> bool:
-    if not is_iast_request_enabled() and not in_iast_env():
+    context_id = _get_iast_context_id()
+    if context_id is None:
         return False
 
     if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
         return False
 
     try:
-        return is_in_taint_map(pyobject, _get_iast_context_id())
+        return is_in_taint_map(pyobject, context_id)
     except ValueError as e:
         iast_propagation_error_log("Checking tainted object error", exc=e)
     return False

--- a/releasenotes/notes/iast-preserve-propagation-during-source-suppression-4f12c9e87a63b5d1.yaml
+++ b/releasenotes/notes/iast-preserve-propagation-during-source-suppression-4f12c9e87a63b5d1.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    IAST: Fixes a crash during request teardown while preserving taint propagation when AppSec temporarily suppresses new taint sources.

--- a/releasenotes/notes/iast-preserve-propagation-during-source-suppression-4f12c9e87a63b5d1.yaml
+++ b/releasenotes/notes/iast-preserve-propagation-during-source-suppression-4f12c9e87a63b5d1.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    IAST: Fixes a crash during request teardown while preserving taint propagation when AppSec temporarily suppresses new taint sources.

--- a/scripts/check_constant_log_message.py
+++ b/scripts/check_constant_log_message.py
@@ -28,7 +28,7 @@ EXCEPTIONS = {
     "ddtrace/appsec/_iast/_logs.py:41",
     "ddtrace/appsec/_iast/_logs.py:45",
     # the non constant part is an object type
-    "ddtrace/appsec/_iast/_taint_tracking/_taint_objects_base.py:76",
+    "ddtrace/appsec/_iast/_taint_tracking/_taint_objects_base.py:75",
     # _safelog wrapper function dispatches to log methods with variable message
     "ddtrace/internal/writer/writer.py:103",
 }

--- a/tests/appsec/iast/taint_tracking/test_context.py
+++ b/tests/appsec/iast/taint_tracking/test_context.py
@@ -1,5 +1,6 @@
 import gc
 
+from ddtrace.appsec._iast._iast_env import in_iast_env
 from ddtrace.appsec._iast._iast_request_context_base import IAST_CONTEXT
 from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request
 from ddtrace.appsec._iast._iast_request_context_base import _num_objects_tainted_in_request
@@ -340,6 +341,18 @@ def test_is_pyobject_tainted_without_context_does_not_consult_native():
 
     finish_request_context(ctx)
     IAST_CONTEXT.set(None)
+
+
+def test_is_pyobject_tainted_without_context_ignores_stale_iast_env(iast_context_defaults):
+    tainted = taint_pyobject("tainted_with_stale_env", "param", "tainted_with_stale_env", OriginType.PARAMETER)
+    assert is_pyobject_tainted(tainted) is True
+
+    token = IAST_CONTEXT.set(None)
+    try:
+        assert in_iast_env() is True
+        assert is_pyobject_tainted(tainted) is False
+    finally:
+        IAST_CONTEXT.reset(token)
 
 
 def test_taint_query_from_finalizer_without_context_is_safe():

--- a/tests/appsec/iast/taint_tracking/test_disable_taint_sources.py
+++ b/tests/appsec/iast/taint_tracking/test_disable_taint_sources.py
@@ -1,10 +1,10 @@
 """Tests for ``iast_suppress_context``: suppressing IAST taint *source* generation.
 
 The context manager is used by the AppSec machinery to avoid creating throwaway tainted objects while
-analysing request data that never reaches the customer's business logic. It works by clearing the active
-IAST request context id (which gates source generation) and restoring it on exit, so it must:
+analysing request data that never reaches the customer's business logic. It works by setting a context-local
+source-suppression flag while preserving the active IAST request context id, so it must:
 - suppress ``taint_pyobject`` while active and restore behaviour afterwards,
-- restore the previous context id (not hard-reset),
+- preserve the current context id,
 - leave taint *propagation* (aspects) untouched,
 - be harmless when there is no active IAST request context.
 """
@@ -36,16 +36,26 @@ def test_taint_sources_suppressed_inside_context(iast_context_defaults):
     assert is_pyobject_tainted(_taint("restored_value"))
 
 
-def test_context_id_is_saved_and_restored(iast_context_defaults):
+def test_context_id_is_preserved(iast_context_defaults):
     context_id = _get_iast_context_id()
     assert context_id is not None
 
     with iast_suppress_context():
-        # The active context id is cleared while suppressed.
-        assert _get_iast_context_id() is None
+        assert _get_iast_context_id() == context_id
 
-    # The original context id is restored on exit.
     assert _get_iast_context_id() == context_id
+
+
+def test_nested_taint_source_suppression(iast_context_defaults):
+    with iast_suppress_context():
+        assert not is_pyobject_tainted(_taint("outer_suppressed_value"))
+
+        with iast_suppress_context():
+            assert not is_pyobject_tainted(_taint("inner_suppressed_value"))
+
+        assert not is_pyobject_tainted(_taint("outer_still_suppressed_value"))
+
+    assert is_pyobject_tainted(_taint("restored_after_nested_suppression"))
 
 
 def test_propagation_is_not_suppressed(iast_context_defaults):


### PR DESCRIPTION
## Description

This is an alternative follow-up to #19065 for the crash addressed by #18996.

#18996 fixes a recurring `SIGSEGV` when a taint query runs from GC/finalizer teardown without an active IAST request context. In that state, `IAST_CONTEXT` is `None`; forwarding that value to the native `is_in_taint_map` binding selects its multi-slot fallback, which can inspect a partially finalized Python object.

#19065 correctly makes a missing request context an unconditional no-taint result. However, the [review discussion](https://github.com/DataDog/dd-trace-py/pull/19065#discussion_r3587022162) identified a separate behavior hidden behind the same state: `iast_suppress_context()` also set `IAST_CONTEXT` to `None` to suppress new taint sources. Consequently, treating every `None` as teardown also disables lookup and propagation of already-tainted values inside AppSec source-suppression blocks, producing IAST false negatives.

This PR preserves the strict no-context guard while separating the two concepts:

- `IAST_CONTEXT` continues to represent the active request's native taint-map slot.
- `_IAST_TAINT_SOURCES_SUPPRESSED` is a separate context-local boolean that gates only new source creation in `taint_pyobject()`.
- Taint queries capture the request context ID once and never enter the native lookup path when it is absent.

A different `ContextVar` is necessary because `IAST_CONTEXT = None` cannot safely encode both states:

1. No active request / teardown: native taint lookup must not run.
2. Active request with source suppression: new sources must be disabled, but existing taint must remain request-scoped and continue propagating.

Checking only the broader IAST environment cannot distinguish these states either, because that environment can remain present during stale or teardown states. Keeping suppression orthogonal to the request context preserves context-local and nested suppression semantics without reopening the unsafe native fallback.

## Testing

Regression coverage verifies source suppression, nested restoration, propagation during suppression, and the stale-environment/no-context teardown case.

## Risks

- Adds one context-local boolean lookup to the taint-source creation path.
- Existing tainted values remain visible to propagation and sink logic while only new source creation is suppressed; this is the intended pre-existing contract and is covered explicitly.
- No public API changes.

## Additional Notes

- The original user-facing crash fix is documented by #18996; this follow-up uses the `changelog/no-changelog` label.
- Preserves the safety objective of #18996 and #19065 while retaining IAST source-suppression capabilities.
