### PR TITLE
fix(aap): reduce noisy out-of-context RASP waf callback warnings

### DIFF
--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -497,8 +497,12 @@ def call_waf_callback(
     if env is not None and env.waf_callable is not None:
         return env.waf_callable(custom_data, crop_trace, rule_type, force_sent)
 
-    logger.warning(WARNING_TAGS.CALL_WAF_CALLBACK_NOT_SET, extra=log_extra, stack_info=True)
-    report_error_on_entry_span("appsec::instrumentation::diagnostic", WARNING_TAGS.CALL_WAF_CALLBACK_NOT_SET)
+    if rule_type is None:
+        logger.warning(WARNING_TAGS.CALL_WAF_CALLBACK_NOT_SET, extra=log_extra, stack_info=True)
+        report_error_on_entry_span("appsec::instrumentation::diagnostic", WARNING_TAGS.CALL_WAF_CALLBACK_NOT_SET)
+    else:
+        # RASP calls out of context are benign (e.g. outbound request with no active request)
+        logger.debug(WARNING_TAGS.CALL_WAF_CALLBACK_NOT_SET, extra=log_extra, stack_info=True)
     return None
 
 

--- a/releasenotes/notes/fix-rasp-out-of-context-waf-noise-c34c161da0c2092b.yaml
+++ b/releasenotes/notes/fix-rasp-out-of-context-waf-noise-c34c161da0c2092b.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    AAP: Reduces noisy warning logs from exploit prevention (RASP) checks running outside of
+    a request context.

--- a/tests/appsec/appsec/test_asm_request_context.py
+++ b/tests/appsec/appsec/test_asm_request_context.py
@@ -163,3 +163,26 @@ def test_log_waf_callback(caplog):
     assert caplog.records[0].levelname == "WARNING"
     assert caplog.records[0].msg.startswith("appsec::asm_context::call_waf_callback::not_set")
     ddlogger.set_tag_rate_limit("asm_context::call_waf_callback::not_set", ddlogger.DAY)
+
+
+def test_log_waf_callback_rasp_out_of_context(caplog):
+    """RASP calls (rule_type set) out of context are benign: log at DEBUG, no warning, no error tag."""
+    from ddtrace import tracer
+    import ddtrace.internal.logger as ddlogger
+
+    ddlogger.set_tag_rate_limit("asm_context::call_waf_callback::not_set", 0)
+    try:
+        with tracer.trace("test", service="test_service") as span:
+            with caplog.at_level(logging.DEBUG), override_global_config({"_asm_enabled": True}):
+                _asm_request_context.call_waf_callback(rule_type="lfi")
+    finally:
+        ddlogger.set_tag_rate_limit("asm_context::call_waf_callback::not_set", ddlogger.DAY)
+
+    root_span = span._local_root or span
+    assert root_span.get_tag("_dd.appsec.error.type") is None
+    assert root_span.get_tag("_dd.appsec.error.message") is None
+
+    records = [r for r in caplog.records if r.msg.startswith("appsec::asm_context::call_waf_callback::not_set")]
+    assert len(records) == 1
+    assert records[0].levelname == "DEBUG"
+    assert not any(r.levelname == "WARNING" for r in caplog.records)


### PR DESCRIPTION
[APPSEC-69318](https://datadoghq.atlassian.net/browse/APPSEC-69318)

RASP exploit-prevention hooks call the WAF on outbound operations that may have no active request context (e.g. a background outbound HTTP request), which produced a steady stream of `call_waf_callback::not_set` warnings. RASP calls pass a `rule_type`, so this uses that signal to log at debug instead of warning when there is no active context; request-lifecycle callers (`rule_type=None`) still emit the warning.

## Testing
Adds `test_log_waf_callback_rasp_out_of_context` asserting RASP out-of-context calls log at debug with no warning and no entry-span error tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[APPSEC-69318]: https://datadoghq.atlassian.net/browse/APPSEC-69318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ