### PR TITLE
fix(llmobs): emit LiteLLM span for OpenRouter calls

### DIFF
--- a/ddtrace/llmobs/_integrations/litellm.py
+++ b/ddtrace/llmobs/_integrations/litellm.py
@@ -162,6 +162,12 @@ class LiteLLMIntegration(BaseLLMIntegration):
 
         if getattr(_litellm, "use_litellm_proxy", False) or env.get("USE_LITELLM_PROXY", "").lower() == "true":
             return False
+        # OpenRouter model slugs (e.g. "openrouter/openai/gpt-4o") contain "openai"/"gpt" but litellm
+        # routes them through its own HTTP handler, not the OpenAI SDK, so no downstream OpenAI span is
+        # created. Without this, the LiteLLM span would be wrongly suppressed and the call would produce
+        # no LLMObs span at all.
+        if model_lower.startswith("openrouter/"):
+            return False
         # best effort attempt to check if Open AI or Azure since model_provider is unknown until request completes
         is_openai_model = any(prefix in model_lower for prefix in ("gpt", "openai", "azure"))
         return is_openai_model and not stream and LLMObs._integration_is_enabled("openai")

--- a/ddtrace/llmobs/_integrations/litellm.py
+++ b/ddtrace/llmobs/_integrations/litellm.py
@@ -162,10 +162,8 @@ class LiteLLMIntegration(BaseLLMIntegration):
 
         if getattr(_litellm, "use_litellm_proxy", False) or env.get("USE_LITELLM_PROXY", "").lower() == "true":
             return False
-        # OpenRouter model slugs (e.g. "openrouter/openai/gpt-4o") contain "openai"/"gpt" but litellm
-        # routes them through its own HTTP handler, not the OpenAI SDK, so no downstream OpenAI span is
-        # created. Without this, the LiteLLM span would be wrongly suppressed and the call would produce
-        # no LLMObs span at all.
+        # OpenRouter routes through litellm's own HTTP handler, not the OpenAI SDK, so there's no
+        # downstream OpenAI span to defer to.
         if model_lower.startswith("openrouter/"):
             return False
         # best effort attempt to check if Open AI or Azure since model_provider is unknown until request completes

--- a/releasenotes/notes/llmobs-openrouter-litellm-span-0117624c0367a7c7.yaml
+++ b/releasenotes/notes/llmobs-openrouter-litellm-span-0117624c0367a7c7.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: Resolves an issue where OpenRouter requests made through the LiteLLM integration produced no span when the OpenAI integration was also enabled.

--- a/tests/contrib/litellm/test_litellm_llmobs.py
+++ b/tests/contrib/litellm/test_litellm_llmobs.py
@@ -727,6 +727,10 @@ def test_completion_use_litellm_proxy_env_var_not_suppressed_when_openai_enabled
         ("gpt-4o", False, False, False),
         # non-OpenAI models are unaffected
         ("anthropic/claude-3", False, True, False),
+        # OpenRouter slugs contain "openai"/"gpt" but litellm routes them via httpx (no OpenAI span),
+        # so they must not be suppressed even with the OpenAI integration enabled
+        ("openrouter/openai/gpt-4o", False, True, False),
+        ("openrouter/openai/gpt-oss-120b", False, True, False),
     ],
 )
 def test_has_downstream_openai_span(model, stream, openai_enabled, expected):

--- a/tests/contrib/litellm/test_litellm_llmobs.py
+++ b/tests/contrib/litellm/test_litellm_llmobs.py
@@ -727,8 +727,6 @@ def test_completion_use_litellm_proxy_env_var_not_suppressed_when_openai_enabled
         ("gpt-4o", False, False, False),
         # non-OpenAI models are unaffected
         ("anthropic/claude-3", False, True, False),
-        # OpenRouter slugs contain "openai"/"gpt" but litellm routes them via httpx (no OpenAI span),
-        # so they must not be suppressed even with the OpenAI integration enabled
         ("openrouter/openai/gpt-4o", False, True, False),
         ("openrouter/openai/gpt-oss-120b", False, True, False),
     ],


### PR DESCRIPTION
## Description

OpenRouter calls made through the LiteLLM integration produced **no LLMObs span** when the OpenAI integration was also enabled (the default once `LLMObs.enable()` auto-enables integrations). `_has_downstream_openai_span` suppresses the LiteLLM span for model slugs containing `openai`/`gpt`, expecting the OpenAI integration to emit one instead — but litellm routes OpenRouter through its own httpx handler (`base_llm_http_handler`), not the OpenAI SDK, so no span was created at all.

Fix: skip the suppression for `openrouter/` model slugs, mirroring the existing `litellm_proxy/` guard.

## Testing

Added `openrouter/openai/*` cases to the existing `test_has_downstream_openai_span` parametrization, asserting the LiteLLM span is not suppressed even with the OpenAI integration enabled.


Repro script
```
import os
from ddtrace.llmobs import LLMObs
LLMObs.enable(...)
import litellm
resp = litellm.completion(
    model="openrouter/openai/gpt-oss-120b",
    messages=[{"role": "user", "content": "What is the capital of Spain?"}],
    api_key=os.environ["OPENROUTER_API_KEY"],
)
```

### Before
No span created.
### After
[Span](https://app.datadoghq.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=true&is_llm_session=false&refresh_mode=sliding&selectedTab=overview&sidepanelContextScopeKind=llm&sp=%5B%7B%22p%22%3A%7B%22eventId%22%3A%22AwAAAZ9xWCKlZh3vXwAAABhBWjl4V0NLbEFBQ0Y0N0VFQXFVQ0FBQUEAAAAkZDE5ZjcxNTgtMzc1ZC00MDhhLThlY2ItM2FjZWVjMDJkZDM0AAABhQ%22%7D%2C%22i%22%3A%22llm-obs-panel%22%7D%5D&spanId=2158988380905558940&start=1784312147453&end=1784313047453&paused=false)
<img width="1203" height="472" alt="Screenshot 2026-07-17 at 2 31 53 PM" src="https://github.com/user-attachments/assets/66fd9447-c9ae-4e61-ac6e-25e931bef470" />


## Risks

Low. Scoped to `openrouter/` slugs; other providers are unchanged. The only theoretical downside — a duplicate span — would require litellm to route OpenRouter through the instrumented OpenAI SDK, which it does not (it uses its own httpx handler).

## Additional Notes

Complements #18985 (OpenRouter cost capture) — without this fix, that cost/token data never lands for the `openrouter/openai/*` route in the default configuration.

Claude session: `39b98e16-b8f2-4a94-b2bc-f9a302dd0c99`
Resume: `claude --resume 39b98e16-b8f2-4a94-b2bc-f9a302dd0c99`

🤖 Generated with [Claude Code](https://claude.com/claude-code)