### PR TITLE
chore: remove google module cloning exclusion

### DIFF
--- a/ddtrace/appsec/_iast/_handlers.py
+++ b/ddtrace/appsec/_iast/_handlers.py
@@ -1,5 +1,6 @@
 from collections.abc import MutableMapping
 import functools
+from types import ModuleType
 from typing import Any
 
 from ddtrace.appsec._constants import IAST
@@ -20,14 +21,22 @@ from ddtrace.appsec._iast._taint_utils import taint_structure
 from ddtrace.appsec._iast.secure_marks.sanitizers import cmdi_sanitizer
 from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.module import ModuleWatchdog
 from ddtrace.internal.settings.asm import config as asm_config
 
 
 MessageMapContainer = None
-try:
-    from google._upb._message import MessageMapContainer  # type: ignore[no-redef]
-except ImportError:
-    pass
+
+
+# Only capture MessageMapContainer if the application (or another dependency)
+# imports google._upb._message on its own: importing it ourselves here would
+# force-load protobuf's upb backend during bootstrap, which the module-cloning
+# cleanup then unloads and can cause a second upb module to be loaded later,
+# breaking isinstance checks against it.
+@ModuleWatchdog.after_module_imported("google._upb._message")
+def _(module: ModuleType) -> None:
+    global MessageMapContainer
+    MessageMapContainer = getattr(module, "MessageMapContainer", None)
 
 
 log = get_logger(__name__)

--- a/ddtrace/bootstrap/cloning.py
+++ b/ddtrace/bootstrap/cloning.py
@@ -74,8 +74,6 @@ def cleanup_loaded_modules() -> None:
             "sre_constants",  # imported by re at runtime
             "logging",
             "attr",
-            "google",
-            "google.protobuf",  # the upb backend in >= 4.21 does not like being unloaded
             "wrapt",
             "bytecode",  # needed by before-fork hooks
             "pathlib",  # used in singledispatch


### PR DESCRIPTION
## Description

Since we no longer depend on protobuf we can remove google packages from the module cloning keep list.