### PR TITLE
test(telemetry): fix import race with core

### DIFF
--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -10,6 +10,7 @@ from typing import Optional
 from typing import Union
 import urllib.parse as parse
 
+from ddtrace.internal import core
 from ddtrace.internal.endpoints import endpoint_collection
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.packages import is_user_code
@@ -596,12 +597,6 @@ class TelemetryWriter(PeriodicService):
             self._logs = set()
         return logs
 
-    def _dispatch(self) -> None:
-        # moved core here to avoid circular import
-        from ddtrace.internal import core
-
-        core.dispatch("telemetry.periodic")
-
     def periodic(self, force_flush: bool = False, shutting_down: bool = False) -> None:
         """Process and send telemetry events in batches.
 
@@ -699,7 +694,7 @@ class TelemetryWriter(PeriodicService):
             "payload": events,
             "request_type": TELEMETRY_EVENT_TYPE.MESSAGE_BATCH.value,
         }
-        self._dispatch()
+        core.dispatch("telemetry.periodic")
         self._client.send_event(batch_event, payload_types)
 
     def app_shutdown(self) -> None:

--- a/tests/appsec/appsec/test_telemetry.py
+++ b/tests/appsec/appsec/test_telemetry.py
@@ -18,6 +18,7 @@ from ddtrace.appsec._utils import _observator
 from ddtrace.constants import APPSEC_ENV
 from ddtrace.contrib.internal.trace_utils import set_http_meta
 from ddtrace.ext import SpanTypes
+from ddtrace.internal import core
 from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.telemetry.constants import TELEMETRY_EVENT_TYPE
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
@@ -402,7 +403,7 @@ def test_appsec_enabled_metric(
         if rc_enabled:
             enable_asm()
 
-        telemetry_writer._dispatch()
+        core.dispatch("telemetry.periodic")
 
         metrics_result = telemetry_writer._report_configurations()
         assert metrics_result == [


### PR DESCRIPTION
## Description

Encountered a race in import of `core` in the PARAMETRIC test scenario: https://github.com/DataDog/dd-trace-py/actions/runs/29724528011/job/88295929308?pr=19106

Moving the import to the module level fixes the issue by ensuring that the core api is loaded before the telemetry writer thread is started.

## Testing

- existing tests only

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

- This only occurs with ridiculously low values of the periodic interval like the ones used in tests. That's the motivation for skipping the release note on that change.
