### PR TITLE
chore(iast): preserve propagation during source suppression [backport 4.11]

### DIFF
--- a/ddtrace/appsec/_iast/_iast_request_context_base.py
+++ b/ddtrace/appsec/_iast/_iast_request_context_base.py
@@ -1,3 +1,4 @@
+import contextlib
 import contextvars
 from typing import Optional
 

--- a/ddtrace/appsec/_iast/_iast_request_context_base.py
+++ b/ddtrace/appsec/_iast/_iast_request_context_base.py
@@ -21,6 +21,27 @@ log = get_logger(__name__)
 
 IAST_CONTEXT: contextvars.ContextVar[Optional[int]] = contextvars.ContextVar("iast_var", default=None)
 
+# Keep source suppression separate from IAST_CONTEXT. Clearing the
+# request context id disables request-scoped taint queries and propagation and
+# can send no-context queries through unsafe native fallback paths.
+_IAST_TAINT_SOURCES_SUPPRESSED: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "iast_taint_sources_suppressed", default=False
+)
+
+
+@contextlib.contextmanager
+def iast_suppress_context():
+    """Temporarily disable IAST taint *source* generation for the current context."""
+    token = _IAST_TAINT_SOURCES_SUPPRESSED.set(True)
+    try:
+        yield
+    finally:
+        _IAST_TAINT_SOURCES_SUPPRESSED.reset(token)
+
+
+def _is_iast_taint_source_enabled() -> bool:
+    return not _IAST_TAINT_SOURCES_SUPPRESSED.get()
+
 
 def _set_span_tag_iast_request_tainted(span):
     total_objects_tainted = _num_objects_tainted_in_request()

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -28,8 +28,12 @@ from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import OriginTy
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import Source  # noqa: F401
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import TagMappingMode  # noqa: F401
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import VulnerabilityType  # noqa: F401
-from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import copy_and_shift_ranges_from_strings  # noqa: F401
-from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import copy_ranges_from_strings  # noqa: F401
+from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import (
+    copy_and_shift_ranges_from_strings as _native_copy_and_shift_ranges_from_strings,
+)
+from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import (
+    copy_ranges_from_strings as _native_copy_ranges_from_strings,
+)
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import get_range_by_hash  # noqa: F401
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import get_ranges as _native_get_ranges
 from ddtrace.appsec._iast._taint_tracking._native.taint_tracking import is_tainted  # noqa: F401
@@ -51,6 +55,15 @@ log = get_logger(__name__)
 _CACHE_GET_IAST_CONTEXT_ID = None
 
 
+def _current_iast_context_id() -> Optional[int]:
+    global _CACHE_GET_IAST_CONTEXT_ID
+    if _CACHE_GET_IAST_CONTEXT_ID is None:
+        from ddtrace.appsec._iast._iast_request_context_base import _get_iast_context_id
+
+        _CACHE_GET_IAST_CONTEXT_ID = _get_iast_context_id
+    return _CACHE_GET_IAST_CONTEXT_ID()
+
+
 def get_ranges(string_input: Any, context_id: Optional[int] = None) -> Any:
     if context_id is None:
         global _CACHE_GET_IAST_CONTEXT_ID
@@ -59,7 +72,26 @@ def get_ranges(string_input: Any, context_id: Optional[int] = None) -> Any:
 
             _CACHE_GET_IAST_CONTEXT_ID = _get_iast_context_id
         context_id = _CACHE_GET_IAST_CONTEXT_ID()
+    if context_id is None:
+        return []
     return _native_get_ranges(string_input, context_id)
+
+
+def copy_ranges_from_strings(str_1: Any, str_2: Any, context_id: Optional[int] = None) -> None:
+    # AIDEV-NOTE: scope the copy to the active request slot to match the scoped
+    # get_ranges() read path; otherwise the native multi-slot resolver may write
+    # the derived taint into a concurrent request's map and the scoped read misses it.
+    if context_id is None:
+        context_id = _current_iast_context_id()
+    _native_copy_ranges_from_strings(str_1, str_2, context_id)
+
+
+def copy_and_shift_ranges_from_strings(
+    str_1: Any, str_2: Any, offset: int, new_length: int = -1, context_id: Optional[int] = None
+) -> None:
+    if context_id is None:
+        context_id = _current_iast_context_id()
+    _native_copy_and_shift_ranges_from_strings(str_1, str_2, offset, new_length, context_id)
 
 
 __all__ = [

--- a/ddtrace/appsec/_iast/_taint_tracking/_taint_objects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/_taint_objects.py
@@ -5,6 +5,7 @@ from typing import Sequence
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._constants import IAST_SPAN_TAGS
 from ddtrace.appsec._iast._iast_request_context_base import _get_iast_context_id
+from ddtrace.appsec._iast._iast_request_context_base import _is_iast_taint_source_enabled
 from ddtrace.appsec._iast._logs import iast_propagation_debug_log
 from ddtrace.appsec._iast._metrics import _set_metric_iast_executed_source
 from ddtrace.appsec._iast._span_metrics import increment_iast_span_metric
@@ -20,7 +21,7 @@ log = get_logger(__name__)
 
 def taint_pyobject(pyobject: Any, source_name: Any, source_value: Any, source_origin=None) -> Any:
     try:
-        if (contextid := _get_iast_context_id()) is not None:
+        if (contextid := _get_iast_context_id()) is not None and _is_iast_taint_source_enabled():
             if source_origin is None:
                 source_origin = OriginType.PARAMETER
             res = _taint_pyobject_base(pyobject, source_name, source_value, source_origin, contextid)

--- a/ddtrace/appsec/_iast/_taint_tracking/_taint_objects_base.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/_taint_objects_base.py
@@ -2,7 +2,6 @@ from typing import Any
 
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast._iast_request_context_base import _get_iast_context_id
-from ddtrace.appsec._iast._iast_request_context_base import is_iast_request_enabled
 from ddtrace.appsec._iast._logs import iast_propagation_debug_log
 from ddtrace.appsec._iast._logs import iast_propagation_error_log
 from ddtrace.appsec._iast._taint_tracking import OriginType
@@ -65,23 +64,28 @@ def _taint_pyobject_base(pyobject: Any, source_name: Any, source_value: Any, sou
 
 
 def get_tainted_ranges(pyobject: Any) -> tuple:
-    if not is_iast_request_enabled():
+    context_id = _get_iast_context_id()
+    if context_id is None:
         return tuple()
     if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
         return tuple()
     try:
-        return get_ranges(pyobject, _get_iast_context_id())
+        return get_ranges(pyobject, context_id)
     except ValueError as e:
         iast_propagation_error_log(f"get_tainted_ranges error (pyobject type {type(pyobject)})", exc=e)
     return tuple()
 
 
 def is_pyobject_tainted(pyobject: Any) -> bool:
+    context_id = _get_iast_context_id()
+    if context_id is None:
+        return False
+
     if not isinstance(pyobject, IAST.TAINTEABLE_TYPES):
         return False
 
     try:
-        return is_in_taint_map(pyobject, _get_iast_context_id())
+        return is_in_taint_map(pyobject, context_id)
     except ValueError as e:
         iast_propagation_error_log("Checking tainted object error", exc=e)
     return False

--- a/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/taint_range.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/taint_range.cpp
@@ -291,13 +291,18 @@ api_get_ranges(const py::handle& string_input, std::optional<size_t> context_id)
 }
 
 void
-api_copy_ranges_from_strings(py::handle& str_1, py::handle& str_2)
+api_copy_ranges_from_strings(py::handle& str_1, py::handle& str_2, std::optional<size_t> context_id)
 {
     if (!taint_engine_context) {
         return;
     }
 
-    const auto tx_map = safe_get_tainted_object_map(str_1.ptr());
+    // With a context_id both the source read and the derived write are pinned
+    // to the active request's slot, matching the scoped get_ranges() read path
+    // so a concurrent request's stale entry cannot capture the copy. Without a
+    // context_id the multi-slot resolver locates the map that owns the source.
+    const auto tx_map = context_id.has_value() ? safe_get_tainted_object_map_by_ctx_id(*context_id)
+                                               : safe_get_tainted_object_map(str_1.ptr());
 
     if (not tx_map) {
         py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
@@ -318,13 +323,17 @@ inline void
 api_copy_and_shift_ranges_from_strings(py::handle& str_1,
                                        py::handle& str_2,
                                        const int offset,
-                                       const int new_length = -1)
+                                       const int new_length,
+                                       std::optional<size_t> context_id)
 {
     if (!taint_engine_context) {
         return;
     }
 
-    const auto tx_map = safe_get_tainted_object_map(str_1.ptr());
+    // See api_copy_ranges_from_strings: context_id scopes both read and write to
+    // the active slot to keep parity with the scoped get_ranges() read path.
+    const auto tx_map = context_id.has_value() ? safe_get_tainted_object_map_by_ctx_id(*context_id)
+                                               : safe_get_tainted_object_map(str_1.ptr());
     if (not tx_map) {
         py::set_error(PyExc_ValueError, MSG_ERROR_TAINT_MAP);
         return;
@@ -452,13 +461,15 @@ pyexport_taintrange(py::module& m)
 
     // m.def("set_ranges", py::overload_cast<PyObject*, const TaintRangeRefs&>(&api_set_ranges), "str"_a, "ranges"_a);
     m.def("set_ranges", &api_set_ranges, "str"_a, "ranges"_a, "contextid"_a);
-    m.def("copy_ranges_from_strings", &api_copy_ranges_from_strings, "str_1"_a, "str_2"_a);
+    m.def(
+      "copy_ranges_from_strings", &api_copy_ranges_from_strings, "str_1"_a, "str_2"_a, "context_id"_a = std::nullopt);
     m.def("copy_and_shift_ranges_from_strings",
           &api_copy_and_shift_ranges_from_strings,
           "str_1"_a,
           "str_2"_a,
           "offset"_a,
-          "new_length"_a = -1);
+          "new_length"_a = -1,
+          "context_id"_a = std::nullopt);
 
     m.def("get_ranges",
           &api_get_ranges,

--- a/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/taint_range.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/taint_range.h
@@ -152,10 +152,14 @@ TaintRangeRefs
 api_get_ranges(const py::handle& string_input, std::optional<size_t> context_id = std::nullopt);
 
 void
-api_copy_ranges_from_strings(py::handle& str_1, py::handle& str_2);
+api_copy_ranges_from_strings(py::handle& str_1, py::handle& str_2, std::optional<size_t> context_id = std::nullopt);
 
 inline void
-api_copy_and_shift_ranges_from_strings(py::handle& str_1, py::handle& str_2, int offset, int new_length);
+api_copy_and_shift_ranges_from_strings(py::handle& str_1,
+                                       py::handle& str_2,
+                                       int offset,
+                                       int new_length = -1,
+                                       std::optional<size_t> context_id = std::nullopt);
 
 PyObject*
 api_taint_pyobject(PyObject* self, PyObject* const* args, const Py_ssize_t nargs);

--- a/releasenotes/notes/fix-iast-scope-copy-ranges-to-active-slot-a1b2c3d4e5f60789.yaml
+++ b/releasenotes/notes/fix-iast-scope-copy-ranges-to-active-slot-a1b2c3d4e5f60789.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Code Security (IAST): This fix scopes ``copy_ranges_from_strings`` and
+    ``copy_and_shift_ranges_from_strings`` to the active request slot, matching the
+    scoped taint read path. Previously these copy helpers resolved the taint map by
+    scanning all request slots, so a concurrent or still-open request could capture the
+    derived taint and the current request would miss the transformed tainted input.

--- a/releasenotes/notes/iast-fix-crash-taint-query-without-context-b3d9f1c47a2e08d6.yaml
+++ b/releasenotes/notes/iast-fix-crash-taint-query-without-context-b3d9f1c47a2e08d6.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    IAST: A crash occurring when using ``uvloop`` has been fixed.
+

--- a/tests/appsec/iast/taint_tracking/test_context.py
+++ b/tests/appsec/iast/taint_tracking/test_context.py
@@ -1,3 +1,6 @@
+import gc
+
+from ddtrace.appsec._iast._iast_env import in_iast_env
 from ddtrace.appsec._iast._iast_request_context_base import IAST_CONTEXT
 from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request
 from ddtrace.appsec._iast._iast_request_context_base import _num_objects_tainted_in_request
@@ -228,4 +231,153 @@ def test_get_ranges_public_api_does_not_leak_across_request_slots():
 
     finish_request_context(ctx_a)
     finish_request_context(ctx_b)
+    IAST_CONTEXT.set(None)
+
+
+def test_copy_ranges_from_strings_writes_to_active_slot_not_earlier_slot():
+    """copy_ranges_from_strings must write the derived taint into the active slot.
+
+    Regression: the native multi-slot resolver picks the first slot holding the
+    source id, so with a stale entry in an earlier slot the derived taint was
+    written there and the scoped get_ranges() read from the active slot missed it.
+    """
+    from ddtrace.appsec._iast._taint_tracking import copy_ranges_from_strings
+    from ddtrace.appsec._iast._taint_tracking import get_ranges
+    from ddtrace.appsec._iast._taint_tracking import set_ranges
+
+    clear_all_request_context_slots()
+    _end_iast_context_and_oce()
+
+    ctx_a = start_request_context()
+    ctx_b = start_request_context()
+    assert ctx_a is not None and ctx_b is not None and ctx_a != ctx_b
+
+    # The same source object lives in both slots, with ctx_a being the earlier slot.
+    shared = _taint_pyobject_base("SECRET", "p", "SECRET", OriginType.PARAMETER, contextid=ctx_a)
+    ranges_a = get_ranges(shared, ctx_a)
+    assert len(ranges_a) > 0
+    set_ranges(shared, ranges_a, ctx_b)
+    assert len(get_ranges(shared, ctx_b)) > 0
+
+    # Active request is the later slot ctx_b.
+    IAST_CONTEXT.set(ctx_b)
+    derived = "X" + shared  # a fresh, otherwise-untracked object
+    copy_ranges_from_strings(shared, derived)
+
+    # The derived taint must be visible from the active slot's scoped read.
+    assert len(get_ranges(derived, ctx_b)) > 0
+
+    finish_request_context(ctx_a)
+    finish_request_context(ctx_b)
+    IAST_CONTEXT.set(None)
+
+
+def test_copy_and_shift_ranges_from_strings_writes_to_active_slot_not_earlier_slot():
+    """copy_and_shift_ranges_from_strings must also be scoped to the active slot."""
+    from ddtrace.appsec._iast._taint_tracking import copy_and_shift_ranges_from_strings
+    from ddtrace.appsec._iast._taint_tracking import get_ranges
+    from ddtrace.appsec._iast._taint_tracking import set_ranges
+
+    clear_all_request_context_slots()
+    _end_iast_context_and_oce()
+
+    ctx_a = start_request_context()
+    ctx_b = start_request_context()
+    assert ctx_a is not None and ctx_b is not None and ctx_a != ctx_b
+
+    shared = _taint_pyobject_base("SECRET", "p", "SECRET", OriginType.PARAMETER, contextid=ctx_a)
+    ranges_a = get_ranges(shared, ctx_a)
+    assert len(ranges_a) > 0
+    set_ranges(shared, ranges_a, ctx_b)
+    assert len(get_ranges(shared, ctx_b)) > 0
+
+    IAST_CONTEXT.set(ctx_b)
+    derived = "X" + shared
+    copy_and_shift_ranges_from_strings(shared, derived, 1, len(derived))
+
+    assert len(get_ranges(derived, ctx_b)) > 0
+
+    finish_request_context(ctx_a)
+    finish_request_context(ctx_b)
+    IAST_CONTEXT.set(None)
+
+
+def test_is_pyobject_tainted_without_context_does_not_consult_native():
+    """Regression for a teardown/GC crash (#18996).
+
+    With no active request context the query must return False without
+    entering native code.
+    """
+    clear_all_request_context_slots()
+    _end_iast_context_and_oce()
+
+    ctx = start_request_context()
+    assert ctx is not None
+    tainted = _taint_pyobject_base(
+        "http://dummy.location.com",
+        "location",
+        "http://dummy.location.com",
+        OriginType.PARAMETER,
+        contextid=ctx,
+    )
+    IAST_CONTEXT.set(ctx)
+    assert is_pyobject_tainted(tainted) is True  # sanity: visible within its own slot
+
+    # Detach the context, as happens once the request finishes but the tainted
+    # object is still referenced by a soon-to-be-finalized structure.
+    IAST_CONTEXT.set(None)
+    assert is_pyobject_tainted(tainted) is False
+    assert get_tainted_ranges(tainted) == tuple()
+
+    finish_request_context(ctx)
+    IAST_CONTEXT.set(None)
+
+
+def test_is_pyobject_tainted_without_context_ignores_stale_iast_env(iast_context_defaults):
+    tainted = taint_pyobject("tainted_with_stale_env", "param", "tainted_with_stale_env", OriginType.PARAMETER)
+    assert is_pyobject_tainted(tainted) is True
+
+    token = IAST_CONTEXT.set(None)
+    try:
+        assert in_iast_env() is True
+        assert is_pyobject_tainted(tainted) is False
+    finally:
+        IAST_CONTEXT.reset(token)
+
+
+def test_taint_query_from_finalizer_without_context_is_safe():
+    clear_all_request_context_slots()
+    _end_iast_context_and_oce()
+    IAST_CONTEXT.set(None)
+
+    results = []
+
+    class _QueriesTaintOnDel:
+        def __init__(self, value):
+            self.value = value
+
+        def __del__(self):
+            results.append(is_pyobject_tainted(self.value))
+
+    obj = _QueriesTaintOnDel("some-tainted-looking-string")
+    del obj
+    gc.collect()
+
+    assert results == [False]
+
+
+def test_get_ranges_public_api_returns_empty_without_context():
+    clear_all_request_context_slots()
+    _end_iast_context_and_oce()
+
+    ctx = start_request_context()
+    assert ctx is not None
+    tainted = _taint_pyobject_base("secret", "p", "secret", OriginType.PARAMETER, contextid=ctx)
+
+    # The tainted object lives in a real slot, but with no active context the
+    # public wrapper must not consult the native multi-slot resolver.
+    IAST_CONTEXT.set(None)
+    assert list(get_ranges(tainted)) == []
+
+    finish_request_context(ctx)
     IAST_CONTEXT.set(None)

--- a/tests/appsec/iast/taint_tracking/test_context.py
+++ b/tests/appsec/iast/taint_tracking/test_context.py
@@ -5,6 +5,7 @@ from ddtrace.appsec._iast._iast_request_context_base import IAST_CONTEXT
 from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request
 from ddtrace.appsec._iast._iast_request_context_base import _num_objects_tainted_in_request
 from ddtrace.appsec._iast._taint_tracking import OriginType
+from ddtrace.appsec._iast._taint_tracking import Source as TaintRangeSource
 from ddtrace.appsec._iast._taint_tracking import TaintRange
 from ddtrace.appsec._iast._taint_tracking import get_ranges
 from ddtrace.appsec._iast._taint_tracking._context import clear_all_request_context_slots
@@ -85,11 +86,10 @@ def test_taint_object_with_no_context_is_noop():
     assert _num_objects_tainted_in_request() == 0
 
     # taint with ranges is also a no-op returning False
-    from ddtrace.appsec._iast._taint_tracking import Source as TaintRangeSource
 
     res = taint_pyobject_with_ranges(
         arg,
-        [TaintRange(0, len(arg), TaintRangeSource(arg, "request_body", OriginType.PARAMETER), [])],
+        (TaintRange(0, len(arg), TaintRangeSource(arg, "request_body", OriginType.PARAMETER), []),),
     )
     assert res is False
 
@@ -112,23 +112,35 @@ def test_get_tainted_ranges_returns_empty_without_context():
     assert get_tainted_ranges("xyz") == tuple()
 
 
-def test_in_taint_map_scans_container_across_active_maps():
+def test_is_pyobject_tainted_is_scoped_to_active_slot():
+    """Taint queries resolve only within the active request slot."""
     clear_all_request_context_slots()
     _end_iast_context_and_oce()
 
-    # Start two independent maps
     ctx1 = start_request_context()
     ctx2 = start_request_context()
     assert ctx1 is not None and ctx2 is not None and ctx1 != ctx2
 
-    target = "TAINT_ME"
-    # Taint the string into ctx1 explicitly without setting ContextVar
-    target_tainted1 = _taint_pyobject_base(target, "p", target, OriginType.PARAMETER, contextid=ctx1)
-    target_tainted2 = _taint_pyobject_base(target, "p", target, OriginType.PARAMETER, contextid=ctx2)
+    # Distinct values -> distinct objects, so each lives in exactly one slot.
+    tainted_in_1 = _taint_pyobject_base("TAINT_ONE", "p", "TAINT_ONE", OriginType.PARAMETER, contextid=ctx1)
+    tainted_in_2 = _taint_pyobject_base("TAINT_TWO", "p", "TAINT_TWO", OriginType.PARAMETER, contextid=ctx2)
 
-    assert is_pyobject_tainted(target) is False
-    assert is_pyobject_tainted(target_tainted1) is True
-    assert is_pyobject_tainted(target_tainted2) is True
+    IAST_CONTEXT.set(ctx1)
+    assert is_pyobject_tainted(tainted_in_1) is True
+    assert is_pyobject_tainted(tainted_in_2) is False
+
+    IAST_CONTEXT.set(ctx2)
+    assert is_pyobject_tainted(tainted_in_2) is True
+    assert is_pyobject_tainted(tainted_in_1) is False
+
+    # No active request => queries short-circuit to False (native is not consulted).
+    IAST_CONTEXT.set(None)
+    assert is_pyobject_tainted(tainted_in_1) is False
+    assert is_pyobject_tainted(tainted_in_2) is False
+
+    finish_request_context(ctx1)
+    finish_request_context(ctx2)
+    IAST_CONTEXT.set(None)
 
 
 def test_num_objects_tainted_is_per_current_context():
@@ -165,8 +177,6 @@ def test_is_pyobject_tainted_false_for_non_taintable_types_without_context():
 def test_copy_ranges_to_string_without_context_is_noop():
     clear_all_request_context_slots()
     _end_iast_context_and_oce()
-
-    from ddtrace.appsec._iast._taint_tracking import Source as TaintRangeSource
 
     src_val = "abc"
     ranges = [TaintRange(0, len(src_val), TaintRangeSource(src_val, "param", OriginType.PARAMETER), [])]
@@ -207,7 +217,6 @@ def test_is_pyobject_tainted_does_not_leak_across_request_slots():
 
 def test_get_ranges_public_api_does_not_leak_across_request_slots():
     """The public ``get_ranges`` (used by sinks and aspects) must also be slot-scoped."""
-    from ddtrace.appsec._iast._taint_tracking import get_ranges
 
     clear_all_request_context_slots()
     _end_iast_context_and_oce()

--- a/tests/appsec/iast/taint_tracking/test_context.py
+++ b/tests/appsec/iast/taint_tracking/test_context.py
@@ -6,6 +6,7 @@ from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request
 from ddtrace.appsec._iast._iast_request_context_base import _num_objects_tainted_in_request
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import TaintRange
+from ddtrace.appsec._iast._taint_tracking import get_ranges
 from ddtrace.appsec._iast._taint_tracking._context import clear_all_request_context_slots
 from ddtrace.appsec._iast._taint_tracking._context import debug_num_tainted_objects
 from ddtrace.appsec._iast._taint_tracking._context import finish_request_context


### PR DESCRIPTION
## Description

Backport of the IAST taint-context guard chain to `4.11`. This single PR
carries **#19091 together with its two prerequisites**, because #19091's
implementation and the tests bundled with the cherry-pick depend on them.
Backporting #19091 alone left the tests asserting behavior the branch did
not yet have, so CI failed on `tests/appsec/iast/taint_tracking/test_context.py`.

### Backported PRs (merged into this single backport)

| PR | Title | What it contributes here |
|----|-------|--------------------------|
| [#18996](https://github.com/DataDog/dd-trace-py/pull/18996) | fix(iast): guard taint queries without a context | `get_ranges()` short-circuits to `[]` with no active context; test rework replacing `test_in_taint_map_scans_container_across_active_maps` → `test_is_pyobject_tainted_is_scoped_to_active_slot` |
| [#19033](https://github.com/DataDog/dd-trace-py/pull/19033) | fix(iast): scope taint copy helpers to the active request slot | native `context_id` param on `copy_ranges_from_strings` / `copy_and_shift_ranges_from_strings` (`taint_range.cpp`/`.h`) + Python wrappers injecting the active context id |
| [#19091](https://github.com/DataDog/dd-trace-py/pull/19091) | chore(iast): preserve propagation during source suppression | strict no-context guard split from source suppression (`_taint_objects_base.py`, `_iast_request_context_base.py`, `_taint_objects.py`) |

#19091 is the alternative follow-up to #19065, so #19065 is intentionally
**not** included.

## Testing

`tests/appsec/iast/taint_tracking/test_context.py` — py3.9: 20 passed, 0 failed
(native extension rebuilt). The four previously-failing tests now pass:
`test_get_ranges_public_api_returns_empty_without_context`,
`test_is_pyobject_tainted_without_context_does_not_consult_native`,
`test_copy_ranges_from_strings_writes_to_active_slot_not_earlier_slot`,
`test_copy_and_shift_ranges_from_strings_writes_to_active_slot_not_earlier_slot`.
Lint clean (Ruff + clang-format).

## Risks

Low. Files were aligned verbatim to `main`'s final state for the affected
paths; no new logic introduced beyond the upstream PRs.

Jira: [APPSEC-69136](https://datadoghq.atlassian.net/browse/APPSEC-69136)


[APPSEC-69136]: https://datadoghq.atlassian.net/browse/APPSEC-69136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ