### PR TITLE
refactor(profiling): copy tags to avoid mutation

### DIFF
--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -183,7 +183,7 @@ class _ProfilerInstance(service.Service):
         super().__init__()
         # User-supplied values
         self.service: Optional[str] = service if service is not None else config.service
-        self.tags: dict[str, str] = tags if tags is not None else profiling_config.tags
+        self.tags: dict[str, str] = dict(tags if tags is not None else profiling_config.tags)
         self.env: Optional[str] = env if env is not None else config.env
         self.version: Optional[str] = version if version is not None else config.version
         self.tracer: Any = tracer

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -97,6 +97,25 @@ def test_copy():
     assert p.tags == c.tags
 
 
+def test_profiler_does_not_mutate_custom_tags():
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self):
+            self.tags["generated"] = "value"
+
+    tags = {"team": "profiling"}
+    p = TestProfiler(
+        tags=tags,
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+
+    assert tags == {"team": "profiling"}
+    assert p.tags == {"team": "profiling", "generated": "value"}
+
+
 def test_failed_start_collector(caplog, monkeypatch):
     class ErrCollect(collector.Collector):
         def _start_service(self):


### PR DESCRIPTION
## What is this PR?

This PR updates the `_ProfilerInstance` class to copy the incoming `tags` as it mutates `self.tags` in `_build_default_exporters` and could thus have unintended side effects.

https://github.com/DataDog/dd-trace-py/blob/48558a3d94b40063d1580b738920825cff039e90/ddtrace/profiling/profiler.py#L219-L221

