### PR TITLE
ci: bump system-tests commit

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -95,11 +95,11 @@ jobs:
   serverless-system-tests:
     needs: [serverless-system-tests-build-layer]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@26fc4221739612bd28dee14c248f94afed91b2a4
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@f80b47dee3bb5871ed9d712d393abe949901d4df
     secrets: inherit
     with:
       library: python_lambda
-      ref: '26fc4221739612bd28dee14c248f94afed91b2a4'
+      ref: 'f80b47dee3bb5871ed9d712d393abe949901d4df'
       binaries_artifact: serverless_system_tests_binaries
       scenarios_groups: lambda_end_to_end
       skip_empty_scenarios: true
@@ -126,11 +126,11 @@ jobs:
     if: github.event_name != 'schedule' || github.event.repository.fork == false
     needs: [integration-frameworks-combine-wheels]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@26fc4221739612bd28dee14c248f94afed91b2a4
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@f80b47dee3bb5871ed9d712d393abe949901d4df
     secrets: inherit
     with:
       library: python
-      ref: '26fc4221739612bd28dee14c248f94afed91b2a4'
+      ref: 'f80b47dee3bb5871ed9d712d393abe949901d4df'
       scenarios: INTEGRATION_FRAMEWORKS
       binaries_artifact: integration-frameworks-wheels
       push_to_test_optimization: true
@@ -138,10 +138,10 @@ jobs:
   tracer-release:
     needs:
       - download-s3-wheels
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@26fc4221739612bd28dee14c248f94afed91b2a4
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@f80b47dee3bb5871ed9d712d393abe949901d4df
     with:
       library: python
-      ref: '26fc4221739612bd28dee14c248f94afed91b2a4'
+      ref: 'f80b47dee3bb5871ed9d712d393abe949901d4df'
       binaries_artifact: wheels-manylinux_x86_64
       desired_execution_time: 900
       scenarios_groups: tracer-release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "26fc4221739612bd28dee14c248f94afed91b2a4"
+  SYSTEM_TESTS_REF: "f80b47dee3bb5871ed9d712d393abe949901d4df"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
   PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v103334885-be1888c-profiling_native"


### PR DESCRIPTION
## Description

Bump the pinned `system-tests` commit to `f80b47dee3bb5871ed9d712d393abe949901d4df`. Automatically managed, use `scripts/update-system-tests-version` to update. Updates the ref in `.github/workflows/system-tests.yml` and `.gitlab-ci.yml`.

## Testing

CI (system-tests) runs against the new ref.

## Risks

None — CI-only version bump.

## Additional Notes

Follow-up to #19077.