### PR TITLE
test(telemetry): fix import cycle when heartbeat is set to test values

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -374,16 +374,18 @@ class TelemetryWriter(PeriodicService):
 
     def _report_endpoints(self) -> Optional[dict[str, Any]]:
         """Adds a Telemetry event which sends the list of HTTP endpoints found at startup to the agent"""
-        import ddtrace.internal.settings.asm as asm_config_module
+        asm_config = getattr(sys.modules.get("ddtrace.internal.settings.asm"), "config", None)
+        if asm_config is None:
+            return None
 
-        if not asm_config_module.config._api_security_endpoint_collection or not self._enabled:
+        if not asm_config._api_security_endpoint_collection or not self._enabled:
             return None
 
         if not endpoint_collection.endpoints:
             return None
 
         with self._service_lock:
-            return endpoint_collection.flush(asm_config_module.config._api_security_endpoint_collection_limit)
+            return endpoint_collection.flush(asm_config._api_security_endpoint_collection_limit)
 
     def _report_products(self) -> dict[str, Any]:
         """Adds a Telemetry event which reports the enablement of an APM product"""

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -1,4 +1,6 @@
 import os
+import sys
+from types import ModuleType
 
 import pytest
 
@@ -18,6 +20,15 @@ assert telemetry_writer._worker is not None
     assert status == 0, stderr
     assert stdout == b"", stderr
     assert stderr == b""
+
+
+def test_report_endpoints_while_asm_config_is_initializing(monkeypatch):
+    from ddtrace.internal.telemetry import telemetry_writer
+
+    initializing_asm = ModuleType("ddtrace.internal.settings.asm")
+    monkeypatch.setitem(sys.modules, initializing_asm.__name__, initializing_asm)
+
+    assert telemetry_writer._report_endpoints() is None
 
 
 def test_enable_fork(test_agent_session, run_python_code_in_subprocess):

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -4,6 +4,8 @@ from types import ModuleType
 
 import pytest
 
+from ddtrace.internal.telemetry import telemetry_writer
+
 
 def test_enable(test_agent_session, run_python_code_in_subprocess):
     code = """
@@ -23,8 +25,6 @@ assert telemetry_writer._worker is not None
 
 
 def test_report_endpoints_while_asm_config_is_initializing(monkeypatch):
-    from ddtrace.internal.telemetry import telemetry_writer
-
     initializing_asm = ModuleType("ddtrace.internal.settings.asm")
     monkeypatch.setitem(sys.modules, initializing_asm.__name__, initializing_asm)
 


### PR DESCRIPTION
## Description

Fix the parametric test failure like this one: https://github.com/DataDog/dd-trace-py/actions/runs/29481596840/job/87571445635?pr=19066

This is an import cycle problem occurring because the telemetry thread starts very early on and because of the test value of the heartbeat (0.1s) it tries to import the yet partially initialized asm config.

The solution is to guard the import and skip the reporting until the whole module is initialized. The endpoints will be sent at the next heartbeat with the whole module initialized.

## Testing

- Regression test

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
