### PR TITLE
chore(ci): pin benchmarking-platform-tools-ubuntu

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -408,6 +408,8 @@ check-slo-breaches:
   extends: .check-slo-breaches
   stage: gate
   when: always
+  # Temporary override while benchmarking platform updates their template
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:6845f3c7
   artifacts:
     name: "artifacts"
     when: always
@@ -424,5 +426,7 @@ notify-slo-breaches:
   stage: notify
   needs: ["check-slo-breaches"]
   when: always
+  # Temporary override while benchmarking platform updates their template
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:6845f3c7
   variables:
     CHANNEL: "apm-python-release"

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -209,6 +209,8 @@ benchmarks-pr-comment:
 check-slo-breaches:
   extends: .check-slo-breaches
   stage: gate
+  # Temporary override while benchmarking platform updates their template
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:6845f3c7
   needs:
     - pipeline: $PARENT_PIPELINE_ID
       job: tests-gen


### PR DESCRIPTION
## Description
Temporarily pinning benchmarking-platform-tools-ubuntu for check-slo-breaches ans the check-slo-breaches template uses the latest tag for benchmarking-platform-tools-ubuntu which is [rejected by K8 rules](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1881150400)

```
Search visible log output
Running with gitlab-runner 18.0.5-7dd18d2e (7dd18d2e)
  on gitlab-runner-amd64-shared-5d89b777bb-w5jr2 _xbvGsbV_, system ID: r_j71DXHh6GYFK
  feature flags: FF_SCRIPT_SECTIONS:true
Preparing the "kubernetes" executor
00:00
Preparing environment
00:01
ERROR: Error cleaning up pod: resource name may not be empty
ERROR: Job failed (system failure): prepare environment: setting up build pod: pods "runner-xbvgsbv-project-358-concurrent-0-zrokn7lz" is forbidden: ValidatingAdmissionPolicy 'image-tag-latest' with binding 'image-tag-latest' denied request: Containers cannot use the "latest" image tag (or omit a tag). Offending container(s): build in namespace gitlab-runner. For more information, see: https://datadoghq.atlassian.net/wiki/spaces/K8S/pages/6345523384/VAP+Policy+Exclusions#Understanding-a-Denial-Message. Check https://docs.gitlab.com/runner/shells/#shell-profile-loading for more information
```

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
