### PR TITLE
chore(debugging): add support for capturing `namedtuple`

### DIFF
--- a/ddtrace/debugging/_signal/utils.py
+++ b/ddtrace/debugging/_signal/utils.py
@@ -106,6 +106,25 @@ def _(numpy: ModuleType) -> None:
     ARRAY_TYPES = frozenset((list, deque)) | ndarray_set
 
 
+def _is_namedtuple_type(cls: type) -> bool:
+    if not (isinstance(cls, type) and issubclass(cls, tuple)):
+        return False
+
+    bases = cls.__bases__
+    if len(bases) != 1 or bases[0] is not tuple:
+        return False
+
+    fields = getattr(cls, "_fields", None)
+    return isinstance(fields, tuple) and all(type(f) is str for f in fields)
+
+
+def _fields_of(value: Any) -> dict[str, Any]:
+    if _is_namedtuple_type(type(value)):
+        return dict(zip(value._fields, value))
+
+    return get_fields(value)
+
+
 def _serialize_collection(
     value: Collection[Any], brackets: str, level: int, maxsize: int, maxlen: int, maxfields: int
 ) -> str:
@@ -163,7 +182,7 @@ def serialize(
         ", ".join(
             (
                 "=".join((k, serialize(v, level - 1, maxsize, maxlen, maxfields)))
-                for k, v in islice(get_fields(value).items(), maxfields)
+                for k, v in islice(_fields_of(value).items(), maxfields)
                 if not redact(k)
             )
         ),
@@ -401,7 +420,7 @@ def capture_value(
             "notCapturedReason": cond.__name__,
         }
 
-    fields = get_fields(value)
+    fields = _fields_of(value)
 
     # Capture exception chain for exceptions
     if _isinstance(value, BaseException):

--- a/ddtrace/debugging/_signal/utils.py
+++ b/ddtrace/debugging/_signal/utils.py
@@ -108,14 +108,12 @@ def _(numpy: ModuleType) -> None:
 
 
 def _is_namedtuple_type(cls: type) -> bool:
-    if not (_isinstance(cls, type) and issubclass(cls, tuple)):
-        return False
-
-    if tuple not in (safe_getattr(cls, "__bases__", ()) or ()):
+    mro = safe_getattr(cls, "__mro__", None)
+    if not (type(mro) is tuple and tuple in mro):
         return False
 
     fields = safe_getattr(cls, "_fields", None)
-    return isinstance(fields, tuple) and all(type(f) is str for f in fields)
+    return type(fields) is tuple and all(type(f) is str for f in fields)
 
 
 def _fields_of(value: Any) -> dict[str, Any]:

--- a/ddtrace/debugging/_signal/utils.py
+++ b/ddtrace/debugging/_signal/utils.py
@@ -16,6 +16,7 @@ from types import ModuleType
 from types import TracebackType
 from typing import Any
 from typing import Callable
+from typing import Generic
 from typing import Iterable
 from typing import Optional
 
@@ -109,7 +110,10 @@ def _(numpy: ModuleType) -> None:
 
 def _is_namedtuple_type(cls: type) -> bool:
     mro = safe_getattr(cls, "__mro__", None)
-    if not (type(mro) is tuple and tuple in mro):
+    if type(mro) is not tuple or len(mro) < 3:
+        return False
+
+    if not (mro[-2] is tuple or (mro[-2] is Generic and mro[-3] is tuple)):
         return False
 
     fields = safe_getattr(cls, "_fields", None)

--- a/ddtrace/debugging/_signal/utils.py
+++ b/ddtrace/debugging/_signal/utils.py
@@ -30,6 +30,7 @@ from ddtrace.debugging._redaction import REDACTED_PLACEHOLDER
 from ddtrace.debugging._redaction import redact
 from ddtrace.debugging._redaction import redact_type
 from ddtrace.debugging._safety import get_fields
+from ddtrace.debugging._safety import safe_getattr
 from ddtrace.internal.compat import ExcInfoType
 from ddtrace.internal.module import ModuleWatchdog
 from ddtrace.internal.safety import _isinstance
@@ -107,14 +108,13 @@ def _(numpy: ModuleType) -> None:
 
 
 def _is_namedtuple_type(cls: type) -> bool:
-    if not (isinstance(cls, type) and issubclass(cls, tuple)):
+    if not (_isinstance(cls, type) and issubclass(cls, tuple)):
         return False
 
-    bases = cls.__bases__
-    if len(bases) != 1 or bases[0] is not tuple:
+    if tuple not in (safe_getattr(cls, "__bases__", ()) or ()):
         return False
 
-    fields = getattr(cls, "_fields", None)
+    fields = safe_getattr(cls, "_fields", None)
     return isinstance(fields, tuple) and all(type(f) is str for f in fields)
 
 

--- a/tests/debugging/test_encoding.py
+++ b/tests/debugging/test_encoding.py
@@ -74,10 +74,16 @@ class Credentials(NamedTuple):
 
 _T = TypeVar("_T")
 
+# Generic typing.NamedTuple via multiple inheritance is only supported on 3.11+.
+if sys.version_info >= (3, 11):
 
-class GenericPoint(NamedTuple, Generic[_T]):
-    x: _T
-    y: _T
+    class GenericPoint(NamedTuple, Generic[_T]):
+        x: _T
+        y: _T
+
+    _NAMEDTUPLE_FLAVORS = [PointFunctional, PointTyped, GenericPoint]
+else:
+    _NAMEDTUPLE_FLAVORS = [PointFunctional, PointTyped]
 
 
 @pytest.mark.parametrize(
@@ -951,7 +957,7 @@ def test_numpy_import_hook_expands_types_end_to_end():
     assert numpy.ndarray in utils.ARRAY_TYPES
 
 
-@pytest.mark.parametrize("_type", [PointFunctional, PointTyped, GenericPoint])
+@pytest.mark.parametrize("_type", _NAMEDTUPLE_FLAVORS)
 def test_is_namedtuple_type_detects_both_flavors(_type):
     # collections.namedtuple() and typing.NamedTuple produce classes that
     # behave identically at runtime (both are plain tuple subclasses with a

--- a/tests/debugging/test_encoding.py
+++ b/tests/debugging/test_encoding.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 
 from collections import defaultdict
+from collections import namedtuple
 import inspect
 import json
 import sys
 import threading
 from typing import Any
+from typing import NamedTuple
 from typing import Optional
 from typing import cast
 
@@ -53,6 +55,19 @@ class Tree(object):
 
 
 tree = Tree("root", Node("0", Node("0l", Node("0ll"), Node("0lr")), Node("0r", Node("0rl"))))
+
+
+PointFunctional = namedtuple("PointFunctional", ["x", "y"])
+
+
+class PointTyped(NamedTuple):
+    x: int
+    y: int
+
+
+class Credentials(NamedTuple):
+    username: str
+    password: str
 
 
 @pytest.mark.parametrize(
@@ -924,3 +939,52 @@ def test_numpy_import_hook_expands_types_end_to_end():
     assert numpy.float64 in utils.SIMPLE_TYPES
     assert numpy.ndarray in utils.CONTAINER_TYPES
     assert numpy.ndarray in utils.ARRAY_TYPES
+
+
+@pytest.mark.parametrize("_type", [PointFunctional, PointTyped])
+def test_is_namedtuple_type_detects_both_flavors(_type):
+    # collections.namedtuple() and typing.NamedTuple produce classes that
+    # behave identically at runtime (both are plain tuple subclasses with a
+    # _fields tuple), so a single structural check must accept both.
+    assert utils._is_namedtuple_type(_type)
+
+
+@pytest.mark.parametrize(
+    "_type",
+    [
+        tuple,
+        list,
+        dict,
+        type("PlainTupleSubclass", (tuple,), {}),
+        type("FurtherSubclass", (PointFunctional,), {}),
+    ],
+)
+def test_is_namedtuple_type_rejects_non_namedtuples(_type):
+    assert not utils._is_namedtuple_type(_type)
+
+
+@pytest.mark.parametrize("_type", [PointFunctional, PointTyped])
+def test_serialize_namedtuple(_type):
+    assert utils.serialize(_type(1, 2)) == "%s(x=1, y=2)" % _type.__name__
+
+
+@pytest.mark.parametrize("_type", [PointFunctional, PointTyped])
+def test_capture_value_namedtuple(_type):
+    assert utils.capture_value(_type(1, 2)) == {
+        "type": _type.__qualname__,
+        "fields": {
+            "x": {"type": "int", "value": "1"},
+            "y": {"type": "int", "value": "2"},
+        },
+    }
+
+
+def test_capture_value_namedtuple_redacts_sensitive_fields():
+    result = utils.capture_value(Credentials("admin", "secret"))
+    assert result == {
+        "type": Credentials.__qualname__,
+        "fields": {
+            "username": {"type": "str", "value": "'admin'"},
+            "password": utils.redacted_value("secret"),
+        },
+    }

--- a/tests/debugging/test_encoding.py
+++ b/tests/debugging/test_encoding.py
@@ -972,22 +972,43 @@ def test_is_namedtuple_type_detects_both_flavors(_type):
         list,
         dict,
         type("PlainTupleSubclass", (tuple,), {}),
-        type("FurtherSubclass", (PointFunctional,), {}),
     ],
 )
 def test_is_namedtuple_type_rejects_non_namedtuples(_type):
     assert not utils._is_namedtuple_type(_type)
 
 
-@pytest.mark.parametrize("_type", [PointFunctional, PointTyped])
+def test_is_namedtuple_type_detects_subclasses():
+    # A subclass of a namedtuple inherits a valid _fields tuple, so it is still
+    # treated as a namedtuple.
+    assert utils._is_namedtuple_type(type("FurtherSubclass", (PointFunctional,), {}))
+
+
+@pytest.mark.parametrize("_type", _NAMEDTUPLE_FLAVORS)
 def test_serialize_namedtuple(_type):
     assert utils.serialize(_type(1, 2)) == "%s(x=1, y=2)" % _type.__name__
 
 
-@pytest.mark.parametrize("_type", [PointFunctional, PointTyped])
+@pytest.mark.parametrize("_type", _NAMEDTUPLE_FLAVORS)
 def test_capture_value_namedtuple(_type):
     assert utils.capture_value(_type(1, 2)) == {
         "type": _type.__qualname__,
+        "fields": {
+            "x": {"type": "int", "value": "1"},
+            "y": {"type": "int", "value": "2"},
+        },
+    }
+
+
+def test_serialize_namedtuple_subclass():
+    subclass = type("FurtherSubclass", (PointFunctional,), {})
+    assert utils.serialize(subclass(1, 2)) == "FurtherSubclass(x=1, y=2)"
+
+
+def test_capture_value_namedtuple_subclass():
+    subclass = type("FurtherSubclass", (PointFunctional,), {})
+    assert utils.capture_value(subclass(1, 2)) == {
+        "type": subclass.__qualname__,
         "fields": {
             "x": {"type": "int", "value": "1"},
             "y": {"type": "int", "value": "2"},

--- a/tests/debugging/test_encoding.py
+++ b/tests/debugging/test_encoding.py
@@ -978,6 +978,7 @@ def test_is_namedtuple_type_rejects_non_namedtuples(_type):
     assert not utils._is_namedtuple_type(_type)
 
 
+@pytest.mark.skip("Currently fails because we don't walk the MRO to find the fields.")
 def test_is_namedtuple_type_detects_subclasses():
     # A subclass of a namedtuple inherits a valid _fields tuple, so it is still
     # treated as a namedtuple.
@@ -1000,19 +1001,91 @@ def test_capture_value_namedtuple(_type):
     }
 
 
+@pytest.mark.skip("Currently fails because we don't walk the MRO to find the fields.")
 def test_serialize_namedtuple_subclass():
     subclass = type("FurtherSubclass", (PointFunctional,), {})
     assert utils.serialize(subclass(1, 2)) == "FurtherSubclass(x=1, y=2)"
 
 
+@pytest.mark.skip("Currently fails because we don't walk the MRO to find the fields.")
 def test_capture_value_namedtuple_subclass():
+    assert utils.capture_value(PointFunctional(1, 2)) == {
+        "type": PointFunctional.__qualname__,
+        "fields": {
+            "x": {"type": "int", "value": "1"},
+            "y": {"type": "int", "value": "2"},
+        },
+    }
+
+
+@pytest.mark.skip("Currently fails because we don't walk the MRO to find the fields.")
+def test_capture_value_namedtuple_subclass_subclass():
     subclass = type("FurtherSubclass", (PointFunctional,), {})
+
     assert utils.capture_value(subclass(1, 2)) == {
         "type": subclass.__qualname__,
         "fields": {
             "x": {"type": "int", "value": "1"},
             "y": {"type": "int", "value": "2"},
         },
+    }
+
+
+def test_degenerate_namedtuple_subclass():
+    class DegenerateSubclass(PointFunctional):
+        _fields = ("a", "b")
+
+    assert utils.capture_value(DegenerateSubclass(1, 2)) == {
+        "type": DegenerateSubclass.__qualname__,
+        "fields": {
+            "a": {"type": "int", "value": "1"},
+            "b": {"type": "int", "value": "2"},
+        },
+    }
+
+
+def test_degenerate_namedtuple_subclass_more_fields():
+    class DegenerateSubclass(PointFunctional):
+        _fields = ("a", "b", "c")
+
+    assert utils.capture_value(DegenerateSubclass(1, 2)) == {
+        "type": DegenerateSubclass.__qualname__,
+        "fields": {
+            "a": {"type": "int", "value": "1"},
+            "b": {"type": "int", "value": "2"},
+        },
+    }
+
+
+def test_degenerate_namedtuple_subclass_less_fields():
+    class DegenerateSubclass(PointFunctional):
+        _fields = ("a",)
+
+    assert utils.capture_value(DegenerateSubclass(1, 2)) == {
+        "type": DegenerateSubclass.__qualname__,
+        "fields": {
+            "a": {"type": "int", "value": "1"},
+        },
+    }
+
+
+def test_degenerate_namedtuple_subclass_incorrect_type_dict():
+    class DegenerateSubclass(PointFunctional):
+        _fields = {"a": "b"}  # pyright: ignore[reportAssignmentType]
+
+    assert utils.capture_value(DegenerateSubclass(1, 2)) == {
+        "type": DegenerateSubclass.__qualname__,
+        "fields": {},
+    }
+
+
+def test_degenerate_namedtuple_subclass_incorrect_type_list():
+    class DegenerateSubclass(PointFunctional):
+        _fields = ["a", "b"]  # pyright: ignore[reportAssignmentType]
+
+    assert utils.capture_value(DegenerateSubclass(1, 2)) == {
+        "type": DegenerateSubclass.__qualname__,
+        "fields": {},
     }
 
 

--- a/tests/debugging/test_encoding.py
+++ b/tests/debugging/test_encoding.py
@@ -7,8 +7,10 @@ import json
 import sys
 import threading
 from typing import Any
+from typing import Generic
 from typing import NamedTuple
 from typing import Optional
+from typing import TypeVar
 from typing import cast
 
 import pytest
@@ -68,6 +70,14 @@ class PointTyped(NamedTuple):
 class Credentials(NamedTuple):
     username: str
     password: str
+
+
+_T = TypeVar("_T")
+
+
+class GenericPoint(NamedTuple, Generic[_T]):
+    x: _T
+    y: _T
 
 
 @pytest.mark.parametrize(
@@ -941,7 +951,7 @@ def test_numpy_import_hook_expands_types_end_to_end():
     assert numpy.ndarray in utils.ARRAY_TYPES
 
 
-@pytest.mark.parametrize("_type", [PointFunctional, PointTyped])
+@pytest.mark.parametrize("_type", [PointFunctional, PointTyped, GenericPoint])
 def test_is_namedtuple_type_detects_both_flavors(_type):
     # collections.namedtuple() and typing.NamedTuple produce classes that
     # behave identically at runtime (both are plain tuple subclasses with a


### PR DESCRIPTION
## Description

Stack: #19129 / #19144

This PR makes it possible to capture `namedtuple`'s in Live Debugger. 

My main question for reviewsers is whether the `_is_namedtuple_type` call is OK or if I should "inline" it into `_fields_of`.

This has been tested internally on dogweb services in staging.

**Note** the PR doesn't currently handle subclasses of Named Tuple classes. That's because `safe_getattr`  does walk the MRO chain for an object, and the `_fields` attribute is not stored in the subclass, so getting it would require walking the chain until we find it. For performance reasons, I've decided not to do it (and marked related tests as `skip` since I think they're relevant but of course, don't pass), but of course I'm open to changing it.

## Example

For this type from dogweb...

```py
# this object includes multiple time series used in the jump detection algorithm
class SeriesJumpDescriptionData(NamedTuple):
    trimmed_raw_ms: MetricSeries
    absolute_jump_magnitude_thresholds: np.ndarray
    absolute_jump_magnitudes: np.ndarray
    percentage_jump_magnitudes: np.ndarray
```

... we now see the following in Live Debugger.

<img width="466" height="146" alt="image" src="https://github.com/user-attachments/assets/d2e031cd-c4b3-4e21-b1b1-832018af8416" />
