### PR TITLE
perf(botocore): compile and cache JSONPath redaction expressions

### DIFF
--- a/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
+++ b/ddtrace/_trace/utils_botocore/aws_payload_tagging.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from ddtrace import config
 from ddtrace._trace.span import Span
-from ddtrace.vendor.jsonpath_ng import parse
+from ddtrace.vendor.jsonpath_ng.parser import JsonPathParser
 
 
 _MAX_TAG_VALUE_LENGTH = 5000
@@ -77,8 +77,9 @@ class AWSPayloadTagging:
         Expands the JSON payload from various AWS services into tags and sets them on the Span.
         """
         if not self.validated:
-            self.request_redaction_paths = self._get_redaction_paths_request()
-            self.response_redaction_paths = self._get_redaction_paths_response()
+            parser = JsonPathParser()  # build LALR parser just once
+            self.request_redaction_paths = [parser.parse(p) for p in self._get_redaction_paths_request(parser)]
+            self.response_redaction_paths = [parser.parse(p) for p in self._get_redaction_paths_response(parser)]
             self.validated = True
 
         if not self.request_redaction_paths and not self.response_redaction_paths:
@@ -107,7 +108,7 @@ class AWSPayloadTagging:
             return True
         return False
 
-    def _validate_json_paths(self, paths: Optional[str]) -> bool:
+    def _validate_json_paths(self, paths: Optional[str], parser: JsonPathParser) -> bool:
         """
         Checks whether paths is "all" or all valid JSONPaths
         """
@@ -124,7 +125,7 @@ class AWSPayloadTagging:
                 if not path.startswith("$"):
                     return False
                 try:
-                    parse(path)
+                    parser.parse(path)
                 except Exception:
                     return False
             else:
@@ -132,16 +133,15 @@ class AWSPayloadTagging:
 
         return True
 
-    def _redact_json(self, data: dict[str, Any], span: Span, paths: list) -> None:
+    def _redact_json(self, data: dict[str, Any], span: Span, expressions: list) -> None:
         """
         Redact sensitive data in the JSON payload based on default and user-provided JSONPath expressions
         """
-        for path in paths:
-            expression = parse(path)
+        for expression in expressions:
             for match in expression.find(data):
                 match.context.value[match.path.fields[0]] = "redacted"
 
-    def _get_redaction_paths_response(self) -> list:
+    def _get_redaction_paths_response(self, parser: JsonPathParser) -> list:
         """
         Get the list of redaction paths, combining defaults with any user-provided JSONPaths.
         """
@@ -149,7 +149,7 @@ class AWSPayloadTagging:
             return []
 
         response_redaction = config.botocore.get("payload_tagging_response")
-        if self._validate_json_paths(response_redaction):
+        if self._validate_json_paths(response_redaction, parser):
             if response_redaction == "all":
                 return self._RESPONSE_REDACTION_PATHS_DEFAULTS + self._REDACTION_PATHS_DEFAULTS
             return (
@@ -158,7 +158,7 @@ class AWSPayloadTagging:
 
         return []
 
-    def _get_redaction_paths_request(self) -> list:
+    def _get_redaction_paths_request(self, parser: JsonPathParser) -> list:
         """
         Get the list of redaction paths, combining defaults with any user-provided JSONPaths.
         """
@@ -166,7 +166,7 @@ class AWSPayloadTagging:
             return []
 
         request_redaction = config.botocore.get("payload_tagging_request")
-        if self._validate_json_paths(request_redaction):
+        if self._validate_json_paths(request_redaction, parser):
             if request_redaction == "all":
                 return self._REQUEST_REDACTION_PATHS_DEFAULTS + self._REDACTION_PATHS_DEFAULTS
             return (

--- a/releasenotes/notes/botocore-perf-cache-payload-tagging-jsonpath-9837d40fdaa008a6.yaml
+++ b/releasenotes/notes/botocore-perf-cache-payload-tagging-jsonpath-9837d40fdaa008a6.yaml
@@ -1,0 +1,8 @@
+---
+other:
+  - |
+    botocore: Improves the performance of AWS payload tagging by compiling each
+    JSONPath redaction expression once and reusing it, instead of rebuilding the
+    JSONPath parser and re-parsing every redaction path on each instrumented AWS
+    API call. This reduces CPU overhead when ``DD_TRACE_CLOUD_REQUEST_PAYLOAD_TAGGING``
+    or ``DD_TRACE_CLOUD_RESPONSE_PAYLOAD_TAGGING`` is enabled.


### PR DESCRIPTION
Mirror of #18662 (fork PR from @olincb, branch `olincb:perf/botocore-cache-payload-tagging-jsonpath`), opened to run internal CI since fork PRs don't get GitLab pipeline / system-tests credentials. Do not merge this PR — merge #18662 once its checks (same commit SHA) go green.

Original PR: #18662