### PR TITLE
chore(python): test for services using subprocess with sys exec

### DIFF
--- a/tests/profiling/_test_subprocess.py
+++ b/tests/profiling/_test_subprocess.py
@@ -1,0 +1,59 @@
+"""
+Parent/worker script for subprocess profiling bootstrap regression tests.
+
+Simulates launchers like torchrun: a ddtrace-run parent starts workers with
+sys.executable (not ddtrace-run). Workers rely on inherited environment
+bootstrap for profiling.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def _worker() -> None:
+    import ddtrace.profiling.bootstrap
+
+    profiler = ddtrace.profiling.bootstrap.profiler  # type: ignore[attr-defined]
+    total = 0
+    for i in range(5_000_000):
+        total += i
+    profiler.stop()
+    print(os.getpid())
+
+
+def _run_workers() -> None:
+    worker_cmd = [sys.executable, __file__, "worker"]
+
+    run_result = subprocess.run(
+        worker_cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert run_result.returncode == 0, (run_result.stdout, run_result.stderr)
+    run_pid = run_result.stdout.strip()
+    assert run_pid.isdigit(), run_result.stdout
+
+    popen = subprocess.Popen(
+        worker_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    popen_stdout, popen_stderr = popen.communicate(timeout=120)
+    assert popen.returncode == 0, (popen_stdout, popen_stderr)
+    popen_pid = popen_stdout.strip()
+    assert popen_pid.isdigit(), popen_stdout
+
+    print(run_pid)
+    print(popen_pid)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "worker":
+        _worker()
+    else:
+        _run_workers()

--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -188,6 +188,36 @@ def test_multiprocessing(method: str, tmp_path: Path) -> None:
     assert len(child_samples) > 0
 
 
+def test_subprocess_inherited_bootstrap(tmp_path: Path) -> None:
+    """Children launched using subprocess with sys.executable (not ddtrace-run)
+    should inherit profiling bootstrap from a ddtrace-run parent.
+
+    Covers the generic child-process model used by launchers like torchrun
+    without using PyTorch in the test matrix.
+    """
+    filename = str(tmp_path / "pprof")
+    env = os.environ.copy()
+    env["DD_PROFILING_OUTPUT_PPROF"] = filename
+    env["DD_PROFILING_ENABLED"] = "1"
+    env["DD_PROFILING_CAPTURE_PCT"] = "100"
+    stdout, stderr, exitcode, _ = call_program(
+        "ddtrace-run",
+        sys.executable,
+        os.path.join(os.path.dirname(__file__), "_test_subprocess.py"),
+        env=env,
+    )
+    assert exitcode == 0, (stdout, stderr)
+    stdout = stdout.decode() if isinstance(stdout, bytes) else stdout
+    run_pid, popen_pid = list(s.strip() for s in stdout.strip().split("\n"))
+
+    for child_pid in (run_pid, popen_pid):
+        child_profile = pprof_utils.parse_newest_profile(f"{filename}.{child_pid}")
+        cpu_samples = pprof_utils.get_samples_with_value_type(child_profile, "cpu-time")
+        wall_samples = pprof_utils.get_samples_with_value_type(child_profile, "wall-time")
+        assert len(cpu_samples) > 0, f"no cpu-time samples for pid {child_pid}"
+        assert len(wall_samples) > 0, f"no wall-time samples for pid {child_pid}"
+
+
 @pytest.mark.subprocess(
     ddtrace_run=True,
     env=dict(DD_PROFILING_ENABLED="1"),


### PR DESCRIPTION
## Description

[PROF-15298](https://datadoghq.atlassian.net/jira/software/c/projects/PROF/boards/27442?selectedIssue=PROF-15298)

Adds test for launchers like torchrun where a `ddtrace-run` parent starts workers with `sys.executable`

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->


[PROF-15298]: https://datadoghq.atlassian.net/browse/PROF-15298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ