### PR TITLE
ci: pin selenium docker image version

### DIFF
--- a/.gitlab/services.yml
+++ b/.gitlab/services.yml
@@ -161,5 +161,5 @@
     name: registry.ddbuild.io/images/mirror/azure-storage/azurite:3.34.0
     alias: azurite
   selenium-chrome:
-    name: registry.ddbuild.io/images/mirror/selenium/standalone-chrome:latest
+    name: registry.ddbuild.io/images/mirror/selenium/standalone-chrome:149.0
     alias: selenium-chrome


### PR DESCRIPTION
## Description

Pin selenium docker image version to avoid using `latest`
