### PR TITLE
fix(openai): coerce None streamed tool call arguments to empty string

### DIFF
--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -1178,7 +1178,7 @@ def openai_construct_tool_call_from_streamed_chunk(stored_tool_calls, tool_call_
     if function_call_chunk:
         if not stored_tool_calls:
             stored_tool_calls.append({"name": getattr(function_call_chunk, "name", ""), "arguments": ""})
-        stored_tool_calls[0]["arguments"] += getattr(function_call_chunk, "arguments", "")
+        stored_tool_calls[0]["arguments"] += getattr(function_call_chunk, "arguments", "") or ""
         return
     if not tool_call_chunk:
         return
@@ -1206,9 +1206,9 @@ def openai_construct_tool_call_from_streamed_chunk(stored_tool_calls, tool_call_
         stored_tool_calls.append(call_dict)
         list_idx = -1
     if function_call:
-        stored_tool_calls[list_idx]["function"]["arguments"] += getattr(function_call, "arguments", "")
+        stored_tool_calls[list_idx]["function"]["arguments"] += getattr(function_call, "arguments", "") or ""
     elif custom_call:
-        stored_tool_calls[list_idx]["custom"]["input"] += getattr(custom_call, "input", "")
+        stored_tool_calls[list_idx]["custom"]["input"] += getattr(custom_call, "input", "") or ""
 
 
 def openai_construct_message_from_streamed_chunks(streamed_chunks: list[Any]) -> dict[str, Any]:

--- a/releasenotes/notes/fix-openai-streamed-toolcall-none-arguments-ba2092f2362527e4.yaml
+++ b/releasenotes/notes/fix-openai-streamed-toolcall-none-arguments-ba2092f2362527e4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: Resolves a ``TypeError`` when reconstructing an OpenAI streamed tool call whose ``arguments`` (or custom tool ``input``) chunk is ``None`` instead of a string. The value is now coerced to an empty string, so the span keeps its ``kind`` tag and is no longer dropped.

--- a/tests/llmobs/test_integrations_utils.py
+++ b/tests/llmobs/test_integrations_utils.py
@@ -18,6 +18,7 @@ from ddtrace.llmobs._integrations.utils import _normalize_prompt_variables
 from ddtrace.llmobs._integrations.utils import _openai_parse_input_response_messages
 from ddtrace.llmobs._integrations.utils import format_image_part
 from ddtrace.llmobs._integrations.utils import openai_construct_message_from_streamed_chunks
+from ddtrace.llmobs._integrations.utils import openai_construct_tool_call_from_streamed_chunk
 from ddtrace.llmobs._integrations.utils import openai_set_meta_tags_from_chat
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import get_llmobs_input_messages
@@ -630,3 +631,40 @@ class TestOpenAIConstructMessageFromStreamedChunks:
         message = openai_construct_message_from_streamed_chunks(chunks)
         assert message["reasoning_content"] == "r"
         assert message["content"] == "c"
+
+
+def test_construct_tool_call_function_call_none_arguments():
+    """A streamed function_call chunk whose arguments is None must not raise (coerced to "")."""
+    stored = []
+    openai_construct_tool_call_from_streamed_chunk(
+        stored, function_call_chunk=SimpleNamespace(name="get_weather", arguments=None)
+    )
+    assert stored == [{"name": "get_weather", "arguments": ""}]
+
+
+def test_construct_tool_call_tool_call_none_arguments():
+    """A streamed tool_call chunk whose function.arguments is None must not raise (coerced to "")."""
+    stored = []
+    openai_construct_tool_call_from_streamed_chunk(
+        stored,
+        tool_call_chunk=SimpleNamespace(
+            index=0,
+            id="call_1",
+            type="function",
+            function=SimpleNamespace(name="get_weather", arguments=None),
+            custom=None,
+        ),
+    )
+    assert stored[0]["function"] == {"name": "get_weather", "arguments": ""}
+
+
+def test_construct_tool_call_arguments_still_concatenate():
+    """Regression guard: real string argument chunks still concatenate across chunks."""
+    stored = []
+    openai_construct_tool_call_from_streamed_chunk(
+        stored, function_call_chunk=SimpleNamespace(name="get_weather", arguments='{"loc"')
+    )
+    openai_construct_tool_call_from_streamed_chunk(
+        stored, function_call_chunk=SimpleNamespace(name="get_weather", arguments=':"NYC"}')
+    )
+    assert stored[0]["arguments"] == '{"loc":"NYC"}'


### PR DESCRIPTION
## Description

`openai_construct_tool_call_from_streamed_chunk` in `ddtrace/llmobs/_integrations/utils.py` reconstructs a tool call from streamed chunks by concatenating arguments with `... += getattr(chunk, "arguments", "")`. The `""` default only applies when the attribute is **missing**; when a chunk carries `arguments` (or a custom tool `input`) that is present but `None`, `getattr` returns `None` and `str += None` raises `TypeError: can only concatenate str (not "NoneType") to str`.

That aborts stream reconstruction, so the LLM Observability span never receives its `kind` tag and `_submit_llmobs_span` then drops the span. This happens for every streamed tool-call response that emits a `None` argument delta (observed via `openai` invoked through LangChain).

The fix coerces the value with `or ""` at the three concatenation sites (function_call chunk arguments, tool_call function arguments, custom tool input), mirroring the existing `or ""` idiom already used elsewhere in this module.

Fixes #19031.

## Testing

Added three unit tests to `tests/llmobs/test_integrations_utils.py`:
- `test_construct_tool_call_function_call_none_arguments` — `function_call` chunk with `arguments=None` no longer raises.
- `test_construct_tool_call_tool_call_none_arguments` — `tool_call` chunk with `function.arguments=None` no longer raises.
- `test_construct_tool_call_arguments_still_concatenate` — regression guard that real string argument chunks still concatenate correctly.

## Risks

None. The change only substitutes a `None` argument value with an empty string before concatenation; string arguments are unaffected and no public API changes.

## Additional Notes

Release note added under `releasenotes/notes/`.