### PR TITLE
fix(llmobs): correctly nest parallel tool spans under step span [MLOB-7551]

### DIFF
--- a/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
@@ -343,10 +343,13 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
         tool_id = getattr(block, "id", "")
         tool_name = getattr(block, "name", "unknown_tool")
         tool_input = getattr(block, "input", {})
+        # Tool spans belong to the current step, not the active tracer context (which is the
+        # previously-opened tool span when parallel ToolUseBlocks arrive back-to-back).
         tool_span = self.integration.trace(
             "claude_agent_sdk.tool",
             submit_to_llmobs=True,
             span_name=f"claude_agent_sdk.tool.{tool_name}",
+            parent_context=self.current_step_span,
         )
         if self._last_llm_span_ref is not None:
             add_span_link(

--- a/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
@@ -343,8 +343,10 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
         tool_id = getattr(block, "id", "")
         tool_name = getattr(block, "name", "unknown_tool")
         tool_input = getattr(block, "input", {})
-        # Tool spans belong to the current step, not the active tracer context (which is the
-        # previously-opened tool span when parallel ToolUseBlocks arrive back-to-back).
+        # AIDEV-NOTE: Tool spans belong to the current step, not the active tracer context (which
+        # is the previously-opened tool span when parallel ToolUseBlocks arrive back-to-back).
+        # BaseLLMIntegration.trace() hardcodes activate=True, so each opened tool span becomes
+        # the active context — without an explicit parent_context, tool#k would chain on tool#k-1.
         tool_span = self.integration.trace(
             "claude_agent_sdk.tool",
             submit_to_llmobs=True,

--- a/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
@@ -344,12 +344,9 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
         tool_id = getattr(block, "id", "")
         tool_name = getattr(block, "name", "unknown_tool")
         tool_input = getattr(block, "input", {})
-        # AIDEV-NOTE: Tool spans belong to the current step, not the previously-opened tool span.
-        # BaseLLMIntegration.trace() hardcodes activate=True and defaults its parent to whichever
-        # span is active in each context provider, so without intervention parallel ToolUseBlocks
-        # chain on the prior in-flight tool span in BOTH the APM trace (via tracer.context_provider)
-        # and the LLM Obs UI (via LLMObs._llmobs_context_provider, which reads parent at span start
-        # in _on_span_start). Pin both: parent_context for APM, activate(step) for LLMObs.
+        # AIDEV-NOTE: Pin each tool span's parent to the current step in both trees — APM
+        # (parent_context) and LLM Obs (activate). Otherwise trace() defaults the parent to the
+        # active span, so parallel tools chain onto the prior open tool instead of nesting siblings.
         if self.current_step_span is not None and LLMObs.enabled:
             LLMObs._instance._llmobs_context_provider.activate(self.current_step_span)
         tool_span = self.integration.trace(

--- a/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
@@ -11,6 +11,7 @@ from ddtrace.contrib.internal.claude_agent_sdk.utils import _extract_model_from_
 from ddtrace.contrib.internal.claude_agent_sdk.utils import _retrieve_context
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils.formats import format_trace_id
+from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs._integrations.base_stream_handler import AsyncStreamHandler
 from ddtrace.llmobs._integrations.base_stream_handler import make_traced_stream
 from ddtrace.llmobs._utils import add_span_link
@@ -343,10 +344,14 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
         tool_id = getattr(block, "id", "")
         tool_name = getattr(block, "name", "unknown_tool")
         tool_input = getattr(block, "input", {})
-        # AIDEV-NOTE: Tool spans belong to the current step, not the active tracer context (which
-        # is the previously-opened tool span when parallel ToolUseBlocks arrive back-to-back).
-        # BaseLLMIntegration.trace() hardcodes activate=True, so each opened tool span becomes
-        # the active context — without an explicit parent_context, tool#k would chain on tool#k-1.
+        # AIDEV-NOTE: Tool spans belong to the current step, not the previously-opened tool span.
+        # BaseLLMIntegration.trace() hardcodes activate=True and defaults its parent to whichever
+        # span is active in each context provider, so without intervention parallel ToolUseBlocks
+        # chain on the prior in-flight tool span in BOTH the APM trace (via tracer.context_provider)
+        # and the LLM Obs UI (via LLMObs._llmobs_context_provider, which reads parent at span start
+        # in _on_span_start). Pin both: parent_context for APM, activate(step) for LLMObs.
+        if self.current_step_span is not None and LLMObs.enabled:
+            LLMObs._instance._llmobs_context_provider.activate(self.current_step_span)
         tool_span = self.integration.trace(
             "claude_agent_sdk.tool",
             submit_to_llmobs=True,

--- a/releasenotes/notes/fix-claude-agent-sdk-parallel-tool-nesting-95113bd0e905e228.yaml
+++ b/releasenotes/notes/fix-claude-agent-sdk-parallel-tool-nesting-95113bd0e905e228.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    LLM Observability: This fix resolves an issue with the ``claude_agent_sdk`` integration where
+    parallel tool spans were incorrectly nested in a chain (``tool#2`` parented on ``tool#1``)
+    instead of as siblings under the same ``claude_agent_sdk.step`` span. Tool spans are now
+    parented on the current step span explicitly, so parallel ``ToolUseBlock``s — whether the SDK
+    delivers them in one ``AssistantMessage`` or across several — render as siblings in the
+    trace tree.

--- a/releasenotes/notes/fix-claude-agent-sdk-parallel-tool-nesting-95113bd0e905e228.yaml
+++ b/releasenotes/notes/fix-claude-agent-sdk-parallel-tool-nesting-95113bd0e905e228.yaml
@@ -2,8 +2,8 @@
 fixes:
   - |
     LLM Observability: This fix resolves an issue with the ``claude_agent_sdk`` integration where
-    parallel tool spans were incorrectly nested in a chain (``tool#2`` parented on ``tool#1``)
-    instead of as siblings under the same ``claude_agent_sdk.step`` span. Tool spans are now
-    parented on the current step span explicitly, so parallel ``ToolUseBlock``s — whether the SDK
-    delivers them in one ``AssistantMessage`` or across several — render as siblings in the
-    trace tree.
+    parallel tool spans were incorrectly recorded as a chain (each tool parented on the previous
+    tool) instead of as siblings under the same ``claude_agent_sdk.step`` span. Tool spans are now
+    parented on the current step span explicitly, so parallel tool calls — whether the SDK
+    delivers them in one assistant message or across several — share the correct parent in the
+    span data.

--- a/releasenotes/notes/fix-claude-agent-sdk-parallel-tool-nesting-95113bd0e905e228.yaml
+++ b/releasenotes/notes/fix-claude-agent-sdk-parallel-tool-nesting-95113bd0e905e228.yaml
@@ -3,7 +3,7 @@ fixes:
   - |
     LLM Observability: This fix resolves an issue with the ``claude_agent_sdk`` integration where
     parallel tool spans were incorrectly recorded as a chain (each tool parented on the previous
-    tool) instead of as siblings under the same ``claude_agent_sdk.step`` span. Tool spans are now
-    parented on the current step span explicitly, so parallel tool calls — whether the SDK
-    delivers them in one assistant message or across several — share the correct parent in the
-    span data.
+    tool) instead of as siblings under the same ``claude_agent_sdk.step`` span. Both the APM
+    parent and the LLM Obs parent are now pinned to the step span when each tool span opens, so
+    parallel tool calls — whether the SDK delivers them in one assistant message or across
+    several — share the correct parent in both the APM trace and the LLM Obs UI.

--- a/releasenotes/notes/fix-claude-agent-sdk-parallel-tool-nesting-95113bd0e905e228.yaml
+++ b/releasenotes/notes/fix-claude-agent-sdk-parallel-tool-nesting-95113bd0e905e228.yaml
@@ -1,9 +1,7 @@
 ---
 fixes:
   - |
-    LLM Observability: This fix resolves an issue with the ``claude_agent_sdk`` integration where
-    parallel tool spans were incorrectly recorded as a chain (each tool parented on the previous
-    tool) instead of as siblings under the same ``claude_agent_sdk.step`` span. Both the APM
+    LLM Observability: This fix resolves an issue with the Claude Agent SDK integration where
+    parallel tool spans were incorrectly recorded as a chain instead of as siblings under the same step span. Both the APM
     parent and the LLM Obs parent are now pinned to the step span when each tool span opens, so
-    parallel tool calls — whether the SDK delivers them in one assistant message or across
-    several — share the correct parent in both the APM trace and the LLM Obs UI.
+    parallel tool calls share the correct parent in both the APM trace and the LLM Obs UI.

--- a/tests/contrib/claude_agent_sdk/conftest.py
+++ b/tests/contrib/claude_agent_sdk/conftest.py
@@ -15,6 +15,7 @@ from tests.contrib.claude_agent_sdk.utils import MOCK_BASH_TOOL_RESPONSE_SEQUENC
 from tests.contrib.claude_agent_sdk.utils import MOCK_CLIENT_RAW_MESSAGES
 from tests.contrib.claude_agent_sdk.utils import MOCK_DOUBLE_ASSISTANT_NO_TOOLS_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_GREP_TOOL_RESPONSE_SEQUENCE
+from tests.contrib.claude_agent_sdk.utils import MOCK_MULTI_ROUND_PARALLEL_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_PARALLEL_BASH_TOOL_USE_SEQUENCE_SEPARATE_MESSAGES
 from tests.contrib.claude_agent_sdk.utils import MOCK_PARALLEL_TOOL_USE_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_QUERY_RESPONSE_SEQUENCE
@@ -101,6 +102,12 @@ def mock_internal_client_parallel_tool_use(claude_agent_sdk):
 @pytest.fixture
 def mock_internal_client_parallel_tool_use_separate_messages(claude_agent_sdk):
     with _create_mock_internal_client(MOCK_PARALLEL_BASH_TOOL_USE_SEQUENCE_SEPARATE_MESSAGES):
+        yield
+
+
+@pytest.fixture
+def mock_internal_client_multi_round_parallel(claude_agent_sdk):
+    with _create_mock_internal_client(MOCK_MULTI_ROUND_PARALLEL_SEQUENCE):
         yield
 
 

--- a/tests/contrib/claude_agent_sdk/conftest.py
+++ b/tests/contrib/claude_agent_sdk/conftest.py
@@ -15,6 +15,7 @@ from tests.contrib.claude_agent_sdk.utils import MOCK_BASH_TOOL_RESPONSE_SEQUENC
 from tests.contrib.claude_agent_sdk.utils import MOCK_CLIENT_RAW_MESSAGES
 from tests.contrib.claude_agent_sdk.utils import MOCK_DOUBLE_ASSISTANT_NO_TOOLS_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_GREP_TOOL_RESPONSE_SEQUENCE
+from tests.contrib.claude_agent_sdk.utils import MOCK_PARALLEL_BASH_TOOL_USE_SEQUENCE_SEPARATE_MESSAGES
 from tests.contrib.claude_agent_sdk.utils import MOCK_PARALLEL_TOOL_USE_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_QUERY_RESPONSE_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_QUERY_RESPONSE_SEQUENCE_WITH_USAGE
@@ -94,6 +95,12 @@ def mock_internal_client_tool_use(claude_agent_sdk):
 @pytest.fixture
 def mock_internal_client_parallel_tool_use(claude_agent_sdk):
     with _create_mock_internal_client(MOCK_PARALLEL_TOOL_USE_SEQUENCE):
+        yield
+
+
+@pytest.fixture
+def mock_internal_client_parallel_tool_use_separate_messages(claude_agent_sdk):
+    with _create_mock_internal_client(MOCK_PARALLEL_BASH_TOOL_USE_SEQUENCE_SEPARATE_MESSAGES):
         yield
 
 

--- a/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
+++ b/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
@@ -958,13 +958,8 @@ class TestLLMObsClaudeAgentSdk:
         claude_agent_sdk_llmobs,
         test_spans,
     ):
-        """Parallel tool calls in a single AssistantMessage produce sibling tool spans.
-
-        Every parallel tool span gets a link from the same llm span
-        (``llm#1 → tool#k``), every parallel tool span links to the next llm
-        span (``tool#k → llm#2``), no tool span links to any other tool span,
-        and every tool span shares the same ``parent_id`` (= step#1) so the
-        trace data records them as siblings, not a chain (MLOB-7551).
+        """Parallel tool calls in one AssistantMessage are siblings under step#1 (MLOB-7551),
+        with span links fanning out from llm#1 — not chained tool-to-tool.
         """
         prompt = "Run three Bash commands in parallel."
         async for _ in claude_agent_sdk.query(prompt=prompt):
@@ -983,8 +978,7 @@ class TestLLMObsClaudeAgentSdk:
         assert len(tool_spans) == 3
         assert {s.name for s in tool_spans} == {"claude_agent_sdk.tool.Bash"}
 
-        # Regression: MLOB-7551 — parallel tools must be siblings under step#1 in both the APM
-        # trace and the LLM Obs UI (which keys off the metastruct parent_id, not span.parent_id).
+        # MLOB-7551: tools sibling under step#1 in both trees (APM parent_id + LLM Obs metastruct).
         step1_id = str(step_spans[0].span_id)
         for tool_span in tool_spans:
             assert tool_span.parent_id == step_spans[0].span_id
@@ -1016,10 +1010,8 @@ class TestLLMObsClaudeAgentSdk:
         claude_agent_sdk_llmobs,
         test_spans,
     ):
-        """N separate AssistantMessages (one ToolUseBlock each), then one UserMessage with all N
-        ToolResultBlocks, still nest every tool span under one step span — the wire pattern the
-        real SDK emits for parallel tools. Regression for MLOB-7551; span-link topology is covered
-        by test_llmobs_parallel_tool_use_links_all_tools_to_assistant.
+        """N separate AssistantMessages (one ToolUseBlock each) still nest every tool under one
+        step — the wire pattern the real SDK emits for parallel tools (MLOB-7551).
         """
         prompt = "Run three Bash commands in parallel (one AssistantMessage each)."
         async for _ in claude_agent_sdk.query(prompt=prompt):
@@ -1029,19 +1021,59 @@ class TestLLMObsClaudeAgentSdk:
         step_spans = sorted([s for s in spans if s.name == "claude_agent_sdk.step"], key=lambda s: s.start_ns)
         tool_spans = [s for s in spans if "tool" in s.name]
 
-        # Sequence: 3 × assistant(1 ToolUseBlock) → user(3 ToolResultBlocks) → final assistant(text)
-        # → result. The three ToolUseBlocks land before any ToolResultBlock, so they share one
-        # step span (step#1). The final text-only assistant message opens step#2.
+        # 3 tool blocks arrive before any result, so they share step#1; the final text message opens step#2.
         assert len(step_spans) == 2
         assert len(tool_spans) == 3
         assert {s.name for s in tool_spans} == {"claude_agent_sdk.tool.Bash"}
 
-        # Regression: MLOB-7551 — parallel tools must be siblings under step#1 in both the APM
-        # trace and the LLM Obs UI (which keys off the metastruct parent_id, not span.parent_id).
+        # MLOB-7551: tools sibling under step#1 in both trees (APM parent_id + LLM Obs metastruct).
         step1_id = str(step_spans[0].span_id)
         for tool_span in tool_spans:
             assert tool_span.parent_id == step_spans[0].span_id
             assert get_llmobs_parent_id(tool_span) == step1_id
+
+    async def test_llmobs_multi_round_parallel_tools_sibling_under_own_step(
+        self,
+        claude_agent_sdk,
+        mock_internal_client_multi_round_parallel,
+        claude_agent_sdk_llmobs,
+        test_spans,
+    ):
+        """Two parallel rounds across a step boundary: each round's tools sibling under their own step.
+
+        Round-2 tools must parent to the second step, never to a round-1 tool (MLOB-7551, both trees).
+        """
+        prompt = "Round 1: echo r1a and r1b in parallel. Then round 2: echo r2a and r2b in parallel."
+        async for _ in claude_agent_sdk.query(prompt=prompt):
+            pass
+
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        step_spans = sorted([s for s in spans if s.name == "claude_agent_sdk.step"], key=lambda s: s.start_ns)
+        tool_spans = sorted([s for s in spans if "tool" in s.name], key=lambda s: s.start_ns)
+        step_ids = {s.span_id for s in step_spans}
+        step_ids_str = {str(s.span_id) for s in step_spans}
+        tool_ids = {s.span_id for s in tool_spans}
+        tool_ids_str = {str(s.span_id) for s in tool_spans}
+
+        assert len(tool_spans) == 4
+        assert len(step_spans) >= 2
+
+        apm_step_parents = set()
+        llmobs_step_parents = set()
+        for tool_span in tool_spans:
+            # every tool parents to a step, never another tool (APM tree)
+            assert tool_span.parent_id in step_ids and tool_span.parent_id not in tool_ids
+            # same invariant in the LLM Obs metastruct tree
+            llmobs_parent = get_llmobs_parent_id(tool_span)
+            assert llmobs_parent in step_ids_str and llmobs_parent not in tool_ids_str
+            apm_step_parents.add(tool_span.parent_id)
+            llmobs_step_parents.add(llmobs_parent)
+
+        # tools split across >=2 distinct steps (round 1 vs round 2), not chained
+        assert len(apm_step_parents) >= 2
+        assert len(llmobs_step_parents) >= 2
+        # first vs last tool live under different steps
+        assert tool_spans[0].parent_id != tool_spans[-1].parent_id
 
     async def test_llmobs_back_to_back_assistant_messages_link_llm_to_llm_directly(
         self,

--- a/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
+++ b/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
@@ -961,8 +961,9 @@ class TestLLMObsClaudeAgentSdk:
 
         Every parallel tool span gets a link from the same llm span
         (``llm#1 → tool#k``), every parallel tool span links to the next llm
-        span (``tool#k → llm#2``), and no tool span links to any other tool
-        span (parallel tools are siblings, not a chain).
+        span (``tool#k → llm#2``), no tool span links to any other tool span,
+        and every tool span shares the same ``parent_id`` (= step#1) so the
+        trace data records them as siblings, not a chain (MLOB-7551).
         """
         prompt = "Run three Bash commands in parallel."
         async for _ in claude_agent_sdk.query(prompt=prompt):
@@ -1042,6 +1043,14 @@ class TestLLMObsClaudeAgentSdk:
         for tool_span in tool_spans:
             _assert_span_link(llm_spans[0], tool_span, "output", "input")
             _assert_span_link(tool_span, llm_spans[1], "output", "input")
+
+        # No tool → tool link: parallel tools are siblings, not chained.
+        for tool_span in tool_spans:
+            for link in get_llmobs_span_links(tool_span) or []:
+                assert link["span_id"] not in {str(s.span_id) for s in tool_spans}, (
+                    f"Tool span {tool_span.span_id} unexpectedly links to another tool span "
+                    f"({link['span_id']}); parallel tools should be siblings, not chained."
+                )
 
         # Step-to-step link is still emitted alongside the fan-out.
         _assert_span_link(step_spans[0], step_spans[1], "output", "input")

--- a/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
+++ b/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
@@ -5,6 +5,7 @@ import pytest
 
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from ddtrace.llmobs._utils import get_llmobs_parent_id
 from ddtrace.llmobs._utils import get_llmobs_span_links
 from ddtrace.llmobs._utils import safe_json
 from tests.contrib.claude_agent_sdk.utils import EXPECTED_ASSISTANT_USAGE
@@ -982,9 +983,12 @@ class TestLLMObsClaudeAgentSdk:
         assert len(tool_spans) == 3
         assert {s.name for s in tool_spans} == {"claude_agent_sdk.tool.Bash"}
 
-        # Regression: MLOB-7551 — parallel tools must be siblings under step#1, not chained.
+        # Regression: MLOB-7551 — parallel tools must be siblings under step#1 in both the APM
+        # trace and the LLM Obs UI (which keys off the metastruct parent_id, not span.parent_id).
+        step1_id = str(step_spans[0].span_id)
         for tool_span in tool_spans:
             assert tool_span.parent_id == step_spans[0].span_id
+            assert get_llmobs_parent_id(tool_span) == step1_id
 
         # Fan-out: each tool gets one incoming link from llm#1.
         for tool_span in tool_spans:
@@ -1012,48 +1016,32 @@ class TestLLMObsClaudeAgentSdk:
         claude_agent_sdk_llmobs,
         test_spans,
     ):
-        """N separate AssistantMessages (one ToolUseBlock each) followed by one UserMessage with
-        all N ToolResultBlocks still fan out under one step span: parent_id, fan-out from llm#1,
-        and fan-in to llm#2 all match the single-AssistantMessage case.
+        """N separate AssistantMessages (one ToolUseBlock each), then one UserMessage with all N
+        ToolResultBlocks, still nest every tool span under one step span — the wire pattern the
+        real SDK emits for parallel tools. Regression for MLOB-7551; span-link topology is covered
+        by test_llmobs_parallel_tool_use_links_all_tools_to_assistant.
         """
         prompt = "Run three Bash commands in parallel (one AssistantMessage each)."
         async for _ in claude_agent_sdk.query(prompt=prompt):
             pass
 
         spans = [s for trace in test_spans.pop_traces() for s in trace]
-        llm_spans = sorted([s for s in spans if s.name == "claude_agent_sdk.llm"], key=lambda s: s.start_ns)
         step_spans = sorted([s for s in spans if s.name == "claude_agent_sdk.step"], key=lambda s: s.start_ns)
         tool_spans = [s for s in spans if "tool" in s.name]
 
         # Sequence: 3 × assistant(1 ToolUseBlock) → user(3 ToolResultBlocks) → final assistant(text)
         # → result. The three ToolUseBlocks land before any ToolResultBlock, so they share one
-        # step span (step#1). The final text-only assistant message opens step#2 + llm#2.
+        # step span (step#1). The final text-only assistant message opens step#2.
         assert len(step_spans) == 2
-        assert len(llm_spans) == 2
         assert len(tool_spans) == 3
         assert {s.name for s in tool_spans} == {"claude_agent_sdk.tool.Bash"}
 
-        # Regression: MLOB-7551 — parallel tools must be siblings under step#1, not chained.
+        # Regression: MLOB-7551 — parallel tools must be siblings under step#1 in both the APM
+        # trace and the LLM Obs UI (which keys off the metastruct parent_id, not span.parent_id).
+        step1_id = str(step_spans[0].span_id)
         for tool_span in tool_spans:
             assert tool_span.parent_id == step_spans[0].span_id
-
-        # Fan-out and fan-in span links must hold for the separate-messages wire pattern too:
-        # every tool links from llm#1 (the only llm span that observed a ToolUseBlock) and
-        # forward into llm#2 (the next inference cycle).
-        for tool_span in tool_spans:
-            _assert_span_link(llm_spans[0], tool_span, "output", "input")
-            _assert_span_link(tool_span, llm_spans[1], "output", "input")
-
-        # No tool → tool link: parallel tools are siblings, not chained.
-        for tool_span in tool_spans:
-            for link in get_llmobs_span_links(tool_span) or []:
-                assert link["span_id"] not in {str(s.span_id) for s in tool_spans}, (
-                    f"Tool span {tool_span.span_id} unexpectedly links to another tool span "
-                    f"({link['span_id']}); parallel tools should be siblings, not chained."
-                )
-
-        # Step-to-step link is still emitted alongside the fan-out.
-        _assert_span_link(step_spans[0], step_spans[1], "output", "input")
+            assert get_llmobs_parent_id(tool_span) == step1_id
 
     async def test_llmobs_back_to_back_assistant_messages_link_llm_to_llm_directly(
         self,

--- a/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
+++ b/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
@@ -981,6 +981,10 @@ class TestLLMObsClaudeAgentSdk:
         assert len(tool_spans) == 3
         assert {s.name for s in tool_spans} == {"claude_agent_sdk.tool.Bash"}
 
+        # Regression: MLOB-7551 — parallel tools must be siblings under step#1, not chained.
+        for tool_span in tool_spans:
+            assert tool_span.parent_id == step_spans[0].span_id
+
         # Fan-out: each tool gets one incoming link from llm#1.
         for tool_span in tool_spans:
             _assert_span_link(llm_spans[0], tool_span, "output", "input")
@@ -996,6 +1000,48 @@ class TestLLMObsClaudeAgentSdk:
                     f"Tool span {tool_span.span_id} unexpectedly links to another tool span "
                     f"({link['span_id']}); parallel tools should be siblings, not chained."
                 )
+
+        # Step-to-step link is still emitted alongside the fan-out.
+        _assert_span_link(step_spans[0], step_spans[1], "output", "input")
+
+    async def test_llmobs_parallel_tool_use_separate_messages_nests_under_one_step(
+        self,
+        claude_agent_sdk,
+        mock_internal_client_parallel_tool_use_separate_messages,
+        claude_agent_sdk_llmobs,
+        test_spans,
+    ):
+        """N separate AssistantMessages (one ToolUseBlock each) followed by one UserMessage with
+        all N ToolResultBlocks still fan out under one step span: parent_id, fan-out from llm#1,
+        and fan-in to llm#2 all match the single-AssistantMessage case.
+        """
+        prompt = "Run three Bash commands in parallel (one AssistantMessage each)."
+        async for _ in claude_agent_sdk.query(prompt=prompt):
+            pass
+
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        llm_spans = sorted([s for s in spans if s.name == "claude_agent_sdk.llm"], key=lambda s: s.start_ns)
+        step_spans = sorted([s for s in spans if s.name == "claude_agent_sdk.step"], key=lambda s: s.start_ns)
+        tool_spans = [s for s in spans if "tool" in s.name]
+
+        # Sequence: 3 × assistant(1 ToolUseBlock) → user(3 ToolResultBlocks) → final assistant(text)
+        # → result. The three ToolUseBlocks land before any ToolResultBlock, so they share one
+        # step span (step#1). The final text-only assistant message opens step#2 + llm#2.
+        assert len(step_spans) == 2
+        assert len(llm_spans) == 2
+        assert len(tool_spans) == 3
+        assert {s.name for s in tool_spans} == {"claude_agent_sdk.tool.Bash"}
+
+        # Regression: MLOB-7551 — parallel tools must be siblings under step#1, not chained.
+        for tool_span in tool_spans:
+            assert tool_span.parent_id == step_spans[0].span_id
+
+        # Fan-out and fan-in span links must hold for the separate-messages wire pattern too:
+        # every tool links from llm#1 (the only llm span that observed a ToolUseBlock) and
+        # forward into llm#2 (the next inference cycle).
+        for tool_span in tool_spans:
+            _assert_span_link(llm_spans[0], tool_span, "output", "input")
+            _assert_span_link(tool_span, llm_spans[1], "output", "input")
 
         # Step-to-step link is still emitted alongside the fan-out.
         _assert_span_link(step_spans[0], step_spans[1], "output", "input")

--- a/tests/contrib/claude_agent_sdk/utils.py
+++ b/tests/contrib/claude_agent_sdk/utils.py
@@ -314,8 +314,7 @@ MOCK_PARALLEL_TOOL_USE_SEQUENCE = [
 ]
 
 
-# Parallel tools delivered as N AssistantMessages (1 ToolUseBlock each) + 1 UserMessage
-# carrying all N ToolResultBlocks — the wire pattern the SDK emits in practice (MLOB-7551).
+# Parallel tools as N AssistantMessages (1 ToolUseBlock each) + 1 UserMessage of results (MLOB-7551).
 MOCK_PARALLEL_BASH_TOOL_USE_SEQUENCE_SEPARATE_MESSAGES = [
     MOCK_SYSTEM_MESSAGE,
     create_mock_assistant_message_with_tool_use(
@@ -328,6 +327,44 @@ MOCK_PARALLEL_BASH_TOOL_USE_SEQUENCE_SEPARATE_MESSAGES = [
         [("Bash", {"command": "echo third"}, MOCK_PARALLEL_BASH_TOOL_IDS[2])],
     ),
     MOCK_PARALLEL_TOOL_RESULT_USER,
+    MOCK_FINAL_ASSISTANT,
+    MOCK_MULTI_TURN_RESULT_MESSAGE,
+]
+
+
+# Two parallel rounds separated by a ToolResult round-trip — MLOB-7551 across a step boundary.
+MOCK_MULTI_ROUND_TOOL_IDS = (
+    "toolu_round1_a",
+    "toolu_round1_b",
+    "toolu_round2_a",
+    "toolu_round2_b",
+)
+MOCK_MULTI_ROUND_PARALLEL_SEQUENCE = [
+    MOCK_SYSTEM_MESSAGE,
+    create_mock_assistant_message_with_tool_use(
+        [
+            ("Bash", {"command": "echo r1a"}, MOCK_MULTI_ROUND_TOOL_IDS[0]),
+            ("Bash", {"command": "echo r1b"}, MOCK_MULTI_ROUND_TOOL_IDS[1]),
+        ],
+    ),
+    create_mock_user_message_with_tool_result(
+        [
+            (MOCK_MULTI_ROUND_TOOL_IDS[0], "r1a"),
+            (MOCK_MULTI_ROUND_TOOL_IDS[1], "r1b"),
+        ],
+    ),
+    create_mock_assistant_message_with_tool_use(
+        [
+            ("Bash", {"command": "echo r2a"}, MOCK_MULTI_ROUND_TOOL_IDS[2]),
+            ("Bash", {"command": "echo r2b"}, MOCK_MULTI_ROUND_TOOL_IDS[3]),
+        ],
+    ),
+    create_mock_user_message_with_tool_result(
+        [
+            (MOCK_MULTI_ROUND_TOOL_IDS[2], "r2a"),
+            (MOCK_MULTI_ROUND_TOOL_IDS[3], "r2b"),
+        ],
+    ),
     MOCK_FINAL_ASSISTANT,
     MOCK_MULTI_TURN_RESULT_MESSAGE,
 ]

--- a/tests/contrib/claude_agent_sdk/utils.py
+++ b/tests/contrib/claude_agent_sdk/utils.py
@@ -314,6 +314,25 @@ MOCK_PARALLEL_TOOL_USE_SEQUENCE = [
 ]
 
 
+# Parallel tools delivered as N AssistantMessages (1 ToolUseBlock each) + 1 UserMessage
+# carrying all N ToolResultBlocks — the wire pattern the SDK emits in practice (MLOB-7551).
+MOCK_PARALLEL_BASH_TOOL_USE_SEQUENCE_SEPARATE_MESSAGES = [
+    MOCK_SYSTEM_MESSAGE,
+    create_mock_assistant_message_with_tool_use(
+        [("Bash", {"command": "echo first"}, MOCK_PARALLEL_BASH_TOOL_IDS[0])],
+    ),
+    create_mock_assistant_message_with_tool_use(
+        [("Bash", {"command": "echo second"}, MOCK_PARALLEL_BASH_TOOL_IDS[1])],
+    ),
+    create_mock_assistant_message_with_tool_use(
+        [("Bash", {"command": "echo third"}, MOCK_PARALLEL_BASH_TOOL_IDS[2])],
+    ),
+    MOCK_PARALLEL_TOOL_RESULT_USER,
+    MOCK_FINAL_ASSISTANT,
+    MOCK_MULTI_TURN_RESULT_MESSAGE,
+]
+
+
 MOCK_TOOL_ERROR_MESSAGE = "Permission denied: /etc/hostname"
 MOCK_TOOL_ERROR_USER_READ = create_mock_user_message_with_tool_result(
     [(MOCK_READ_TOOL_ID, MOCK_TOOL_ERROR_MESSAGE)],


### PR DESCRIPTION
## Description

Fixes [MLOB-7551](https://datadoghq.atlassian.net/browse/MLOB-7551). Parallel `ToolUseBlock` spans in the `claude_agent_sdk` integration chained (`tool#2.parent = tool#1`) instead of nesting as siblings under one `claude_agent_sdk.step`. Every `parent_id` consumer — the APM flame graph **and** the LLM Obs UI — saw the wrong agent shape.

**Root cause.** `BaseLLMIntegration.trace()` opens each span with `activate=True` and defaults its parent to the currently-active span. Parallel tools open *before any finishes* (a tool span closes later, when its `ToolResultBlock` arrives), so when tool#2 opens, tool#1 is still active and becomes its parent — a chain.

**Two independent trees.** The APM parent comes from `tracer.context_provider`; the LLM Obs UI parent is recorded separately on the span metastruct at span-start from `LLMObs._llmobs_context_provider`. An APM-only fix leaves the UI still chained. This PR pins **both**, before each tool opens: `parent_context=self.current_step_span` (APM) and `LLMObs._llmobs_context_provider.activate(step)` (LLM Obs). Re-pinning per tool means even though `trace(activate=True)` makes each new tool active, the next iteration resets the parent to the step.

## Testing

- `parent_id` + `get_llmobs_parent_id` regression guards on the parallel tests (APM tree **and** LLM Obs metastruct tree) — both fail without the fix, pass with it.
- Coverage across the real SDK wire patterns: N tools in one `AssistantMessage`; N separate `AssistantMessage`s × 1 tool; and two parallel rounds across a step boundary (`test_llmobs_multi_round_parallel_tools_sibling_under_own_step` — round-2 tools sibling under their own step, never chaining onto round 1).
- Full `tests/contrib/claude_agent_sdk/` green: **50 passed** (Py 3.12). Lint (style + typing) clean.

**Live preprod (real parallel Bash via AI Gateway) — same scenario, Before vs After:**

```
BEFORE (trace 6a5e50f8) — chain
  step          = 7931050807544507999
  tool#1.parent = 7931050807544507999   (= step)
  tool#2.parent = 11305938562990717318  (= tool#1 — CHAIN)
  tool#3.parent = 16964754198309533419  (= tool#2 — CHAIN)

AFTER (trace 6a5a8d92) — siblings
  step              = 17053422030877391222
  tool#1/2/3.parent = 17053422030877391222   (all = step)
```

- **Before — parallel tools chained:** https://dd.datad0g.com/llm/traces?query=trace_id:6a5e50f800000000289a25dd39711a15
- **After — siblings under one step:** https://dd.datad0g.com/llm/traces?query=trace_id:6a5a8d9200000000fe19059d15faa56d

Full trace set (incl. the two-rounds scenario) linked on [MLOB-7551](https://datadoghq.atlassian.net/browse/MLOB-7551).

**APM + LLM Obs (same spans, APM-enabled re-run).** Re-ran with APM tracing enabled so the identical spans land in both intakes. In both the APM flame graph and the LLM Obs UI, every `claude_agent_sdk.tool.Bash` parents its `claude_agent_sdk.step` (never another tool), and steps parent the query root — confirming the two-tree fix end-to-end, not just the LLM Obs side. (Spans correlated via `llmobs_trace_id`.)

- APM flame graph: https://dd.datad0g.com/apm/trace/6a60e6d200000000deb54a22a35d4382?graphType=flamegraph
- LLM Obs trace: https://dd.datad0g.com/llm/traces?query=trace_id:6a60e6d200000000c0dfe714140220f6

## Risks

Integration-local, ~10 lines, one-line revert. Sibling integrations (`openai_agents`, `crewai`, `pydantic_ai`, `langgraph`) don't hold overlapping long-lived spans inside a tight loop, so they aren't susceptible to this bug class. The one non-obvious dependency is the private `LLMObs._instance._llmobs_context_provider`, guarded by `LLMObs.enabled` and documented in an `AIDEV-NOTE`.

[MLOB-7551]: https://datadoghq.atlassian.net/browse/MLOB-7551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MLOB-7551]: https://datadoghq.atlassian.net/browse/MLOB-7551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ