### PR TITLE
fix(mcp): avoid LLMObs recursive imports during patching [backport 4.10]

### DIFF
--- a/ddtrace/llmobs/_integration_api.py
+++ b/ddtrace/llmobs/_integration_api.py
@@ -1,0 +1,40 @@
+"""Minimal LLMObs API used by integrations during their import-time setup.
+
+Integrations can be imported while the full LLMObs service is initializing. Keep
+this module independent from ``_llmobs`` so integration setup does not recursively
+import the service through ``BaseLLMIntegration``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Optional
+
+
+if TYPE_CHECKING:
+    from ddtrace.llmobs._llmobs import LLMObs
+
+
+# The registered service is the ``LLMObs`` class itself, not an instance. The
+# annotation is only resolved by type checkers (via ``from __future__ import
+# annotations``), so importing ``LLMObs`` here would never run at runtime and the
+# module stays free of the ``_llmobs`` dependency it is meant to avoid.
+_llmobs_service: Optional[type[LLMObs]] = None
+
+
+def register_llmobs_service(service: type[LLMObs]) -> None:
+    """Register the concrete LLMObs service after it has finished importing."""
+    global _llmobs_service
+    _llmobs_service = service
+
+
+def is_enabled() -> bool:
+    """Return whether the registered LLMObs service is enabled."""
+    return bool(_llmobs_service and _llmobs_service.enabled)
+
+
+def annotate(*args: Any, **kwargs: Any) -> None:
+    """Delegate annotations to the registered LLMObs service, when available."""
+    if _llmobs_service is not None:
+        _llmobs_service.annotate(*args, **kwargs)

--- a/ddtrace/llmobs/_integrations/__init__.py
+++ b/ddtrace/llmobs/_integrations/__init__.py
@@ -1,28 +1,39 @@
-from .anthropic import AnthropicIntegration
-from .base import BaseLLMIntegration
-from .bedrock import BedrockIntegration
-from .claude_agent_sdk import ClaudeAgentSdkIntegration
-from .google_adk import GoogleAdkIntegration
-from .google_genai import GoogleGenAIIntegration
-from .langchain import LangChainIntegration
-from .litellm import LiteLLMIntegration
-from .llama_index import LlamaIndexIntegration
-from .openai import OpenAIIntegration
-from .pydantic_ai import PydanticAIIntegration
-from .vertexai import VertexAIIntegration
+"""LLMObs integration classes.
+
+Integration patch modules import one concrete integration at a time. Resolve those
+classes lazily so patching one integration does not import the full LLMObs service
+through every other integration.
+"""
+
+from importlib import import_module
+from typing import Any
 
 
-__all__ = [
-    "AnthropicIntegration",
-    "BaseLLMIntegration",
-    "BedrockIntegration",
-    "ClaudeAgentSdkIntegration",
-    "GoogleAdkIntegration",
-    "GoogleGenAIIntegration",
-    "LangChainIntegration",
-    "LiteLLMIntegration",
-    "LlamaIndexIntegration",
-    "OpenAIIntegration",
-    "PydanticAIIntegration",
-    "VertexAIIntegration",
-]
+_INTEGRATION_MODULES = {
+    "AnthropicIntegration": ".anthropic",
+    "BaseLLMIntegration": ".base",
+    "BedrockIntegration": ".bedrock",
+    "ClaudeAgentSdkIntegration": ".claude_agent_sdk",
+    "GoogleAdkIntegration": ".google_adk",
+    "GoogleGenAIIntegration": ".google_genai",
+    "LangChainIntegration": ".langchain",
+    "LiteLLMIntegration": ".litellm",
+    "LlamaIndexIntegration": ".llama_index",
+    "OpenAIIntegration": ".openai",
+    "PydanticAIIntegration": ".pydantic_ai",
+    "VertexAIIntegration": ".vertexai",
+}
+
+
+def __getattr__(name: str) -> Any:
+    try:
+        module_name = _INTEGRATION_MODULES[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+
+    integration = getattr(import_module(module_name, __name__), name)
+    globals()[name] = integration
+    return integration
+
+
+__all__ = list(_INTEGRATION_MODULES)

--- a/ddtrace/llmobs/_integrations/base.py
+++ b/ddtrace/llmobs/_integrations/base.py
@@ -27,7 +27,7 @@ from ddtrace.llmobs._constants import OUTPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import PROXY_REQUEST
 from ddtrace.llmobs._constants import REQUEST_BASE_URL
 from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
-from ddtrace.llmobs._llmobs import LLMObs
+from ddtrace.llmobs._integration_api import is_enabled
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.trace import Span
 from ddtrace.trace import tracer
@@ -46,7 +46,7 @@ class BaseLLMIntegration:
     @property
     def llmobs_enabled(self) -> bool:
         """Return whether submitting llmobs payloads is enabled."""
-        return LLMObs.enabled
+        return is_enabled()
 
     def is_pc_sampled_llmobs(self, span: Span) -> bool:
         # Sampling of llmobs payloads is independent of spans, but we're using a RateSampler for consistency.

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -9,7 +9,7 @@ from ddtrace.llmobs._constants import CACHE_READ_INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import CACHE_WRITE_INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import LLMOBS_STRUCT
 from ddtrace.llmobs._constants import PROXY_REQUEST
-from ddtrace.llmobs._integrations import BaseLLMIntegration
+from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._integrations.bedrock_agents import DEFAULT_SPAN_DURATION_NS
 from ddtrace.llmobs._integrations.bedrock_agents import _extract_trace_step_id
 from ddtrace.llmobs._integrations.bedrock_agents import _extract_trace_type

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -118,6 +118,7 @@ from ddtrace.llmobs._experiment import _pydantic_async_evaluator_wrapper
 from ddtrace.llmobs._experiment import _pydantic_async_report_evaluator_wrapper
 from ddtrace.llmobs._experiment import _pydantic_evaluator_wrapper
 from ddtrace.llmobs._experiment import _pydantic_report_evaluator_wrapper
+from ddtrace.llmobs._integration_api import register_llmobs_service
 from ddtrace.llmobs._prompt_optimization import PromptOptimization
 from ddtrace.llmobs._prompt_optimization import validate_dataset
 from ddtrace.llmobs._prompt_optimization import validate_dataset_split
@@ -3023,5 +3024,10 @@ class LLMObs(Service):
         cls._instance._activate_llmobs_distributed_context(request_headers, context, _soft_fail=False)
 
 
-# initialize the default llmobs instance
+# Initialize the default LLMObs instance before exposing the service to integrations.
 LLMObs._instance = LLMObs()
+
+# BaseLLMIntegration depends on this lightweight API instead of importing this
+# module during integration auto-patching. Register only after LLMObs is fully
+# initialized so integrations can be imported during an experiment import.
+register_llmobs_service(LLMObs)

--- a/releasenotes/notes/fix-mcp-llmobs-import-1278d47cd97277d9.yaml
+++ b/releasenotes/notes/fix-mcp-llmobs-import-1278d47cd97277d9.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    MCP: Fixes an issue where MCP instrumentation can fail to initialize when LLM
+    Observability is imported during application startup.

--- a/tests/contrib/mcp/test_mcp_patch.py
+++ b/tests/contrib/mcp/test_mcp_patch.py
@@ -55,3 +55,41 @@ class TestMCPPatch(PatchTestCase.Base):
         self.assert_not_double_wrapped(RequestResponder.__enter__)
         self.assert_not_double_wrapped(RequestResponder.__exit__)
         self.assert_not_double_wrapped(RequestResponder.respond)
+
+
+def test_mcp_auto_patch_during_experiment_import(run_python_code_in_subprocess):
+    """MCP auto-patching must not recursively import a partial LLMObs experiment module."""
+    code = """
+import sys
+
+from ddtrace._monkey import patch
+
+patch(raise_errors=False, mcp=True)
+
+
+class ImportMCPWhileExperimentInitializes:
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname != "pydantic_evals":
+            return None
+
+        sys.meta_path.remove(self)
+        import mcp
+
+        assert getattr(mcp, "__datadog_patch", False) is True
+        return None
+
+
+sys.meta_path.insert(0, ImportMCPWhileExperimentInitializes())
+try:
+    import ddtrace.llmobs._experiment
+except ModuleNotFoundError as error:
+    # The MCP suite does not require pydantic-evals. Its import is only used to
+    # pause experiment initialization at the point that exposes this cycle.
+    if error.name != "pydantic_evals":
+        raise
+"""
+
+    _, stderr, status, _ = run_python_code_in_subprocess(code)
+
+    assert status == 0, stderr.decode()
+    assert b"failed to enable ddtrace support for mcp" not in stderr

--- a/tests/llmobs/test_llmobs_integrations.py
+++ b/tests/llmobs/test_llmobs_integrations.py
@@ -21,23 +21,23 @@ def ddtrace_global_config():
         yield mock_global_config
 
 
-@mock.patch("ddtrace.llmobs._integrations.base.LLMObs")
-def test_integration_llmobs_enabled(mock_llmobs, mock_integration_config):
-    mock_llmobs.enabled = True
+@mock.patch("ddtrace.llmobs._integrations.base.is_enabled")
+def test_integration_llmobs_enabled(mock_is_enabled, mock_integration_config):
+    mock_is_enabled.return_value = True
     integration = BaseLLMIntegration(mock_integration_config)
     assert integration.llmobs_enabled is True
-    mock_llmobs.enabled = False
+    mock_is_enabled.return_value = False
     integration = BaseLLMIntegration(mock_integration_config)
     assert integration.llmobs_enabled is False
 
 
-@mock.patch("ddtrace.llmobs._integrations.base.LLMObs")
-def test_pc_span_sampling_llmobs(mock_llmobs, mock_integration_config, tracer):
-    mock_llmobs.enabled = True
+@mock.patch("ddtrace.llmobs._integrations.base.is_enabled")
+def test_pc_span_sampling_llmobs(mock_is_enabled, mock_integration_config, tracer):
+    mock_is_enabled.return_value = True
     integration = BaseLLMIntegration(mock_integration_config)
     with tracer.trace("Dummy span") as mock_span:
         assert integration.is_pc_sampled_llmobs(mock_span) is True
-    mock_llmobs.enabled = False
+    mock_is_enabled.return_value = False
     integration = BaseLLMIntegration(mock_integration_config)
     with tracer.trace("Dummy span") as mock_span:
         assert integration.is_pc_sampled_llmobs(mock_span) is False
@@ -58,8 +58,8 @@ def test_integration_trace(mock_integration_config, test_spans):
 
 
 @mock.patch("ddtrace.llmobs._integrations.base.log")
-@mock.patch("ddtrace.llmobs._integrations.base.LLMObs")
-def test_llmobs_set_tags(mock_llmobs, mock_log, tracer, mock_integration_config):
+@mock.patch("ddtrace.llmobs._integrations.base.is_enabled", return_value=True)
+def test_llmobs_set_tags(mock_is_enabled, mock_log, tracer, mock_integration_config):
     span = tracer.trace("Dummy span", service="dummy_service")
     integration = BaseLLMIntegration(mock_integration_config)
     integration._llmobs_set_tags = mock.Mock()


### PR DESCRIPTION
## Description

Backports main commit [`96ef19d635100ce7caf47c2888c88cdfb24acc51`](https://github.com/DataDog/dd-trace-py/commit/96ef19d635100ce7caf47c2888c88cdfb24acc51), originally merged in #19198, to the 4.10 release branch.

This fixes MCP auto-patching when LLMObs experiment initialization is in progress. The backport keeps the 4.10-specific integration export set and `BaseLLMIntegration` behavior while applying the same import-cycle break.

## Testing

- The upstream change's regression test fails without the fix and passes with the fix in the Python 3.13 MCP Riot environment.
- The main PR's prebuilt CPython 3.13 manylinux wheel passed the pinned customer-environment Docker reproducer.
- Updated the 4.10-only probabilistic-sampling test to mock the dependency-inverted `is_enabled()` API rather than the removed `base.LLMObs` import.
- `scripts/lint fmt -- tests/llmobs/test_llmobs_integrations.py` passed on the updated backport branch.
- `scripts/lint style` passed on the 4.10 backport branch before this test-only adjustment.
- Release-branch CI will run the backported regression test.

## Risks

The integration package now resolves integration classes lazily. Existing exports remain available, but their corresponding modules are imported only when requested.

## Additional Notes

- Includes the MCP release-note fragment.
- The standalone customer-environment reproducer is available in the [public gist](https://gist.github.com/taegyunkim/eeef8c04c05f9f658a20e13327b7612d).
