### PR TITLE
fix(tracer): republish metadata after fork

### DIFF
--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -192,6 +192,9 @@ class Tracer(object):
 
         self._new_process = False
 
+        self._store_metadata()
+
+    def _store_metadata(self) -> None:
         metadata = PyTracerMetadata(
             runtime_id=get_runtime_id(),
             tracer_version=__version__,
@@ -405,6 +408,7 @@ class Tracer(object):
         self._pid = getpid()
         self._recreate(reset_buffer=True)
         self._new_process = True
+        self._store_metadata()
         # Re-dispatch activation post-fork: native code clears profiler span links; inherited context is unchanged.
         active = self.context_provider.active()
         if active is not None:

--- a/releasenotes/notes/tracer-publish-metadata-on-fork-ca4f1ebb2d6b4b55.yaml
+++ b/releasenotes/notes/tracer-publish-metadata-on-fork-ca4f1ebb2d6b4b55.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    tracing: This fix resolves an issue where forked child processes did not
-    republish tracer metadata, the context was inherited from the parent and
-    contained stale metadata.
+    tracing: Fixes an issue in applications that fork where the security agent
+    could read stale process metadata, preventing security signals from being
+    correlated with APM traces.

--- a/releasenotes/notes/tracer-publish-metadata-on-fork-ca4f1ebb2d6b4b55.yaml
+++ b/releasenotes/notes/tracer-publish-metadata-on-fork-ca4f1ebb2d6b4b55.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    tracing: This fix resolves an issue where forked child processes did not
+    republish tracer metadata, the context was inherited from the parent and
+    contained stale metadata.

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -1873,6 +1873,25 @@ def test_fork_pid():
     assert exit_code == 12
 
 
+@pytest.mark.subprocess(err=None, env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
+def test_fork_republishes_tracer_metadata():
+    import os
+    from unittest import mock
+
+    import ddtrace.auto  # noqa
+
+    with mock.patch("ddtrace._trace.tracer.store_metadata") as mock_store_metadata:
+        pid = os.fork()
+
+        if pid == 0:
+            mock_store_metadata.assert_called()
+            os._exit(12)
+
+    _, status = os.waitpid(pid, 0)
+    exit_code = os.WEXITSTATUS(status)
+    assert exit_code == 12
+
+
 @pytest.mark.subprocess
 def test_tracer_api_version():
     from ddtrace.internal.encoding import MsgpackEncoderV05

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -7,6 +7,7 @@ import contextlib
 import gc
 import logging
 from os import getpid
+import sys
 import threading
 import time
 from unittest.case import SkipTest
@@ -1873,19 +1874,38 @@ def test_fork_pid():
     assert exit_code == 12
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="tracer metadata is stored in a memfd on Linux only")
 @pytest.mark.subprocess(err=None, env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
-def test_fork_republishes_tracer_metadata():
+def test_fork_republishes_tracer_metadata_linux():
     import os
-    from unittest import mock
+
+    import msgpack
 
     import ddtrace.auto  # noqa
+    from ddtrace.internal.runtime import get_runtime_id
 
-    with mock.patch("ddtrace._trace.tracer.store_metadata") as mock_store_metadata:
-        pid = os.fork()
+    pid = os.fork()
 
-        if pid == 0:
-            mock_store_metadata.assert_called()
-            os._exit(12)
+    if pid == 0:
+        metadata = []
+        for fd in os.listdir("/proc/self/fd"):
+            path = "/proc/self/fd/" + fd
+            try:
+                if not os.readlink(path).startswith("/memfd:datadog-tracer-info-"):
+                    continue
+                with open(path, "rb") as file:
+                    metadata.append(msgpack.unpackb(file.read(), raw=False))
+            except FileNotFoundError:
+                continue
+
+        runtime_id = None
+        for entry in metadata:
+            if "runtime_id" in entry:
+                runtime_id = entry["runtime_id"]
+                break
+
+        assert runtime_id == get_runtime_id()
+        os._exit(12)
 
     _, status = os.waitpid(pid, 0)
     exit_code = os.WEXITSTATUS(status)


### PR DESCRIPTION
APPSEC-69172

## Description

The native `store_metadata` function publishes two contexts for external readers:
- a `datadog-tracer-info-{uid}` memfd
- the standard [otel process context](https://github.com/DataDog/libdatadog/blob/v37.0.0/libdd-library-config/src/tracer_metadata.rs#L187)

Across fork, the first one was inherited but contained a stale `runtime_id`. The second one was entirely dropped.
This change ensures that both contexts are present and up to date in the child processes.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
