### PR TITLE
test(profiling): fix flaky exception raise test

### DIFF
--- a/ddtrace/profiling/collector/_exception.pyx
+++ b/ddtrace/profiling/collector/_exception.pyx
@@ -131,7 +131,12 @@ cpdef void _on_exception(object code, int instruction_offset, object exception):
         if state.counter < state.next_sample:
             return
 
-        state.next_sample = max(state.sampler.sample(state.sampling_interval), 1)
+        # sampling_interval=1 means sample every exception. Skip Poisson so
+        # variance cannot insert gaps of 2+.
+        if state.sampling_interval == 1:
+            state.next_sample = 1
+        else:
+            state.next_sample = max(state.sampler.sample(state.sampling_interval), 1)
         state.counter = 0
 
         # At the raise site the head of the traceback is the raising frame;

--- a/tests/profiling/collector/test_exception.py
+++ b/tests/profiling/collector/test_exception.py
@@ -808,7 +808,7 @@ def test_raise_fires_once_per_exception(tmp_path: Path) -> None:
     profile: pprof_pb2.Profile = pprof_utils.parse_newest_profile(output_filename)
     samples: list[pprof_pb2.Sample] = pprof_utils.get_samples_with_value_type(profile, "exception-samples")
 
-    # With sampling_interval=1, the first exception is always sampled. ddup aggregates samples
+    # With sampling_interval=1 every exception is sampled. ddup aggregates samples
     # with identical stacks into a single pprof row with a summed count value.
     # The invariant we are looking for is that the total exception-samples count for the
     # ValueError we raised must not exceed 1.


### PR DESCRIPTION
## Description

When `sampling_interval=1`, skip Poisson sampling so every exception is collected instead of allowing random gaps of 2+. That removes the flake where a stray exception could consume the sample slot and miss intentional exceptions thrown. Used claude for verif script

## Testing
ran the exception test file 100x...
```
# Build -k expression from test function names in the file, then loop 100x
scripts/ddtest bash -c '
set -e
KEXPR=$(python3 - <<'"'"'PY'"'"'
import ast, pathlib
src = pathlib.Path("tests/profiling/collector/test_exception.py").read_text()
names = [n.name for n in ast.walk(ast.parse(src)) if isinstance(n, ast.FunctionDef) and n.name.startswith("test_")]
print(" or ".join(names))
PY
)
echo "Filter: $KEXPR"
echo "Collect check:"
riot -v run --pass-env -s daba82d -- -k "$KEXPR" --collect-only -q 2>&1 | tail -30

fail=0
passed=0
for i in $(seq 1 100); do
  if riot -v run --pass-env -s daba82d -- -k "$KEXPR" --tb=line -q >/tmp/exc_file.out 2>&1; then
    passed=$((passed+1))
    echo "PASS $i/100"
  else
    echo "FAIL on run $i/100"
    tail -80 /tmp/exc_file.out
    fail=1
    break
  fi
done
echo "RESULT: passed=$passed/100 fail=$fail"
exit $fail
'
```
```
PASS 1/100
PASS 2/100
PASS 3/100
PASS 4/100
...
PASS 99/100
PASS 100/100
```

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
