### PR TITLE
chore(dev): ignore core files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,6 +221,12 @@ tests/appsec/iast/fixtures/taint_sinks/not_exists.txt
 *.debug
 *.dSYM/
 
+# Core dump files
+/core
+/core.[0-9]*
+*.core
+vgcore.*
+
 # Rust build artifacts
 src/native/target*
 


### PR DESCRIPTION
## Description
We had a PR in the past (#18887) accidentally introduce a core file into the repo. Lets add these to the gitignore, so this doesnt happen in the future.

Ignores
1. core -- default core dump filename
2. core.[0-9]* -- PID-suffixed
3. *.core -- .core extension files
4. vgcore.* -- valgrind 


## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
