### PR TITLE
refactor(profiling): fix off-by-one issue in serverless scheduler

### DIFF
--- a/ddtrace/profiling/scheduler.py
+++ b/ddtrace/profiling/scheduler.py
@@ -78,6 +78,8 @@ class ServerlessScheduler(Scheduler):
         self._profiled_intervals: int = 0
 
     def periodic(self) -> None:
+        self._profiled_intervals += 1
+
         # Check both the number of intervals and time frame to be sure we don't flush, e.g., empty profiles
         if self._profiled_intervals >= self.FLUSH_AFTER_INTERVALS and (time.time_ns() - self._last_export) >= int(
             self.FORCED_INTERVAL * self.FLUSH_AFTER_INTERVALS * 1e9
@@ -88,5 +90,3 @@ class ServerlessScheduler(Scheduler):
                 # Override interval so it's always back to the value we need
                 self.interval = self.FORCED_INTERVAL
                 self._profiled_intervals = 0
-        else:
-            self._profiled_intervals += 1

--- a/tests/profiling/test_scheduler.py
+++ b/tests/profiling/test_scheduler.py
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8 -*-
 import logging
-import time
 from unittest import mock
 
 from ddtrace.profiling import scheduler
@@ -42,16 +41,21 @@ def test_before_flush_failure(caplog):
 
 
 @mock.patch("ddtrace.profiling.scheduler.Scheduler.periodic")
-def test_serverless_periodic(mock_periodic):
+@mock.patch("ddtrace.profiling.scheduler.time.time_ns")
+def test_serverless_periodic(mock_time_ns, mock_periodic):
     s = scheduler.ServerlessScheduler()
     # Fake start()
-    s._last_export = time.time_ns()
-    s.periodic()
-    assert s._profiled_intervals == 1
+    s._last_export = 0
+    mock_time_ns.return_value = int(s.FORCED_INTERVAL * s.FLUSH_AFTER_INTERVALS * 1e9)
+
+    for _ in range(int(s.FLUSH_AFTER_INTERVALS) - 1):
+        s.periodic()
+
+    assert s._profiled_intervals == s.FLUSH_AFTER_INTERVALS - 1
     mock_periodic.assert_not_called()
-    s._last_export = time.time_ns() - int(65 * 1e9)
-    s._profiled_intervals = 65
+
     s.periodic()
+
     assert s._profiled_intervals == 0
     assert s.interval == 1
-    mock_periodic.assert_called()
+    mock_periodic.assert_called_once_with()


### PR DESCRIPTION
## What is this PR?

This PR updates the serverless scheduler for the Profiler to make it upload profiles after `self.FLUSH_AFTER_INTERVALS` instead of `self.FLUSH_AFTER_INTERVALS + 1`. Previously, we would do  `self._profiled_intervals += 1` only after checking if we had reached `self.FLUSH_AFTER_INTERVAL`, which was incorrect given that `periodic` would be first called at the end of the first interval.