### PR TITLE
feat(llmobs): support prompt environment IDs

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -2051,6 +2051,7 @@ class LLMObs(Service):
         description: str = "",
         user_version: str = "",
         labels: Optional[list[str]] = None,
+        env_ids: Optional[list[str]] = None,
     ) -> PromptResponse:
         """Create a new prompt in the registry.
 
@@ -2061,6 +2062,7 @@ class LLMObs(Service):
             description: Optional description of the prompt.
             user_version: Optional user-defined version string.
             labels: Optional list containing ``production`` and/or ``development``.
+            env_ids: Optional feature-flag environment IDs to deploy the first version to.
 
         Returns:
             The created prompt.
@@ -2073,7 +2075,13 @@ class LLMObs(Service):
         """
         prompt_manager = cls._ensure_prompt_manager()
         return prompt_manager.create_prompt(
-            prompt_id, template, title=title, description=description, user_version=user_version, labels=labels
+            prompt_id,
+            template,
+            title=title,
+            description=description,
+            user_version=user_version,
+            labels=labels,
+            env_ids=env_ids,
         )
 
     @classmethod
@@ -2085,6 +2093,7 @@ class LLMObs(Service):
         description: str = "",
         user_version: str = "",
         labels: Optional[list[str]] = None,
+        env_ids: Optional[list[str]] = None,
     ) -> PromptVersionResponse:
         """Create a new version of an existing prompt.
 
@@ -2094,6 +2103,7 @@ class LLMObs(Service):
             description: Optional description of this version.
             user_version: Optional user-defined version string.
             labels: Optional list containing ``production`` and/or ``development``.
+            env_ids: Optional feature-flag environment IDs to deploy this version to.
 
         Returns:
             The created prompt version.
@@ -2106,7 +2116,12 @@ class LLMObs(Service):
         """
         prompt_manager = cls._ensure_prompt_manager()
         return prompt_manager.create_prompt_version(
-            prompt_id, template, description=description, user_version=user_version, labels=labels
+            prompt_id,
+            template,
+            description=description,
+            user_version=user_version,
+            labels=labels,
+            env_ids=env_ids,
         )
 
     @classmethod
@@ -2144,6 +2159,7 @@ class LLMObs(Service):
         *,
         labels: Optional[list[str]] = None,
         description: Optional[str] = None,
+        env_ids: Optional[list[str]] = None,
     ) -> PromptVersionResponse:
         """Update a specific prompt version's metadata.
 
@@ -2152,6 +2168,7 @@ class LLMObs(Service):
             version: The numeric version number (auto-incremented by the API, e.g. 1, 2, 3).
             labels: New labels for the version. Values must be ``production`` and/or ``development``.
             description: New description for the version.
+            env_ids: Feature-flag environment IDs to deploy this version to.
 
         Returns:
             The updated prompt version.
@@ -2163,7 +2180,9 @@ class LLMObs(Service):
             PromptServerError: Server-side error.
         """
         prompt_manager = cls._ensure_prompt_manager()
-        return prompt_manager.update_prompt_version(prompt_id, version, labels=labels, description=description)
+        return prompt_manager.update_prompt_version(
+            prompt_id, version, labels=labels, description=description, env_ids=env_ids
+        )
 
     @classmethod
     def delete_prompt(cls, prompt_id: str) -> DeletedPromptResponse:

--- a/ddtrace/llmobs/_prompts/manager.py
+++ b/ddtrace/llmobs/_prompts/manager.py
@@ -589,6 +589,7 @@ class PromptManager:
         description: str = "",
         user_version: str = "",
         labels: Optional[list[str]] = None,
+        env_ids: Optional[list[str]] = None,
     ) -> PromptResponse:
         body: dict[str, Any] = {"prompt_id": prompt_id, "template": template}
         if title:
@@ -599,6 +600,8 @@ class PromptManager:
             body["user_version"] = user_version
         if labels is not None:
             body["labels"] = labels
+        if env_ids is not None:
+            body["env_ids"] = env_ids
         result: PromptResponse = self._request("POST", PROMPTS_ENDPOINT, body=body)
         self._evict_prompt_caches(prompt_id)
         return result
@@ -611,6 +614,7 @@ class PromptManager:
         description: str = "",
         user_version: str = "",
         labels: Optional[list[str]] = None,
+        env_ids: Optional[list[str]] = None,
     ) -> PromptVersionResponse:
         escaped_id = quote(prompt_id, safe="")
         body: dict[str, Any] = {"template": template}
@@ -620,6 +624,8 @@ class PromptManager:
             body["user_version"] = user_version
         if labels is not None:
             body["labels"] = labels
+        if env_ids is not None:
+            body["env_ids"] = env_ids
         result: PromptVersionResponse = self._request("POST", f"{PROMPTS_ENDPOINT}/{escaped_id}/versions", body=body)
         self._evict_prompt_caches(prompt_id)
         return result
@@ -650,15 +656,18 @@ class PromptManager:
         *,
         labels: Optional[list[str]] = None,
         description: Optional[str] = None,
+        env_ids: Optional[list[str]] = None,
     ) -> PromptVersionResponse:
-        if labels is None and description is None:
-            raise PromptValidationError(0, "At least one of labels or description must be provided")
+        if labels is None and description is None and env_ids is None:
+            raise PromptValidationError(0, "At least one of labels, description, or env_ids must be provided")
         escaped_id = quote(prompt_id, safe="")
         body: dict[str, Any] = {}
         if labels is not None:
             body["labels"] = labels
         if description is not None:
             body["description"] = description
+        if env_ids is not None:
+            body["env_ids"] = env_ids
         result: PromptVersionResponse = self._request(
             "PATCH", f"{PROMPTS_ENDPOINT}/{escaped_id}/versions/{version}", body=body
         )

--- a/releasenotes/notes/llmobs-prompt-environment-ids-c19d1be3125ee693.yaml
+++ b/releasenotes/notes/llmobs-prompt-environment-ids-c19d1be3125ee693.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    LLM Observability: Adds the ``env_ids`` argument to prompt creation and version update methods, allowing prompt versions to be deployed to feature-flag environments.

--- a/tests/llmobs/test_prompts.py
+++ b/tests/llmobs/test_prompts.py
@@ -723,6 +723,22 @@ class TestPromptManagement:
     """Tests for prompt management (write) operations."""
 
     @pytest.mark.parametrize(
+        "call",
+        [
+            lambda: LLMObs.create_prompt("p1", [{"role": "user", "content": "hi"}], env_ids=["env-1"]),
+            lambda: LLMObs.create_prompt_version("p1", [{"role": "user", "content": "hi"}], env_ids=["env-1"]),
+            lambda: LLMObs.update_prompt_version("p1", 1, env_ids=["env-1"]),
+        ],
+    )
+    def test_write_prompt_env_ids(self, call):
+        manager = _make_manager()
+        conn, mock_patch = _mock_write_api(200, {})
+        with mock_patch, patch.object(LLMObs, "_ensure_prompt_manager", return_value=manager):
+            call()
+
+        assert json.loads(conn.requests[-1]["body"])["env_ids"] == ["env-1"]
+
+    @pytest.mark.parametrize(
         "status,exc_type",
         [
             (400, PromptValidationError),


### PR DESCRIPTION
## Description

Add the optional `env_ids` argument to `LLMObs.create_prompt()`, `LLMObs.create_prompt_version()`, and `LLMObs.update_prompt_version()`.

The Prompt API already accepts environment IDs when creating or updating prompt versions, but the Python SDK did not expose them. As a result, SDK users could register a prompt version but could not deploy it to an environment in the same operation. The SDK now forwards `env_ids` when supplied, including for an `env_ids`-only version update.

This is transport plumbing only; environment validation and deployment remain backend responsibilities.

## Testing

Added a trivial test.

## Risks

The arguments are optional, and request bodies are unchanged when `env_ids` is omitted.

## Additional Notes

The release note documents the new public arguments.
