### PR TITLE
chore(ci): pin selenium chrome to 4.46 instead of latest

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -408,6 +408,8 @@ check-slo-breaches:
   extends: .check-slo-breaches
   stage: gate
   when: always
+  # Temporary override while benchmarking platform updates their template
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:6845f3c7
   artifacts:
     name: "artifacts"
     when: always
@@ -424,5 +426,7 @@ notify-slo-breaches:
   stage: notify
   needs: ["check-slo-breaches"]
   when: always
+  # Temporary override while benchmarking platform updates their template
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:6845f3c7
   variables:
     CHANNEL: "apm-python-release"

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -209,6 +209,8 @@ benchmarks-pr-comment:
 check-slo-breaches:
   extends: .check-slo-breaches
   stage: gate
+  # Temporary override while benchmarking platform updates their template
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:6845f3c7
   needs:
     - pipeline: $PARENT_PIPELINE_ID
       job: tests-gen

--- a/.gitlab/services.yml
+++ b/.gitlab/services.yml
@@ -161,5 +161,5 @@
     name: registry.ddbuild.io/images/mirror/azure-storage/azurite:3.34.0
     alias: azurite
   selenium-chrome:
-    name: registry.ddbuild.io/images/mirror/selenium/standalone-chrome:latest
+    name: registry.ddbuild.io/images/mirror/selenium/standalone-chrome:4.34.0
     alias: selenium-chrome

--- a/.gitlab/services.yml
+++ b/.gitlab/services.yml
@@ -161,5 +161,5 @@
     name: registry.ddbuild.io/images/mirror/azure-storage/azurite:3.34.0
     alias: azurite
   selenium-chrome:
-    name: registry.ddbuild.io/images/mirror/selenium/standalone-chrome:4.34.0
+    name: registry.ddbuild.io/images/mirror/selenium/standalone-chrome:4.46.0
     alias: selenium-chrome

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,7 +191,7 @@ services:
 
 
     selenium-chrome:
-        image: selenium/standalone-chrome:latest
+        image: registry.ddbuild.io/images/mirror/selenium/standalone-chrome:4.34.0
         platform: linux/amd64
         network_mode: host
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,7 +191,7 @@ services:
 
 
     selenium-chrome:
-        image: registry.ddbuild.io/images/mirror/selenium/standalone-chrome:4.34.0
+        image: selenium/standalone-chrome:4.34.0
         platform: linux/amd64
         network_mode: host
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,7 +191,7 @@ services:
 
 
     selenium-chrome:
-        image: selenium/standalone-chrome:4.34.0
+        image: selenium/standalone-chrome:latest
         platform: linux/amd64
         network_mode: host
         environment:


### PR DESCRIPTION
## Description

We are getting such [failures](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1881035850):
```
Running with gitlab-runner 18.0.5-7dd18d2e (7dd18d2e)
  on gitlab-runner-amd64-shared-5d89b777bb-rbgfd _xbvGsbV_, system ID: r_YdjzSWYyFzzs
  feature flags: FF_SCRIPT_SECTIONS:true
Preparing the "kubernetes" executor
00:01
Preparing environment
00:00
ERROR: Error cleaning up pod: resource name may not be empty
ERROR: Job failed (system failure): prepare environment: setting up build pod: pods "runner-xbvgsbv-project-358-concurrent-0-kutwp28r" is forbidden: ValidatingAdmissionPolicy 'image-tag-latest' with binding 'image-tag-latest' denied request: Containers cannot use the "latest" image tag (or omit a tag). Offending container(s): selenium-chrome in namespace gitlab-runner. For more information, see: https://datadoghq.atlassian.net/wiki/spaces/K8S/pages/6345523384/VAP+Policy+Exclusions#Understanding-a-Denial-Message. Check https://docs.gitlab.com/runner/shells/#shell-profile-loading for more information
```

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
