### PR TITLE
chore(profiling): dont call clear in postfork_child

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/thread_span_links.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/thread_span_links.cpp
@@ -55,6 +55,15 @@ ThreadSpanLinks::postfork_child()
     auto& instance = get_instance();
     // NB placement-new to re-init and leak the mutex because doing anything else is UB
     new (&instance.mtx) std::mutex();
+    // thread_id_to_span may be in a mid-mutation state if fork raced with
+    // link_span/unlink_span. Its inherited pointers may be inconsistent,
+    // so calling clear (or letting the destructor run) would traverse the same
+    // corrupted linked-list state, which is UB. Instead, reconstruct the map in
+    // place with placement-new without inspecting its contents. This intentionally
+    // leaks the old map's heap allocations (nodes/buckets), but that memory belonged
+    // to the parent's address space snapshot and is a bounded, one-time leak per
+    // fork in the child; freeing it safely is impossible given the possible
+    // corruption, so leaking is the correct trade-off.
     new (&instance.thread_id_to_span) std::unordered_map<uint64_t, std::unique_ptr<Span>>();
 }
 

--- a/ddtrace/internal/datadog/profiling/stack/src/thread_span_links.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/thread_span_links.cpp
@@ -52,9 +52,10 @@ ThreadSpanLinks::reset()
 void
 ThreadSpanLinks::postfork_child()
 {
+    auto& instance = get_instance();
     // NB placement-new to re-init and leak the mutex because doing anything else is UB
-    new (&get_instance().mtx) std::mutex();
-    get_instance().reset();
+    new (&instance.mtx) std::mutex();
+    new (&instance.thread_id_to_span) std::unordered_map<uint64_t, std::unique_ptr<Span>>();
 }
 
 } // namespace Datadog


### PR DESCRIPTION
[PROF-15438](https://datadoghq.atlassian.net/jira/software/c/projects/PROF/boards/11?selectedIssue=PROF-15438)

workspace-gyuheon-1
## Description

Instead of calling `reset()` (which calls `thread_id_to_span.clear()` and would traverse potentially corrupted pointers inherited from a fork that raced with a mutation), it reconstructs the map in place using `placement-new`. This intentionally leaks the old map's nodes, but this is safe/necessary since inspecting or destroying the inconsistent container would be UB.

`clear()` is still used in [stack.cpp](https://github.com/DataDog/dd-trace-py/blob/b25d7df821cfdcf76d49db604a1f36beb2c1d515/ddtrace/internal/datadog/profiling/stack/src/stack.cpp#L44-L55) so we keep it

This follows th[e pattern of what we do for](https://github.com/DataDog/dd-trace-py/blob/4e5894b231c777cf4b47c4c49e8a9ab7a9f07868/ddtrace/internal/datadog/profiling/stack/echion/echion/strings.h#L89-L104) `StringTable`: 

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->


[PROF-15438]: https://datadoghq.atlassian.net/browse/PROF-15438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ