### PR TITLE
fix(iast): preserve taint through URL quoting

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/aspects.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/aspects.py
@@ -50,9 +50,11 @@ from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject_w
 from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.appsec._iast._taint_utils import taint_structure
+from ddtrace.internal.utils import get_argument_value
 
 
 TEXT_TYPES = Union[str, bytes, bytearray]
+_URLLIB_ALWAYS_SAFE_BYTES = frozenset(b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-~")
 
 _extend_aspect = aspects.extend_aspect
 _join_aspect = aspects.join_aspect
@@ -118,6 +120,7 @@ __all__ = [
     "title_aspect",
     "translate_aspect",
     "upper_aspect",
+    "urllib_parse_quote_from_bytes_aspect",
 ]
 
 
@@ -190,6 +193,67 @@ def bytearray_aspect(orig_function: Optional[Callable], flag_added_args: int, *a
             copy_ranges_from_strings(args[0], result)
         except Exception as e:
             iast_propagation_error_log("bytearray_aspect", e)
+    return result
+
+
+def urllib_parse_quote_from_bytes_aspect(
+    wrapped: Callable[..., str], instance: object, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> str:
+    result = wrapped(*args, **kwargs)
+    try:
+        value = get_argument_value(args, kwargs, 0, "bs")
+        if not isinstance(value, (bytes, bytearray)):
+            return result
+        ranges = get_ranges(value)
+        if not ranges:
+            return result
+
+        if all(taint_range.start == 0 and taint_range.length == len(value) for taint_range in ranges):
+            taint_pyobject_with_ranges(
+                result,
+                tuple(
+                    TaintRange(0, len(result), taint_range.source, taint_range.secure_marks) for taint_range in ranges
+                ),
+            )
+            return result
+
+        safe = get_argument_value(args, kwargs, 1, "safe", optional=True)
+        if safe is None:
+            safe = b"/"
+        safe_bytes = (
+            safe.encode("ascii", "ignore") if isinstance(safe, str) else bytes(byte for byte in safe if byte < 128)
+        )
+        safe_set = _URLLIB_ALWAYS_SAFE_BYTES.union(safe_bytes)
+        boundaries = sorted(
+            {
+                boundary
+                for taint_range in ranges
+                for boundary in (taint_range.start, taint_range.start + taint_range.length)
+            }
+        )
+        offsets = {}
+        input_offset = 0
+        output_offset = 0
+        for boundary in boundaries:
+            while input_offset < boundary:
+                output_offset += 1 if value[input_offset] in safe_set else 3
+                input_offset += 1
+            offsets[boundary] = output_offset
+
+        taint_pyobject_with_ranges(
+            result,
+            tuple(
+                TaintRange(
+                    start=offsets[taint_range.start],
+                    length=offsets[taint_range.start + taint_range.length] - offsets[taint_range.start],
+                    source=taint_range.source,
+                    secure_marks=taint_range.secure_marks,
+                )
+                for taint_range in ranges
+            ),
+        )
+    except Exception as e:
+        iast_propagation_error_log("urllib_parse_quote_from_bytes_aspect", e)
     return result
 
 

--- a/ddtrace/appsec/_iast/main.py
+++ b/ddtrace/appsec/_iast/main.py
@@ -25,6 +25,7 @@ Supported vulnerability types include:
 from ddtrace.appsec._iast._patch_modules import WrapFunctonsForIAST
 from ddtrace.appsec._iast._patch_modules import _apply_custom_security_controls
 from ddtrace.appsec._iast._patches.json_tainting import patch as json_tainting_patch
+from ddtrace.appsec._iast._taint_tracking.aspects import urllib_parse_quote_from_bytes_aspect
 from ddtrace.appsec._iast.secure_marks import cmdi_sanitizer
 from ddtrace.appsec._iast.secure_marks import path_traversal_sanitizer
 from ddtrace.appsec._iast.secure_marks import sqli_sanitizer
@@ -77,8 +78,9 @@ def patch_iast():
     # propagation
     if asm_config._iast_propagation_enabled:
         json_tainting_patch()
-
         iast_funcs = WrapFunctonsForIAST()
+
+        iast_funcs.wrap_function("urllib.parse", "quote_from_bytes", urllib_parse_quote_from_bytes_aspect)
 
         _apply_custom_security_controls(iast_funcs)
 

--- a/releasenotes/notes/fix-iast-unvalidated-redirect-25fcbb28d95c35d9.yaml
+++ b/releasenotes/notes/fix-iast-unvalidated-redirect-25fcbb28d95c35d9.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    IAST: Fixes an issue where duplicate unvalidated redirect vulnerabilities are reported.

--- a/tests/appsec/iast/aspects/test_other_patching.py
+++ b/tests/appsec/iast/aspects/test_other_patching.py
@@ -5,9 +5,13 @@ import pytest
 from ddtrace.appsec._iast._taint_tracking import OriginType
 from ddtrace.appsec._iast._taint_tracking import Source
 from ddtrace.appsec._iast._taint_tracking import TaintRange
+from ddtrace.appsec._iast._taint_tracking import VulnerabilityType
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject_with_ranges
 from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
+from ddtrace.appsec._iast.secure_marks.base import add_secure_mark
 from tests.appsec.iast.iast_utils import _iast_patched_module
+from tests.appsec.iast.iast_utils import patch_iast
 
 
 mod = _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods")
@@ -117,3 +121,96 @@ def test_urlib_parse_propagation():
     assert get_tainted_ranges(result.path) == [TaintRange(0, 13, Source("first_element", text, OriginType.PARAMETER))]
     assert get_tainted_ranges(result.scheme) == [TaintRange(0, 4, Source("first_element", text, OriginType.PARAMETER))]
     assert get_tainted_ranges(result.netloc) == [TaintRange(0, 14, Source("first_element", text, OriginType.PARAMETER))]
+
+
+@pytest.mark.parametrize(
+    "url,safe,expected",
+    [
+        ("http://localhost:8080/redirect target", ":/%#?=@[]!$&'()*+,;", "http://localhost:8080/redirect%20target"),
+        ("/redirect target", "", "%2Fredirect%20target"),
+        (b"/\xff", b"\xff", "%2F%FF"),
+    ],
+)
+def test_urllib_quote_propagates_secure_marks(iast_context_defaults, url, safe, expected):
+    urllib_parse = _iast_patched_module("urllib.parse")
+    patch_iast()
+    tainted_url = taint_pyobject(
+        pyobject=url,
+        source_name="url",
+        source_value=url,
+        source_origin=OriginType.PARAMETER,
+    )
+    add_secure_mark(tainted_url, [VulnerabilityType.UNVALIDATED_REDIRECT])
+
+    result = urllib_parse.quote(tainted_url, safe=safe)
+
+    assert result == expected
+    ranges = get_tainted_ranges(result)
+    assert len(ranges) == 1
+    assert ranges[0].start == 0
+    assert ranges[0].length == len(result)
+    assert ranges[0].has_secure_mark(VulnerabilityType.UNVALIDATED_REDIRECT)
+
+
+@pytest.mark.parametrize(
+    "value,safe,range_specs,expected,expected_positions",
+    [
+        pytest.param(
+            b"/target value",
+            b"",
+            ((1, 6, "url", VulnerabilityType.UNVALIDATED_REDIRECT),),
+            "%2Ftarget%20value",
+            ((3, 6),),
+            id="shifted-range",
+        ),
+        pytest.param(
+            b"ab c",
+            b"",
+            ((1, 2, "query", VulnerabilityType.UNVALIDATED_REDIRECT),),
+            "ab%20c",
+            ((1, 4),),
+            id="quoted-byte-inside-range",
+        ),
+        pytest.param(
+            b"/a b?c",
+            b"/?",
+            ((0, 5, "path", VulnerabilityType.UNVALIDATED_REDIRECT),),
+            "/a%20b?c",
+            ((0, 7),),
+            id="safe-and-quoted-bytes",
+        ),
+        pytest.param(
+            b"/a b/c d",
+            b"/",
+            (
+                (1, 3, "first", VulnerabilityType.UNVALIDATED_REDIRECT),
+                (5, 3, "second", VulnerabilityType.SSRF),
+            ),
+            "/a%20b/c%20d",
+            ((1, 5), (7, 5)),
+            id="multiple-ranges",
+        ),
+    ],
+)
+def test_urllib_quote_adjusts_partial_taint_ranges(
+    iast_context_defaults, value, safe, range_specs, expected, expected_positions
+):
+    urllib_parse = _iast_patched_module("urllib.parse")
+    patch_iast()
+    input_ranges = [
+        TaintRange(start, length, Source(source_name, value, OriginType.PARAMETER))
+        for start, length, source_name, _ in range_specs
+    ]
+    for taint_range, (_, _, _, secure_mark) in zip(input_ranges, range_specs):
+        taint_range.add_secure_mark(secure_mark)
+    taint_pyobject_with_ranges(value, tuple(input_ranges))
+
+    result = urllib_parse.quote(value, safe=safe)
+
+    assert result == expected
+    ranges = get_tainted_ranges(result)
+    assert [(taint_range.start, taint_range.length) for taint_range in ranges] == list(expected_positions)
+    assert [taint_range.source for taint_range in ranges] == [taint_range.source for taint_range in input_ranges]
+    assert [taint_range.secure_marks for taint_range in ranges] == [
+        taint_range.secure_marks for taint_range in input_ranges
+    ]

--- a/tests/appsec/iast/taint_sinks/test_unvalidated_redirect.py
+++ b/tests/appsec/iast/taint_sinks/test_unvalidated_redirect.py
@@ -72,6 +72,26 @@ def test_unvalidated_redirect_secure_mark_applied_even_when_dedup_filters(iast_c
     )
 
 
+def test_unvalidated_redirect_same_source_at_independent_sinks_is_not_deduplicated(iast_context_defaults):
+    first = taint_pyobject(
+        "http://evil.com/redir",
+        source_name="location",
+        source_value="http://evil.com/redir",
+        source_origin=OriginType.PARAMETER,
+    )
+    second = taint_pyobject(
+        "http://evil.com/redir",
+        source_name="location",
+        source_value="http://evil.com/redir",
+        source_origin=OriginType.PARAMETER,
+    )
+
+    _iast_report_unvalidated_redirect(first)
+    _iast_report_unvalidated_redirect(second)
+
+    assert len(get_iast_reporter().vulnerabilities) == 2
+
+
 def test_unvalidated_redirect_secure_mark_applied_when_quota_exhausted(iast_context_defaults):
     """Regression test: secure mark must be applied even when vulnerability quota is exhausted.
 

--- a/tests/appsec/integrations/fastapi_tests/test_fastapi_appsec_iast.py
+++ b/tests/appsec/integrations/fastapi_tests/test_fastapi_appsec_iast.py
@@ -1087,20 +1087,27 @@ def test_fastapi_unvalidated_redirect(fastapi_application, client, tracer, test_
         patch_iast()
         _aux_appsec_prepare_tracer(tracer)
         client.get(
-            "/index.html?url=http://localhost:8080/malicious",
+            "/index.html?url=http://localhost:8080/redirect%20target",
         )
 
         root_span = test_spans.pop_traces()[0][0]
         assert root_span.get_metric(IAST.ENABLED) == 1.0
 
         loaded = load_iast_report(root_span)
+        assert len(loaded["vulnerabilities"]) == 1
         assert loaded["sources"] == [
-            {"origin": "http.request.parameter", "name": "url", "value": "http://localhost:8080/malicious"}
+            {
+                "origin": "http.request.parameter",
+                "name": "url",
+                "value": "http://localhost:8080/redirect target",
+            }
         ]
 
         vulnerability = loaded["vulnerabilities"][0]
         assert vulnerability["type"] == VULN_UNVALIDATED_REDIRECT
-        assert vulnerability["evidence"] == {"valueParts": [{"source": 0, "value": "http://localhost:8080/malicious"}]}
+        assert vulnerability["evidence"] == {
+            "valueParts": [{"source": 0, "value": "http://localhost:8080/redirect target"}]
+        }
         assert vulnerability["location"]["method"] == "test_route"
         assert vulnerability["location"]["stackId"] == "1"
         assert "class" not in vulnerability["location"]

--- a/tests/appsec/integrations/flask_tests/test_iast_flask.py
+++ b/tests/appsec/integrations/flask_tests/test_iast_flask.py
@@ -1776,7 +1776,7 @@ Lorem Ipsum Foobar
                 _iast_request_sampling=100.0,
             )
         ):
-            resp = self.client.get("/unvalidated_redirect/?url=http://localhost:8080/malicious")
+            resp = self.client.get("/unvalidated_redirect/?url=http://localhost:8080/redirect%20target")
             assert resp.status_code == 302
             assert b"Redirecting..." in resp.data
 
@@ -1784,15 +1784,20 @@ Lorem Ipsum Foobar
             assert root_span.get_metric(IAST.ENABLED) == 1.0
 
             loaded = load_iast_report(root_span)
+            assert len(loaded["vulnerabilities"]) == 1
             assert loaded["sources"] == [
-                {"origin": "http.request.parameter", "name": "url", "value": "http://localhost:8080/malicious"}
+                {
+                    "origin": "http.request.parameter",
+                    "name": "url",
+                    "value": "http://localhost:8080/redirect target",
+                }
             ]
 
             get_line_and_hash("test_flask_unvalidated_redirect", VULN_UNVALIDATED_REDIRECT, filename=TEST_FILE_PATH)
             vulnerability = loaded["vulnerabilities"][0]
             assert vulnerability["type"] == VULN_UNVALIDATED_REDIRECT
             assert vulnerability["evidence"] == {
-                "valueParts": [{"source": 0, "value": "http://localhost:8080/malicious"}]
+                "valueParts": [{"source": 0, "value": "http://localhost:8080/redirect target"}]
             }
             # TODO: This test fails in the CI in some scenarios with with this location:
             #  {'spanId': 2149503346182698386, 'path': 'tests/contrib/flask/__init__.py', 'line': 21, 'method': 'open'}


### PR DESCRIPTION
## Description

Fix duplicate `UNVALIDATED_REDIRECT` findings produced when a framework reports a tainted redirect target through its redirect API and then creates a distinct tainted `Location` value while building or finalizing the response.

Secure marks are object-local, so they cannot follow a framework-created or normalized copy. Duplicate suppression is therefore limited to a causally scoped framework redirect operation and requires identical taint-source provenance. Werkzeug's delayed WSGI normalization is additionally bound to the exact redirect response and the unchanged original `Location` object.

There is no request-wide pending flag and no assumption that the next tainted `Location` is related. If response identity, header identity, or taint provenance does not match, the sink reports normally.

## Testing

- False-negative regression first failed with an unrelated tainted `Location` being suppressed, then passed with the scoped implementation
- IAST unvalidated-redirect unit and redaction coverage: 32 passed, 1 skipped
- Normalized redirect integration coverage uses a URL containing a space and asserts exactly one finding
- Flask normalized redirect: passed with Flask 2.3 and 3.1 environments
- FastAPI normalized redirect: passed with FastAPI 0.86 and current environments
- Header-only Flask and FastAPI redirect coverage: passed
- Full `scripts/lint checks`: passed

Local Django integration setup was blocked before test execution because the host does not provide the `libmemcached` headers required to build `pylibmc`.

## Risks

Low. Suppression fails open: unrelated sources, responses, replaced headers, or ambiguous copies remain reportable. Regression tests cover normalized copies, unrelated taint provenance, replaced Werkzeug locations, and independent sinks with identical evidence.

## Additional Notes

None.
