### PR TITLE
refactor(profiling): exception safety for sampling thread

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/include/sampler.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/sampler.hpp
@@ -48,6 +48,15 @@ class Sampler
     std::mutex thread_exit_mutex;
     std::condition_variable thread_exit_cv;
 
+    // Whether the sampler is currently active. Unlike thread_running (which tracks
+    // the thread's actual lifecycle) this is set synchronously in start/stop, so
+    // it is not subject to the sampling-thread startup race.
+    // It becomes false in stop and also when the sampling thread aborts on an
+    // unexpected exception, since the sampler is then no longer active.
+    // prefork reads this to decide whether to restart the sampler after fork,
+    // ensuring a sampler that stopped due to an error is not silently restarted.
+    std::atomic<bool> sampler_active_{ false };
+
     // Pause synchronization — allows the faulthandler wrapper to temporarily
     // suspend sampling so signal handlers can be safely swapped without racing
     // with in-flight safe_memcpy calls.
@@ -73,6 +82,10 @@ class Sampler
     std::minstd_rand rng{ std::random_device{}() };
     std::vector<PyThreadState> thread_candidates;
     void adapt_sampling_interval();
+
+    // Captures one sampling cycle across all threads (or a reservoir-sampled subset thereof
+    // when max_threads_per_sample is set).
+    void capture_samples(microsecond_t wall_time_us);
 
     // Rolling window for p_stable: ring buffer of process_delta values (us CPU per adapt window).
     // p_stable is the p-th percentile of this buffer, giving a stable estimate of app CPU usage

--- a/ddtrace/internal/datadog/profiling/stack/include/stack_renderer.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/stack_renderer.hpp
@@ -85,6 +85,9 @@ class StackRenderer
     void render_native_frame(const std::string& name, const std::string& module);
     void render_stack_end();
 
+    // Drop a partially-built sample without flushing it.
+    void abort_sample();
+
     // Clear caches after fork to avoid using stale interned string/function IDs
     void postfork_child();
 };

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -239,6 +239,103 @@ Sampler::adapt_sampling_interval()
 }
 
 void
+Sampler::capture_samples(const microsecond_t wall_time_us)
+{
+    auto* const runtime = &_PyRuntime;
+
+    // When max_threads_per_sample is set, we collect all threads first, then apply
+    // reservoir sampling (Algorithm R) to select a uniform random subset, and only
+    // sample the selected threads. This caps the O(n_threads) stack-unwinding cost.
+    if (max_threads_per_sample == 0) {
+        for_each_interp(runtime, [&](InterpreterInfo& interp) -> void {
+            for_each_thread(*echion, interp, [&](PyThreadState* tstate, ThreadInfo& thread) {
+                auto success = thread.sample(*echion, tstate, wall_time_us);
+                if (success) {
+                    Sample::profile_borrow().stats().increment_sample_count();
+                }
+            });
+        });
+    } else {
+        thread_candidates.clear();
+
+        for_each_interp(runtime, [&](InterpreterInfo& interp) -> void {
+            for_each_thread(*echion, interp, [&](PyThreadState* tstate, ThreadInfo& /*thread*/) {
+                thread_candidates.push_back(*tstate);
+            });
+        });
+
+        // Algorithm R: if we have more threads than the cap, select a uniform random subset.
+        // Selected threads are placed in [0, sample_count). Overflow threads remain in
+        // [sample_count, size) as fallbacks in case a selected thread was unregistered
+        // between collection and sampling.
+        // We use Algorithm R rather than the asymptotically faster Algorithm L because we
+        // already traverse all threads unconditionally above (the CPython thread list is a
+        // linked list, so discovery always costs O(n)). Algorithm L's advantage is skipping
+        // elements to reduce random-number generation, but that only pays off when iteration
+        // itself is expensive — it isn't here. Algorithm R is simpler and sufficient.
+        size_t sample_count = thread_candidates.size();
+        if (sample_count > max_threads_per_sample) {
+            for (size_t i = max_threads_per_sample; i < sample_count; i++) {
+                std::uniform_int_distribution<size_t> dist(0, i);
+                size_t j = dist(rng);
+                if (j < max_threads_per_sample) {
+                    std::swap(thread_candidates[j], thread_candidates[i]);
+                }
+            }
+            sample_count = max_threads_per_sample;
+        }
+
+        // Apply inverse-probability weighting: each sampled thread represents n/k threads,
+        // so scale wall_time_us up to preserve correct absolute wall-time totals.
+        // Note: If a thread disappears between snapshot collection and sampling, fewer than
+        // sample_count threads are actually sampled. The weight per sample is pre-computed
+        // so the total reported wall time can be slightly under the true value under high
+        // thread churn. This is a rare edge case.
+        const size_t n_total = thread_candidates.size();
+        const microsecond_t effective_wall_time_us =
+          (sample_count < n_total)
+            ? wall_time_us * static_cast<microsecond_t>(n_total) / static_cast<microsecond_t>(sample_count)
+            : wall_time_us;
+
+        size_t fallback_idx = sample_count;
+        for (size_t i = 0; i < sample_count; i++) {
+            // The lock is acquired per iteration rather than for the whole loop so that new
+            // threads can register (which also needs this lock) between stack unwinds. Holding
+            // it for the entire loop would block thread registration for the full sampling cycle.
+            const std::lock_guard<std::mutex> guard(echion->thread_info_map_lock());
+
+            // The tstate is a snapshot captured earlier, and thread_info_map is re-looked up
+            // here by thread_id. Under extreme thread churn a pthread_t could theoretically
+            // be reused between snapshot collection and this lookup (old thread exits, new
+            // thread registers with same ID), causing the new ThreadInfo to be paired with
+            // the old tstate. This window is a few microseconds and pthread_t reuse within
+            // it is unlikely.
+            auto it = echion->thread_info_map().find(thread_candidates[i].thread_id);
+            if (it == echion->thread_info_map().end()) {
+                // Thread was unregistered; try to fill from overflow
+                for (; fallback_idx < thread_candidates.size(); ++fallback_idx) {
+                    auto fb_it = echion->thread_info_map().find(thread_candidates[fallback_idx].thread_id);
+                    if (fb_it != echion->thread_info_map().end()) {
+                        thread_candidates[i] = thread_candidates[fallback_idx];
+                        it = fb_it;
+                        // Advance so this candidate isn't reused on the next fallback search
+                        fallback_idx++;
+                        break;
+                    }
+                }
+                if (it == echion->thread_info_map().end()) {
+                    continue;
+                }
+            }
+            auto success = it->second->sample(*echion, &thread_candidates[i], effective_wall_time_us);
+            if (success) {
+                Sample::profile_borrow().stats().increment_sample_count();
+            }
+        }
+    }
+}
+
+void
 Sampler::sampling_thread(const uint64_t seq_num)
 {
     // Mark thread as running
@@ -258,7 +355,6 @@ Sampler::sampling_thread(const uint64_t seq_num)
     auto sample_time_prev = steady_clock::now();
     auto interval_adjust_time_prev = sample_time_prev;
 
-    auto* const runtime = &_PyRuntime;
     while (seq_num == thread_seq_num.load()) {
         // Check if a pause has been requested (e.g., for signal handler swapping).
         // Block until resumed or the thread is asked to stop.
@@ -286,141 +382,67 @@ Sampler::sampling_thread(const uint64_t seq_num)
         // Reset per-cycle asyncio task accumulator before iterating sampled threads
         echion->reset_asyncio_task_count();
 
-        // When max_threads_per_sample is set, we collect all threads first, then apply
-        // reservoir sampling (Algorithm R) to select a uniform random subset, and only
-        // sample the selected threads. This caps the O(n_threads) stack-unwinding cost.
-        if (max_threads_per_sample == 0) {
-            for_each_interp(runtime, [&](InterpreterInfo& interp) -> void {
-                for_each_thread(*echion, interp, [&](PyThreadState* tstate, ThreadInfo& thread) {
-                    auto success = thread.sample(*echion, tstate, wall_time_us);
-                    if (success) {
-                        Sample::profile_borrow().stats().increment_sample_count();
-                    }
-                });
-            });
-        } else {
-            thread_candidates.clear();
+        try {
+            capture_samples(wall_time_us);
 
-            for_each_interp(runtime, [&](InterpreterInfo& interp) -> void {
-                for_each_thread(*echion, interp, [&](PyThreadState* tstate, ThreadInfo& /*thread*/) {
-                    thread_candidates.push_back(*tstate);
-                });
-            });
-
-            // Algorithm R: if we have more threads than the cap, select a uniform random subset.
-            // Selected threads are placed in [0, sample_count). Overflow threads remain in
-            // [sample_count, size) as fallbacks in case a selected thread was unregistered
-            // between collection and sampling.
-            // We use Algorithm R rather than the asymptotically faster Algorithm L because we
-            // already traverse all threads unconditionally above (the CPython thread list is a
-            // linked list, so discovery always costs O(n)). Algorithm L's advantage is skipping
-            // elements to reduce random-number generation, but that only pays off when iteration
-            // itself is expensive — it isn't here. Algorithm R is simpler and sufficient.
-            size_t sample_count = thread_candidates.size();
-            if (sample_count > max_threads_per_sample) {
-                for (size_t i = max_threads_per_sample; i < sample_count; i++) {
-                    std::uniform_int_distribution<size_t> dist(0, i);
-                    size_t j = dist(rng);
-                    if (j < max_threads_per_sample) {
-                        std::swap(thread_candidates[j], thread_candidates[i]);
-                    }
-                }
-                sample_count = max_threads_per_sample;
+            // Collect greenlet count before acquiring the profile lock to avoid
+            // holding two locks simultaneously (greenlet lock then profile lock).
+            size_t greenlet_count;
+            {
+                const std::lock_guard<std::mutex> guard(echion->greenlet_info_map_lock());
+                greenlet_count = echion->greenlet_info_map().size();
             }
 
-            // Apply inverse-probability weighting: each sampled thread represents n/k threads,
-            // so scale wall_time_us up to preserve correct absolute wall-time totals.
-            // Note: If a thread disappears between snapshot collection and sampling, fewer than
-            // sample_count threads are actually sampled. The weight per sample is pre-computed
-            // so the total reported wall time can be slightly under the true value under high
-            // thread churn. This is a rare edge case.
-            const size_t n_total = thread_candidates.size();
-            const microsecond_t effective_wall_time_us =
-              (sample_count < n_total)
-                ? wall_time_us * static_cast<microsecond_t>(n_total) / static_cast<microsecond_t>(sample_count)
-                : wall_time_us;
+            // Drain copy_memory errors accumulated since the last sampling cycle.
+            auto copy_errors = g_copy_memory_error_count.exchange(0, std::memory_order_relaxed);
 
-            size_t fallback_idx = sample_count;
-            for (size_t i = 0; i < sample_count; i++) {
-                // The lock is acquired per iteration rather than for the whole loop so that new
-                // threads can register (which also needs this lock) between stack unwinds. Holding
-                // it for the entire loop would block thread registration for the full sampling cycle.
-                const std::lock_guard<std::mutex> guard(echion->thread_info_map_lock());
-
-                // The tstate is a snapshot captured earlier, and thread_info_map is re-looked up
-                // here by thread_id. Under extreme thread churn a pthread_t could theoretically
-                // be reused between snapshot collection and this lookup (old thread exits, new
-                // thread registers with same ID), causing the new ThreadInfo to be paired with
-                // the old tstate. This window is a few microseconds and pthread_t reuse within
-                // it is unlikely.
-                auto it = echion->thread_info_map().find(thread_candidates[i].thread_id);
-                if (it == echion->thread_info_map().end()) {
-                    // Thread was unregistered; try to fill from overflow
-                    for (; fallback_idx < thread_candidates.size(); ++fallback_idx) {
-                        auto fb_it = echion->thread_info_map().find(thread_candidates[fallback_idx].thread_id);
-                        if (fb_it != echion->thread_info_map().end()) {
-                            thread_candidates[i] = thread_candidates[fallback_idx];
-                            it = fb_it;
-                            // Advance so this candidate isn't reused on the next fallback search
-                            fallback_idx++;
-                            break;
-                        }
-                    }
-                    if (it == echion->thread_info_map().end()) {
-                        continue;
-                    }
-                }
-                auto success = it->second->sample(*echion, &thread_candidates[i], effective_wall_time_us);
-                if (success) {
-                    Sample::profile_borrow().stats().increment_sample_count();
+            if (do_adaptive_sampling) {
+                // Adjust the sampling interval at most every second
+                if (sample_time_now - interval_adjust_time_prev > microseconds(g_adaptive_sampling_interval_us)) {
+                    adapt_sampling_interval();
+                    interval_adjust_time_prev = sample_time_now;
                 }
             }
-        }
 
-        // Collect greenlet count before acquiring the profile lock to avoid
-        // holding two locks simultaneously (greenlet lock then profile lock).
-        size_t greenlet_count;
-        {
-            const std::lock_guard<std::mutex> guard(echion->greenlet_info_map_lock());
-            greenlet_count = echion->greenlet_info_map().size();
-        }
+            // Measure CPU time before acquiring the profile lock so lock-wait time is
+            // not counted as sampling overhead.
+            auto sample_capture_cpu_after = get_thread_cpu_time_us();
 
-        // Drain copy_memory errors accumulated since the last sampling cycle.
-        auto copy_errors = g_copy_memory_error_count.exchange(0, std::memory_order_relaxed);
+            // Update all end-of-cycle stats under a single borrow so they always land in
+            // the same upload window as the samples they describe. Without this, the uploader
+            // could swap cur_profiler_stats between two separate borrow calls, silently
+            // shifting some counters (including sample_capture_cpu_time_us) into the next window.
+            {
+                auto borrow = Sample::profile_borrow();
 
-        if (do_adaptive_sampling) {
-            // Adjust the sampling interval at most every second
-            if (sample_time_now - interval_adjust_time_prev > microseconds(g_adaptive_sampling_interval_us)) {
-                adapt_sampling_interval();
-                interval_adjust_time_prev = sample_time_now;
+                borrow.stats().increment_sampling_event_count();
+                borrow.stats().set_string_table_count(echion->string_table().size());
+                borrow.stats().set_fast_copy_memory_enabled(fast_copy_active);
+                borrow.stats().set_asyncio_task_count(echion->asyncio_task_count());
+                borrow.stats().set_greenlet_count(greenlet_count);
+
+                if (copy_errors > 0) {
+                    borrow.stats().add_copy_memory_error_count(copy_errors);
+                }
+
+                size_t cpu_diff = sample_capture_cpu_after - sample_capture_cpu_before;
+                if (cpu_diff > 0) {
+                    borrow.stats().add_sample_capture_cpu_time_us(cpu_diff);
+                }
             }
-        }
+        } catch (const std::exception& e) {
+            std::cerr << "Unexpected error in sampling thread: " << e.what() << std::endl;
 
-        // Measure CPU time before acquiring the profile lock so lock-wait time is
-        // not counted as sampling overhead.
-        auto sample_capture_cpu_after = get_thread_cpu_time_us();
+            // If the exception interrupted a sample mid-build (after render_thread_begin
+            // but before render_stack_end), return it to the pool instead of leaking it.
+            echion->renderer().abort_sample();
 
-        // Update all end-of-cycle stats under a single borrow so they always land in
-        // the same upload window as the samples they describe. Without this, the uploader
-        // could swap cur_profiler_stats between two separate borrow calls, silently
-        // shifting some counters (including sample_capture_cpu_time_us) into the next window.
-        {
-            auto borrow = Sample::profile_borrow();
+            // Mark the sampler inactive so a subsequent fork does not restart this
+            // sampler that has stopped due to an error (see prefork).
+            sampler_active_.store(false);
 
-            borrow.stats().increment_sampling_event_count();
-            borrow.stats().set_string_table_count(echion->string_table().size());
-            borrow.stats().set_fast_copy_memory_enabled(fast_copy_active);
-            borrow.stats().set_asyncio_task_count(echion->asyncio_task_count());
-            borrow.stats().set_greenlet_count(greenlet_count);
-
-            if (copy_errors > 0) {
-                borrow.stats().add_copy_memory_error_count(copy_errors);
-            }
-
-            size_t cpu_diff = sample_capture_cpu_after - sample_capture_cpu_before;
-            if (cpu_diff > 0) {
-                borrow.stats().add_sample_capture_cpu_time_us(cpu_diff);
-            }
+            // Stop the sampling loop.
+            break;
         }
 
         // Before sleeping, check whether the user has called for this thread to die.
@@ -516,22 +538,23 @@ Sampler::postfork_child()
 void
 Sampler::prefork()
 {
-    was_running_at_fork_ = thread_seq_num.load() & 1;
+    was_running_at_fork_ = sampler_active_.load();
 }
 
 void
 Sampler::postfork_parent()
 {
     // The parent's sampling thread survives the fork unchanged; no restart needed.
-    // Calling start() here would launch a second thread, corrupt the thread_seq_num
-    // parity invariant used by prefork(), and cause a data race on EchionSampler state.
+    // Calling start() here would launch a second thread and cause a data race on
+    // EchionSampler state.
 }
 
 bool
 Sampler::restart_after_fork()
 {
     // Restart the sampler if it was running before fork.
-    // We use the saved flag because prefork changed the thread_seq_num parity.
+    // We use the saved flag because postfork_child() resets the live sampler
+    // state (thread_running, etc.) before this runs.
     if (was_running_at_fork_) {
         return start();
     }
@@ -651,6 +674,8 @@ Sampler::start()
     static std::once_flag once;
     std::call_once(once, [this]() { this->one_time_setup(); });
 
+    sampler_active_.store(true);
+
     // Launch the sampling thread.
     // Thread lifetime is bounded by the value of the sequence number.  When it is changed from the value the thread was
     // launched with, the thread will exit.
@@ -664,6 +689,7 @@ Sampler::start()
     const size_t stack_size = (stack_sz.rlim_cur == RLIM_INFINITY) ? 8ULL * 1024 * 1024 : stack_sz.rlim_cur;
     auto thread_id = create_thread_with_stack(stack_size, this, ++thread_seq_num);
     if (thread_id == 0) {
+        sampler_active_.store(false);
         return false;
     }
 
@@ -673,6 +699,7 @@ Sampler::start()
         std::thread t(&Sampler::sampling_thread, this, ++thread_seq_num);
         t.detach();
     } catch (const std::exception& e) {
+        sampler_active_.store(false);
         return false;
     }
 #endif
@@ -682,6 +709,8 @@ Sampler::start()
 void
 Sampler::stop()
 {
+    sampler_active_.store(false);
+
     // Modifying the thread sequence number will cause the sampling thread to exit when it completes
     // a sampling loop.
     ++thread_seq_num;

--- a/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
@@ -264,6 +264,18 @@ StackRenderer::render_stack_end()
     sample = nullptr;
 }
 
+void
+StackRenderer::abort_sample()
+{
+    if (sample == nullptr) {
+        return;
+    }
+
+    // Return the partially-built sample to the pool without flushing it.
+    SampleManager::drop_sample(sample);
+    sample = nullptr;
+}
+
 Datadog::StackRenderer::StackRenderer()
 {
     function_id_cache.reserve(100'000);


### PR DESCRIPTION
## Description

This PR updates the Sampling Thread logic:
- It moves the sample capturing logic to a dedicated method 
- It wraps the call to this method in a `try` block so that if for whatever reason, it throws, we don't have a hard crash.

Note that we don't have any proof this currently ever happens, but in the past we have seen some crashes (from Crash Tracker) we could not explain and that we thought could be attributed to unhandled exceptions. In our case, and as far as I know, the only exceptions that should be surfaced through this code path are `std::bad_alloc` (in which case the Python process, overall, will probably die soon enough as well), but there might be other I am missing.

If the sampling logic raises an exception, the `catch` will log the exception message, then stop the sampling thread. It will not re-raise (for obvious reasons) but it'll also not try to keep the sampling thread running. The reason for that is, if we hit `std::bad_alloc` -- which may happen -- or any other exceptions -- which, as far as I know, we don't expect to ever happen -- then things are _very bad_ and we should probably keep our head low.

Also note that this change is practically free: although handling C++ exceptions bears significant cost, we would already pay the same cost today if an exception was raised (but we would crash instead of log), and this cost is only paid _if_ an exception is raised. In the nominal case where the sampling logic never throws an exception, this change is effectively free. 

**Open question** It'd be great if we could somehow surface those errors through Crash Tracking or some sort of telemetry when they happen. Will reach out to people about that.  
**Answer** There's [an API to do that](https://github.com/DataDog/libdatadog/blob/69a1471ec69b4f51c67f6ce61d501645a3dd4d57/libdd-crashtracker/src/collector/crash_handler.rs#L466-L474) but we don't currently have it available in `dd-trace-py`. I'll add support for it in a follow-up PR.