### PR TITLE
ci: change the GitLab id_token audience [SINT-5468]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -686,7 +686,7 @@ test-dd-sts:
   image: registry.ddbuild.io/images/mirror/ubuntu:24.04
   id_tokens:
     DD_STS_OIDC_TOKEN:
-      aud: rapid-seceng-sit
+      aud: dd-sts
   script:
     - apt-get update && apt-get install -y curl
     - 'curl -s -o /dev/null -w "API key request http status code: %{http_code}\n" -H "Authorization: Bearer ${DD_STS_OIDC_TOKEN}" "https://dd-sts.us1.ddbuild.io/sts/datadog/exchange?policy=dd-trace-py-gitlab"'

--- a/.gitlab/release.yml
+++ b/.gitlab/release.yml
@@ -50,7 +50,7 @@ notify_datadog_release:
   image: ${PYPI_PUBLISH_IMAGE}
   id_tokens:
     DD_STS_OIDC_TOKEN:
-      aud: rapid-seceng-sit
+      aud: dd-sts
   tags: [ "arch:amd64" ]
   before_script:
     - apt-get update && apt-get install --no-install-recommends -y curl jq

--- a/.gitlab/system-tests.yml
+++ b/.gitlab/system-tests.yml
@@ -7,7 +7,7 @@
   stage: system-tests
   id_tokens:
     DD_STS_OIDC_TOKEN:
-      aud: rapid-seceng-sit
+      aud: dd-sts
   variables:
     TEST_LIBRARY: python
     KUBERNETES_CPU_REQUEST: "4"


### PR DESCRIPTION
## Description
We switch from `rapid-seceng-sit` to `dd-sts` audience in the dd-sts id_token from GitLab to be able to restrict this token claim to this service and not the other APIs SDLC Security team owns.

<!-- Provide an overview of the change and motivation for the change -->

## Testing

See https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1864606107 
<!-- Describe your testing strategy or note what tests are included -->

## Risks
No risk, a lot of users already use this audiance
<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes
See [this user guide](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5769659435/User+guide+dd-sts#Gitlab-CI-job)
<!-- Any other information that would be helpful for reviewers -->
