### PR TITLE
ci: run tests with 2 second http timeout (#18529) [backport 4.9]

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -97,6 +97,7 @@ _base_env = {
     "DD_PYTEST_USE_NEW_PLUGIN": "true",
     "DD_TRACE_COMPUTE_STATS": "false",
     "DD_CODE_ORIGIN_FOR_SPANS_ENABLED": "false",
+    "DD_CIVISIBILITY_BACKEND_API_TIMEOUT_MILLIS": "2000",  # 2-second timeout
 }
 if _nightly_build:
     _base_env["DD_CIVISIBILITY_CODE_COVERAGE_REPORT_UPLOAD_ENABLED"] = "1"

--- a/tests/testing/internal/test_http.py
+++ b/tests/testing/internal/test_http.py
@@ -29,7 +29,12 @@ class TestBackendConnector:
 
     def test_constants(self) -> None:
         """Test module constants."""
-        assert DEFAULT_TIMEOUT_SECONDS == 30.0
+        # Verify the parsing function returns the correct default when no env var is set
+        assert _http_module._parse_timeout_millis(None) == 30.0
+        # Verify the module constant matches what it should be for the current environment
+        # (may be overridden if env var was set at module import time)
+        expected = _http_module._parse_timeout_millis(os.environ.get("DD_CIVISIBILITY_BACKEND_API_TIMEOUT_MILLIS"))
+        assert DEFAULT_TIMEOUT_SECONDS == expected
 
     @patch("http.client.HTTPSConnection")
     def test_init_default_parameters(self, mock_https_connection: Mock) -> None:


### PR DESCRIPTION
Reduce Test Optimization API requests' timeout to 2 seconds, to avoid CI jo

(cherry picked from commit 9f6f4abd47fba6d4282aef2f3d5b7f40d18a6ab0)
