### PR TITLE
fix(ci_visibility): bump backend HTTP request timeout and make it configurable [backport 4.8]

### DIFF
--- a/ddtrace/testing/internal/http.py
+++ b/ddtrace/testing/internal/http.py
@@ -30,11 +30,32 @@ from ddtrace.testing.internal.telemetry import TelemetryAPIRequestMetrics
 from ddtrace.testing.internal.utils import asbool
 
 
-DEFAULT_TIMEOUT_SECONDS = 15.0
+log = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT_SECONDS = 30.0
+_MAX_TIMEOUT_SECONDS = 300.0  # 5 minutes
+
+
+def _parse_timeout_millis(raw: t.Optional[str]) -> float:
+    if raw:
+        try:
+            _parsed = float(raw) / 1000.0
+            if not (0 < _parsed <= _MAX_TIMEOUT_SECONDS):
+                raise ValueError("must be between 1 ms and 300 000 ms")
+            return _parsed
+        except ValueError:
+            log.warning(
+                "Invalid value for DD_CIVISIBILITY_BACKEND_API_TIMEOUT_MILLIS: %r; using default %.1fs",
+                raw,
+                _DEFAULT_TIMEOUT_SECONDS,
+            )
+    return _DEFAULT_TIMEOUT_SECONDS
+
+
+DEFAULT_TIMEOUT_SECONDS = _parse_timeout_millis(env.get("DD_CIVISIBILITY_BACKEND_API_TIMEOUT_MILLIS"))
+
 MAX_ATTEMPTS = 5
 MAX_RETRY_AFTER_SECONDS = 120.0
-
-log = logging.getLogger(__name__)
 
 T = t.TypeVar("T")
 

--- a/releasenotes/notes/civisibility-backend-request-timeout-d74ed9cc27cb4108.yaml
+++ b/releasenotes/notes/civisibility-backend-request-timeout-d74ed9cc27cb4108.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    CI Visibility: fix the default HTTP timeout for backend requests from 15 seconds to 30 seconds,
+    and add the ``DD_CIVISIBILITY_BACKEND_API_TIMEOUT_MILLIS`` environment variable (previously
+    missing) to override it. The value is expressed in milliseconds (e.g. ``60000`` for 60 seconds),
+    consistent with the Java tracer. The same timeout now applies uniformly to all backend requests,
+    including skippable test fetches.

--- a/riotfile.py
+++ b/riotfile.py
@@ -96,6 +96,7 @@ _base_env = {
     "CARGO_BUILD_JOBS": "12",
     "DD_PYTEST_USE_NEW_PLUGIN": "true",
     "DD_TRACE_COMPUTE_STATS": "false",
+    "DD_CIVISIBILITY_BACKEND_API_TIMEOUT_MILLIS": "2000",  # 2-second timeout
 }
 if _nightly_build:
     _base_env["DD_CIVISIBILITY_CODE_COVERAGE_REPORT_UPLOAD_ENABLED"] = "1"

--- a/tests/testing/internal/test_http.py
+++ b/tests/testing/internal/test_http.py
@@ -1,6 +1,7 @@
 """Tests for ddtrace.testing.internal.http module."""
 
 import http.client
+import logging
 import os
 from unittest.mock import Mock
 from unittest.mock import call
@@ -9,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from ddtrace.testing.internal.errors import SetupError
+import ddtrace.testing.internal.http as _http_module
 from ddtrace.testing.internal.http import DEFAULT_TIMEOUT_SECONDS
 from ddtrace.testing.internal.http import MAX_RETRY_AFTER_SECONDS
 from ddtrace.testing.internal.http import BackendConnector
@@ -27,7 +29,7 @@ class TestBackendConnector:
 
     def test_constants(self) -> None:
         """Test module constants."""
-        assert DEFAULT_TIMEOUT_SECONDS == 15.0
+        assert DEFAULT_TIMEOUT_SECONDS == 30.0
 
     @patch("http.client.HTTPSConnection")
     def test_init_default_parameters(self, mock_https_connection: Mock) -> None:
@@ -1095,6 +1097,43 @@ class TestUnixDomainSocketTimeout:
 
             mock_sock.settimeout.assert_called_once_with(3.5)
             mock_sock.connect.assert_called_once_with("/tmp/nonexistent.sock")
+
+
+class TestBackendTimeoutEnvVar:
+    """Tests for DD_CIVISIBILITY_BACKEND_API_TIMEOUT_MILLIS parsing via _parse_timeout_millis."""
+
+    # AIDEV-NOTE: Tests call _parse_timeout_millis() directly to avoid importlib.reload, which
+    # mutates the module's __dict__ in place and breaks isinstance checks in other test classes
+    # (old imported class objects see new reloaded classes via shared __globals__).
+
+    def test_default_when_unset(self) -> None:
+        assert _http_module._parse_timeout_millis(None) == 30.0
+
+    def test_default_when_empty_string(self) -> None:
+        assert _http_module._parse_timeout_millis("") == 30.0
+
+    def test_integer_string_is_accepted(self) -> None:
+        assert _http_module._parse_timeout_millis("60000") == 60.0
+
+    def test_float_string_is_accepted(self) -> None:
+        assert _http_module._parse_timeout_millis("30500") == 30.5
+
+    def test_non_numeric_value_falls_back_to_default(self) -> None:
+        http_logger = logging.getLogger("ddtrace.testing.internal.http")
+        with patch.object(http_logger, "warning") as mock_warning:
+            result = _http_module._parse_timeout_millis("fast")
+        assert result == 30.0
+        mock_warning.assert_called_once()
+        fmt_string, bad_value = mock_warning.call_args[0][0], mock_warning.call_args[0][1]
+        assert "DD_CIVISIBILITY_BACKEND_API_TIMEOUT_MILLIS" in fmt_string
+        assert bad_value == "fast"
+
+    def test_non_numeric_value_does_not_raise(self) -> None:
+        assert _http_module._parse_timeout_millis("not-a-number") == 30.0
+
+    @pytest.mark.parametrize("bad_value", ["0", "-5000", "inf", "-inf", "nan", "300001"])
+    def test_non_positive_or_out_of_range_falls_back_to_default(self, bad_value: str) -> None:
+        assert _http_module._parse_timeout_millis(bad_value) == 30.0
 
 
 class TestRequestFailureWarning:

--- a/tests/testing/internal/test_http.py
+++ b/tests/testing/internal/test_http.py
@@ -29,7 +29,12 @@ class TestBackendConnector:
 
     def test_constants(self) -> None:
         """Test module constants."""
-        assert DEFAULT_TIMEOUT_SECONDS == 30.0
+        # Verify the parsing function returns the correct default when no env var is set
+        assert _http_module._parse_timeout_millis(None) == 30.0
+        # Verify the module constant matches what it should be for the current environment
+        # (may be overridden if env var was set at module import time)
+        expected = _http_module._parse_timeout_millis(os.environ.get("DD_CIVISIBILITY_BACKEND_API_TIMEOUT_MILLIS"))
+        assert DEFAULT_TIMEOUT_SECONDS == expected
 
     @patch("http.client.HTTPSConnection")
     def test_init_default_parameters(self, mock_https_connection: Mock) -> None:


### PR DESCRIPTION
## Description

Backport https://github.com/DataDog/dd-trace-py/pull/18243 to 4.8