### PR TITLE
chore(microbenchmarks): bump iastaspects-rep_aspect slo

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -541,7 +541,7 @@ experiments:
               - max_rss_usage < 48.00 MB
           - name: iastaspects-repr_aspect
             thresholds:
-              - execution_time < 0.50 ms
+              - execution_time < 0.52 ms
               - max_rss_usage < 48.00 MB
           - name: iastaspects-repr_noaspect
             thresholds:


### PR DESCRIPTION
`iastaspects-repr_aspect` SLO is flaky on main causing `check-slo-breaches` to fail. 

This PR bumps the SLO. 