### PR TITLE
chore: break circular imports [backport 4.12]

### DIFF
--- a/ddtrace/internal/_service_state.py
+++ b/ddtrace/internal/_service_state.py
@@ -1,0 +1,29 @@
+"""Shared, dependency-free holder for service-resolution facts.
+
+ddtrace.internal.settings._config computes whether the service name was
+explicitly provided by the user (as opposed to auto-detected/defaulted).
+ddtrace.internal.process_tags needs that same fact to build its tags, but
+importing _config from there would recreate the
+process_tags -> _config -> telemetry -> process_tags circular import
+(_config depends on ddtrace.internal.telemetry for configuration lookups,
+and telemetry depends on process_tags for its payload data).
+
+This module lives directly under ddtrace.internal (rather than
+ddtrace.internal.settings) and has no dependencies of its own, so it can sit
+underneath both without closing that loop: _config.py sets the value once
+during Config construction, and process_tags reads it directly.
+"""
+
+from typing import Optional
+
+
+_is_user_provided_service: Optional[bool] = None
+
+
+def set_is_user_provided_service(value: bool) -> None:
+    global _is_user_provided_service
+    _is_user_provided_service = value
+
+
+def is_user_provided_service() -> bool:
+    return bool(_is_user_provided_service)

--- a/ddtrace/internal/atexit.py
+++ b/ddtrace/internal/atexit.py
@@ -9,6 +9,7 @@ import signal
 import threading
 import typing
 
+from ddtrace.internal.native import config as _native_config
 from ddtrace.internal.utils import signals
 
 
@@ -29,10 +30,7 @@ def _make_safe_wrapper(func: typing.Callable) -> typing.Callable:
         try:
             func(*args, **kwargs)
         except Exception:
-            # Lazy import to avoid circular dependencies at module load time.
-            from ddtrace import config
-
-            if config._raise:
+            if _native_config.get_raise():
                 raise
 
     return _wrapped
@@ -71,10 +69,7 @@ def register_on_exit_signal(f: typing.Callable) -> None:
         try:
             f()
         except Exception:
-            # Lazy import to avoid circular dependencies at module load time.
-            from ddtrace import config
-
-            if config._raise:
+            if _native_config.get_raise():
                 raise
 
     if threading.current_thread() is threading.main_thread():

--- a/ddtrace/internal/process_tags/__init__.py
+++ b/ddtrace/internal/process_tags/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 from typing import Callable
 from typing import Optional
 
+from ddtrace.internal._service_state import is_user_provided_service
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings.process_tags import process_tags_config
 from ddtrace.internal.utils.fnv import fnv1_64
@@ -108,7 +109,6 @@ def generate_process_tags() -> tuple[Optional[str], Optional[list[str]]]:
     if not process_tags_config.enabled:
         return None, None
 
-    from ddtrace import config as ddtrace_config
     from ddtrace.internal.settings._inferred_base_service import detect_service
 
     tag_definitions = [
@@ -116,12 +116,10 @@ def generate_process_tags() -> tuple[Optional[str], Optional[list[str]]]:
         (ENTRYPOINT_BASEDIR_TAG, lambda: Path(sys.argv[0]).resolve().parent.name),
         (ENTRYPOINT_NAME_TAG, _get_entrypoint_name),
         (ENTRYPOINT_TYPE_TAG, _get_entrypoint_type),
-        (SVC_USER_TAG, lambda: "true" if ddtrace_config._is_user_provided_service else None),
+        (SVC_USER_TAG, lambda: "true" if is_user_provided_service() else None),
         (
             SVC_AUTO_TAG,
-            lambda: (detect_service(sys.argv) or _get_entrypoint_name())
-            if not ddtrace_config._is_user_provided_service
-            else None,
+            lambda: (detect_service(sys.argv) or _get_entrypoint_name()) if not is_user_provided_service() else None,
         ),
     ]
 

--- a/ddtrace/internal/schema/__init__.py
+++ b/ddtrace/internal/schema/__init__.py
@@ -3,7 +3,7 @@ import logging
 from ddtrace.internal.settings import env
 from ddtrace.internal.utils.formats import asbool
 
-from .span_attribute_schema import _DEFAULT_SPAN_SERVICE_NAMES
+from .default import _get_schema_version
 from .span_attribute_schema import _SPAN_ATTRIBUTE_TO_FUNCTION
 from .span_attribute_schema import SpanDirection
 
@@ -11,35 +11,10 @@ from .span_attribute_schema import SpanDirection
 log = logging.getLogger(__name__)
 
 
-# Span attribute schema
-def _validate_schema(version):
-    error_message = (
-        "You have specified an invalid span attribute schema version: '{}'.".format(version),
-        "Valid options are: {}. You can change the specified value by updating".format(
-            _SPAN_ATTRIBUTE_TO_FUNCTION.keys()
-        ),
-        "the value exported in the 'DD_TRACE_SPAN_ATTRIBUTE_SCHEMA' environment variable.",
-    )
-
-    if version not in _SPAN_ATTRIBUTE_TO_FUNCTION.keys():
-        log.warning(" ".join(error_message))
-        return False
-
-    return True
-
-
-def _get_schema_version():
-    version = env.get("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", default="v0")
-    if not _validate_schema(version):
-        version = "v0"
-    return version
-
-
 SCHEMA_VERSION = _get_schema_version()
 _remove_client_service_names = asbool(env.get("DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED", default=False))
 _service_name_schema_version = "v0" if SCHEMA_VERSION == "v0" and not _remove_client_service_names else "v1"
 
-DEFAULT_SPAN_SERVICE_NAME = _DEFAULT_SPAN_SERVICE_NAMES[_service_name_schema_version]
 schematize_cache_operation = _SPAN_ATTRIBUTE_TO_FUNCTION[SCHEMA_VERSION]["cache_operation"]
 schematize_cloud_api_operation = _SPAN_ATTRIBUTE_TO_FUNCTION[SCHEMA_VERSION]["cloud_api_operation"]
 schematize_cloud_faas_operation = _SPAN_ATTRIBUTE_TO_FUNCTION[SCHEMA_VERSION]["cloud_faas_operation"]
@@ -50,7 +25,6 @@ schematize_service_name = _SPAN_ATTRIBUTE_TO_FUNCTION[_service_name_schema_versi
 schematize_url_operation = _SPAN_ATTRIBUTE_TO_FUNCTION[SCHEMA_VERSION]["url_operation"]
 
 __all__ = [
-    "DEFAULT_SPAN_SERVICE_NAME",
     "SCHEMA_VERSION",
     "SpanDirection",
     "schematize_cache_operation",

--- a/ddtrace/internal/schema/default.py
+++ b/ddtrace/internal/schema/default.py
@@ -1,0 +1,50 @@
+import logging
+import sys
+import typing as t
+
+from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
+from ddtrace.internal.settings import env
+from ddtrace.internal.settings._inferred_base_service import detect_service
+from ddtrace.internal.utils.formats import asbool
+
+
+VALID_VERSIONS = ["v0", "v1"]
+
+
+log = logging.getLogger(__name__)
+
+
+def _validate_schema(version: str) -> bool:
+    error_message = (
+        "You have specified an invalid span attribute schema version: '{}'.".format(version),
+        "Valid options are: {}. You can change the specified value by updating".format(VALID_VERSIONS),
+        "the value exported in the 'DD_TRACE_SPAN_ATTRIBUTE_SCHEMA' environment variable.",
+    )
+
+    if version not in VALID_VERSIONS:
+        log.warning(" ".join(error_message))
+        return False
+
+    return True
+
+
+def _get_schema_version() -> t.Any:
+    version = env.get("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", default="v0")
+    if not _validate_schema(version):
+        version = "v0"
+    return version
+
+
+SCHEMA_VERSION = _get_schema_version()
+_remove_client_service_names = asbool(env.get("DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED", default=False))
+_service_name_schema_version = "v0" if SCHEMA_VERSION == "v0" and not _remove_client_service_names else "v1"
+
+_inferred_base_service: t.Optional[str] = detect_service(sys.argv)
+
+
+_DEFAULT_SPAN_SERVICE_NAMES: dict[str, t.Optional[str]] = {
+    "v0": _inferred_base_service or None,
+    "v1": _inferred_base_service or DEFAULT_SERVICE_NAME,
+}
+
+DEFAULT_SPAN_SERVICE_NAME = _DEFAULT_SPAN_SERVICE_NAMES[_service_name_schema_version]

--- a/ddtrace/internal/schema/span_attribute_schema.py
+++ b/ddtrace/internal/schema/span_attribute_schema.py
@@ -1,9 +1,4 @@
 from enum import Enum
-import sys
-from typing import Optional
-
-from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
-from ddtrace.internal.settings._inferred_base_service import detect_service
 
 
 class SpanDirection(Enum):
@@ -112,11 +107,4 @@ _SPAN_ATTRIBUTE_TO_FUNCTION = {
         "service_name": service_name_v1,
         "url_operation": url_operation_v1,
     },
-}
-
-_inferred_base_service: Optional[str] = detect_service(sys.argv)
-
-_DEFAULT_SPAN_SERVICE_NAMES: dict[str, Optional[str]] = {
-    "v0": _inferred_base_service or None,
-    "v1": _inferred_base_service or DEFAULT_SERVICE_NAME,
 }

--- a/ddtrace/internal/schema/span_attribute_schema.py
+++ b/ddtrace/internal/schema/span_attribute_schema.py
@@ -12,7 +12,7 @@ def service_name_v0(v0_service_name):
 
 
 def service_name_v1(*_, **__):
-    from ddtrace import config as dd_config
+    from ddtrace.internal.settings._config import config as dd_config
 
     return dd_config.service
 

--- a/ddtrace/internal/settings/_config.py
+++ b/ddtrace/internal/settings/_config.py
@@ -26,7 +26,7 @@ from ddtrace.internal.evp_proxy.constants import DEFAULT_EVP_PAYLOAD_SIZE_LIMIT
 from ddtrace.internal.logger import get_log_injection_state
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.native import config as _native_config
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.serverless import in_aws_lambda
 from ddtrace.internal.serverless import in_azure_function
 from ddtrace.internal.serverless import in_gcp_function

--- a/ddtrace/internal/settings/_config.py
+++ b/ddtrace/internal/settings/_config.py
@@ -9,6 +9,7 @@ from typing import Literal  # noqa:F401
 from typing import Optional  # noqa:F401
 from typing import Union  # noqa:F401
 
+from ddtrace.internal import _service_state
 from ddtrace.internal import gitmetadata
 from ddtrace.internal.constants import _PROPAGATION_BEHAVIOR_DEFAULT
 from ddtrace.internal.constants import _PROPAGATION_BEHAVIOR_IGNORE
@@ -19,6 +20,7 @@ from ddtrace.internal.constants import DEFAULT_MAX_PAYLOAD_SIZE
 from ddtrace.internal.constants import DEFAULT_PROCESSING_INTERVAL
 from ddtrace.internal.constants import DEFAULT_REUSE_CONNECTIONS
 from ddtrace.internal.constants import DEFAULT_SAMPLING_RATE_LIMIT
+from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
 from ddtrace.internal.constants import DEFAULT_TIMEOUT
 from ddtrace.internal.constants import PROPAGATION_STYLE_ALL
 from ddtrace.internal.evp_proxy.constants import DEFAULT_EVP_EVENT_SIZE_LIMIT
@@ -26,7 +28,6 @@ from ddtrace.internal.evp_proxy.constants import DEFAULT_EVP_PAYLOAD_SIZE_LIMIT
 from ddtrace.internal.logger import get_log_injection_state
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.native import config as _native_config
-from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.serverless import in_aws_lambda
 from ddtrace.internal.serverless import in_azure_function
 from ddtrace.internal.serverless import in_gcp_function
@@ -523,17 +524,31 @@ class Config(object):
         self.service = _get_config("DD_SERVICE", self.tags.get("service", None), otel_env="OTEL_SERVICE_NAME")
 
         self._is_user_provided_service = self.service is not None
+        _service_state.set_is_user_provided_service(self._is_user_provided_service)
 
         self._inferred_base_service = detect_service(sys.argv)
 
+        # AIDEV-NOTE: Mirrors ddtrace.internal.schema's span-service-name-schema resolution
+        # (v0 vs v1) without importing that package, which would recreate the
+        # _config -> schema -> span_attribute_schema -> _config circular import.
+        _span_service_name_schema_version = env.get("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", default="v0")
+        if _span_service_name_schema_version not in ("v0", "v1"):
+            _span_service_name_schema_version = "v0"
+        if _span_service_name_schema_version == "v0" and not asbool(
+            env.get("DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED", default=False)
+        ):
+            default_span_service_name = self._inferred_base_service or None
+        else:
+            default_span_service_name = self._inferred_base_service or DEFAULT_SERVICE_NAME
+
         if self.service is None and in_aws_lambda():
-            self.service = _get_config("AWS_LAMBDA_FUNCTION_NAME", DEFAULT_SPAN_SERVICE_NAME)
+            self.service = _get_config("AWS_LAMBDA_FUNCTION_NAME", default_span_service_name)
         if self.service is None and in_gcp_function():
-            self.service = _get_config(["K_SERVICE", "FUNCTION_NAME"], DEFAULT_SPAN_SERVICE_NAME)
+            self.service = _get_config(["K_SERVICE", "FUNCTION_NAME"], default_span_service_name)
         if self.service is None and in_azure_function():
-            self.service = _get_config("WEBSITE_SITE_NAME", DEFAULT_SPAN_SERVICE_NAME)
-        if self.service is None and DEFAULT_SPAN_SERVICE_NAME:
-            self.service = _get_config("DD_SERVICE", DEFAULT_SPAN_SERVICE_NAME)
+            self.service = _get_config("WEBSITE_SITE_NAME", default_span_service_name)
+        if self.service is None and default_span_service_name:
+            self.service = _get_config("DD_SERVICE", default_span_service_name)
 
         self._extra_services: set[str] = set()
         self.version = _get_config("DD_VERSION", self.tags.get("version"))

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -56,7 +56,7 @@ from .writer_client import WriterClientBase
 
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ddtrace.trace import Span  # noqa:F401
+    from ddtrace._trace.span import Span  # noqa:F401
     from ddtrace.vendor.dogstatsd import DogStatsd
 
     from .utils.http import ConnectionType  # noqa:F401

--- a/tests/ci_visibility/api_client/test_ci_visibility_api_client.py
+++ b/tests/ci_visibility/api_client/test_ci_visibility_api_client.py
@@ -58,14 +58,13 @@ def _patch_env_for_testing():
             return_value=TestVisibilityAPISettings(),
         ),
         mock.patch("ddtrace.config._ci_visibility_agentless_enabled", True),
-        # AIDEV-NOTE: In xdist workers, DEFAULT_SPAN_SERVICE_NAME is set at module-import
-        # time (span_attribute_schema.py) from _DD_PYTEST_XDIST_INFERRED_SERVICE (e.g.
-        # "tests.ci_visibility"). That frozen value leaks into Config() built here, causing
-        # Config.service to be "tests.ci_visibility" even after env is cleared, which then
-        # propagates to CIVisibility._instance._api_client._service instead of the expected
-        # "dd-test-py" (derived from the mocked git repository URL).  Patching it to None
-        # removes the fallback so the URL-based extraction path is taken instead.
-        mock.patch("ddtrace.internal.settings._config.DEFAULT_SPAN_SERVICE_NAME", None),
+        # AIDEV-NOTE: In xdist workers, detect_service() picks up _DD_PYTEST_XDIST_INFERRED_SERVICE
+        # (e.g. "tests.ci_visibility") from the environment. That value leaks into Config() built
+        # here, causing Config.service to be "tests.ci_visibility" even after env is cleared, which
+        # then propagates to CIVisibility._instance._api_client._service instead of the expected
+        # "dd-test-py" (derived from the mocked git repository URL). Patching detect_service to
+        # return None removes the fallback so the URL-based extraction path is taken instead.
+        mock.patch("ddtrace.internal.settings._config.detect_service", return_value=None),
     ):
         # Rebuild the config (yes, this is horrible)
         new_ddconfig = Config()

--- a/tests/ci_visibility/test_ci_visibility.py
+++ b/tests/ci_visibility/test_ci_visibility.py
@@ -152,11 +152,12 @@ def test_ci_visibility_service_enable_without_service(tracer):
         mock.patch(
             "ddtrace.internal.ci_visibility.recorder._extract_repository_name_from_url", return_value="test-repo"
         ),
-        # AIDEV-NOTE: Patch DEFAULT_SPAN_SERVICE_NAME to None to prevent xdist worker env leakage.
-        # When running under pytest-xdist, the outer worker sets _DD_PYTEST_XDIST_INFERRED_SERVICE
-        # which freezes DEFAULT_SPAN_SERVICE_NAME at import time, causing Config().service to be
-        # non-None and override the expected service value derived from the repository URL.
-        mock.patch("ddtrace.internal.settings._config.DEFAULT_SPAN_SERVICE_NAME", None),
+        # AIDEV-NOTE: Patch detect_service to None to prevent xdist worker env leakage.
+        # When running under pytest-xdist, the outer worker sets _DD_PYTEST_XDIST_INFERRED_SERVICE,
+        # which detect_service() picks up and Config() uses as the default span service name,
+        # causing Config().service to be non-None and override the expected service value
+        # derived from the repository URL.
+        mock.patch("ddtrace.internal.settings._config.detect_service", return_value=None),
         # AIDEV-NOTE: Patch ci.tags to ensure REPOSITORY_URL is present regardless of the git
         # environment.  In Docker containers started from a git worktree, `git rev-parse` fails
         # with "fatal: not a git repository", so ci.tags() returns no REPOSITORY_URL and the

--- a/tests/contrib/aiohttp/test_middleware.py
+++ b/tests/contrib/aiohttp/test_middleware.py
@@ -72,7 +72,7 @@ import pytest
 import asyncio
 from tests.conftest import *
 from tests.contrib.aiohttp.conftest import *
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 
 def test(app, loop, aiohttp_client, test_spans):
     async def async_test(app, aiohttp_client, test_spans):

--- a/tests/contrib/aiomysql/test_aiomysql.py
+++ b/tests/contrib/aiomysql/test_aiomysql.py
@@ -7,7 +7,7 @@ import pytest
 
 from ddtrace.contrib.internal.aiomysql.patch import patch
 from ddtrace.contrib.internal.aiomysql.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib import shared_tests_async as shared_tests
 from tests.contrib.asyncio.utils import AsyncioTestCase
 from tests.contrib.asyncio.utils import mark_asyncio

--- a/tests/contrib/aiopg/test.py
+++ b/tests/contrib/aiopg/test.py
@@ -7,7 +7,7 @@ import pytest
 # project
 from ddtrace.contrib.internal.aiopg.patch import patch
 from ddtrace.contrib.internal.aiopg.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib.asyncio.utils import AsyncioTestCase
 from tests.contrib.config import POSTGRES_CONFIG
 from tests.subprocesstest import run_in_subprocess

--- a/tests/contrib/boto/test.py
+++ b/tests/contrib/boto/test.py
@@ -18,7 +18,7 @@ from moto import mock_sts
 from ddtrace.contrib.internal.boto.patch import patch
 from ddtrace.contrib.internal.boto.patch import unpatch
 from ddtrace.ext import http
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 from tests.utils import assert_span_http_status_code

--- a/tests/contrib/botocore/test.py
+++ b/tests/contrib/botocore/test.py
@@ -41,7 +41,7 @@ from ddtrace.contrib.internal.botocore.patch import patch
 from ddtrace.contrib.internal.botocore.patch import patch_submodules
 from ddtrace.contrib.internal.botocore.patch import unpatch
 from ddtrace.internal.compat import PYTHON_VERSION_INFO
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from tests.utils import TracerTestCase

--- a/tests/contrib/bottle/test.py
+++ b/tests/contrib/bottle/test.py
@@ -6,7 +6,7 @@ from ddtrace import config
 from ddtrace.constants import USER_KEEP
 from ddtrace.contrib.internal.bottle.patch import TracePlugin
 from ddtrace.ext import http
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured

--- a/tests/contrib/consul/test.py
+++ b/tests/contrib/consul/test.py
@@ -6,7 +6,7 @@ from wrapt import BoundFunctionWrapper
 from ddtrace.contrib.internal.consul.patch import patch
 from ddtrace.contrib.internal.consul.patch import unpatch
 from ddtrace.ext import consul as consulx
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 

--- a/tests/contrib/elasticsearch/test_elasticsearch.py
+++ b/tests/contrib/elasticsearch/test_elasticsearch.py
@@ -15,7 +15,7 @@ from ddtrace.contrib.internal.elasticsearch.patch import get_versions
 from ddtrace.contrib.internal.elasticsearch.patch import patch
 from ddtrace.contrib.internal.elasticsearch.patch import unpatch
 from ddtrace.ext import http
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib.patch import emit_integration_and_version_to_test_agent
 from tests.utils import TracerTestCase
 

--- a/tests/contrib/flask_cache/test.py
+++ b/tests/contrib/flask_cache/test.py
@@ -4,7 +4,7 @@ from flask import Flask
 from ddtrace.contrib.internal.flask_cache.patch import CACHE_BACKEND
 from ddtrace.contrib.internal.flask_cache.patch import get_traced_cache
 from ddtrace.ext import net
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_dict_issuperset
 from tests.utils import assert_is_measured

--- a/tests/contrib/grpc/test_grpc.py
+++ b/tests/contrib/grpc/test_grpc.py
@@ -12,7 +12,7 @@ from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.internal.grpc.patch import _unpatch_server
 from ddtrace.contrib.internal.grpc.patch import patch
 from ddtrace.contrib.internal.grpc.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import snapshot
 

--- a/tests/contrib/httplib/test_httplib.py
+++ b/tests/contrib/httplib/test_httplib.py
@@ -15,7 +15,7 @@ from ddtrace.contrib.internal.httplib.patch import patch
 from ddtrace.contrib.internal.httplib.patch import unpatch
 from ddtrace.ext import http
 from ddtrace.internal.constants import _HTTPLIB_NO_TRACE_REQUEST
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_span_http_status_code
 from tests.utils import override_global_tracer

--- a/tests/contrib/kombu/test.py
+++ b/tests/contrib/kombu/test.py
@@ -10,7 +10,7 @@ from ddtrace.contrib.internal.kombu.patch import unpatch
 from ddtrace.ext import kombu as kombux
 from ddtrace.internal.datastreams.processor import PROPAGATION_KEY_BASE_64
 from ddtrace.internal.native import DDSketch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 

--- a/tests/contrib/mako/test_mako.py
+++ b/tests/contrib/mako/test_mako.py
@@ -8,7 +8,7 @@ from mako.template import Template
 from ddtrace.contrib.internal.mako.constants import DEFAULT_TEMPLATE_NAME
 from ddtrace.contrib.internal.mako.patch import patch
 from ddtrace.contrib.internal.mako.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 

--- a/tests/contrib/molten/test_molten.py
+++ b/tests/contrib/molten/test_molten.py
@@ -8,7 +8,7 @@ from ddtrace.constants import USER_KEEP
 from ddtrace.contrib.internal.molten.patch import patch
 from ddtrace.contrib.internal.molten.patch import unpatch
 from ddtrace.ext import http
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID

--- a/tests/contrib/mysqldb/test_mysqldb.py
+++ b/tests/contrib/mysqldb/test_mysqldb.py
@@ -4,7 +4,7 @@ import pytest
 
 from ddtrace.contrib.internal.mysqldb.patch import patch
 from ddtrace.contrib.internal.mysqldb.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib import shared_tests
 from tests.utils import TracerTestCase
 from tests.utils import assert_dict_issuperset

--- a/tests/contrib/psycopg/test_psycopg.py
+++ b/tests/contrib/psycopg/test_psycopg.py
@@ -10,7 +10,7 @@ from psycopg.sql import Literal
 
 from ddtrace.contrib.internal.psycopg.patch import patch
 from ddtrace.contrib.internal.psycopg.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.utils.version import parse_version
 from tests.contrib.config import POSTGRES_CONFIG
 from tests.utils import TracerTestCase

--- a/tests/contrib/psycopg2/test_psycopg.py
+++ b/tests/contrib/psycopg2/test_psycopg.py
@@ -9,7 +9,7 @@ from psycopg2 import extras
 
 from ddtrace.contrib.internal.psycopg.patch import patch
 from ddtrace.contrib.internal.psycopg.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.utils.version import parse_version
 from tests.contrib.config import POSTGRES_CONFIG
 from tests.utils import TracerTestCase

--- a/tests/contrib/pymemcache/test_client.py
+++ b/tests/contrib/pymemcache/test_client.py
@@ -14,7 +14,7 @@ from ddtrace.contrib.internal.pymemcache.client import WrappedClient
 from ddtrace.contrib.internal.pymemcache.patch import patch
 from ddtrace.contrib.internal.pymemcache.patch import unpatch
 from ddtrace.internal.compat import is_wrapted
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import override_config
 

--- a/tests/contrib/pymysql/test_pymysql.py
+++ b/tests/contrib/pymysql/test_pymysql.py
@@ -3,7 +3,7 @@ import pymysql
 
 from ddtrace.contrib.internal.pymysql.patch import patch
 from ddtrace.contrib.internal.pymysql.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib import shared_tests
 from tests.utils import TracerTestCase
 from tests.utils import assert_dict_issuperset

--- a/tests/contrib/pynamodb/test_pynamodb.py
+++ b/tests/contrib/pynamodb/test_pynamodb.py
@@ -6,7 +6,7 @@ import pytest
 
 from ddtrace.contrib.internal.pynamodb.patch import patch
 from ddtrace.contrib.internal.pynamodb.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 

--- a/tests/contrib/pyodbc/test_pyodbc.py
+++ b/tests/contrib/pyodbc/test_pyodbc.py
@@ -2,7 +2,7 @@ import pyodbc
 
 from ddtrace.contrib.internal.pyodbc.patch import patch
 from ddtrace.contrib.internal.pyodbc.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 

--- a/tests/contrib/pyramid/test_pyramid.py
+++ b/tests/contrib/pyramid/test_pyramid.py
@@ -8,7 +8,7 @@ import pytest
 from ddtrace import config
 from ddtrace.constants import _ORIGIN_KEY
 from ddtrace.constants import _SAMPLING_PRIORITY_KEY
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
 from tests.utils import TracerTestCase
 from tests.webclient import Client

--- a/tests/contrib/redis/test_redis_cluster.py
+++ b/tests/contrib/redis/test_redis_cluster.py
@@ -9,7 +9,7 @@ from ddtrace.contrib.internal.redis.patch import unpatch
 from ddtrace.contrib.internal.redis_utils import _build_tags
 from ddtrace.ext import net
 from ddtrace.internal.compat import PYTHON_VERSION_INFO
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib.config import REDISCLUSTER_CONFIG
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured

--- a/tests/contrib/redis/test_redis_cluster_asyncio.py
+++ b/tests/contrib/redis/test_redis_cluster_asyncio.py
@@ -246,7 +246,7 @@ def test_default_service_name_v1():
     import redis
 
     from ddtrace.contrib.internal.redis.patch import patch
-    from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+    from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
     from tests.contrib.config import REDISCLUSTER_CONFIG
     from tests.utils import TracerSpanContainer
     from tests.utils import scoped_tracer

--- a/tests/contrib/rediscluster/test.py
+++ b/tests/contrib/rediscluster/test.py
@@ -5,7 +5,7 @@ import rediscluster
 from ddtrace.contrib.internal.rediscluster.patch import REDISCLUSTER_VERSION
 from ddtrace.contrib.internal.rediscluster.patch import patch
 from ddtrace.contrib.internal.rediscluster.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib.config import REDISCLUSTER_CONFIG
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured

--- a/tests/contrib/requests/test_requests.py
+++ b/tests/contrib/requests/test_requests.py
@@ -16,7 +16,7 @@ from ddtrace.contrib.internal.requests.connection import _extract_query_string
 from ddtrace.contrib.internal.requests.patch import patch
 from ddtrace.contrib.internal.requests.patch import unpatch
 from ddtrace.ext import http
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 from tests.utils import assert_span_http_status_code

--- a/tests/contrib/sqlalchemy/test_mysql.py
+++ b/tests/contrib/sqlalchemy/test_mysql.py
@@ -3,7 +3,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import ProgrammingError
 
 from ddtrace.constants import ERROR_MSG
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 

--- a/tests/contrib/sqlite3/test_sqlite3.py
+++ b/tests/contrib/sqlite3/test_sqlite3.py
@@ -19,7 +19,7 @@ from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.internal.sqlite3.patch import TracedSQLiteCursor
 from ddtrace.contrib.internal.sqlite3.patch import patch
 from ddtrace.contrib.internal.sqlite3.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import assert_is_measured
 from tests.utils import assert_is_not_measured

--- a/tests/contrib/tornado/test_tornado_web.py
+++ b/tests/contrib/tornado/test_tornado_web.py
@@ -4,7 +4,7 @@ from ddtrace.constants import _SAMPLING_PRIORITY_KEY
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import USER_KEEP
 from ddtrace.ext import http
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
 from tests.utils import assert_is_measured
 from tests.utils import assert_span_http_status_code

--- a/tests/contrib/urllib3/test_urllib3.py
+++ b/tests/contrib/urllib3/test_urllib3.py
@@ -10,7 +10,7 @@ from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.internal.urllib3.patch import patch
 from ddtrace.contrib.internal.urllib3.patch import unpatch
 from ddtrace.ext import http
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib.config import HTTPBIN_CONFIG
 from tests.utils import TracerTestCase
 from tests.utils import snapshot

--- a/tests/contrib/valkey/test_valkey.py
+++ b/tests/contrib/valkey/test_valkey.py
@@ -6,7 +6,7 @@ import valkey
 
 from ddtrace.contrib.internal.valkey.patch import patch
 from ddtrace.contrib.internal.valkey.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.utils import TracerTestCase
 from tests.utils import snapshot
 

--- a/tests/contrib/valkey/test_valkey_cluster.py
+++ b/tests/contrib/valkey/test_valkey_cluster.py
@@ -3,7 +3,7 @@ import valkey
 
 from ddtrace.contrib.internal.valkey.patch import patch
 from ddtrace.contrib.internal.valkey.patch import unpatch
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from tests.contrib.config import VALKEY_CLUSTER_CONFIG
 from tests.contrib.redis.utils import find_redis_span
 from tests.utils import TracerTestCase

--- a/tests/contrib/valkey/test_valkey_cluster_asyncio.py
+++ b/tests/contrib/valkey/test_valkey_cluster_asyncio.py
@@ -175,7 +175,7 @@ def test_default_service_name_v1():
     import valkey
 
     from ddtrace.contrib.internal.valkey.patch import patch
-    from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+    from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
     from tests.contrib.config import VALKEY_CLUSTER_CONFIG
     from tests.utils import TracerSpanContainer
     from tests.utils import scoped_tracer

--- a/tests/contrib/vertica/test_vertica.py
+++ b/tests/contrib/vertica/test_vertica.py
@@ -7,7 +7,7 @@ from ddtrace.constants import ERROR_TYPE
 from ddtrace.contrib.internal.vertica.patch import patch
 from ddtrace.contrib.internal.vertica.patch import unpatch
 from ddtrace.internal.compat import is_wrapted
-from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
+from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
 from ddtrace.internal.settings._config import _deepmerge
 from tests.contrib.config import VERTICA_CONFIG
 from tests.utils import TracerSpanContainer

--- a/tests/internal/service_name/test_imports.py
+++ b/tests/internal/service_name/test_imports.py
@@ -3,12 +3,12 @@ import pytest
 
 @pytest.mark.subprocess(env=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
 def test_service_names_import_default():
-    from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
     from ddtrace.internal.schema import schematize_cache_operation
     from ddtrace.internal.schema import schematize_cloud_api_operation
     from ddtrace.internal.schema import schematize_database_operation
     from ddtrace.internal.schema import schematize_service_name
     from ddtrace.internal.schema import schematize_url_operation
+    from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
     from ddtrace.internal.schema.span_attribute_schema import cache_operation_v0
     from ddtrace.internal.schema.span_attribute_schema import cloud_api_operation_v0
     from ddtrace.internal.schema.span_attribute_schema import database_operation_v0
@@ -26,12 +26,12 @@ def test_service_names_import_default():
 
 @pytest.mark.subprocess(env=dict(DD_TRACE_SPAN_ATTRIBUTE_SCHEMA="v0"))
 def test_service_names_import_and_v0():
-    from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
     from ddtrace.internal.schema import schematize_cache_operation
     from ddtrace.internal.schema import schematize_cloud_api_operation
     from ddtrace.internal.schema import schematize_database_operation
     from ddtrace.internal.schema import schematize_service_name
     from ddtrace.internal.schema import schematize_url_operation
+    from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
     from ddtrace.internal.schema.span_attribute_schema import cache_operation_v0
     from ddtrace.internal.schema.span_attribute_schema import cloud_api_operation_v0
     from ddtrace.internal.schema.span_attribute_schema import database_operation_v0
@@ -52,12 +52,12 @@ def test_service_names_import_and_v0():
     parametrize={"DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED": ["False", "True"]},
 )
 def test_service_name_imports_v1():
-    from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
     from ddtrace.internal.schema import schematize_cache_operation
     from ddtrace.internal.schema import schematize_cloud_api_operation
     from ddtrace.internal.schema import schematize_database_operation
     from ddtrace.internal.schema import schematize_service_name
     from ddtrace.internal.schema import schematize_url_operation
+    from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
     from ddtrace.internal.schema.span_attribute_schema import cache_operation_v1
     from ddtrace.internal.schema.span_attribute_schema import cloud_api_operation_v1
     from ddtrace.internal.schema.span_attribute_schema import database_operation_v1
@@ -80,12 +80,12 @@ def test_service_name_import_with_client_service_names_enabled_v0():
     """
     Service name parameters are flipped when DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED is True for v0
     """
-    from ddtrace.internal.schema import DEFAULT_SPAN_SERVICE_NAME
     from ddtrace.internal.schema import schematize_cache_operation
     from ddtrace.internal.schema import schematize_cloud_api_operation
     from ddtrace.internal.schema import schematize_database_operation
     from ddtrace.internal.schema import schematize_service_name
     from ddtrace.internal.schema import schematize_url_operation
+    from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
     from ddtrace.internal.schema.span_attribute_schema import cache_operation_v0
     from ddtrace.internal.schema.span_attribute_schema import cloud_api_operation_v0
     from ddtrace.internal.schema.span_attribute_schema import database_operation_v0


### PR DESCRIPTION
## Description

Backports #19030, #18851, and #19005 to 4.12.

These changes separate default service-name resolution from the span schema, remove reverse dependencies through the public tracing API and global config, and simplify atexit configuration access. Together they align the 4.12 import graph with main and unblock circular-import validation for 4.12 backports.

The 4.12 branch has 4,974 detected circular import paths before these changes and 61 afterward.

## Testing

- `cycles.py analyze` — 4,974 → 61 circular imports
- `cycles.py compare` — 4,913 circular imports removed, no new cycles
- Python 3.14 internal tests for process tags, service-name imports, and atexit — 78 passed, 1 skipped
- Python 3.14 tracer atexit tests — passed
- Targeted formatting and lint checks — passed

## Risks

Low. These are direct backports of three fixes already merged to main.

## Additional Notes

Internal refactor only; no changelog entry is needed.
