### PR TITLE
fix(ci_visibility): stop telemetry_api fixture from hijacking the glo…

### DIFF
--- a/tests/testing/internal/test_telemetry.py
+++ b/tests/testing/internal/test_telemetry.py
@@ -28,9 +28,18 @@ def mock_writer() -> Mock:
 
 @pytest.fixture
 def telemetry_api(mock_writer: Mock) -> t.Generator[TelemetryAPI, None, None]:
+    # `TelemetryAPI.__init__` has the side effect of overwriting the process-wide
+    # `TelemetryAPI._instance` singleton. These tests only ever call methods directly
+    # on `api`, never through `TelemetryAPI.get()`, so restore whatever singleton was
+    # live beforehand right away. Otherwise, for the duration of the test, any code
+    # elsewhere that calls the real `TelemetryAPI.get()` (e.g. a background writer
+    # flush thread from ddtrace's own self-instrumented test run) could resolve to
+    # this test's `api`/`mock_writer` and inject unrelated calls into our assertions.
+    previous_instance = TelemetryAPI._instance
     api = TelemetryAPI(connector_setup=Mock())
     api.writer = mock_writer
     mock_writer.reset_mock()
+    TelemetryAPI._instance = previous_instance
     yield api
 
 


### PR DESCRIPTION
…bal TelemetryAPI singleton

TelemetryAPI.__init__ overwrites the process-wide TelemetryAPI._instance singleton as a side effect. Since dd-trace-py's own test suite is self-instrumented, a real background writer flush thread can call TelemetryAPI.get() during the window the fixture's throwaway instance is live, injecting unrelated telemetry calls into a test's call_args_list assertions and causing flakiness like test_record_event_payload_error[rate_limited-status_code][py3.10].

Restore the previous singleton immediately after constructing the fixture's instance, since these tests only ever call methods directly on the fixture's `api`, never through TelemetryAPI.get().

## Description

<!-- Provide an overview of the change and motivation for the change.
     Implementation detail and rationale belong here, not in the release note -
     release notes are customer-facing (see docs/releasenotes.rst). -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
