### PR TITLE
fix(llmobs): capture missing OpenRouter cost details [backport 4.11]

### DIFF
--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -72,6 +72,12 @@ REASONING_OUTPUT_TOKENS_METRIC_KEY = "reasoning_output_tokens"
 CACHE_WRITE_1H_INPUT_TOKENS_METRIC_KEY = "ephemeral_1h_input_tokens"
 CACHE_WRITE_5M_INPUT_TOKENS_METRIC_KEY = "ephemeral_5m_input_tokens"
 
+# Cost metric keys (USD). When set on a span, these take precedence over any cost estimated from
+# token metrics. Integrations set them when a provider returns the actual cost (e.g. OpenRouter).
+INPUT_COST_METRIC_KEY = "input_cost"
+OUTPUT_COST_METRIC_KEY = "output_cost"
+TOTAL_COST_METRIC_KEY = "total_cost"
+
 LLMOBS_APM_SHADOW_INPUT_TOKENS_METRIC_KEY = "_dd.llmobs.input_tokens"
 LLMOBS_APM_SHADOW_OUTPUT_TOKENS_METRIC_KEY = "_dd.llmobs.output_tokens"
 LLMOBS_APM_SHADOW_TOTAL_TOKENS_METRIC_KEY = "_dd.llmobs.total_tokens"

--- a/ddtrace/llmobs/_integrations/litellm.py
+++ b/ddtrace/llmobs/_integrations/litellm.py
@@ -17,6 +17,7 @@ from ddtrace.llmobs._constants import UNKNOWN_MODEL_PROVIDER
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._integrations.openai import openai_set_meta_tags_from_chat
 from ddtrace.llmobs._integrations.openai import openai_set_meta_tags_from_completion
+from ddtrace.llmobs._integrations.utils import get_openrouter_cost_metrics
 from ddtrace.llmobs._llmobs import LLMObs
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _get_attr
@@ -259,6 +260,8 @@ class LiteLLMIntegration(BaseLLMIntegration):
                 # if no cache write TTL breakdown available, assume all writes are 5m TTL
                 metrics[CACHE_WRITE_1H_INPUT_TOKENS_METRIC_KEY] = 0
                 metrics[CACHE_WRITE_5M_INPUT_TOKENS_METRIC_KEY] = cache_creation_tokens
+
+        metrics.update(get_openrouter_cost_metrics(token_usage))
 
         return metrics
 

--- a/ddtrace/llmobs/_integrations/openai.py
+++ b/ddtrace/llmobs/_integrations/openai.py
@@ -15,6 +15,7 @@ from ddtrace.llmobs._constants import UNKNOWN_MODEL_PROVIDER
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._integrations.utils import _compute_completion_tokens
 from ddtrace.llmobs._integrations.utils import _compute_prompt_tokens
+from ddtrace.llmobs._integrations.utils import get_openrouter_cost_metrics
 from ddtrace.llmobs._integrations.utils import openai_set_meta_tags_from_chat
 from ddtrace.llmobs._integrations.utils import openai_set_meta_tags_from_completion
 from ddtrace.llmobs._integrations.utils import openai_set_meta_tags_from_response
@@ -241,6 +242,7 @@ class OpenAIIntegration(BaseLLMIntegration):
             reasoning_output_tokens = _get_attr(reasoning_output_tokens_details, "reasoning_tokens", None)
             if reasoning_output_tokens is not None:
                 metrics[REASONING_OUTPUT_TOKENS_METRIC_KEY] = reasoning_output_tokens
+            metrics.update(get_openrouter_cost_metrics(token_usage))
             return metrics
         elif kwargs.get("stream") and resp is not None:
             prompt_tokens = _compute_prompt_tokens(kwargs.get("prompt", None), kwargs.get("messages", None))

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -14,15 +14,18 @@ from ddtrace.llmobs._constants import DISPATCH_ON_LLM_TOOL_CHOICE
 from ddtrace.llmobs._constants import DISPATCH_ON_TOOL_CALL_OUTPUT_USED
 from ddtrace.llmobs._constants import FILE_FALLBACK_MARKER
 from ddtrace.llmobs._constants import IMAGE_FALLBACK_MARKER
+from ddtrace.llmobs._constants import INPUT_COST_METRIC_KEY
 from ddtrace.llmobs._constants import INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import INPUT_TYPE_FILE
 from ddtrace.llmobs._constants import INPUT_TYPE_IMAGE
 from ddtrace.llmobs._constants import INPUT_TYPE_TEXT
 from ddtrace.llmobs._constants import INSTRUMENTATION_METHOD_AUTO
 from ddtrace.llmobs._constants import OAI_HANDOFF_TOOL_ARG
+from ddtrace.llmobs._constants import OUTPUT_COST_METRIC_KEY
 from ddtrace.llmobs._constants import OUTPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import PROMPT_MULTIMODAL
 from ddtrace.llmobs._constants import PROMPT_TRACKING_INSTRUMENTATION_METHOD
+from ddtrace.llmobs._constants import TOTAL_COST_METRIC_KEY
 from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _get_attr
@@ -194,6 +197,34 @@ def parse_llmobs_metric_args(metrics):
     if total_tokens is not None:
         usage[TOTAL_TOKENS_METRIC_KEY] = total_tokens
     return usage
+
+
+def get_openrouter_cost_metrics(token_usage: Any) -> dict[str, float]:
+    """Extract OpenRouter's returned cost (USD) from an OpenAI-compatible ``usage`` object.
+
+    OpenRouter returns billed cost on ``usage.cost`` (with a ``usage.cost_details`` breakdown) in
+    every response. Returns an empty dict for responses without a cost (e.g. other providers).
+    """
+    cost = _get_attr(token_usage, "cost", None)
+    if not isinstance(cost, (int, float)):
+        return {}
+    total_cost = float(cost)
+    metrics: dict[str, float] = {TOTAL_COST_METRIC_KEY: total_cost}
+    # Only emit the input/output breakdown when it reconciles with the billed total: the
+    # upstream_inference_* costs are wholesale and can diverge from `cost` (e.g. BYOK surcharge).
+    # Reconcile at nanodollar precision (how the backend stores cost) so binary-float noise in the
+    # decimal components doesn't spuriously reject a breakdown that actually sums to the total.
+    cost_details = _get_attr(token_usage, "cost_details", {}) or {}
+    input_cost = _get_attr(cost_details, "upstream_inference_prompt_cost", None)
+    output_cost = _get_attr(cost_details, "upstream_inference_completions_cost", None)
+    if (
+        isinstance(input_cost, (int, float))
+        and isinstance(output_cost, (int, float))
+        and round((input_cost + output_cost) * 1e9) == round(total_cost * 1e9)
+    ):
+        metrics[INPUT_COST_METRIC_KEY] = float(input_cost)
+        metrics[OUTPUT_COST_METRIC_KEY] = float(output_cost)
+    return metrics
 
 
 LANGCHAIN_ROLE_MAPPING = {

--- a/releasenotes/notes/llmobs-openrouter-cost-fae726e488f8b085.yaml
+++ b/releasenotes/notes/llmobs-openrouter-cost-fae726e488f8b085.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: Resolves an issue where the OpenAI and LiteLLM integrations were missing cost data when using OpenRouter as a provider.

--- a/tests/contrib/litellm/cassettes/completion_openrouter.yaml
+++ b/tests/contrib/litellm/cassettes/completion_openrouter.yaml
@@ -1,0 +1,73 @@
+interactions:
+- request:
+    body: '{"model": "openai/gpt-oss-120b", "messages": [{"content": "What is the
+      capital of France?", "role": "user"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '109'
+      Content-Type:
+      - application/json
+      HTTP-Referer:
+      - https://litellm.ai
+      Host:
+      - openrouter.ai
+      User-Agent:
+      - litellm/1.65.4
+      X-Title:
+      - liteLLM
+    method: POST
+    uri: https://openrouter.ai/api/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/+JSgAEuAAAAAP//4kIwAQAAAP//QmICAAAA//98Ul2PmzAQ/CvIjxFJA3dcrry2
+        atWnVu2pqlSdLMcs4MbYyGvyoYj/3vVxEKJLy4ul2dmdmV3OTBUsZxWYZbJ5vE+Tx4fNZmnErw/Z
+        Q/a9PHx+Kj826fFnlbCY2e0fkJ7oshZ+JW3TavDKGipJB8IDjbpMiVljC9BEty0Yod5VrV9axGWS
+        rrfU0jq7VwU4InwlwhdTggMjgUp4Qg8NL5WpwLVOGRI1ndZUAbdXErhXoXHAZG0JQpb/pjSmgCPL
+        1zHTtiKFLY4sGqaw5uQTyXHO0NuWpIzwag/8H9UGEEUFLD8zZzW9TCAq9IIckbA1HoI39lRDJEWr
+        vNCRLaNPTlCQSGG0WHwTTuFisSK+g7JDoUdHgxhlpAE/VFjmQHpFeQFeKD3k8qc2qE/FlYdjsPDy
+        zNtL6xoRoM7sjD2E24w76Z/7/jlm3ZiI1tO0nnu7A0Mqm/uQaLzpBKcJqVgKNiHvs0BEElmv1uHL
+        7ujYCvn2ZHcsL4VGiK+nX7KcmRSyhmKaRqd6QfjBKQ9zWHSFsnMg/C4zoB9szGd3LXraUcPV+Dfx
+        t05vkF7NXnHTNI1vDxx3hNcNd0nW31jh3N/luNN6aXMNHeQ/wfu+/wsAAP//AwCYnUUyyAMAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-RAY:
+      - a1c251f0bc578f9c-BOS
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 16:17:58 GMT
+      Permissions-Policy:
+      - payment=(self "https://checkout.stripe.com" "https://connect-js.stripe.com"
+        "https://js.stripe.com" "https://*.js.stripe.com" "https://hooks.stripe.com")
+      Referrer-Policy:
+      - no-referrer, strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Generation-Id:
+      - gen-1784218677-naXC565RfwGTfDm2xVg1
+      access-control-expose-headers:
+      - X-Generation-Id,X-Provider-Name,cf-ray
+      set-cookie:
+      - __cf_bm=nMpdgBw_18NcidF6hbR.dfB1ClpPrWDZaMfl5gIDgRI-1784218677.8763235-1.0.1.1-NrwMSHZe9LHo.9l_6gMCGlPBywuyo7ihxXmmjuZodohOHQdaNibf3TsG.s64oJ1ktDGVlHwKHLGgkshN8Hqmqa9o0LMNuKh2Le4swYqOGgElDJJkScO0LoF3eRJ2J2Fn;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=openrouter.ai; Expires=Thu,
+        16 Jul 2026 16:47:58 GMT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/contrib/litellm/conftest.py
+++ b/tests/contrib/litellm/conftest.py
@@ -1,3 +1,4 @@
+import os
 from unittest import mock
 
 import pytest
@@ -15,9 +16,16 @@ def litellm(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "<not-a-real-key>")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "<not-a-real-key>")
     monkeypatch.setenv("COHERE_API_KEY", "<not-a-real-key>")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "<not-a-real-key>")
     patch()
     import litellm
 
+    # Pin tiktoken to litellm's bundled encoding cache so token counting never hits the network.
+    # Unrecognized model slugs fall back to tiktoken.get_encoding("cl100k_base"), which would
+    # otherwise fetch the encoding over HTTP (unrecordable / fails in CI).
+    monkeypatch.setenv(
+        "TIKTOKEN_CACHE_DIR", os.path.join(os.path.dirname(litellm.__file__), "litellm_core_utils", "tokenizers")
+    )
     yield litellm
     unpatch()
 

--- a/tests/contrib/litellm/test_litellm_llmobs.py
+++ b/tests/contrib/litellm/test_litellm_llmobs.py
@@ -854,3 +854,26 @@ def test_shadow_tags_completion_with_cache_tokens(tracer):
 
     assert span.get_metric("_dd.llmobs.cache_read_input_tokens") == 7
     assert span.get_metric("_dd.llmobs.cache_write_input_tokens") == 4
+
+
+def test_completion_openrouter_cost(litellm, request_vcr, litellm_llmobs, test_spans):
+    """OpenRouter cost (usage.cost) captured through litellm is surfaced on the span's cost metrics.
+
+    OpenRouter returns the billed cost in every response; the litellm integration should emit it as
+    ``total_cost`` (plus ``input_cost``/``output_cost`` when they reconcile). Note: the
+    ``openrouter/openai/*`` model string is the case where litellm may defer to the openai
+    integration via ``_has_downstream_openai_span`` — this test also documents whether a span is
+    emitted at all for that route.
+    """
+    with request_vcr.use_cassette("completion_openrouter.yaml"):
+        litellm.completion(
+            model="openrouter/openai/gpt-oss-120b",
+            messages=[{"content": "What is the capital of France?", "role": "user"}],
+        )
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
+    assert len(spans) == 1
+    metrics = get_llmobs_metrics(spans[0])
+    assert "total_cost" in metrics
+    assert metrics["total_cost"] > 0
+    if "input_cost" in metrics or "output_cost" in metrics:
+        assert round((metrics["input_cost"] + metrics["output_cost"]) * 1e9) == round(metrics["total_cost"] * 1e9)

--- a/tests/contrib/openai/cassettes/v1/chat_completion_openrouter.yaml
+++ b/tests/contrib/openai/cassettes/v1/chat_completion_openrouter.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": "What is the capital of France?"}],
+      "model": "openai/gpt-oss-120b"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '109'
+      content-type:
+      - application/json
+      host:
+      - openrouter.ai
+      user-agent:
+      - OpenAI/Python 1.0.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.0.0
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://openrouter.ai/api/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/+JSgAEuAAAAAP//4kIwAQAAAP//QmICAAAA//9CYgIAAAD//0JiAgAAAP//QmIC
+        AAAA//9CYgIAAAD//0JiAgAAAP//QmICAAAA//9CYgIAAAD//0JiAgAAAP//fFJha9swEP0rRh+D
+        k8VuQlJ/bKEw2NhY+20Uo8hnW4ssCZ2cJgT/953q2nFoNn8RvHt37707n5ksWMYq0PNks12lyXZ7
+        v5wfKwvHZPVUfd9+e1w9wMuvZ81iZnZ/QHiii5r7hTCNVeClCSXhgHugUZcpMWtMAYroxoLm8ktl
+        /dwgzpN0uaMW68xBFuCI8IMIX3UJDrQAKuEJPTR5KXUFzjqpSVS3SlEF3EEKyL0MjT0makMQsuw3
+        pdEFHFlG4spUpLDDgUXDJNY5+URynDH0xpKU5l4eIP9HtQFEXgHLzswZRS/jiBI9J0ckbLSH4I29
+        1BAJbqXnKjJl9OQ4BYkkRrPZT+4kzmYL4jsoW+RqcNSLUUYa8CzDMnvSB5oX4LlUfS5/skF9LC48
+        HIOF92faXhrX8AC1eq/NW7jNsJPuteteY9YOiWg9jfW5N3vQpLJZhUTDTUc4TUjFULARuV8HIpLI
+        crEM3/puQyqY705mz7KSK4T4evoly5kJLmooxml0qnckf3PSwxTmbSHNFAi/ywToehvT2a1FTztq
+        cjn8TflnpzdIH2avuGmaxrcHDjvC64a7ZN3dWOHU3+W443ppcw0d5D/Bu677CwAA//8DAFaKtZQg
+        BAAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-RAY:
+      - a1c257222c461bf6-BOS
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 16 Jul 2026 16:21:34 GMT
+      Permissions-Policy:
+      - payment=(self "https://checkout.stripe.com" "https://connect-js.stripe.com"
+        "https://js.stripe.com" "https://*.js.stripe.com" "https://hooks.stripe.com")
+      Referrer-Policy:
+      - no-referrer, strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Generation-Id:
+      - gen-1784218890-xgpex14FgM8LC4BeTRSn
+      access-control-expose-headers:
+      - X-Generation-Id,X-Provider-Name,cf-ray
+      set-cookie:
+      - __cf_bm=j35RyeROLDjuYuxjgADh2WH6xIZ78oMLaX_Ei8Q2P.c-1784218890.5876756-1.0.1.1-YN_TJ16xqvt4mMDV0zExci9SrhrirUYd5cfUCv9wtw9bbhYQIEZrOC2cokQCMaUSUVm1UqvJKF4lr.7YjKXPElnO7vKEQcIDJeu58Y8a4F_6PfbIJ2L7e3Wx7merNCAk;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=openrouter.ai; Expires=Thu,
+        16 Jul 2026 16:51:34 GMT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/contrib/openai/test_openai_llmobs.py
+++ b/tests/contrib/openai/test_openai_llmobs.py
@@ -9,6 +9,7 @@ from ddtrace.llmobs._integrations.utils import _est_tokens
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import get_llmobs_input_messages
 from ddtrace.llmobs._utils import get_llmobs_metadata
+from ddtrace.llmobs._utils import get_llmobs_metrics
 from ddtrace.llmobs._utils import get_llmobs_model_name
 from ddtrace.llmobs._utils import get_llmobs_model_provider
 from ddtrace.llmobs._utils import get_llmobs_output_messages
@@ -3167,3 +3168,29 @@ def test_shadow_tags_chat_completion_with_cache_tokens(tracer):
 
     assert span.get_metric("_dd.llmobs.cache_read_input_tokens") == 12
     assert span.get_metric("_dd.llmobs.cache_write_input_tokens") == 34
+
+
+class TestLLMObsOpenAIOpenRouter:
+    """OpenRouter cost capture through the OpenAI-compatible client.
+
+    OpenRouter returns the billed cost on ``usage.cost`` (plus a ``usage.cost_details`` breakdown)
+    in every response. The integration should surface it on the span's ``total_cost`` metric, adding
+    ``input_cost``/``output_cost`` only when the upstream breakdown reconciles with the billed total.
+    """
+
+    def test_chat_completion_openrouter_cost(self, openai, openai_llmobs, test_spans):
+        with get_openai_vcr(subdirectory_name="v1").use_cassette("chat_completion_openrouter.yaml"):
+            client = openai.OpenAI(base_url="https://openrouter.ai/api/v1")
+            client.chat.completions.create(
+                model="openai/gpt-oss-120b",
+                messages=[{"role": "user", "content": "What is the capital of France?"}],
+            )
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        metrics = get_llmobs_metrics(spans[0])
+        # total_cost is OpenRouter's billed cost, captured directly rather than estimated from tokens.
+        assert "total_cost" in metrics
+        assert metrics["total_cost"] > 0
+        # input_cost/output_cost are present only when they sum to total_cost; if present, verify that.
+        if "input_cost" in metrics or "output_cost" in metrics:
+            assert round((metrics["input_cost"] + metrics["output_cost"]) * 1e9) == round(metrics["total_cost"] * 1e9)


### PR DESCRIPTION
Backport #18985 to 4.11.

The automatic `backport 4.11` job on #18985 failed with a cherry-pick conflict in `tests/contrib/litellm/test_litellm_llmobs.py` (the 4.11 branch lacks the Azure streaming tests that surround the new test on `main`). This PR resolves that conflict manually, applying only the OpenRouter cost changes from #18985 — the `test_completion_openrouter_cost` test is appended after the existing cache-token test. Source changes (`_constants.py`, `litellm.py`, `openai.py`, `utils.py`) and cassettes are identical to the original.

Claude session: `e7691297-3912-4dfb-9c2a-9e8d0c79d93c`
Resume: `claude --resume e7691297-3912-4dfb-9c2a-9e8d0c79d93c`

🤖 Generated with [Claude Code](https://claude.com/claude-code)