### PR TITLE
refactor(appsec): isolate telemetry configuration

### DIFF
--- a/.cursor/rules/appsec.mdc
+++ b/.cursor/rules/appsec.mdc
@@ -17,7 +17,8 @@ Datadog Application Security provides multiple layers of protection for Python a
 5. **AI Guard** - LLM input/output safety monitoring
 6. **User Event Tracking** - Login/signup event monitoring
 
-**All features are configured via environment variables** defined in `ddtrace/internal/settings/asm.py`.
+**All features are configured via environment variables.** Most are defined in `ddtrace/internal/settings/asm.py`;
+SCA and endpoint-collection telemetry settings live in `ddtrace/internal/settings/appsec_telemetry.py`.
 
 ---
 
@@ -291,7 +292,7 @@ Automatic discovery and cataloging of your APIs:
 | `DD_API_SECURITY_SAMPLE_DELAY` | `30.0` | Seconds between samples per endpoint |
 | `DD_API_SECURITY_PARSE_RESPONSE_BODY` | `true` | Capture response body schemas |
 | `DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED` | `true` | Enable endpoint collection |
-| `DD_API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT` | `5000` | Max endpoints to track |
+| `DD_API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT` | `300` | Max endpoints to track |
 | `DD_API_SECURITY_DOWNSTREAM_BODY_ANALYSIS_SAMPLE_RATE` | `0.5` | Rate for downstream request analysis |
 | `DD_API_SECURITY_MAX_DOWNSTREAM_REQUEST_BODY_ANALYSIS` | `1` | Max downstream requests analyzed per request |
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -152,6 +152,7 @@ ddtrace/internal/_exceptions.py     @DataDog/asm-python
 ddtrace/internal/appsec/            @DataDog/asm-python
 ddtrace/internal/iast/              @DataDog/asm-python
 ddtrace/internal/sca/               @DataDog/asm-python
+ddtrace/internal/settings/appsec_telemetry.py    @DataDog/asm-python
 ddtrace/internal/settings/asm.py             @DataDog/asm-python
 # tests files
 tests/aiguard/                      @DataDog/asm-python

--- a/benchmarks/telemetry_dependencies/scenario.py
+++ b/benchmarks/telemetry_dependencies/scenario.py
@@ -13,7 +13,23 @@ from unittest.mock import patch
 from bm import Scenario
 
 from ddtrace.internal.settings._telemetry import config as telemetry_config
-from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
+
+
+try:
+    from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
+except ModuleNotFoundError as error:
+    if error.name != "ddtrace.internal.settings.appsec_telemetry":
+        raise
+
+    from ddtrace.internal.settings._config import config as tracer_config
+
+    def _enable_sca():
+        tracer_config._sca_enabled = True
+
+else:
+
+    def _enable_sca():
+        appsec_telemetry_config.SCA_ENABLED = True
 
 
 # --- Backward-compatible imports ---
@@ -49,7 +65,7 @@ if not HAS_OLD_API:
 def _populate_tracker(tracker, n, sca_enabled):
     """Pre-populate a DependencyTracker with n dependencies as already-reported."""
     if sca_enabled:
-        appsec_telemetry_config.SCA_ENABLED = True
+        _enable_sca()
     for i in range(n):
         name = "package-%d" % i
         meta = [] if sca_enabled else None
@@ -155,7 +171,7 @@ class TelemetryDependencies(Scenario):
         for _ in range(loops):
             tracker = DependencyTracker()
             if sca:
-                appsec_telemetry_config.SCA_ENABLED = True
+                _enable_sca()
             t0 = time.perf_counter()
             _collect_report_new_modules(tracker, module_names, dists)
             total += time.perf_counter() - t0

--- a/benchmarks/telemetry_dependencies/scenario.py
+++ b/benchmarks/telemetry_dependencies/scenario.py
@@ -12,6 +12,9 @@ from unittest.mock import patch
 
 from bm import Scenario
 
+from ddtrace.internal.settings._telemetry import config as telemetry_config
+from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
+
 
 # --- Backward-compatible imports ---
 # New API (this branch): DependencyTracker with collect_report()
@@ -46,9 +49,7 @@ if not HAS_OLD_API:
 def _populate_tracker(tracker, n, sca_enabled):
     """Pre-populate a DependencyTracker with n dependencies as already-reported."""
     if sca_enabled:
-        from ddtrace.internal.settings._config import config as tracer_config
-
-        tracer_config._sca_enabled = True
+        appsec_telemetry_config.SCA_ENABLED = True
     for i in range(n):
         name = "package-%d" % i
         meta = [] if sca_enabled else None
@@ -86,9 +87,8 @@ def _collect_report_no_new_modules(tracker):
     """Run collect_report with no new module discovery (mocked)."""
     with (
         patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
-        patch("ddtrace.internal.telemetry.dependency_tracker.config") as mock_config,
+        patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True),
     ):
-        mock_config.DEPENDENCY_COLLECTION = True
         mock_modules.get_newly_imported_modules.return_value = set()
         return tracker.collect_report()
 
@@ -101,13 +101,12 @@ def _collect_report_new_modules(tracker, module_names, dists):
 
     with (
         patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
-        patch("ddtrace.internal.telemetry.dependency_tracker.config") as mock_config,
+        patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True),
         patch(
             "ddtrace.internal.telemetry.dependency_tracker.get_module_distribution_versions",
             side_effect=fake_get_dist,
         ),
     ):
-        mock_config.DEPENDENCY_COLLECTION = True
         mock_modules.get_newly_imported_modules.return_value = module_names
         return tracker.collect_report()
 
@@ -156,9 +155,7 @@ class TelemetryDependencies(Scenario):
         for _ in range(loops):
             tracker = DependencyTracker()
             if sca:
-                from ddtrace.internal.settings._config import config as tracer_config
-
-                tracer_config._sca_enabled = True
+                appsec_telemetry_config.SCA_ENABLED = True
             t0 = time.perf_counter()
             _collect_report_new_modules(tracker, module_names, dists)
             total += time.perf_counter() - t0

--- a/ddtrace/contrib/internal/django/patch.py
+++ b/ddtrace/contrib/internal/django/patch.py
@@ -37,6 +37,7 @@ from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.internal.settings import env
+from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
 from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.settings.integration import IntegrationConfig
 from ddtrace.internal.telemetry import get_config as _get_config
@@ -399,7 +400,7 @@ def _collect_routes_once(resolver: "Optional[URLResolver]") -> None:
     would discard the collected entries anyway, and if the flag is later
     flipped on the WeakSet stays empty so the next request will walk.
     """
-    if resolver is None or not asm_config._api_security_endpoint_collection:
+    if resolver is None or not appsec_telemetry_config.ENDPOINT_COLLECTION_ENABLED:
         return
     try:
         if resolver in _collected_resolvers:

--- a/ddtrace/contrib/internal/flask/patch.py
+++ b/ddtrace/contrib/internal/flask/patch.py
@@ -15,7 +15,7 @@ from ddtrace.internal.packages import get_version_for_package
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
-from ddtrace.internal.settings.asm import config as asm_config
+from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
 from ddtrace.internal.utils import get_blocked
 
 
@@ -435,7 +435,7 @@ def _walk_wsgi_mounts(wsgi_app, script_name):
 
 def _collect_routes_once(app, script_name=""):
     """Walk ``app`` (and any DM reachable from its wsgi_app) once per ``(app, script_name)``."""
-    if not asm_config._api_security_endpoint_collection:
+    if not appsec_telemetry_config.ENDPOINT_COLLECTION_ENABLED:
         return
     if not isinstance(app, flask.Flask):
         return
@@ -467,7 +467,7 @@ def _collect_routes_once(app, script_name=""):
 def patched_dispatcher_middleware_init(wrapped, instance, args, kwargs):
     """Walk DM mounts eagerly at construction so sub-apps that never receive traffic still reach discovery."""
     wrapped(*args, **kwargs)
-    if not asm_config._api_security_endpoint_collection:
+    if not appsec_telemetry_config.ENDPOINT_COLLECTION_ENABLED:
         return
     try:
         for sub_app, sub_prefix in _walk_wsgi_mounts(getattr(instance, "app", None), ""):
@@ -512,7 +512,7 @@ def patched_add_url_rule(wrapped, instance, args, kwargs):
             provide_automatic_options=provide_automatic_options,
             **kwargs,
         )
-        if asm_config._api_security_endpoint_collection:
+        if appsec_telemetry_config.ENDPOINT_COLLECTION_ENABLED:
             try:
                 scripts = _collected_scripts_by_app.get(instance)
             except TypeError:

--- a/ddtrace/internal/sca/product.py
+++ b/ddtrace/internal/sca/product.py
@@ -14,7 +14,7 @@ At startup (when DD_APPSEC_SCA_ENABLED=true):
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.serverless import in_aws_lambda
-from ddtrace.internal.settings._config import config as tracer_config
+from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
 
 
 log = get_logger(__name__)
@@ -23,7 +23,7 @@ requires: list[str] = []
 
 
 def enabled() -> bool:
-    return tracer_config._sca_enabled and not in_aws_lambda()
+    return bool(appsec_telemetry_config.SCA_ENABLED) and not in_aws_lambda()
 
 
 def _get_installed_packages():
@@ -35,7 +35,11 @@ def _get_installed_packages():
     try:
         from importlib.metadata import distributions
 
-        return {name.lower(): dist.version for dist in distributions() if (name := dist.metadata.get("Name"))}  # type: ignore[attr-defined]
+        return {
+            name.lower(): dist.version
+            for dist in distributions()
+            if (name := dist.metadata.get("Name"))  # type: ignore[attr-defined]
+        }
     except Exception:
         log.debug("Could not enumerate installed packages", exc_info=True)
         return {}

--- a/ddtrace/internal/settings/_config.py
+++ b/ddtrace/internal/settings/_config.py
@@ -400,11 +400,6 @@ def _default_config() -> dict[str, _ConfigItem]:
             otel_env="OTEL_TRACES_EXPORTER",
             modifier=asbool,
         ),
-        "_sca_enabled": _ConfigItem(
-            default=None,
-            envs=["DD_APPSEC_SCA_ENABLED"],
-            modifier=asbool,
-        ),
         "_llmobs_enabled": _ConfigItem(
             default=False,
             envs=["DD_LLMOBS_ENABLED"],

--- a/ddtrace/internal/settings/_core.py
+++ b/ddtrace/internal/settings/_core.py
@@ -71,7 +71,8 @@ class DDConfig(Env):
             setattr(self.parsed, name, getattr(self, name))
 
         # Initialize the value sources
-        self._value_source = {}
+        self._value_source: dict[str, ValueSource] = {}
+        self._config_ids: dict[str, Optional[str]] = {}
 
         for name, e in type(self).items(recursive=True):
             if e.private:
@@ -103,12 +104,13 @@ class DDConfig(Env):
             self._value_source[env_name] = value_source
 
             if value_source == ValueSource.FLEET_STABLE_CONFIG:
-                self.config_id = FLEET_CONFIG_IDS.get(env_name)
-            else:
-                self.config_id = None
+                self._config_ids[env_name] = FLEET_CONFIG_IDS.get(env_name)
 
     def value_source(self, env_name: str) -> str:
         return self._value_source.get(env_name, ValueSource.UNKNOWN)
+
+    def config_id(self, env_name: str) -> Optional[str]:
+        return self._config_ids.get(env_name)
 
     def dump_settings(self) -> dict[str, Any]:
         """Return a {dotted_name: value} snapshot of this config tree,

--- a/ddtrace/internal/settings/_core.pyi
+++ b/ddtrace/internal/settings/_core.pyi
@@ -22,7 +22,7 @@ class DDConfig(Env):
     local_source: dict[str, str]
     env_source: dict[str, str]
     _value_source: dict[str, str]
-    config_id: Optional[str]
+    _config_ids: dict[str, Optional[str]]
 
     def __init__(
         self,
@@ -31,3 +31,4 @@ class DDConfig(Env):
         dynamic: Optional[dict[str, str]] = None,
     ) -> None: ...
     def value_source(self, env_name: str) -> str: ...
+    def config_id(self, env_name: str) -> Optional[str]: ...

--- a/ddtrace/internal/settings/appsec_telemetry.py
+++ b/ddtrace/internal/settings/appsec_telemetry.py
@@ -1,0 +1,14 @@
+import typing as t
+
+from ddtrace.internal.settings._core import DDConfig
+
+
+class AppSecTelemetryConfig(DDConfig):
+    __prefix__ = "dd"
+
+    SCA_ENABLED = DDConfig.v(t.Optional[bool], "appsec.sca.enabled", default=None)
+    ENDPOINT_COLLECTION_ENABLED = DDConfig.v(bool, "api.security.endpoint.collection.enabled", default=True)
+    ENDPOINT_COLLECTION_LIMIT = DDConfig.v(int, "api.security.endpoint.collection.message.limit", default=300)
+
+
+config = AppSecTelemetryConfig()

--- a/ddtrace/internal/settings/asm.py
+++ b/ddtrace/internal/settings/asm.py
@@ -18,6 +18,7 @@ from ddtrace.internal.serverless import in_aws_lambda
 from ddtrace.internal.settings import env
 from ddtrace.internal.settings._config import config as tracer_config
 from ddtrace.internal.settings._core import DDConfig
+from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
 
 
 def _validate_non_negative_int(r: int) -> None:
@@ -99,11 +100,6 @@ class ASMConfig(DDConfig):
     _api_security_enabled = DDConfig.var(bool, API_SECURITY.ENV_VAR_ENABLED, default=True)
     _api_security_sample_delay = DDConfig.var(float, API_SECURITY.SAMPLE_DELAY, default=30.0)
     _api_security_parse_response_body = DDConfig.var(bool, API_SECURITY.PARSE_RESPONSE_BODY, default=True)
-    _api_security_endpoint_collection = DDConfig.var(bool, API_SECURITY.ENDPOINT_COLLECTION, default=True)
-    _api_security_endpoint_collection_limit = DDConfig.var(
-        int, API_SECURITY.ENDPOINT_COLLECTION_LIMIT, default=DEFAULT.ENDPOINT_COLLECTION_LIMIT
-    )
-
     # internal state of the API security Manager service.
     # updated in API Manager enable/disable
     _api_security_active = False
@@ -327,7 +323,7 @@ class ASMConfig(DDConfig):
         return (
             self._asm_enabled
             or self._iast_enabled
-            or tracer_config._sca_enabled is True
+            or appsec_telemetry_config.SCA_ENABLED is True
             or aiguard_config._ai_guard_enabled
         ) and not self._apm_tracing_enabled
 

--- a/ddtrace/internal/telemetry/__init__.py
+++ b/ddtrace/internal/telemetry/__init__.py
@@ -145,7 +145,7 @@ def report_configuration(config: DDConfig) -> None:
         for p in name.split("."):
             env_val = getattr(env_val, p)
 
-        telemetry_writer.add_configuration(env_name, env_val, config.value_source(env_name), config.config_id)
+        telemetry_writer.add_configuration(env_name, env_val, config.value_source(env_name), config.config_id(env_name))
 
 
 def _invalid_otel_config(otel_env):

--- a/ddtrace/internal/telemetry/__init__.py
+++ b/ddtrace/internal/telemetry/__init__.py
@@ -18,6 +18,7 @@ from ddtrace.internal.settings._otel_remapper import SUPPORTED_OTEL_ENV_VARS
 from ddtrace.internal.settings._otel_remapper import parse_otel_env
 from ddtrace.internal.settings._supported_configurations import CONFIGURATION_ALIASES
 from ddtrace.internal.settings._supported_configurations import SENSITIVE_CONFIGURATIONS
+from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
 from ddtrace.internal.settings.process_tags import process_tags_config
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.internal.utils.formats import asbool
@@ -224,5 +225,6 @@ def _hiding_otel_config(otel_env, dd_env):
 
 
 # TODO: Remove this once the telemetry feature is refactored to a better design
+report_configuration(appsec_telemetry_config)
 report_configuration(agent_config)
 report_configuration(process_tags_config)

--- a/ddtrace/internal/telemetry/dependency_tracker.py
+++ b/ddtrace/internal/telemetry/dependency_tracker.py
@@ -18,7 +18,8 @@ from typing import Optional
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.packages import get_module_distribution_versions
-from ddtrace.internal.settings._telemetry import config
+from ddtrace.internal.settings._telemetry import config as telemetry_config
+from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
 
 from . import modules
 from .dependency import DependencyEntry
@@ -46,10 +47,8 @@ class DependencyTracker:
 
     All mutable access is protected by an internal lock.
 
-    SCA-enabled state is read from ``tracer_config._sca_enabled`` so
-    it reacts dynamically to Remote Configuration changes instead of
-    relying on a one-time snapshot.  The DependencyEntry.metadata field
-    state drives the wire format:
+    SCA-enabled state is read from the AppSec telemetry configuration.
+    The DependencyEntry.metadata field state drives the wire format:
     - metadata is None  -> entry serialized without "metadata" key
     - metadata is not None -> entry serialized with "metadata" key
     SCA product is responsible for setting metadata to [] on existing
@@ -67,7 +66,7 @@ class DependencyTracker:
         When a dependency has unsent metadata (attached by the SCA hook),
         it is re-reported with ALL metadata (sent + unsent) per the RFC.
         """
-        if not config.DEPENDENCY_COLLECTION:
+        if not telemetry_config.DEPENDENCY_COLLECTION:
             return None
 
         with self._lock:
@@ -83,9 +82,7 @@ class DependencyTracker:
             # scan over all _imported_dependencies is pure overhead (~887us
             # at 10K deps).  Only entries created by the SCA hook or with
             # metadata attached can trigger needs_report() after initial send.
-            from ddtrace.internal.settings._config import config as tracer_config
-
-            if not tracer_config._sca_enabled:
+            if not appsec_telemetry_config.SCA_ENABLED:
                 return new_deps if new_deps else None
 
             re_report_deps = self._collect_rereports(new_keys)
@@ -140,10 +137,8 @@ class DependencyTracker:
 
         Caller must hold self._lock.
         """
-        from ddtrace.internal.settings._config import config as tracer_config
-
         key = _normalize_dep_name(package_name)
-        if key not in self._imported_dependencies and tracer_config._sca_enabled:
+        if key not in self._imported_dependencies and appsec_telemetry_config.SCA_ENABLED:
             try:
                 from importlib.metadata import version as importlib_metadata_version
 
@@ -198,7 +193,7 @@ class DependencyTracker:
 
         Called by the SCA product on start.  Sets metadata from None to []
         on all existing entries so the wire format includes the "metadata"
-        key.  Future entries pick up the flag from tracer_config._sca_enabled.
+        key. Future entries pick up the flag from AppSec telemetry configuration.
         """
         with self._lock:
             for entry in self._imported_dependencies.values():
@@ -222,24 +217,20 @@ def update_imported_dependencies(
     newly discovered package.  Returns the list of serialized dependency
     dicts ready for the ``app-dependencies-loaded`` telemetry payload.
 
-    SCA-enabled state is read from ``tracer_config._sca_enabled`` so it
-    reacts dynamically to Remote Configuration changes.
+    SCA-enabled state is read from ``appsec_telemetry_config.SCA_ENABLED``.
 
     NOTE: This function is kept for backward compatibility with
     tests and benchmarks that call it directly.  Production code should use
     DependencyTracker instead.
 
     Defensive: on interpreter shutdown or partial teardown, ``importlib.metadata``
-    and ``sys.path`` resolution can fail, and even the ``tracer_config`` import
-    itself may raise once ``sys.modules`` starts being torn down.  Any exception
-    is swallowed so the telemetry path never propagates to ``sys.excepthook``.
+    and ``sys.path`` resolution can fail. Any exception is swallowed so the
+    telemetry path never propagates to ``sys.excepthook``.
     """
     try:
-        from ddtrace.internal.settings._config import config as tracer_config
-
-        sca_enabled = tracer_config._sca_enabled
+        sca_enabled = appsec_telemetry_config.SCA_ENABLED
     except Exception:
-        log.debug("update_imported_dependencies: failed to read tracer config", exc_info=True)
+        log.debug("update_imported_dependencies: failed to read AppSec telemetry config", exc_info=True)
         return []
 
     deps: list[dict] = []

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -17,6 +17,7 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.packages import is_user_code
 from ddtrace.internal.settings._agent import config as agent_config
 from ddtrace.internal.settings._telemetry import config
+from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
 from ddtrace.internal.utils.http import get_connection
 
 from ...internal import atexit
@@ -375,18 +376,14 @@ class TelemetryWriter(PeriodicService):
 
     def _report_endpoints(self) -> Optional[dict[str, Any]]:
         """Adds a Telemetry event which sends the list of HTTP endpoints found at startup to the agent"""
-        asm_config = getattr(sys.modules.get("ddtrace.internal.settings.asm"), "config", None)
-        if asm_config is None:
-            return None
-
-        if not asm_config._api_security_endpoint_collection or not self._enabled:
+        if not appsec_telemetry_config.ENDPOINT_COLLECTION_ENABLED or not self._enabled:
             return None
 
         if not endpoint_collection.endpoints:
             return None
 
         with self._service_lock:
-            return endpoint_collection.flush(asm_config._api_security_endpoint_collection_limit)
+            return endpoint_collection.flush(appsec_telemetry_config.ENDPOINT_COLLECTION_LIMIT)
 
     def _report_products(self) -> dict[str, Any]:
         """Adds a Telemetry event which reports the enablement of an APM product"""

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -2,7 +2,6 @@
 import http.client as httplib
 import itertools
 import os
-import sys
 import time
 import traceback
 from typing import Any

--- a/scripts/perf_bench_heartbeat_cycles.py
+++ b/scripts/perf_bench_heartbeat_cycles.py
@@ -24,7 +24,7 @@ import time
 import tracemalloc
 from unittest.mock import patch
 
-from ddtrace.internal.settings._config import config as tracer_config
+from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
 from ddtrace.internal.telemetry.dependency import DependencyEntry
 from ddtrace.internal.telemetry.dependency import attach_reachability_metadata
 from ddtrace.internal.telemetry.dependency import register_cve_metadata
@@ -42,7 +42,7 @@ _HEADER_WIDTH = 135
 def _populate_tracker(tracker: DependencyTracker, n: int, sca_enabled: bool) -> None:
     """Pre-populate a tracker with n dependencies, as if discovered by the first heartbeat."""
     if sca_enabled:
-        tracer_config._sca_enabled = True
+        appsec_telemetry_config.SCA_ENABLED = True
     for i in range(n):
         name = f"package-{i}"
         meta = [] if sca_enabled else None
@@ -94,7 +94,7 @@ def _make_tracker_for_loop(n: int, sca_enabled: bool, phase: str, pct_cve: int, 
     if phase == "first":
         # All deps are new: NOT pre-populated (will be "discovered" by collect_report mock)
         if sca_enabled:
-            tracer_config._sca_enabled = True
+            appsec_telemetry_config.SCA_ENABLED = True
         return tracker
     # For all other phases, pre-populate as already reported
     _populate_tracker(tracker, n, sca_enabled)
@@ -138,7 +138,7 @@ class _idle_mock_ctx:
 
     def __enter__(self):
         self._p1 = patch("ddtrace.internal.telemetry.dependency_tracker.modules")
-        self._p2 = patch("ddtrace.internal.telemetry.dependency_tracker.config")
+        self._p2 = patch("ddtrace.internal.telemetry.dependency_tracker.telemetry_config")
         mock_modules = self._p1.__enter__()
         mock_config = self._p2.__enter__()
         mock_config.DEPENDENCY_COLLECTION = True
@@ -162,7 +162,7 @@ class _new_modules_mock_ctx:
             return self._dists.get(module_name)
 
         self._p1 = patch("ddtrace.internal.telemetry.dependency_tracker.modules")
-        self._p2 = patch("ddtrace.internal.telemetry.dependency_tracker.config")
+        self._p2 = patch("ddtrace.internal.telemetry.dependency_tracker.telemetry_config")
         self._p3 = patch(
             "ddtrace.internal.telemetry.dependency_tracker.get_module_distribution_versions",
             side_effect=fake_get_dist,
@@ -237,7 +237,7 @@ def bench_loop1_first_heartbeat(n: int, sca_enabled: bool, iterations: int = 50)
         def run():
             tracker = DependencyTracker()
             if sca_enabled:
-                tracer_config._sca_enabled = True
+                appsec_telemetry_config.SCA_ENABLED = True
             tracker.collect_report()
 
         return bench_time(run, warmup=2, iterations=iterations)
@@ -463,7 +463,7 @@ def main():
                     dists = {f"mod-{i}": (f"package-{i}", f"{i}.0.0") for i in range(n)}
                     tracker = DependencyTracker()
                     if sca_on:
-                        tracer_config._sca_enabled = True
+                        appsec_telemetry_config.SCA_ENABLED = True
                     result = _collect_report_new_modules(tracker, module_names, dists)
                 else:
                     tracker = _make_tracker_for_loop(n, sca_on, phase, pct_cve, cves_per_dep)

--- a/tests/appsec/appsec/test_asm_standalone.py
+++ b/tests/appsec/appsec/test_asm_standalone.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 import copy
+from unittest import mock
 
 import pytest
 
-import ddtrace
 from ddtrace.contrib.internal.trace_utils import set_http_meta
 from ddtrace.ext import SpanTypes
-from tests.utils import override_env
+from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
 
 
 @pytest.fixture(
@@ -21,11 +21,8 @@ from tests.utils import override_env
     + [{"DD_APPSEC_SCA_ENABLED": sca, "iast_enabled": iast} for sca in ["1", "0"] for iast in [True, False]]
 )
 def tracer_appsec_standalone(request, tracer):
-    new_env = {k: v for k, v in request.param.items() if k.startswith("DD_")}
-    with override_env(new_env):
-        # Reset the config so it picks up the env var value
-        ddtrace.config._reset()
-
+    sca_enabled = request.param["DD_APPSEC_SCA_ENABLED"] == "1"
+    with mock.patch.object(appsec_telemetry_config, "SCA_ENABLED", sca_enabled):
         # Copy the params to a new dict, including the env var
         request_param_copy = copy.deepcopy(request.param)
 
@@ -36,7 +33,6 @@ def tracer_appsec_standalone(request, tracer):
         yield tracer, request_param_copy
 
     # Reset tracer configuration
-    ddtrace.config._reset()
     tracer.configure(appsec_enabled=False, apm_tracing_disabled=False, iast_enabled=False)
 
 

--- a/tests/appsec/appsec/test_config_telemetry.py
+++ b/tests/appsec/appsec/test_config_telemetry.py
@@ -1,0 +1,116 @@
+"""Tests for AppSec configuration telemetry."""
+
+import os
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "env_var,value,expected_value",
+    [
+        ("DD_APPSEC_SCA_ENABLED", "true", True),
+        ("DD_APPSEC_SCA_ENABLED", "True", True),
+        ("DD_APPSEC_SCA_ENABLED", "1", True),
+        ("DD_APPSEC_SCA_ENABLED", "false", False),
+        ("DD_APPSEC_SCA_ENABLED", "False", False),
+        ("DD_APPSEC_SCA_ENABLED", "0", False),
+        ("DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED", "false", False),
+        ("DD_API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT", "42", 42),
+    ],
+)
+def test_app_started_event_configuration_override(
+    test_agent_session, run_python_code_in_subprocess, env_var, value, expected_value
+):
+    """Assert that AppSec configuration overrides are included in telemetry."""
+    env = os.environ.copy()
+    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    env["DD_APPSEC_ENABLED"] = "true"
+    env[env_var] = value
+    _, stderr, status, _ = run_python_code_in_subprocess("import ddtrace.auto", env=env)
+    assert status == 0, stderr
+
+    configuration = test_agent_session.get_configurations(name=env_var, remove_seq_id=True, effective=True)
+    assert len(configuration) == 1, configuration
+    assert configuration[0] == {"name": env_var, "origin": "env_var", "value": expected_value}
+
+
+def test_app_started_event_fleet_config_id(test_agent_session, run_python_code_in_subprocess, tmpdir):
+    managed_config = tmpdir.join("application_monitoring.yaml")
+    managed_config.write(
+        """
+config_id: sca-policy
+apm_configuration_default:
+  DD_APPSEC_SCA_ENABLED: true
+"""
+    )
+
+    env = os.environ.copy()
+    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    env["_DD_SC_MANAGED_FILE_OVERRIDE"] = str(managed_config)
+    _, stderr, status, _ = run_python_code_in_subprocess("import ddtrace.auto", env=env)
+    assert status == 0, stderr
+
+    sca_configuration = test_agent_session.get_configurations(
+        name="DD_APPSEC_SCA_ENABLED", remove_seq_id=True, effective=True
+    )
+    assert sca_configuration == [
+        {
+            "name": "DD_APPSEC_SCA_ENABLED",
+            "origin": "fleet_stable_config",
+            "value": True,
+            "config_id": "sca-policy",
+        }
+    ]
+
+    endpoint_configuration = test_agent_session.get_configurations(
+        name="DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED", remove_seq_id=True, effective=True
+    )
+    assert endpoint_configuration == [
+        {
+            "name": "DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED",
+            "origin": "default",
+            "value": True,
+        }
+    ]
+
+
+@pytest.mark.parametrize("onboarding_value", ["true", "false", "1", "0", ""])
+def test_app_started_event_agentic_onboarding_reported_verbatim(
+    test_agent_session, run_python_code_in_subprocess, onboarding_value
+):
+    """RFC-1113: DD_APPSEC_AGENTIC_ONBOARDING is reported verbatim as an ordinary config key."""
+    env = os.environ.copy()
+    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    env["DD_APPSEC_AGENTIC_ONBOARDING"] = onboarding_value
+    _, stderr, status, _ = run_python_code_in_subprocess("import ddtrace.auto", env=env)
+    assert status == 0, stderr
+
+    configuration = test_agent_session.get_configurations(
+        name="DD_APPSEC_AGENTIC_ONBOARDING", remove_seq_id=True, effective=True
+    )
+    assert len(configuration) == 1, configuration
+    assert configuration[0] == {
+        "name": "DD_APPSEC_AGENTIC_ONBOARDING",
+        "origin": "env_var",
+        "value": onboarding_value,
+    }
+
+
+def test_app_started_event_agentic_onboarding_absent(test_agent_session, run_python_code_in_subprocess):
+    """RFC-1113: when unset, the key is still reported with an empty value and origin=default."""
+    env = os.environ.copy()
+    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+    env["DD_APPSEC_ENABLED"] = "true"
+    env.pop("DD_APPSEC_AGENTIC_ONBOARDING", None)
+    _, stderr, status, _ = run_python_code_in_subprocess("import ddtrace.auto", env=env)
+    assert status == 0, stderr
+
+    configuration = test_agent_session.get_configurations(
+        name="DD_APPSEC_AGENTIC_ONBOARDING", remove_seq_id=True, effective=True
+    )
+    assert len(configuration) == 1, configuration
+    assert configuration[0] == {
+        "name": "DD_APPSEC_AGENTIC_ONBOARDING",
+        "origin": "default",
+        "value": "",
+    }

--- a/tests/appsec/sca/test_instrumenter.py
+++ b/tests/appsec/sca/test_instrumenter.py
@@ -23,7 +23,7 @@ from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
 @pytest.fixture(autouse=True)
 def _restore_instrumenter_globals():
     """Save and restore module-level singletons and config to prevent cross-test contamination."""
-    from ddtrace.internal.settings._config import config as tracer_config
+    from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
 
     saved_registry = _instrumenter_mod._registry
     saved_instance = _instrumenter_mod._instrumenter_instance
@@ -32,7 +32,7 @@ def _restore_instrumenter_globals():
         module_name: target_names.copy() for module_name, target_names in _instrumenter_mod._lazy_module_targets.items()
     }
     saved_global_registry = _registry_mod._global_registry
-    saved_sca_enabled = tracer_config._sca_enabled
+    saved_sca_enabled = appsec_telemetry_config.SCA_ENABLED
     yield
     _instrumenter_mod._registry = saved_registry
     _instrumenter_mod._instrumenter_instance = saved_instance
@@ -41,7 +41,7 @@ def _restore_instrumenter_globals():
     _instrumenter_mod._lazy_module_targets.clear()
     _instrumenter_mod._lazy_module_targets.update(saved_lazy_targets)
     _registry_mod._global_registry = saved_global_registry
-    tracer_config._sca_enabled = saved_sca_enabled
+    appsec_telemetry_config.SCA_ENABLED = saved_sca_enabled
 
 
 # ---------------------------------------------------------------------------
@@ -136,9 +136,9 @@ class TestSCADetectionHookIntegration:
         instrumenter = Instrumenter(registry)
 
         tracker = DependencyTracker()
-        from ddtrace.internal.settings._config import config as tracer_config
+        from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
 
-        tracer_config._sca_enabled = True
+        appsec_telemetry_config.SCA_ENABLED = True
 
         # Pre-populate a dependency with registered CVE
         entry = DependencyEntry(name="fakepkg", version="1.0.0", metadata=[])
@@ -251,9 +251,9 @@ class TestCallerInfoToReachedArray:
         instrumenter = Instrumenter(registry)
 
         tracker = DependencyTracker()
-        from ddtrace.internal.settings._config import config as tracer_config
+        from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
 
-        tracer_config._sca_enabled = True
+        appsec_telemetry_config.SCA_ENABLED = True
 
         entry = DependencyEntry(name="fakepkg", version="1.0.0", metadata=[])
         entry.mark_initial_sent()
@@ -305,9 +305,9 @@ class TestCallerInfoToReachedArray:
         instrumenter = Instrumenter(registry)
 
         tracker = DependencyTracker()
-        from ddtrace.internal.settings._config import config as tracer_config
+        from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
 
-        tracer_config._sca_enabled = True
+        appsec_telemetry_config.SCA_ENABLED = True
 
         entry = DependencyEntry(name="fakepkg", version="1.0.0", metadata=[])
         entry.mark_initial_sent()
@@ -520,7 +520,7 @@ class TestForkCallbackOrdering:
             reset_calls.append("registry_reset")
 
         with (
-            patch("ddtrace.internal.sca.product.tracer_config") as mock_config,
+            patch("ddtrace.internal.sca.product.appsec_telemetry_config") as mock_config,
             patch(
                 "ddtrace.appsec.sca._instrumenter._reset_after_fork",
                 side_effect=track_reset,
@@ -533,7 +533,7 @@ class TestForkCallbackOrdering:
             patch("ddtrace.internal.sca.product._load_and_instrument") as mock_load,
             patch("ddtrace.internal.sca.product.stop"),
         ):
-            mock_config._sca_enabled = True  # Must be True or restart() returns early
+            mock_config.SCA_ENABLED = True  # Must be True or restart() returns early
             restart()
 
         # Both resets should have been called

--- a/tests/appsec/sca/test_telemetry.py
+++ b/tests/appsec/sca/test_telemetry.py
@@ -1,0 +1,712 @@
+"""Tests for SCA dependency telemetry."""
+
+import json
+
+import pytest
+
+from ddtrace.internal.settings._telemetry import config as telemetry_config
+from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
+from ddtrace.internal.telemetry.dependency import DependencyEntry
+from ddtrace.internal.telemetry.dependency import ReachabilityMetadata
+from ddtrace.internal.telemetry.dependency import attach_reachability_metadata
+from ddtrace.internal.telemetry.dependency import register_cve_metadata
+
+
+@pytest.fixture(autouse=True)
+def _restore_sca_config():
+    """Save and restore appsec_telemetry_config.SCA_ENABLED to prevent cross-test contamination."""
+    saved = appsec_telemetry_config.SCA_ENABLED
+    yield
+    appsec_telemetry_config.SCA_ENABLED = saved
+
+
+class TestReachabilityMetadata:
+    def test_to_telemetry_dict_serializes_value_as_json_string(self):
+        meta = ReachabilityMetadata(
+            type="reachability",
+            value={"id": "CVE-2024-1234", "reached": [{"path": "mod.sub", "symbol": "func", "line": 10}]},
+        )
+        result = meta.to_telemetry_dict()
+        assert result["type"] == "reachability"
+        assert isinstance(result["value"], str)
+        parsed = json.loads(result["value"])
+        assert parsed["id"] == "CVE-2024-1234"
+        assert isinstance(parsed["reached"], list)
+        assert len(parsed["reached"]) == 1
+        assert parsed["reached"][0]["path"] == "mod.sub"
+        assert parsed["reached"][0]["symbol"] == "func"
+        assert parsed["reached"][0]["line"] == 10
+
+    def test_sent_tracking(self):
+        meta = ReachabilityMetadata(type="reachability", value={"id": "CVE-1", "reached": []})
+        assert meta.is_sent is False
+        meta._mark_sent()
+        assert meta.is_sent is True
+
+    def test_cve_id_property(self):
+        meta = ReachabilityMetadata(type="reachability", value={"id": "CVE-1", "reached": []})
+        assert meta.cve_id == "CVE-1"
+
+    def test_cve_id_property_missing(self):
+        meta = ReachabilityMetadata(type="reachability", value={"reached": []})
+        assert meta.cve_id is None
+
+    def test_add_reached_entry_first_hit(self):
+        meta = ReachabilityMetadata(type="reachability", value={"id": "CVE-1", "reached": []})
+        assert meta.add_reached_entry("mod.views", "func1", 33) is True
+        assert len(meta.value["reached"]) == 1
+        assert meta.value["reached"][0] == {"path": "mod.views", "symbol": "func1", "line": 33}
+        assert meta.is_sent is False
+
+    def test_add_reached_entry_max_one(self):
+        """RFC says reporting a single occurrence is sufficient — max 1."""
+        meta = ReachabilityMetadata(type="reachability", value={"id": "CVE-1", "reached": []})
+        assert meta.add_reached_entry("mod.views", "func1", 33) is True
+        assert meta.add_reached_entry("mod.services", "func2", 44) is False
+        assert len(meta.value["reached"]) == 1
+
+    def test_add_reached_entry_marks_unsent(self):
+        meta = ReachabilityMetadata(type="reachability", value={"id": "CVE-1", "reached": []})
+        meta._mark_sent()
+        assert meta.is_sent is True
+        meta.add_reached_entry("mod", "func", 1)
+        assert meta.is_sent is False
+
+
+class TestScaDependencyEntry:
+    def test_to_telemetry_dict_metadata_empty_list(self):
+        """metadata=[] -> metadata key with empty list (SCA active, no findings)."""
+        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
+        result = entry.to_telemetry_dict()
+        assert result == {"name": "requests", "version": "2.28.0", "metadata": []}
+
+    def test_to_telemetry_dict_with_metadata(self):
+        """metadata with entries -> metadata key with serialized entries."""
+        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
+        entry.add_metadata("CVE-2024-1234", "requests.sessions", "send", 1)
+        result = entry.to_telemetry_dict()
+        assert result["name"] == "requests"
+        assert result["version"] == "2.28.0"
+        assert len(result["metadata"]) == 1
+        assert result["metadata"][0]["type"] == "reachability"
+        parsed = json.loads(result["metadata"][0]["value"])
+        assert parsed["id"] == "CVE-2024-1234"
+        assert isinstance(parsed["reached"], list)
+        assert len(parsed["reached"]) == 1
+
+    def test_add_metadata_same_cve_first_hit_wins(self):
+        """Same CVE from different call sites — first hit wins (max reached=1)."""
+        entry = DependencyEntry(name="pkg", version="1.0")
+        assert entry.add_metadata("CVE-1", "mymodule.views", "func1", 33) is True
+        assert entry.add_metadata("CVE-1", "views.endpoint2", "func2", 456) is False
+        assert len(entry.metadata) == 1
+        assert len(entry.metadata[0].value["reached"]) == 1
+
+    def test_add_metadata_different_cves(self):
+        entry = DependencyEntry(name="pkg", version="1.0")
+        assert entry.add_metadata("CVE-1", "mod", "func", 1) is True
+        assert entry.add_metadata("CVE-2", "mod", "func", 1) is True
+        assert len(entry.metadata) == 2
+
+    def test_add_metadata_rejects_no_cve_id(self):
+        entry = DependencyEntry(name="pkg", version="1.0")
+        assert entry.add_metadata("") is False
+        assert entry.metadata is None
+
+    def test_add_metadata_initializes_list_from_none(self):
+        """add_metadata on a None-metadata entry initializes the list."""
+        entry = DependencyEntry(name="pkg", version="1.0")
+        assert entry.metadata is None
+        entry.add_metadata("CVE-1")
+        assert entry.metadata is not None
+        assert len(entry.metadata) == 1
+
+    def test_add_metadata_register_cve_empty_reached(self):
+        """Registering a CVE without call-site creates reached=[]."""
+        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
+        assert entry.add_metadata("CVE-1") is True
+        assert len(entry.metadata) == 1
+        assert entry.metadata[0].value == {"id": "CVE-1", "reached": []}
+
+    def test_add_metadata_register_then_hit(self):
+        """Register CVE with reached=[], then hit fills it."""
+        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
+        entry.add_metadata("CVE-1")  # register with reached=[]
+        assert entry.metadata[0].value["reached"] == []
+        assert entry.add_metadata("CVE-1", "mod.views", "func1", 33) is True
+        assert len(entry.metadata) == 1
+        assert len(entry.metadata[0].value["reached"]) == 1
+        assert entry.metadata[0].value["reached"][0] == {"path": "mod.views", "symbol": "func1", "line": 33}
+
+    def test_add_metadata_duplicate_registration_is_idempotent(self):
+        """Registering the same CVE twice does not create duplicates."""
+        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
+        assert entry.add_metadata("CVE-1") is True
+        assert entry.add_metadata("CVE-1") is False
+        assert len(entry.metadata) == 1
+
+    def test_needs_report_after_initial_send_with_unsent_metadata(self):
+        entry = DependencyEntry(name="pkg", version="1.0")
+        entry.mark_initial_sent()
+        entry.add_metadata("CVE-1")
+        assert entry.needs_report() is True
+
+    def test_needs_report_after_all_metadata_sent(self):
+        entry = DependencyEntry(name="pkg", version="1.0")
+        entry.mark_initial_sent()
+        entry.add_metadata("CVE-1")
+        entry.mark_all_metadata_sent()
+        assert entry.needs_report() is False
+
+    def test_add_metadata_respects_max_cve_cap(self):
+        """add_metadata silently drops CVEs once _MAX_METADATA_ENTRIES is reached."""
+        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
+        for i in range(DependencyEntry._MAX_METADATA_ENTRIES):
+            assert entry.add_metadata(f"CVE-{i}") is True
+        assert len(entry.metadata) == DependencyEntry._MAX_METADATA_ENTRIES
+        assert entry.add_metadata("CVE-overflow") is False
+        assert len(entry.metadata) == DependencyEntry._MAX_METADATA_ENTRIES
+
+    def test_get_unsent_metadata(self):
+        entry = DependencyEntry(name="pkg", version="1.0")
+        entry.add_metadata("CVE-1")
+        entry.mark_all_metadata_sent()  # mark CVE-1 as sent
+        entry.add_metadata("CVE-2")  # CVE-2 is unsent
+        unsent = entry.get_unsent_metadata()
+        assert len(unsent) == 1
+        assert unsent[0].value["id"] == "CVE-2"
+
+    def test_to_telemetry_dict_only_unsent(self):
+        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
+        entry.add_metadata("CVE-1")
+        entry.mark_all_metadata_sent()  # CVE-1 is now sent
+        entry.add_metadata("CVE-2")  # CVE-2 is unsent
+        result = entry.to_telemetry_dict(include_all_metadata=False)
+        assert len(result["metadata"]) == 1
+        parsed = json.loads(result["metadata"][0]["value"])
+        assert parsed["id"] == "CVE-2"
+
+    def test_to_telemetry_dict_include_all(self):
+        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
+        entry.add_metadata("CVE-1")
+        entry.mark_all_metadata_sent()  # CVE-1 is now sent
+        entry.add_metadata("CVE-2")  # CVE-2 is unsent
+        result = entry.to_telemetry_dict(include_all_metadata=True)
+        assert len(result["metadata"]) == 2
+
+    def test_to_telemetry_dict_all_sent_empty_metadata(self):
+        """When all metadata is sent and include_all_metadata=False, empty list."""
+        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
+        entry.add_metadata("CVE-1")
+        entry.mark_all_metadata_sent()
+        result = entry.to_telemetry_dict(include_all_metadata=False)
+        assert result["metadata"] == []
+
+
+class TestAttachReachabilityMetadata:
+    def test_attach_to_existing_dependency(self):
+        deps = {"requests": DependencyEntry(name="requests", version="2.28.0")}
+        result = attach_reachability_metadata(deps, "requests", "CVE-2024-1234", "requests.sessions", "send", 10)
+        assert result is True
+        assert len(deps["requests"].metadata) == 1
+        assert deps["requests"].metadata[0].value["id"] == "CVE-2024-1234"
+        assert len(deps["requests"].metadata[0].value["reached"]) == 1
+
+    def test_attach_to_unknown_package(self):
+        deps = {"requests": DependencyEntry(name="requests", version="2.28.0")}
+        result = attach_reachability_metadata(deps, "flask", "CVE-2024-9999", "flask.app", "run", 1)
+        assert result is False
+
+    def test_attach_multiple_cves_to_same_package(self):
+        deps = {"requests": DependencyEntry(name="requests", version="2.28.0")}
+        attach_reachability_metadata(deps, "requests", "CVE-1", "mod", "func1", 1)
+        attach_reachability_metadata(deps, "requests", "CVE-2", "mod", "func2", 5)
+        assert len(deps["requests"].metadata) == 2
+
+    def test_attach_same_cve_first_hit_wins(self):
+        """Same CVE from different call sites — first hit wins (max reached=1)."""
+        deps = {"requests": DependencyEntry(name="requests", version="2.28.0")}
+        assert attach_reachability_metadata(deps, "requests", "CVE-1", "mod.views", "func1", 33) is True
+        assert attach_reachability_metadata(deps, "requests", "CVE-1", "views.ep2", "func2", 456) is False
+        assert len(deps["requests"].metadata) == 1
+        assert len(deps["requests"].metadata[0].value["reached"]) == 1
+
+
+class TestRegisterCveMetadata:
+    def test_register_cve_to_tracked_dependency(self):
+        deps = {"requests": DependencyEntry(name="requests", version="2.28.0", metadata=[])}
+        result = register_cve_metadata(deps, "requests", "CVE-1")
+        assert result is True
+        assert len(deps["requests"].metadata) == 1
+        assert deps["requests"].metadata[0].value == {"id": "CVE-1", "reached": []}
+
+    def test_register_cve_to_unknown_package(self):
+        deps = {"requests": DependencyEntry(name="requests", version="2.28.0")}
+        result = register_cve_metadata(deps, "flask", "CVE-1")
+        assert result is False
+
+    def test_register_then_hit(self):
+        deps = {"requests": DependencyEntry(name="requests", version="2.28.0", metadata=[])}
+        register_cve_metadata(deps, "requests", "CVE-1")
+        attach_reachability_metadata(deps, "requests", "CVE-1", "mod", "func", 10)
+        assert len(deps["requests"].metadata) == 1
+        assert len(deps["requests"].metadata[0].value["reached"]) == 1
+
+    def test_register_duplicate_is_idempotent(self):
+        deps = {"requests": DependencyEntry(name="requests", version="2.28.0", metadata=[])}
+        assert register_cve_metadata(deps, "requests", "CVE-1") is True
+        assert register_cve_metadata(deps, "requests", "CVE-1") is False
+        assert len(deps["requests"].metadata) == 1
+
+    def test_register_multiple_cves(self):
+        deps = {"requests": DependencyEntry(name="requests", version="2.28.0", metadata=[])}
+        register_cve_metadata(deps, "requests", "CVE-1")
+        register_cve_metadata(deps, "requests", "CVE-2")
+        assert len(deps["requests"].metadata) == 2
+        cve_ids = {m.value["id"] for m in deps["requests"].metadata}
+        assert cve_ids == {"CVE-1", "CVE-2"}
+
+
+def _make_writer_and_tracker(sca_enabled=False, deps=None, enabled=True):
+    """Shared factory for writer-level tests.
+
+    Sets appsec_telemetry_config.SCA_ENABLED so DependencyTracker reads the live
+    config flag.  Callers should use the _restore_sca_config fixture
+    (autouse in this module) to ensure cleanup.
+    """
+    from unittest.mock import MagicMock
+
+    from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
+    from ddtrace.internal.telemetry.writer import TelemetryWriter
+
+    appsec_telemetry_config.SCA_ENABLED = sca_enabled
+    writer = TelemetryWriter.__new__(TelemetryWriter)
+    writer._service_lock = MagicMock()
+    writer._enabled = enabled
+    tracker = DependencyTracker()
+    if deps:
+        tracker._imported_dependencies = deps
+    writer._dependency_tracker = tracker
+    return writer, tracker
+
+
+class TestWriterAttachDependencyMetadata:
+    """Writer-level tests for attach_dependency_metadata (via DependencyTracker)."""
+
+    def test_attach_metadata_to_tracked_dependency(self):
+        writer, tracker = _make_writer_and_tracker(
+            deps={"requests": DependencyEntry(name="requests", version="2.28.0")}
+        )
+
+        result = writer.attach_dependency_metadata("requests", "CVE-1", "mod", "func", 1)
+
+        assert result is True
+        entry = tracker._imported_dependencies["requests"]
+        assert len(entry.metadata) == 1
+        assert entry.metadata[0].value["id"] == "CVE-1"
+        assert len(entry.metadata[0].value["reached"]) == 1
+
+    def test_attach_returns_false_for_unknown_package(self):
+        writer, tracker = _make_writer_and_tracker(
+            deps={"requests": DependencyEntry(name="requests", version="2.28.0")}
+        )
+
+        result = writer.attach_dependency_metadata("flask", "CVE-1", "mod", "func", 1)
+
+        assert result is False
+        assert "flask" not in tracker._imported_dependencies
+
+    def test_attach_auto_creates_entry_when_sca_active(self):
+        """When SCA is active and package not tracked, auto-create the entry."""
+        from unittest.mock import patch
+
+        writer, tracker = _make_writer_and_tracker(sca_enabled=True)
+
+        with patch("importlib.metadata.version", return_value="2.28.0"):
+            result = writer.attach_dependency_metadata("requests", "CVE-1", "mod", "func", 1)
+
+        assert result is True
+        assert "requests" in tracker._imported_dependencies
+        entry = tracker._imported_dependencies["requests"]
+        assert entry.version == "2.28.0"
+        assert entry.metadata is not None
+        assert len(entry.metadata) == 1
+        assert entry.metadata[0].value["id"] == "CVE-1"
+
+    def test_attach_does_not_auto_create_when_sca_inactive(self):
+        """When SCA is not active, unknown packages return False."""
+        writer, tracker = _make_writer_and_tracker(sca_enabled=False)
+
+        result = writer.attach_dependency_metadata("requests", "CVE-1", "mod", "func", 1)
+
+        assert result is False
+        assert "requests" not in tracker._imported_dependencies
+
+
+class TestWriterEnableScaMetadata:
+    """Tests for enable_sca_metadata method (via DependencyTracker)."""
+
+    def test_enable_sca_metadata_sets_none_to_empty_list(self):
+        writer, tracker = _make_writer_and_tracker(
+            deps={
+                "requests": DependencyEntry(name="requests", version="2.28.0"),
+                "flask": DependencyEntry(name="flask", version="3.0.0"),
+            }
+        )
+        assert tracker._imported_dependencies["requests"].metadata is None
+        assert tracker._imported_dependencies["flask"].metadata is None
+
+        writer.enable_sca_metadata()
+
+        assert tracker._imported_dependencies["requests"].metadata == []
+        assert tracker._imported_dependencies["flask"].metadata == []
+
+    def test_enable_sca_metadata_preserves_existing_metadata(self):
+        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
+        entry.add_metadata("CVE-1")
+
+        writer, tracker = _make_writer_and_tracker(deps={"requests": entry})
+
+        writer.enable_sca_metadata()
+
+        # Should not overwrite existing metadata
+        assert len(tracker._imported_dependencies["requests"].metadata) == 1
+
+
+class TestWriterReReporting:
+    """Tests for _report_dependencies re-reporting behavior with metadata."""
+
+    def test_report_dependencies_rereports_on_new_metadata(self):
+        from unittest.mock import patch
+
+        writer, tracker = _make_writer_and_tracker(sca_enabled=True)
+
+        # Pre-populate with an already-reported dep (SCA active: metadata=[])
+        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
+        entry.mark_initial_sent()
+        tracker._imported_dependencies["requests"] = entry
+
+        # Attach metadata after initial report
+        writer.attach_dependency_metadata("requests", "CVE-1", "requests.sessions", "send", 10)
+
+        with (
+            patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
+            patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True),
+            patch.object(appsec_telemetry_config, "SCA_ENABLED", True),
+        ):
+            mock_modules.get_newly_imported_modules.return_value = set()
+
+            result = writer._report_dependencies()
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["name"] == "requests"
+        assert len(result[0]["metadata"]) == 1
+        parsed = json.loads(result[0]["metadata"][0]["value"])
+        assert parsed["id"] == "CVE-1"
+        assert isinstance(parsed["reached"], list)
+        assert len(parsed["reached"]) == 1
+
+        # Metadata should be marked as sent now
+        assert entry.has_unsent_metadata() is False
+
+    def test_report_dependencies_no_rereport_without_new_metadata(self):
+        from unittest.mock import patch
+
+        writer, tracker = _make_writer_and_tracker()
+
+        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
+        entry.mark_initial_sent()
+        tracker._imported_dependencies["requests"] = entry
+
+        with (
+            patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
+            patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True),
+            patch.object(appsec_telemetry_config, "SCA_ENABLED", False),
+        ):
+            mock_modules.get_newly_imported_modules.return_value = set()
+
+            result = writer._report_dependencies()
+
+        # No new deps, no new metadata -> None
+        assert result is None
+
+    def test_rereport_includes_all_metadata_per_rfc(self):
+        """Re-report includes ALL metadata (sent + unsent) per RFC."""
+        from unittest.mock import patch
+
+        writer, tracker = _make_writer_and_tracker(sca_enabled=True)
+
+        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
+        entry.mark_initial_sent()
+        tracker._imported_dependencies["requests"] = entry
+
+        # Attach first CVE and mark as sent
+        writer.attach_dependency_metadata("requests", "CVE-1", "mod.views", "func1", 33)
+        entry.mark_all_metadata_sent()
+
+        # Register second CVE (unsent, with reached=[])
+        writer.register_cve_metadata("requests", "CVE-2")
+
+        with (
+            patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
+            patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True),
+            patch.object(appsec_telemetry_config, "SCA_ENABLED", True),
+        ):
+            mock_modules.get_newly_imported_modules.return_value = set()
+
+            result = writer._report_dependencies()
+
+        assert result is not None
+        assert len(result) == 1
+        # Should include ALL metadata (both CVE-1 and CVE-2)
+        assert len(result[0]["metadata"]) == 2
+
+    def test_rereport_on_cve_registration(self):
+        """Registering CVEs after initial dep report triggers re-report with reached=[]."""
+        from unittest.mock import patch
+
+        writer, tracker = _make_writer_and_tracker(sca_enabled=True)
+
+        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
+        entry.mark_initial_sent()
+        entry.mark_all_metadata_sent()
+        tracker._imported_dependencies["requests"] = entry
+
+        # Register CVE (simulates CVE load at startup)
+        writer.register_cve_metadata("requests", "CVE-1")
+
+        with (
+            patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
+            patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True),
+            patch.object(appsec_telemetry_config, "SCA_ENABLED", True),
+        ):
+            mock_modules.get_newly_imported_modules.return_value = set()
+
+            result = writer._report_dependencies()
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["name"] == "requests"
+        assert len(result[0]["metadata"]) == 1
+        parsed = json.loads(result[0]["metadata"][0]["value"])
+        assert parsed["id"] == "CVE-1"
+        assert parsed["reached"] == []
+
+    def test_new_deps_without_sca_have_no_metadata_key(self):
+        """New deps created without SCA enabled have no metadata key."""
+        from unittest.mock import patch
+
+        writer, tracker = _make_writer_and_tracker()
+
+        with (
+            patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
+            patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True),
+            patch.object(appsec_telemetry_config, "SCA_ENABLED", False),
+            patch(
+                "ddtrace.internal.telemetry.dependency_tracker.get_module_distribution_versions",
+                return_value=("requests", "2.28.0"),
+            ),
+        ):
+            mock_modules.get_newly_imported_modules.return_value = {"requests"}
+
+            result = writer._report_dependencies()
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["name"] == "requests"
+        assert "metadata" not in result[0]
+
+
+class TestWriterRegisterCveMetadata:
+    """Writer-level tests for register_cve_metadata (via DependencyTracker)."""
+
+    def test_register_cve_auto_creates_entry_when_sca_active(self):
+        """register_cve_metadata auto-creates an entry when SCA is active and package untracked."""
+        from unittest.mock import patch
+
+        writer, tracker = _make_writer_and_tracker(sca_enabled=True)
+
+        with patch("importlib.metadata.version", return_value="1.0"):
+            result = writer.register_cve_metadata("flask", "CVE-NEW")
+
+        assert result is True
+        assert "flask" in tracker._imported_dependencies
+        entry = tracker._imported_dependencies["flask"]
+        assert entry.version == "1.0"
+        assert entry.metadata is not None
+        assert len(entry.metadata) == 1
+        assert entry.metadata[0].value == {"id": "CVE-NEW", "reached": []}
+
+    def test_register_cve_does_not_auto_create_when_sca_inactive(self):
+        writer, tracker = _make_writer_and_tracker(sca_enabled=False)
+        result = writer.register_cve_metadata("flask", "CVE-NEW")
+        assert result is False
+        assert "flask" not in tracker._imported_dependencies
+
+    def test_auto_create_with_version_lookup_failure(self):
+        """When importlib.metadata.version raises PackageNotFoundError, entry is created with version=""."""
+        from importlib.metadata import PackageNotFoundError
+        from unittest.mock import patch
+
+        writer, tracker = _make_writer_and_tracker(sca_enabled=True)
+
+        with patch(
+            "importlib.metadata.version",
+            side_effect=PackageNotFoundError("unknown-pkg"),
+        ):
+            result = writer.register_cve_metadata("unknown-pkg", "CVE-1")
+
+        assert result is True
+        assert tracker._imported_dependencies["unknown-pkg"].version == ""
+
+
+class TestScaTrackerNameNormalization:
+    """Tests that SCA dependency metadata uses normalized package names."""
+
+    def test_ensure_entry_no_duplicate_with_different_casing(self):
+        """_ensure_entry should not create a duplicate when the same package has different casing."""
+        from unittest.mock import patch
+
+        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
+
+        appsec_telemetry_config.SCA_ENABLED = True
+        tracker = DependencyTracker()
+
+        with patch("importlib.metadata.version", return_value="6.0"):
+            # Telemetry discovers "PyYAML" first
+            tracker._imported_dependencies["pyyaml"] = DependencyEntry(name="PyYAML", version="6.0", metadata=[])
+            # SCA tries to ensure "pyyaml" — should find the existing entry
+            with tracker._lock:
+                tracker._ensure_entry("pyyaml")
+
+        assert len(tracker._imported_dependencies) == 1
+
+    def test_attach_metadata_matches_differently_cased_key(self):
+        """attach_metadata with lowercase name should find an entry stored via telemetry discovery."""
+        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
+        from ddtrace.internal.telemetry.dependency_tracker import _normalize_dep_name
+
+        tracker = DependencyTracker()
+        # Simulate telemetry discovering "PyYAML" (stored under normalized key)
+        key = _normalize_dep_name("PyYAML")
+        tracker._imported_dependencies[key] = DependencyEntry(name="PyYAML", version="6.0", metadata=[])
+
+        # SCA attaches metadata using lowercase name from CVE data
+        result = tracker.attach_metadata("pyyaml", "CVE-2024-1234", "yaml.loader", "load", 10)
+
+        assert result is True
+        entry = tracker._imported_dependencies[key]
+        assert len(entry.metadata) == 1
+        assert entry.metadata[0].value["id"] == "CVE-2024-1234"
+
+    def test_register_cve_matches_differently_cased_key(self):
+        """register_cve with lowercase name should find an entry stored via telemetry discovery."""
+        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
+        from ddtrace.internal.telemetry.dependency_tracker import _normalize_dep_name
+
+        tracker = DependencyTracker()
+        key = _normalize_dep_name("PyYAML")
+        tracker._imported_dependencies[key] = DependencyEntry(name="PyYAML", version="6.0", metadata=[])
+
+        result = tracker.register_cve("pyyaml", "CVE-2024-5678")
+
+        assert result is True
+        entry = tracker._imported_dependencies[key]
+        assert len(entry.metadata) == 1
+        assert entry.metadata[0].value == {"id": "CVE-2024-5678", "reached": []}
+
+    def test_update_imported_dependencies_swallows_appsec_telemetry_config_failure(self):
+        """If reading AppSec telemetry config fails during shutdown, return [] without raising."""
+        from unittest.mock import patch
+
+        from ddtrace.internal.telemetry.dependency_tracker import update_imported_dependencies
+
+        class BrokenConfig:
+            @property
+            def SCA_ENABLED(self):
+                raise RuntimeError("config module torn down")
+
+        with patch("ddtrace.internal.telemetry.dependency_tracker.appsec_telemetry_config", BrokenConfig()):
+            result = update_imported_dependencies({}, ["requests"])
+
+        assert result == []
+
+
+class TestScaSnapshotForHeartbeat:
+    """Tests for SCA metadata in extended-heartbeat dependency snapshots."""
+
+    def test_returns_all_entries_serialized(self):
+        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
+
+        tracker = DependencyTracker()
+        tracker._imported_dependencies = {
+            "requests": DependencyEntry(name="requests", version="2.28.0", metadata=[]),
+            "flask": DependencyEntry(name="flask", version="3.0.0"),
+        }
+        tracker._imported_dependencies["requests"].add_metadata("CVE-1", "mod", "func", 10)
+
+        snapshot = tracker.snapshot_for_heartbeat()
+
+        assert len(snapshot) == 2
+        by_name = {d["name"]: d for d in snapshot}
+        assert by_name["requests"]["version"] == "2.28.0"
+        assert "metadata" in by_name["requests"]
+        assert len(by_name["requests"]["metadata"]) == 1
+        # flask has metadata=None -> no "metadata" key
+        assert "metadata" not in by_name["flask"]
+
+    def test_includes_already_sent_metadata(self):
+        """Extended heartbeat must re-send sent metadata (include_all_metadata=True)."""
+        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
+
+        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
+        entry.add_metadata("CVE-1", "mod", "func", 10)
+        entry.mark_all_metadata_sent()
+
+        tracker = DependencyTracker()
+        tracker._imported_dependencies = {"requests": entry}
+
+        snapshot = tracker.snapshot_for_heartbeat()
+        assert len(snapshot[0]["metadata"]) == 1
+
+    def test_serialization_holds_lock_against_concurrent_mutation(self):
+        """Concurrent attach_metadata must not race iteration inside json.dumps.
+
+        Spawns a writer thread repeatedly adding CVEs to a tracked entry while the
+        heartbeat serializer builds snapshots. Without the lock, the writer thread
+        could append to ReachabilityMetadata.value["reached"] mid-serialization —
+        json.dumps on a list being mutated in another thread is not safe.
+        """
+        import threading
+
+        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
+
+        appsec_telemetry_config.SCA_ENABLED = True
+        tracker = DependencyTracker()
+        tracker._imported_dependencies["requests"] = DependencyEntry(name="requests", version="2.28.0", metadata=[])
+
+        stop = threading.Event()
+        errors: list[BaseException] = []
+
+        def writer():
+            i = 0
+            while not stop.is_set():
+                try:
+                    tracker.attach_metadata("requests", f"CVE-{i}", "mod", "func", i)
+                    i += 1
+                except BaseException as exc:  # pragma: no cover — asserted below
+                    errors.append(exc)
+                    return
+
+        t = threading.Thread(target=writer, daemon=True)
+        t.start()
+        try:
+            for _ in range(200):
+                snapshot = tracker.snapshot_for_heartbeat()
+                assert snapshot and snapshot[0]["name"] == "requests"
+        finally:
+            stop.set()
+            t.join(timeout=2)
+
+        assert not errors, errors

--- a/tests/telemetry/test_dependency.py
+++ b/tests/telemetry/test_dependency.py
@@ -1,156 +1,16 @@
-"""Tests for ddtrace.internal.telemetry.dependency module."""
-
-import json
-
-import pytest
+"""Tests for generic telemetry dependency collection."""
 
 from ddtrace.internal.settings._telemetry import config as telemetry_config
 from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
 from ddtrace.internal.telemetry.dependency import DependencyEntry
-from ddtrace.internal.telemetry.dependency import ReachabilityMetadata
-from ddtrace.internal.telemetry.dependency import attach_reachability_metadata
-from ddtrace.internal.telemetry.dependency import register_cve_metadata
-
-
-@pytest.fixture(autouse=True)
-def _restore_sca_config():
-    """Save and restore appsec_telemetry_config.SCA_ENABLED to prevent cross-test contamination."""
-    saved = appsec_telemetry_config.SCA_ENABLED
-    yield
-    appsec_telemetry_config.SCA_ENABLED = saved
-
-
-class TestReachabilityMetadata:
-    def test_to_telemetry_dict_serializes_value_as_json_string(self):
-        meta = ReachabilityMetadata(
-            type="reachability",
-            value={"id": "CVE-2024-1234", "reached": [{"path": "mod.sub", "symbol": "func", "line": 10}]},
-        )
-        result = meta.to_telemetry_dict()
-        assert result["type"] == "reachability"
-        assert isinstance(result["value"], str)
-        parsed = json.loads(result["value"])
-        assert parsed["id"] == "CVE-2024-1234"
-        assert isinstance(parsed["reached"], list)
-        assert len(parsed["reached"]) == 1
-        assert parsed["reached"][0]["path"] == "mod.sub"
-        assert parsed["reached"][0]["symbol"] == "func"
-        assert parsed["reached"][0]["line"] == 10
-
-    def test_sent_tracking(self):
-        meta = ReachabilityMetadata(type="reachability", value={"id": "CVE-1", "reached": []})
-        assert meta.is_sent is False
-        meta._mark_sent()
-        assert meta.is_sent is True
-
-    def test_cve_id_property(self):
-        meta = ReachabilityMetadata(type="reachability", value={"id": "CVE-1", "reached": []})
-        assert meta.cve_id == "CVE-1"
-
-    def test_cve_id_property_missing(self):
-        meta = ReachabilityMetadata(type="reachability", value={"reached": []})
-        assert meta.cve_id is None
-
-    def test_add_reached_entry_first_hit(self):
-        meta = ReachabilityMetadata(type="reachability", value={"id": "CVE-1", "reached": []})
-        assert meta.add_reached_entry("mod.views", "func1", 33) is True
-        assert len(meta.value["reached"]) == 1
-        assert meta.value["reached"][0] == {"path": "mod.views", "symbol": "func1", "line": 33}
-        assert meta.is_sent is False
-
-    def test_add_reached_entry_max_one(self):
-        """RFC says reporting a single occurrence is sufficient — max 1."""
-        meta = ReachabilityMetadata(type="reachability", value={"id": "CVE-1", "reached": []})
-        assert meta.add_reached_entry("mod.views", "func1", 33) is True
-        assert meta.add_reached_entry("mod.services", "func2", 44) is False
-        assert len(meta.value["reached"]) == 1
-
-    def test_add_reached_entry_marks_unsent(self):
-        meta = ReachabilityMetadata(type="reachability", value={"id": "CVE-1", "reached": []})
-        meta._mark_sent()
-        assert meta.is_sent is True
-        meta.add_reached_entry("mod", "func", 1)
-        assert meta.is_sent is False
 
 
 class TestDependencyEntry:
     def test_to_telemetry_dict_metadata_none(self):
-        """metadata=None -> no metadata key (SCA not active)."""
         entry = DependencyEntry(name="requests", version="2.28.0")
         result = entry.to_telemetry_dict()
         assert result == {"name": "requests", "version": "2.28.0"}
         assert "metadata" not in result
-
-    def test_to_telemetry_dict_metadata_empty_list(self):
-        """metadata=[] -> metadata key with empty list (SCA active, no findings)."""
-        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
-        result = entry.to_telemetry_dict()
-        assert result == {"name": "requests", "version": "2.28.0", "metadata": []}
-
-    def test_to_telemetry_dict_with_metadata(self):
-        """metadata with entries -> metadata key with serialized entries."""
-        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
-        entry.add_metadata("CVE-2024-1234", "requests.sessions", "send", 1)
-        result = entry.to_telemetry_dict()
-        assert result["name"] == "requests"
-        assert result["version"] == "2.28.0"
-        assert len(result["metadata"]) == 1
-        assert result["metadata"][0]["type"] == "reachability"
-        parsed = json.loads(result["metadata"][0]["value"])
-        assert parsed["id"] == "CVE-2024-1234"
-        assert isinstance(parsed["reached"], list)
-        assert len(parsed["reached"]) == 1
-
-    def test_add_metadata_same_cve_first_hit_wins(self):
-        """Same CVE from different call sites — first hit wins (max reached=1)."""
-        entry = DependencyEntry(name="pkg", version="1.0")
-        assert entry.add_metadata("CVE-1", "mymodule.views", "func1", 33) is True
-        assert entry.add_metadata("CVE-1", "views.endpoint2", "func2", 456) is False
-        assert len(entry.metadata) == 1
-        assert len(entry.metadata[0].value["reached"]) == 1
-
-    def test_add_metadata_different_cves(self):
-        entry = DependencyEntry(name="pkg", version="1.0")
-        assert entry.add_metadata("CVE-1", "mod", "func", 1) is True
-        assert entry.add_metadata("CVE-2", "mod", "func", 1) is True
-        assert len(entry.metadata) == 2
-
-    def test_add_metadata_rejects_no_cve_id(self):
-        entry = DependencyEntry(name="pkg", version="1.0")
-        assert entry.add_metadata("") is False
-        assert entry.metadata is None
-
-    def test_add_metadata_initializes_list_from_none(self):
-        """add_metadata on a None-metadata entry initializes the list."""
-        entry = DependencyEntry(name="pkg", version="1.0")
-        assert entry.metadata is None
-        entry.add_metadata("CVE-1")
-        assert entry.metadata is not None
-        assert len(entry.metadata) == 1
-
-    def test_add_metadata_register_cve_empty_reached(self):
-        """Registering a CVE without call-site creates reached=[]."""
-        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
-        assert entry.add_metadata("CVE-1") is True
-        assert len(entry.metadata) == 1
-        assert entry.metadata[0].value == {"id": "CVE-1", "reached": []}
-
-    def test_add_metadata_register_then_hit(self):
-        """Register CVE with reached=[], then hit fills it."""
-        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
-        entry.add_metadata("CVE-1")  # register with reached=[]
-        assert entry.metadata[0].value["reached"] == []
-        assert entry.add_metadata("CVE-1", "mod.views", "func1", 33) is True
-        assert len(entry.metadata) == 1
-        assert len(entry.metadata[0].value["reached"]) == 1
-        assert entry.metadata[0].value["reached"][0] == {"path": "mod.views", "symbol": "func1", "line": 33}
-
-    def test_add_metadata_duplicate_registration_is_idempotent(self):
-        """Registering the same CVE twice does not create duplicates."""
-        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
-        assert entry.add_metadata("CVE-1") is True
-        assert entry.add_metadata("CVE-1") is False
-        assert len(entry.metadata) == 1
 
     def test_needs_report_new_entry(self):
         entry = DependencyEntry(name="pkg", version="1.0")
@@ -160,421 +20,6 @@ class TestDependencyEntry:
         entry = DependencyEntry(name="pkg", version="1.0")
         entry.mark_initial_sent()
         assert entry.needs_report() is False
-
-    def test_needs_report_after_initial_send_with_unsent_metadata(self):
-        entry = DependencyEntry(name="pkg", version="1.0")
-        entry.mark_initial_sent()
-        entry.add_metadata("CVE-1")
-        assert entry.needs_report() is True
-
-    def test_needs_report_after_all_metadata_sent(self):
-        entry = DependencyEntry(name="pkg", version="1.0")
-        entry.mark_initial_sent()
-        entry.add_metadata("CVE-1")
-        entry.mark_all_metadata_sent()
-        assert entry.needs_report() is False
-
-    def test_add_metadata_respects_max_cve_cap(self):
-        """add_metadata silently drops CVEs once _MAX_METADATA_ENTRIES is reached."""
-        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
-        for i in range(DependencyEntry._MAX_METADATA_ENTRIES):
-            assert entry.add_metadata(f"CVE-{i}") is True
-        assert len(entry.metadata) == DependencyEntry._MAX_METADATA_ENTRIES
-        assert entry.add_metadata("CVE-overflow") is False
-        assert len(entry.metadata) == DependencyEntry._MAX_METADATA_ENTRIES
-
-    def test_get_unsent_metadata(self):
-        entry = DependencyEntry(name="pkg", version="1.0")
-        entry.add_metadata("CVE-1")
-        entry.mark_all_metadata_sent()  # mark CVE-1 as sent
-        entry.add_metadata("CVE-2")  # CVE-2 is unsent
-        unsent = entry.get_unsent_metadata()
-        assert len(unsent) == 1
-        assert unsent[0].value["id"] == "CVE-2"
-
-    def test_to_telemetry_dict_only_unsent(self):
-        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
-        entry.add_metadata("CVE-1")
-        entry.mark_all_metadata_sent()  # CVE-1 is now sent
-        entry.add_metadata("CVE-2")  # CVE-2 is unsent
-        result = entry.to_telemetry_dict(include_all_metadata=False)
-        assert len(result["metadata"]) == 1
-        parsed = json.loads(result["metadata"][0]["value"])
-        assert parsed["id"] == "CVE-2"
-
-    def test_to_telemetry_dict_include_all(self):
-        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
-        entry.add_metadata("CVE-1")
-        entry.mark_all_metadata_sent()  # CVE-1 is now sent
-        entry.add_metadata("CVE-2")  # CVE-2 is unsent
-        result = entry.to_telemetry_dict(include_all_metadata=True)
-        assert len(result["metadata"]) == 2
-
-    def test_to_telemetry_dict_all_sent_empty_metadata(self):
-        """When all metadata is sent and include_all_metadata=False, empty list."""
-        entry = DependencyEntry(name="pkg", version="1.0", metadata=[])
-        entry.add_metadata("CVE-1")
-        entry.mark_all_metadata_sent()
-        result = entry.to_telemetry_dict(include_all_metadata=False)
-        assert result["metadata"] == []
-
-
-class TestAttachReachabilityMetadata:
-    def test_attach_to_existing_dependency(self):
-        deps = {"requests": DependencyEntry(name="requests", version="2.28.0")}
-        result = attach_reachability_metadata(deps, "requests", "CVE-2024-1234", "requests.sessions", "send", 10)
-        assert result is True
-        assert len(deps["requests"].metadata) == 1
-        assert deps["requests"].metadata[0].value["id"] == "CVE-2024-1234"
-        assert len(deps["requests"].metadata[0].value["reached"]) == 1
-
-    def test_attach_to_unknown_package(self):
-        deps = {"requests": DependencyEntry(name="requests", version="2.28.0")}
-        result = attach_reachability_metadata(deps, "flask", "CVE-2024-9999", "flask.app", "run", 1)
-        assert result is False
-
-    def test_attach_multiple_cves_to_same_package(self):
-        deps = {"requests": DependencyEntry(name="requests", version="2.28.0")}
-        attach_reachability_metadata(deps, "requests", "CVE-1", "mod", "func1", 1)
-        attach_reachability_metadata(deps, "requests", "CVE-2", "mod", "func2", 5)
-        assert len(deps["requests"].metadata) == 2
-
-    def test_attach_same_cve_first_hit_wins(self):
-        """Same CVE from different call sites — first hit wins (max reached=1)."""
-        deps = {"requests": DependencyEntry(name="requests", version="2.28.0")}
-        assert attach_reachability_metadata(deps, "requests", "CVE-1", "mod.views", "func1", 33) is True
-        assert attach_reachability_metadata(deps, "requests", "CVE-1", "views.ep2", "func2", 456) is False
-        assert len(deps["requests"].metadata) == 1
-        assert len(deps["requests"].metadata[0].value["reached"]) == 1
-
-
-class TestRegisterCveMetadata:
-    def test_register_cve_to_tracked_dependency(self):
-        deps = {"requests": DependencyEntry(name="requests", version="2.28.0", metadata=[])}
-        result = register_cve_metadata(deps, "requests", "CVE-1")
-        assert result is True
-        assert len(deps["requests"].metadata) == 1
-        assert deps["requests"].metadata[0].value == {"id": "CVE-1", "reached": []}
-
-    def test_register_cve_to_unknown_package(self):
-        deps = {"requests": DependencyEntry(name="requests", version="2.28.0")}
-        result = register_cve_metadata(deps, "flask", "CVE-1")
-        assert result is False
-
-    def test_register_then_hit(self):
-        deps = {"requests": DependencyEntry(name="requests", version="2.28.0", metadata=[])}
-        register_cve_metadata(deps, "requests", "CVE-1")
-        attach_reachability_metadata(deps, "requests", "CVE-1", "mod", "func", 10)
-        assert len(deps["requests"].metadata) == 1
-        assert len(deps["requests"].metadata[0].value["reached"]) == 1
-
-    def test_register_duplicate_is_idempotent(self):
-        deps = {"requests": DependencyEntry(name="requests", version="2.28.0", metadata=[])}
-        assert register_cve_metadata(deps, "requests", "CVE-1") is True
-        assert register_cve_metadata(deps, "requests", "CVE-1") is False
-        assert len(deps["requests"].metadata) == 1
-
-    def test_register_multiple_cves(self):
-        deps = {"requests": DependencyEntry(name="requests", version="2.28.0", metadata=[])}
-        register_cve_metadata(deps, "requests", "CVE-1")
-        register_cve_metadata(deps, "requests", "CVE-2")
-        assert len(deps["requests"].metadata) == 2
-        cve_ids = {m.value["id"] for m in deps["requests"].metadata}
-        assert cve_ids == {"CVE-1", "CVE-2"}
-
-
-def _make_writer_and_tracker(sca_enabled=False, deps=None, enabled=True):
-    """Shared factory for writer-level tests.
-
-    Sets appsec_telemetry_config.SCA_ENABLED so DependencyTracker reads the live
-    config flag.  Callers should use the _restore_sca_config fixture
-    (autouse in this module) to ensure cleanup.
-    """
-    from unittest.mock import MagicMock
-
-    from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
-    from ddtrace.internal.telemetry.writer import TelemetryWriter
-
-    appsec_telemetry_config.SCA_ENABLED = sca_enabled
-    writer = TelemetryWriter.__new__(TelemetryWriter)
-    writer._service_lock = MagicMock()
-    writer._enabled = enabled
-    tracker = DependencyTracker()
-    if deps:
-        tracker._imported_dependencies = deps
-    writer._dependency_tracker = tracker
-    return writer, tracker
-
-
-class TestWriterAttachDependencyMetadata:
-    """Writer-level tests for attach_dependency_metadata (via DependencyTracker)."""
-
-    def test_attach_metadata_to_tracked_dependency(self):
-        writer, tracker = _make_writer_and_tracker(
-            deps={"requests": DependencyEntry(name="requests", version="2.28.0")}
-        )
-
-        result = writer.attach_dependency_metadata("requests", "CVE-1", "mod", "func", 1)
-
-        assert result is True
-        entry = tracker._imported_dependencies["requests"]
-        assert len(entry.metadata) == 1
-        assert entry.metadata[0].value["id"] == "CVE-1"
-        assert len(entry.metadata[0].value["reached"]) == 1
-
-    def test_attach_returns_false_for_unknown_package(self):
-        writer, tracker = _make_writer_and_tracker(
-            deps={"requests": DependencyEntry(name="requests", version="2.28.0")}
-        )
-
-        result = writer.attach_dependency_metadata("flask", "CVE-1", "mod", "func", 1)
-
-        assert result is False
-        assert "flask" not in tracker._imported_dependencies
-
-    def test_attach_auto_creates_entry_when_sca_active(self):
-        """When SCA is active and package not tracked, auto-create the entry."""
-        from unittest.mock import patch
-
-        writer, tracker = _make_writer_and_tracker(sca_enabled=True)
-
-        with patch("importlib.metadata.version", return_value="2.28.0"):
-            result = writer.attach_dependency_metadata("requests", "CVE-1", "mod", "func", 1)
-
-        assert result is True
-        assert "requests" in tracker._imported_dependencies
-        entry = tracker._imported_dependencies["requests"]
-        assert entry.version == "2.28.0"
-        assert entry.metadata is not None
-        assert len(entry.metadata) == 1
-        assert entry.metadata[0].value["id"] == "CVE-1"
-
-    def test_attach_does_not_auto_create_when_sca_inactive(self):
-        """When SCA is not active, unknown packages return False."""
-        writer, tracker = _make_writer_and_tracker(sca_enabled=False)
-
-        result = writer.attach_dependency_metadata("requests", "CVE-1", "mod", "func", 1)
-
-        assert result is False
-        assert "requests" not in tracker._imported_dependencies
-
-
-class TestWriterEnableScaMetadata:
-    """Tests for enable_sca_metadata method (via DependencyTracker)."""
-
-    def test_enable_sca_metadata_sets_none_to_empty_list(self):
-        writer, tracker = _make_writer_and_tracker(
-            deps={
-                "requests": DependencyEntry(name="requests", version="2.28.0"),
-                "flask": DependencyEntry(name="flask", version="3.0.0"),
-            }
-        )
-        assert tracker._imported_dependencies["requests"].metadata is None
-        assert tracker._imported_dependencies["flask"].metadata is None
-
-        writer.enable_sca_metadata()
-
-        assert tracker._imported_dependencies["requests"].metadata == []
-        assert tracker._imported_dependencies["flask"].metadata == []
-
-    def test_enable_sca_metadata_preserves_existing_metadata(self):
-        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
-        entry.add_metadata("CVE-1")
-
-        writer, tracker = _make_writer_and_tracker(deps={"requests": entry})
-
-        writer.enable_sca_metadata()
-
-        # Should not overwrite existing metadata
-        assert len(tracker._imported_dependencies["requests"].metadata) == 1
-
-
-class TestWriterReReporting:
-    """Tests for _report_dependencies re-reporting behavior with metadata."""
-
-    def test_report_dependencies_rereports_on_new_metadata(self):
-        from unittest.mock import patch
-
-        writer, tracker = _make_writer_and_tracker(sca_enabled=True)
-
-        # Pre-populate with an already-reported dep (SCA active: metadata=[])
-        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
-        entry.mark_initial_sent()
-        tracker._imported_dependencies["requests"] = entry
-
-        # Attach metadata after initial report
-        writer.attach_dependency_metadata("requests", "CVE-1", "requests.sessions", "send", 10)
-
-        with (
-            patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
-            patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True),
-            patch.object(appsec_telemetry_config, "SCA_ENABLED", True),
-        ):
-            mock_modules.get_newly_imported_modules.return_value = set()
-
-            result = writer._report_dependencies()
-
-        assert result is not None
-        assert len(result) == 1
-        assert result[0]["name"] == "requests"
-        assert len(result[0]["metadata"]) == 1
-        parsed = json.loads(result[0]["metadata"][0]["value"])
-        assert parsed["id"] == "CVE-1"
-        assert isinstance(parsed["reached"], list)
-        assert len(parsed["reached"]) == 1
-
-        # Metadata should be marked as sent now
-        assert entry.has_unsent_metadata() is False
-
-    def test_report_dependencies_no_rereport_without_new_metadata(self):
-        from unittest.mock import patch
-
-        writer, tracker = _make_writer_and_tracker()
-
-        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
-        entry.mark_initial_sent()
-        tracker._imported_dependencies["requests"] = entry
-
-        with (
-            patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
-            patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True),
-            patch.object(appsec_telemetry_config, "SCA_ENABLED", False),
-        ):
-            mock_modules.get_newly_imported_modules.return_value = set()
-
-            result = writer._report_dependencies()
-
-        # No new deps, no new metadata -> None
-        assert result is None
-
-    def test_rereport_includes_all_metadata_per_rfc(self):
-        """Re-report includes ALL metadata (sent + unsent) per RFC."""
-        from unittest.mock import patch
-
-        writer, tracker = _make_writer_and_tracker(sca_enabled=True)
-
-        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
-        entry.mark_initial_sent()
-        tracker._imported_dependencies["requests"] = entry
-
-        # Attach first CVE and mark as sent
-        writer.attach_dependency_metadata("requests", "CVE-1", "mod.views", "func1", 33)
-        entry.mark_all_metadata_sent()
-
-        # Register second CVE (unsent, with reached=[])
-        writer.register_cve_metadata("requests", "CVE-2")
-
-        with (
-            patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
-            patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True),
-            patch.object(appsec_telemetry_config, "SCA_ENABLED", True),
-        ):
-            mock_modules.get_newly_imported_modules.return_value = set()
-
-            result = writer._report_dependencies()
-
-        assert result is not None
-        assert len(result) == 1
-        # Should include ALL metadata (both CVE-1 and CVE-2)
-        assert len(result[0]["metadata"]) == 2
-
-    def test_rereport_on_cve_registration(self):
-        """Registering CVEs after initial dep report triggers re-report with reached=[]."""
-        from unittest.mock import patch
-
-        writer, tracker = _make_writer_and_tracker(sca_enabled=True)
-
-        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
-        entry.mark_initial_sent()
-        entry.mark_all_metadata_sent()
-        tracker._imported_dependencies["requests"] = entry
-
-        # Register CVE (simulates CVE load at startup)
-        writer.register_cve_metadata("requests", "CVE-1")
-
-        with (
-            patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
-            patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True),
-            patch.object(appsec_telemetry_config, "SCA_ENABLED", True),
-        ):
-            mock_modules.get_newly_imported_modules.return_value = set()
-
-            result = writer._report_dependencies()
-
-        assert result is not None
-        assert len(result) == 1
-        assert result[0]["name"] == "requests"
-        assert len(result[0]["metadata"]) == 1
-        parsed = json.loads(result[0]["metadata"][0]["value"])
-        assert parsed["id"] == "CVE-1"
-        assert parsed["reached"] == []
-
-    def test_new_deps_without_sca_have_no_metadata_key(self):
-        """New deps created without SCA enabled have no metadata key."""
-        from unittest.mock import patch
-
-        writer, tracker = _make_writer_and_tracker()
-
-        with (
-            patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
-            patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True),
-            patch.object(appsec_telemetry_config, "SCA_ENABLED", False),
-            patch(
-                "ddtrace.internal.telemetry.dependency_tracker.get_module_distribution_versions",
-                return_value=("requests", "2.28.0"),
-            ),
-        ):
-            mock_modules.get_newly_imported_modules.return_value = {"requests"}
-
-            result = writer._report_dependencies()
-
-        assert result is not None
-        assert len(result) == 1
-        assert result[0]["name"] == "requests"
-        assert "metadata" not in result[0]
-
-
-class TestWriterRegisterCveMetadata:
-    """Writer-level tests for register_cve_metadata (via DependencyTracker)."""
-
-    def test_register_cve_auto_creates_entry_when_sca_active(self):
-        """register_cve_metadata auto-creates an entry when SCA is active and package untracked."""
-        from unittest.mock import patch
-
-        writer, tracker = _make_writer_and_tracker(sca_enabled=True)
-
-        with patch("importlib.metadata.version", return_value="1.0"):
-            result = writer.register_cve_metadata("flask", "CVE-NEW")
-
-        assert result is True
-        assert "flask" in tracker._imported_dependencies
-        entry = tracker._imported_dependencies["flask"]
-        assert entry.version == "1.0"
-        assert entry.metadata is not None
-        assert len(entry.metadata) == 1
-        assert entry.metadata[0].value == {"id": "CVE-NEW", "reached": []}
-
-    def test_register_cve_does_not_auto_create_when_sca_inactive(self):
-        writer, tracker = _make_writer_and_tracker(sca_enabled=False)
-        result = writer.register_cve_metadata("flask", "CVE-NEW")
-        assert result is False
-        assert "flask" not in tracker._imported_dependencies
-
-    def test_auto_create_with_version_lookup_failure(self):
-        """When importlib.metadata.version raises PackageNotFoundError, entry is created with version=""."""
-        from importlib.metadata import PackageNotFoundError
-        from unittest.mock import patch
-
-        writer, tracker = _make_writer_and_tracker(sca_enabled=True)
-
-        with patch(
-            "importlib.metadata.version",
-            side_effect=PackageNotFoundError("unknown-pkg"),
-        ):
-            result = writer.register_cve_metadata("unknown-pkg", "CVE-1")
-
-        assert result is True
-        assert tracker._imported_dependencies["unknown-pkg"].version == ""
 
 
 class TestNormalizeDepName:
@@ -617,62 +62,9 @@ class TestNormalizeDepName:
 
 
 class TestTrackerNameNormalization:
-    """Tests that DependencyTracker normalizes package names to avoid duplicates and lookup misses."""
-
-    def test_ensure_entry_no_duplicate_with_different_casing(self):
-        """_ensure_entry should not create a duplicate when the same package has different casing."""
-        from unittest.mock import patch
-
-        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
-
-        appsec_telemetry_config.SCA_ENABLED = True
-        tracker = DependencyTracker()
-
-        with patch("importlib.metadata.version", return_value="6.0"):
-            # Telemetry discovers "PyYAML" first
-            tracker._imported_dependencies["pyyaml"] = DependencyEntry(name="PyYAML", version="6.0", metadata=[])
-            # SCA tries to ensure "pyyaml" — should find the existing entry
-            with tracker._lock:
-                tracker._ensure_entry("pyyaml")
-
-        assert len(tracker._imported_dependencies) == 1
-
-    def test_attach_metadata_matches_differently_cased_key(self):
-        """attach_metadata with lowercase name should find an entry stored via telemetry discovery."""
-        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
-        from ddtrace.internal.telemetry.dependency_tracker import _normalize_dep_name
-
-        tracker = DependencyTracker()
-        # Simulate telemetry discovering "PyYAML" (stored under normalized key)
-        key = _normalize_dep_name("PyYAML")
-        tracker._imported_dependencies[key] = DependencyEntry(name="PyYAML", version="6.0", metadata=[])
-
-        # SCA attaches metadata using lowercase name from CVE data
-        result = tracker.attach_metadata("pyyaml", "CVE-2024-1234", "yaml.loader", "load", 10)
-
-        assert result is True
-        entry = tracker._imported_dependencies[key]
-        assert len(entry.metadata) == 1
-        assert entry.metadata[0].value["id"] == "CVE-2024-1234"
-
-    def test_register_cve_matches_differently_cased_key(self):
-        """register_cve with lowercase name should find an entry stored via telemetry discovery."""
-        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
-        from ddtrace.internal.telemetry.dependency_tracker import _normalize_dep_name
-
-        tracker = DependencyTracker()
-        key = _normalize_dep_name("PyYAML")
-        tracker._imported_dependencies[key] = DependencyEntry(name="PyYAML", version="6.0", metadata=[])
-
-        result = tracker.register_cve("pyyaml", "CVE-2024-5678")
-
-        assert result is True
-        entry = tracker._imported_dependencies[key]
-        assert len(entry.metadata) == 1
-        assert entry.metadata[0].value == {"id": "CVE-2024-5678", "reached": []}
+    """Tests that DependencyTracker normalizes package names for dependency collection."""
 
     def test_update_imported_dependencies_normalizes_keys(self):
-        """update_imported_dependencies should store entries under normalized keys."""
         from unittest.mock import patch
 
         from ddtrace.internal.telemetry.dependency_tracker import _normalize_dep_name
@@ -686,13 +78,12 @@ class TestTrackerNameNormalization:
             result = update_imported_dependencies(already_imported, ["yaml"])
 
         assert len(result) == 1
-        assert result[0]["name"] == "PyYAML"  # wire format preserves original name
+        assert result[0]["name"] == "PyYAML"
         normalized = _normalize_dep_name("PyYAML")
         assert normalized in already_imported
         assert already_imported[normalized].name == "PyYAML"
 
     def test_update_imported_dependencies_deduplicates_with_normalized_keys(self):
-        """A second module mapping to the same dist (different casing) should not create a duplicate."""
         from unittest.mock import patch
 
         from ddtrace.internal.telemetry.dependency_tracker import _normalize_dep_name
@@ -712,7 +103,6 @@ class TestTrackerNameNormalization:
         assert len(already_imported) == 1
 
     def test_update_imported_dependencies_swallows_per_module_exception(self):
-        """One bad module must not abort the whole batch or propagate to sys.excepthook."""
         from unittest.mock import patch
 
         from ddtrace.internal.telemetry.dependency_tracker import update_imported_dependencies
@@ -733,24 +123,7 @@ class TestTrackerNameNormalization:
         assert result[0]["name"] == "requests"
         assert "requests" in already_imported
 
-    def test_update_imported_dependencies_swallows_appsec_telemetry_config_failure(self):
-        """If reading AppSec telemetry config fails during shutdown, return [] without raising."""
-        from unittest.mock import patch
-
-        from ddtrace.internal.telemetry.dependency_tracker import update_imported_dependencies
-
-        class BrokenConfig:
-            @property
-            def SCA_ENABLED(self):
-                raise RuntimeError("config module torn down")
-
-        with patch("ddtrace.internal.telemetry.dependency_tracker.appsec_telemetry_config", BrokenConfig()):
-            result = update_imported_dependencies({}, ["requests"])
-
-        assert result == []
-
     def test_collect_report_marks_sent_with_normalized_lookup(self):
-        """collect_report should find entries by normalized key when marking as sent."""
         from unittest.mock import patch
 
         from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
@@ -775,14 +148,13 @@ class TestTrackerNameNormalization:
         assert len(result) == 1
         assert result[0]["name"] == "PyYAML"
 
-        # Entry should be stored under normalized key and marked as sent
         key = _normalize_dep_name("PyYAML")
         assert key in tracker._imported_dependencies
         assert tracker._imported_dependencies[key]._initial_report_sent is True
 
 
 class TestSnapshotForHeartbeat:
-    """Tests for DependencyTracker.snapshot_for_heartbeat — lock-protected extended-heartbeat payload."""
+    """Tests for generic dependency snapshots in extended heartbeats."""
 
     def test_empty_tracker_returns_empty_list(self):
         from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
@@ -795,72 +167,13 @@ class TestSnapshotForHeartbeat:
 
         tracker = DependencyTracker()
         tracker._imported_dependencies = {
-            "requests": DependencyEntry(name="requests", version="2.28.0", metadata=[]),
+            "requests": DependencyEntry(name="requests", version="2.28.0"),
             "flask": DependencyEntry(name="flask", version="3.0.0"),
         }
-        tracker._imported_dependencies["requests"].add_metadata("CVE-1", "mod", "func", 10)
 
         snapshot = tracker.snapshot_for_heartbeat()
 
-        assert len(snapshot) == 2
-        by_name = {d["name"]: d for d in snapshot}
-        assert by_name["requests"]["version"] == "2.28.0"
-        assert "metadata" in by_name["requests"]
-        assert len(by_name["requests"]["metadata"]) == 1
-        # flask has metadata=None -> no "metadata" key
-        assert "metadata" not in by_name["flask"]
-
-    def test_includes_already_sent_metadata(self):
-        """Extended heartbeat must re-send sent metadata (include_all_metadata=True)."""
-        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
-
-        entry = DependencyEntry(name="requests", version="2.28.0", metadata=[])
-        entry.add_metadata("CVE-1", "mod", "func", 10)
-        entry.mark_all_metadata_sent()
-
-        tracker = DependencyTracker()
-        tracker._imported_dependencies = {"requests": entry}
-
-        snapshot = tracker.snapshot_for_heartbeat()
-        assert len(snapshot[0]["metadata"]) == 1
-
-    def test_serialization_holds_lock_against_concurrent_mutation(self):
-        """Concurrent attach_metadata must not race iteration inside json.dumps.
-
-        Spawns a writer thread repeatedly adding CVEs to a tracked entry while the
-        heartbeat serializer builds snapshots. Without the lock, the writer thread
-        could append to ReachabilityMetadata.value["reached"] mid-serialization —
-        json.dumps on a list being mutated in another thread is not safe.
-        """
-        import threading
-
-        from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
-
-        appsec_telemetry_config.SCA_ENABLED = True
-        tracker = DependencyTracker()
-        tracker._imported_dependencies["requests"] = DependencyEntry(name="requests", version="2.28.0", metadata=[])
-
-        stop = threading.Event()
-        errors: list[BaseException] = []
-
-        def writer():
-            i = 0
-            while not stop.is_set():
-                try:
-                    tracker.attach_metadata("requests", f"CVE-{i}", "mod", "func", i)
-                    i += 1
-                except BaseException as exc:  # pragma: no cover — asserted below
-                    errors.append(exc)
-                    return
-
-        t = threading.Thread(target=writer, daemon=True)
-        t.start()
-        try:
-            for _ in range(200):
-                snapshot = tracker.snapshot_for_heartbeat()
-                assert snapshot and snapshot[0]["name"] == "requests"
-        finally:
-            stop.set()
-            t.join(timeout=2)
-
-        assert not errors, errors
+        assert snapshot == [
+            {"name": "requests", "version": "2.28.0"},
+            {"name": "flask", "version": "3.0.0"},
+        ]

--- a/tests/telemetry/test_dependency.py
+++ b/tests/telemetry/test_dependency.py
@@ -4,6 +4,8 @@ import json
 
 import pytest
 
+from ddtrace.internal.settings._telemetry import config as telemetry_config
+from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
 from ddtrace.internal.telemetry.dependency import DependencyEntry
 from ddtrace.internal.telemetry.dependency import ReachabilityMetadata
 from ddtrace.internal.telemetry.dependency import attach_reachability_metadata
@@ -12,12 +14,10 @@ from ddtrace.internal.telemetry.dependency import register_cve_metadata
 
 @pytest.fixture(autouse=True)
 def _restore_sca_config():
-    """Save and restore tracer_config._sca_enabled to prevent cross-test contamination."""
-    from ddtrace.internal.settings._config import config as tracer_config
-
-    saved = tracer_config._sca_enabled
+    """Save and restore appsec_telemetry_config.SCA_ENABLED to prevent cross-test contamination."""
+    saved = appsec_telemetry_config.SCA_ENABLED
     yield
-    tracer_config._sca_enabled = saved
+    appsec_telemetry_config.SCA_ENABLED = saved
 
 
 class TestReachabilityMetadata:
@@ -286,17 +286,16 @@ class TestRegisterCveMetadata:
 def _make_writer_and_tracker(sca_enabled=False, deps=None, enabled=True):
     """Shared factory for writer-level tests.
 
-    Sets tracer_config._sca_enabled so DependencyTracker reads the live
+    Sets appsec_telemetry_config.SCA_ENABLED so DependencyTracker reads the live
     config flag.  Callers should use the _restore_sca_config fixture
     (autouse in this module) to ensure cleanup.
     """
     from unittest.mock import MagicMock
 
-    from ddtrace.internal.settings._config import config as tracer_config
     from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
     from ddtrace.internal.telemetry.writer import TelemetryWriter
 
-    tracer_config._sca_enabled = sca_enabled
+    appsec_telemetry_config.SCA_ENABLED = sca_enabled
     writer = TelemetryWriter.__new__(TelemetryWriter)
     writer._service_lock = MagicMock()
     writer._enabled = enabled
@@ -408,9 +407,9 @@ class TestWriterReReporting:
 
         with (
             patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
-            patch("ddtrace.internal.telemetry.dependency_tracker.config") as mock_config,
+            patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True),
+            patch.object(appsec_telemetry_config, "SCA_ENABLED", True),
         ):
-            mock_config.DEPENDENCY_COLLECTION = True
             mock_modules.get_newly_imported_modules.return_value = set()
 
             result = writer._report_dependencies()
@@ -438,9 +437,9 @@ class TestWriterReReporting:
 
         with (
             patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
-            patch("ddtrace.internal.telemetry.dependency_tracker.config") as mock_config,
+            patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True),
+            patch.object(appsec_telemetry_config, "SCA_ENABLED", False),
         ):
-            mock_config.DEPENDENCY_COLLECTION = True
             mock_modules.get_newly_imported_modules.return_value = set()
 
             result = writer._report_dependencies()
@@ -467,9 +466,9 @@ class TestWriterReReporting:
 
         with (
             patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
-            patch("ddtrace.internal.telemetry.dependency_tracker.config") as mock_config,
+            patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True),
+            patch.object(appsec_telemetry_config, "SCA_ENABLED", True),
         ):
-            mock_config.DEPENDENCY_COLLECTION = True
             mock_modules.get_newly_imported_modules.return_value = set()
 
             result = writer._report_dependencies()
@@ -495,9 +494,9 @@ class TestWriterReReporting:
 
         with (
             patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
-            patch("ddtrace.internal.telemetry.dependency_tracker.config") as mock_config,
+            patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True),
+            patch.object(appsec_telemetry_config, "SCA_ENABLED", True),
         ):
-            mock_config.DEPENDENCY_COLLECTION = True
             mock_modules.get_newly_imported_modules.return_value = set()
 
             result = writer._report_dependencies()
@@ -518,13 +517,13 @@ class TestWriterReReporting:
 
         with (
             patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
-            patch("ddtrace.internal.telemetry.dependency_tracker.config") as mock_config,
+            patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True),
+            patch.object(appsec_telemetry_config, "SCA_ENABLED", False),
             patch(
                 "ddtrace.internal.telemetry.dependency_tracker.get_module_distribution_versions",
                 return_value=("requests", "2.28.0"),
             ),
         ):
-            mock_config.DEPENDENCY_COLLECTION = True
             mock_modules.get_newly_imported_modules.return_value = {"requests"}
 
             result = writer._report_dependencies()
@@ -624,10 +623,9 @@ class TestTrackerNameNormalization:
         """_ensure_entry should not create a duplicate when the same package has different casing."""
         from unittest.mock import patch
 
-        from ddtrace.internal.settings._config import config as tracer_config
         from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
 
-        tracer_config._sca_enabled = True
+        appsec_telemetry_config.SCA_ENABLED = True
         tracker = DependencyTracker()
 
         with patch("importlib.metadata.version", return_value="6.0"):
@@ -735,32 +733,18 @@ class TestTrackerNameNormalization:
         assert result[0]["name"] == "requests"
         assert "requests" in already_imported
 
-    def test_update_imported_dependencies_swallows_tracer_config_failure(self):
-        """If reading tracer_config fails (e.g. during shutdown), return [] without raising."""
+    def test_update_imported_dependencies_swallows_appsec_telemetry_config_failure(self):
+        """If reading AppSec telemetry config fails during shutdown, return [] without raising."""
         from unittest.mock import patch
 
         from ddtrace.internal.telemetry.dependency_tracker import update_imported_dependencies
 
         class BrokenConfig:
             @property
-            def _sca_enabled(self):
+            def SCA_ENABLED(self):
                 raise RuntimeError("config module torn down")
 
-        with patch("ddtrace.internal.settings._config.config", BrokenConfig()):
-            result = update_imported_dependencies({}, ["requests"])
-
-        assert result == []
-
-    def test_update_imported_dependencies_swallows_tracer_config_import_failure(self):
-        """If the tracer_config import itself fails (e.g. sys.modules torn down), return [] without raising."""
-        import sys
-        from unittest.mock import patch
-
-        from ddtrace.internal.telemetry.dependency_tracker import update_imported_dependencies
-
-        broken_module = type(sys)("ddtrace.internal.settings._config")
-
-        with patch.dict(sys.modules, {"ddtrace.internal.settings._config": broken_module}):
+        with patch("ddtrace.internal.telemetry.dependency_tracker.appsec_telemetry_config", BrokenConfig()):
             result = update_imported_dependencies({}, ["requests"])
 
         assert result == []
@@ -776,13 +760,13 @@ class TestTrackerNameNormalization:
 
         with (
             patch("ddtrace.internal.telemetry.dependency_tracker.modules") as mock_modules,
-            patch("ddtrace.internal.telemetry.dependency_tracker.config") as mock_config,
+            patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True),
+            patch.object(appsec_telemetry_config, "SCA_ENABLED", False),
             patch(
                 "ddtrace.internal.telemetry.dependency_tracker.get_module_distribution_versions",
                 return_value=("PyYAML", "6.0"),
             ),
         ):
-            mock_config.DEPENDENCY_COLLECTION = True
             mock_modules.get_newly_imported_modules.return_value = {"yaml"}
 
             result = tracker.collect_report()
@@ -850,10 +834,9 @@ class TestSnapshotForHeartbeat:
         """
         import threading
 
-        from ddtrace.internal.settings._config import config as tracer_config
         from ddtrace.internal.telemetry.dependency_tracker import DependencyTracker
 
-        tracer_config._sca_enabled = True
+        appsec_telemetry_config.SCA_ENABLED = True
         tracker = DependencyTracker()
         tracker._imported_dependencies["requests"] = DependencyEntry(name="requests", version="2.28.0", metadata=[])
 

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -1,10 +1,6 @@
 import os
-import sys
-from types import ModuleType
 
 import pytest
-
-from ddtrace.internal.telemetry import telemetry_writer
 
 
 def test_enable(test_agent_session, run_python_code_in_subprocess):
@@ -24,11 +20,13 @@ assert telemetry_writer._worker is not None
     assert stderr == b""
 
 
-def test_report_endpoints_while_asm_config_is_initializing(monkeypatch):
-    initializing_asm = ModuleType("ddtrace.internal.settings.asm")
-    monkeypatch.setitem(sys.modules, initializing_asm.__name__, initializing_asm)
+def test_enable_with_short_heartbeat_does_not_race_imports(test_agent_session, run_python_code_in_subprocess):
+    env = os.environ.copy()
+    env["DD_TELEMETRY_HEARTBEAT_INTERVAL"] = "0.00001"
 
-    assert telemetry_writer._report_endpoints() is None
+    _, stderr, status, _ = run_python_code_in_subprocess("import ddtrace", env=env)
+
+    assert status == 0, stderr
 
 
 def test_enable_fork(test_agent_session, run_python_code_in_subprocess):

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -7,7 +7,6 @@ from unittest import mock
 
 import pytest
 
-import ddtrace
 from ddtrace._trace._span_link import SpanLink
 from ddtrace._trace.span import _get_64_lowest_order_bits_as_int
 from ddtrace.appsec._trace_utils import _asm_manual_keep
@@ -27,6 +26,7 @@ from ddtrace.internal.constants import PROPAGATION_STYLE_B3_MULTI
 from ddtrace.internal.constants import PROPAGATION_STYLE_B3_SINGLE
 from ddtrace.internal.constants import PROPAGATION_STYLE_DATADOG
 from ddtrace.internal.constants import W3C_TRACESTATE_KEY
+from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
 from ddtrace.propagation._utils import get_wsgi_header
 from ddtrace.propagation.http import _HTTP_BAGGAGE_PREFIX
 from ddtrace.propagation.http import _HTTP_HEADER_B3_FLAGS
@@ -52,7 +52,6 @@ from tests.contrib.fastapi.conftest import fastapi_application  # noqa:F401
 from tests.contrib.fastapi.conftest import fastapi_tracer as fastapi_tracer  # noqa:F401
 from tests.contrib.fastapi.conftest import test_spans as fastapi_test_spans  # noqa:F401
 
-from ..utils import override_env
 from ..utils import override_global_config
 
 
@@ -307,9 +306,7 @@ def test_asm_standalone_minimum_trace_per_minute_has_no_downstream_propagation(
     if not appsec_enabled and not iast_enabled and sca_enabled == "false":
         pytest.skip("SCA, AppSec or IAST must be enabled")
 
-    with override_env({"DD_APPSEC_SCA_ENABLED": sca_enabled}):
-        ddtrace.config._reset()
-
+    with mock.patch.object(appsec_telemetry_config, "SCA_ENABLED", sca_enabled == "true"):
         tracer.configure(appsec_enabled=appsec_enabled, apm_tracing_disabled=True, iast_enabled=iast_enabled)
         try:
             headers = {
@@ -351,8 +348,7 @@ def test_asm_standalone_minimum_trace_per_minute_has_no_downstream_propagation(
             assert span._get_numeric_attribute("_sampling_priority_v1") == AUTO_KEEP
 
         finally:
-            with override_env({"DD_APPSEC_SCA_ENABLED": "0"}):
-                ddtrace.config._reset()
+            with mock.patch.object(appsec_telemetry_config, "SCA_ENABLED", False):
                 tracer.configure(appsec_enabled=False, apm_tracing_disabled=False, iast_enabled=False)
 
 
@@ -368,9 +364,7 @@ def test_asm_standalone_missing_propagation_tags_no_appsec_event_trace_dropped(
     if not appsec_enabled and not iast_enabled and sca_enabled == "false":
         pytest.skip("SCA, AppSec or IAST must be enabled")
 
-    with override_env({"DD_APPSEC_SCA_ENABLED": sca_enabled}):
-        ddtrace.config._reset()
-
+    with mock.patch.object(appsec_telemetry_config, "SCA_ENABLED", sca_enabled == "true"):
         tracer.configure(appsec_enabled=appsec_enabled, apm_tracing_disabled=True, iast_enabled=iast_enabled)
         try:
             with tracer.trace("local_root_span0"):
@@ -399,8 +393,7 @@ def test_asm_standalone_missing_propagation_tags_no_appsec_event_trace_dropped(
             # Ensure span is dropped (no appsec event upstream or in this span)
             assert span._get_numeric_attribute("_sampling_priority_v1") == AUTO_REJECT
         finally:
-            with override_env({"DD_APPSEC_SCA_ENABLED": "0"}):
-                ddtrace.config._reset()
+            with mock.patch.object(appsec_telemetry_config, "SCA_ENABLED", False):
                 tracer.configure(appsec_enabled=False, apm_tracing_disabled=False, iast_enabled=False)
 
 
@@ -450,8 +443,7 @@ def test_asm_standalone_missing_appsec_tag_no_appsec_event_propagation_resets(
     if not appsec_enabled and not iast_enabled and sca_enabled == "false":
         pytest.skip("SCA, AppSec or IAST must be enabled")
 
-    with override_env({"DD_APPSEC_SCA_ENABLED": sca_enabled}):
-        ddtrace.config._reset()
+    with mock.patch.object(appsec_telemetry_config, "SCA_ENABLED", sca_enabled == "true"):
         tracer.configure(appsec_enabled=appsec_enabled, apm_tracing_disabled=True, iast_enabled=iast_enabled)
         try:
             with tracer.trace("local_root_span0"):
@@ -495,8 +487,7 @@ def test_asm_standalone_missing_appsec_tag_no_appsec_event_propagation_resets(
             # As we have a rate limiter, priorities used are AUTO_KEEP and AUTO_REJECT
             assert span._get_numeric_attribute("_sampling_priority_v1") == AUTO_REJECT
         finally:
-            with override_env({"DD_APPSEC_SCA_ENABLED": "false"}):
-                ddtrace.config._reset()
+            with mock.patch.object(appsec_telemetry_config, "SCA_ENABLED", False):
                 tracer.configure(appsec_enabled=False, apm_tracing_disabled=False, iast_enabled=False)
 
 
@@ -562,8 +553,7 @@ def test_asm_standalone_present_appsec_tag_no_appsec_event_propagation_set_to_us
     if not appsec_enabled and not iast_enabled and sca_enabled == "false":
         pytest.skip("SCA, AppSec or IAST must be enabled")
 
-    with override_env({"DD_APPSEC_SCA_ENABLED": sca_enabled}):
-        ddtrace.config._reset()
+    with mock.patch.object(appsec_telemetry_config, "SCA_ENABLED", sca_enabled == "true"):
         tracer.configure(appsec_enabled=appsec_enabled, apm_tracing_disabled=True, iast_enabled=iast_enabled)
         try:
             with tracer.trace("local_root_span0"):
@@ -615,8 +605,7 @@ def test_asm_standalone_present_appsec_tag_no_appsec_event_propagation_set_to_us
             assert span._get_numeric_attribute("_sampling_priority_v1") == USER_KEEP
 
         finally:
-            with override_env({"DD_APPSEC_SCA_ENABLED": sca_enabled}):
-                ddtrace.config._reset()
+            with mock.patch.object(appsec_telemetry_config, "SCA_ENABLED", sca_enabled == "true"):
                 tracer.configure(appsec_enabled=False, apm_tracing_disabled=False, iast_enabled=False)
 
 
@@ -634,8 +623,7 @@ def test_asm_standalone_present_appsec_tag_appsec_event_present_propagation_forc
     if not appsec_enabled and not iast_enabled and sca_enabled == "false":
         pytest.skip("SCA, AppSec or IAST must be enabled")
 
-    with override_env({"DD_APPSEC_SCA_ENABLED": sca_enabled}):
-        ddtrace.config._reset()
+    with mock.patch.object(appsec_telemetry_config, "SCA_ENABLED", sca_enabled == "true"):
         tracer.configure(appsec_enabled=appsec_enabled, apm_tracing_disabled=True, iast_enabled=iast_enabled)
         try:
             with tracer.trace("local_root_span0"):
@@ -688,8 +676,7 @@ def test_asm_standalone_present_appsec_tag_appsec_event_present_propagation_forc
             assert span._get_numeric_attribute("_sampling_priority_v1") == USER_KEEP  # user keep always
 
         finally:
-            with override_env({"DD_APPSEC_SCA_ENABLED": sca_enabled}):
-                ddtrace.config._reset()
+            with mock.patch.object(appsec_telemetry_config, "SCA_ENABLED", sca_enabled == "true"):
                 tracer.configure(appsec_enabled=False, apm_tracing_disabled=False, iast_enabled=False)
 
 

--- a/tests/tracer/test_tracer_appsec.py
+++ b/tests/tracer/test_tracer_appsec.py
@@ -1,6 +1,7 @@
+from unittest import mock
+
 import pytest
 
-import ddtrace
 from ddtrace._trace.processor import SpanAggregator
 from ddtrace._trace.processor import TraceProcessor
 from ddtrace._trace.sampler import RateSampler
@@ -11,12 +12,12 @@ from ddtrace.ext import http
 from ddtrace.ext import net
 from ddtrace.internal.rate_limiter import RateLimiter
 from ddtrace.internal.settings._config import Config
+from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
 from ddtrace.internal.settings.integration import IntegrationConfig
 from ddtrace.internal.writer import NativeWriter
 from ddtrace.trace import Span
 from ddtrace.trace import Tracer
 from tests.appsec.utils import asm_context
-from tests.utils import override_env
 
 
 class DummyProcessor(TraceProcessor):
@@ -203,8 +204,7 @@ def test_asm_standalone_ignores_agent_based_samplers(tracer: Tracer):
     In ASM standalone mode, agent-based samplers should not interfere
     with the rate limiter.
     """
-    with override_env({"DD_APPSEC_SCA_ENABLED": "true"}):
-        ddtrace.config._reset()
+    with mock.patch.object(appsec_telemetry_config, "SCA_ENABLED", True):
         tracer.configure(appsec_enabled=True, apm_tracing_disabled=True)
 
         try:
@@ -223,8 +223,7 @@ def test_asm_standalone_ignores_agent_based_samplers(tracer: Tracer):
             )
 
         finally:
-            with override_env({"DD_APPSEC_SCA_ENABLED": "false"}):
-                ddtrace.config._reset()
+            with mock.patch.object(appsec_telemetry_config, "SCA_ENABLED", False):
                 tracer.configure(appsec_enabled=False, apm_tracing_disabled=False)
 
 
@@ -235,11 +234,10 @@ def test_asm_standalone_configuration(sca_enabled, appsec_enabled, iast_enabled,
     if not appsec_enabled and not iast_enabled and sca_enabled == "false":
         pytest.skip("SCA, AppSec or IAST must be enabled")
 
-    with override_env({"DD_APPSEC_SCA_ENABLED": sca_enabled}):
-        ddtrace.config._reset()
+    with mock.patch.object(appsec_telemetry_config, "SCA_ENABLED", sca_enabled == "true"):
         tracer.configure(appsec_enabled=appsec_enabled, iast_enabled=iast_enabled, apm_tracing_disabled=True)
         if sca_enabled == "true":
-            assert bool(ddtrace.config._sca_enabled) is True
+            assert appsec_telemetry_config.SCA_ENABLED is True
         assert tracer.enabled is False
 
         assert isinstance(tracer._sampler.limiter, RateLimiter)
@@ -249,6 +247,5 @@ def test_asm_standalone_configuration(sca_enabled, appsec_enabled, iast_enabled,
         assert tracer._span_aggregator.sampling_processor._compute_stats_enabled is False
 
     # reset tracer values
-    with override_env({"DD_APPSEC_SCA_ENABLED": "false"}):
-        ddtrace.config._reset()
+    with mock.patch.object(appsec_telemetry_config, "SCA_ENABLED", False):
         tracer.configure(appsec_enabled=False, iast_enabled=False, apm_tracing_disabled=False)


### PR DESCRIPTION
APPSEC-69212

## Description

Telemetry dependency and endpoint collection imported the global tracer and ASM configuration objects. Because the telemetry worker starts during tracer initialization, those imports created circular dependencies and could race with partially initialized settings modules.

This change moves `DD_APPSEC_SCA_ENABLED`, `DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED`, and `DD_API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT` into a dedicated AppSec-owned `DDConfig` module: `ddtrace.internal.settings.appsec_telemetry`.

SCA, telemetry, Flask, and Django consumers now read from that leaf configuration module. The environment variables, defaults, and telemetry configuration names remain unchanged.

## Testing

- Import-cycle analysis: 37 cycles on `origin/main`, 33 on this branch; 4 removed and 0 introduced
- Telemetry focused tests: 78 passed
- SCA suite: 75 passed
- ASM standalone tests: 24 passed
- Tracer ASM standalone tests: 59 passed, 8 skipped
- `scripts/lint checks`
- `git diff --check origin/main`

## Risks

Low. The moved settings are internal, and their environment-variable contracts and defaults are preserved. Focused tests cover SCA behavior, standalone ASM behavior, endpoint reporting, and startup import races.

## Additional Notes

- Adds explicit AppSec ownership for the new settings module in `.github/CODEOWNERS`.
- No public API change; the existing `changelog/no-changelog` label remains appropriate.
