### PR TITLE
perf(coverage): optimize file-level monitoring callbacks

### DIFF
--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -309,6 +309,11 @@ class ModuleCodeCollector(ModuleWatchdog):
             _tls_coverage.covered = ctx_covered.get()[-1]
             _tls_coverage.covered_files = ctx_covered_files.get()[-1]
 
+            if _PY_GE_312:
+                from ddtrace.internal.coverage.instrumentation_py3_12 import set_active_context_covered_files
+
+                set_active_context_covered_files(_tls_coverage.covered_files)
+
             # For Python 3.12+, dynamically detect whether other sys.monitoring tools are
             # active and update the DISABLE optimisation flag accordingly.  Then re-enable
             # monitoring only when the optimisation is active (restart_events is global and
@@ -342,6 +347,11 @@ class ModuleCodeCollector(ModuleWatchdog):
             else:
                 _tls_coverage.covered = covered_lines_stack[-1]
                 _tls_coverage.covered_files = covered_files_stack[-1]
+
+            if _PY_GE_312:
+                from ddtrace.internal.coverage.instrumentation_py3_12 import set_active_context_covered_files
+
+                set_active_context_covered_files(_tls_coverage.covered_files)
 
         def get_covered_lines(self) -> dict[str, CoverageLines]:
             covered_lines = _get_ctx_covered_lines()

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -47,30 +47,30 @@ _tls_coverage = _threading.local()
 
 
 def _get_ctx_covered_lines() -> defaultdict[str, CoverageLines]:
+    # sys.monitoring callbacks are hot and Python 3.14+ callbacks cannot see ContextVar changes made in the current
+    # thread. Keep a thread-local pointer for every supported version: it is required on 3.14+ and is a cheaper fast
+    # path on 3.12/3.13.
+    tls_covered = getattr(_tls_coverage, "covered", None)
+    if tls_covered is not None:
+        return tls_covered
+
     if ctx_coverage_enabled.get():
         if context_stack := ctx_covered.get():
             return context_stack[-1]
         log.debug("_get_ctx_covered_lines() called but ctx_covered stack is empty")
 
-    # Fallback for Python 3.14+ where sys.monitoring callbacks can't see ContextVars
-    if _PY_GE_314:
-        tls_covered = getattr(_tls_coverage, "covered", None)
-        if tls_covered is not None:
-            return tls_covered
-
     return defaultdict(CoverageLines)
 
 
 def _get_ctx_covered_files() -> set[str]:
+    tls_covered_files = getattr(_tls_coverage, "covered_files", None)
+    if tls_covered_files is not None:
+        return tls_covered_files
+
     if ctx_coverage_enabled.get():
         if context_stack := ctx_covered_files.get():
             return context_stack[-1]
         log.debug("_get_ctx_covered_files() called but ctx_covered_files stack is empty")
-
-    if _PY_GE_314:
-        tls_covered_files = getattr(_tls_coverage, "covered_files", None)
-        if tls_covered_files is not None:
-            return tls_covered_files
 
     return set()
 
@@ -141,35 +141,42 @@ class ModuleCodeCollector(ModuleWatchdog):
                 lambda x: True, cls._instance._exit_context_on_exception_hook
             )
 
+    def hook_import(self, path: str, import_name: tuple[str, tuple[str, ...]]) -> None:
+        if self._collect_import_coverage:
+            self._import_names_by_path[path].add(import_name)
+
+    def hook_file(self, path: str) -> None:
+        if self._coverage_enabled and path not in self._covered_files:
+            self._covered_files.add(path)
+            self.covered[path].add(0)
+
+        if ctx_coverage_enabled.get() or getattr(_tls_coverage, "covered", None) is not None:
+            ctx_covered_file_paths = _get_ctx_covered_files()
+            if path not in ctx_covered_file_paths:
+                ctx_covered_file_paths.add(path)
+                _get_ctx_covered_lines()[path].add(0)
+
     def hook(self, arg: tuple[t.Optional[int], str, t.Optional[tuple[str, tuple[str, ...]]]]):
         line: t.Optional[int]
         path: str
         import_name: t.Optional[tuple[str, tuple[str, ...]]]
         line, path, import_name = arg
 
-        if import_name is not None and self._collect_import_coverage:
-            self._import_names_by_path[path].add(import_name)
+        if import_name is not None:
+            self.hook_import(path, import_name)
 
         if line is None:
             return
 
         if self._file_level_coverage and line == 0:
-            if self._coverage_enabled and path not in self._covered_files:
-                self._covered_files.add(path)
-                self.covered[path].add(line)
-
-            if ctx_coverage_enabled.get() or (_PY_GE_314 and getattr(_tls_coverage, "covered", None) is not None):
-                ctx_covered_file_paths = _get_ctx_covered_files()
-                if path not in ctx_covered_file_paths:
-                    ctx_covered_file_paths.add(path)
-                    _get_ctx_covered_lines()[path].add(line)
+            self.hook_file(path)
             return
 
         if self._coverage_enabled:
             lines = self.covered[path]
             lines.add(line)
 
-        if ctx_coverage_enabled.get() or (_PY_GE_314 and getattr(_tls_coverage, "covered", None) is not None):
+        if ctx_coverage_enabled.get() or getattr(_tls_coverage, "covered", None) is not None:
             # Import-time contexts store their lines in a non-context variable to be aggregated on request when
             # reporting coverage
             ctx_lines = _get_ctx_covered_lines()[path]
@@ -297,11 +304,10 @@ class ModuleCodeCollector(ModuleWatchdog):
             if self.is_import_coverage:
                 ctx_is_import_coverage.set(self.is_import_coverage)
 
-            # Python 3.14+ sys.monitoring callbacks can't see ContextVar changes,
-            # so also store in thread-local as a fallback for the hook.
-            if _PY_GE_314:
-                _tls_coverage.covered = ctx_covered.get()[-1]
-                _tls_coverage.covered_files = ctx_covered_files.get()[-1]
+            # sys.monitoring callbacks are hot. Store the active context in thread-local storage for a cheaper fast
+            # path on 3.12/3.13 and as a correctness fallback on 3.14+, where callbacks can't see ContextVar changes.
+            _tls_coverage.covered = ctx_covered.get()[-1]
+            _tls_coverage.covered_files = ctx_covered_files.get()[-1]
 
             # For Python 3.12+, dynamically detect whether other sys.monitoring tools are
             # active and update the DISABLE optimisation flag accordingly.  Then re-enable
@@ -331,10 +337,9 @@ class ModuleCodeCollector(ModuleWatchdog):
             # Stop coverage if we're exiting the last context
             if len(covered_lines_stack) == 0:
                 ctx_coverage_enabled.set(False)
-                if _PY_GE_314:
-                    _tls_coverage.covered = None
-                    _tls_coverage.covered_files = None
-            elif _PY_GE_314:
+                _tls_coverage.covered = None
+                _tls_coverage.covered_files = None
+            else:
                 _tls_coverage.covered = covered_lines_stack[-1]
                 _tls_coverage.covered_files = covered_files_stack[-1]
 

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -314,10 +314,10 @@ class ModuleCodeCollector(ModuleWatchdog):
                 _tls_coverage.covered = ctx_covered.get()[-1]
                 _tls_coverage.covered_files = ctx_covered_files.get()[-1]
 
-            if _PY_GE_314:
+            if _PY_GE_312:
                 from ddtrace.internal.coverage.instrumentation_py3_12 import set_active_context_covered_files
 
-                set_active_context_covered_files(_tls_coverage.covered_files)
+                set_active_context_covered_files(ctx_covered_files.get()[-1])
 
             # For Python 3.12+, dynamically detect whether other sys.monitoring tools are
             # active and update the DISABLE optimisation flag accordingly.  Then re-enable
@@ -354,10 +354,10 @@ class ModuleCodeCollector(ModuleWatchdog):
                 _tls_coverage.covered = covered_lines_stack[-1]
                 _tls_coverage.covered_files = covered_files_stack[-1]
 
-            if _PY_GE_314:
+            if _PY_GE_312:
                 from ddtrace.internal.coverage.instrumentation_py3_12 import set_active_context_covered_files
 
-                set_active_context_covered_files(_tls_coverage.covered_files)
+                set_active_context_covered_files(covered_files_stack[-1] if covered_files_stack else None)
 
         def get_covered_lines(self) -> dict[str, CoverageLines]:
             covered_lines = _get_ctx_covered_lines()

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -37,6 +37,7 @@ _PY_GE_313 = sys.version_info >= (3, 13)
 _PY_GE_314 = sys.version_info >= (3, 14)
 
 ctx_covered: ContextVar[list[defaultdict[str, CoverageLines]]] = ContextVar("ctx_covered", default=[])
+ctx_covered_files: ContextVar[list[set[str]]] = ContextVar("ctx_covered_files", default=[])
 ctx_is_import_coverage = ContextVar("ctx_is_import_coverage", default=False)
 ctx_coverage_enabled = ContextVar("ctx_coverage_enabled", default=False)
 
@@ -60,6 +61,20 @@ def _get_ctx_covered_lines() -> defaultdict[str, CoverageLines]:
     return defaultdict(CoverageLines)
 
 
+def _get_ctx_covered_files() -> set[str]:
+    if ctx_coverage_enabled.get():
+        if context_stack := ctx_covered_files.get():
+            return context_stack[-1]
+        log.debug("_get_ctx_covered_files() called but ctx_covered_files stack is empty")
+
+    if _PY_GE_314:
+        tls_covered_files = getattr(_tls_coverage, "covered_files", None)
+        if tls_covered_files is not None:
+            return tls_covered_files
+
+    return set()
+
+
 class ModuleCodeCollector(ModuleWatchdog):
     _instance: t.Optional["ModuleCodeCollector"] = None
 
@@ -76,11 +91,13 @@ class ModuleCodeCollector(ModuleWatchdog):
         self._exclude_paths.append(Path(__file__).resolve().parent)
 
         self._coverage_enabled: bool = False
+        self._file_level_coverage: bool = False
         self.seen: set[tuple[CodeType, str]] = set()
 
         # Data structures for coverage data
         self.lines: defaultdict[str, CoverageLines] = defaultdict(CoverageLines)
         self.covered: defaultdict[str, CoverageLines] = defaultdict(CoverageLines)
+        self._covered_files: set[str] = set()
 
         # Import-time coverage data
         self._import_time_covered: defaultdict[str, CoverageLines] = defaultdict(CoverageLines)
@@ -101,6 +118,7 @@ class ModuleCodeCollector(ModuleWatchdog):
         cls,
         include_paths: t.Optional[list[Path]] = None,
         collect_import_time_coverage: bool = False,
+        file_level_coverage: bool = False,
     ):
         if ModuleCodeCollector.is_installed():
             return
@@ -116,17 +134,36 @@ class ModuleCodeCollector(ModuleWatchdog):
 
         cls._instance._include_paths = include_paths
         cls._instance._collect_import_coverage = collect_import_time_coverage
+        cls._instance._file_level_coverage = file_level_coverage
 
         if collect_import_time_coverage:
             ModuleCodeCollector.register_import_exception_hook(
                 lambda x: True, cls._instance._exit_context_on_exception_hook
             )
 
-    def hook(self, arg: tuple[int, str, t.Optional[tuple[str, tuple[str, ...]]]]):
-        line: int
+    def hook(self, arg: tuple[t.Optional[int], str, t.Optional[tuple[str, tuple[str, ...]]]]):
+        line: t.Optional[int]
         path: str
         import_name: t.Optional[tuple[str, tuple[str, ...]]]
         line, path, import_name = arg
+
+        if import_name is not None and self._collect_import_coverage:
+            self._import_names_by_path[path].add(import_name)
+
+        if line is None:
+            return
+
+        if self._file_level_coverage and line == 0:
+            if self._coverage_enabled and path not in self._covered_files:
+                self._covered_files.add(path)
+                self.covered[path].add(line)
+
+            if ctx_coverage_enabled.get() or (_PY_GE_314 and getattr(_tls_coverage, "covered", None) is not None):
+                ctx_covered_file_paths = _get_ctx_covered_files()
+                if path not in ctx_covered_file_paths:
+                    ctx_covered_file_paths.add(path)
+                    _get_ctx_covered_lines()[path].add(line)
+            return
 
         if self._coverage_enabled:
             lines = self.covered[path]
@@ -137,9 +174,6 @@ class ModuleCodeCollector(ModuleWatchdog):
             # reporting coverage
             ctx_lines = _get_ctx_covered_lines()[path]
             ctx_lines.add(line)
-
-        if import_name is not None and self._collect_import_coverage:
-            self._import_names_by_path[path].add(import_name)
 
     @classmethod
     def inject_coverage(
@@ -161,11 +195,16 @@ class ModuleCodeCollector(ModuleWatchdog):
             for path, path_lines in lines.items():
                 instance.lines[path].update(path_lines)
         if covered:
+            ctx_covered_file_paths = _get_ctx_covered_files() if ctx_coverage_enabled.get() else None
             for path, path_covered in covered.items():
                 if instance._coverage_enabled:
                     instance.covered[path].update(path_covered)
+                    if instance._file_level_coverage:
+                        instance._covered_files.add(path)
                 if ctx_coverage_enabled.get() and ctx_covered_lines is not None:
                     ctx_covered_lines[path].update(path_covered)
+                    if instance._file_level_coverage and ctx_covered_file_paths is not None:
+                        ctx_covered_file_paths.add(path)
 
     @classmethod
     def report(cls, workspace_path: Path, ignore_nocover: bool = False):
@@ -247,9 +286,12 @@ class ModuleCodeCollector(ModuleWatchdog):
             self.is_import_coverage = is_import_coverage
             if ctx_covered.get() is None:
                 ctx_covered.set([])
+            if ctx_covered_files.get() is None:
+                ctx_covered_files.set([])
 
         def __enter__(self):
             ctx_covered.get().append(defaultdict(CoverageLines))
+            ctx_covered_files.get().append(set())
             ctx_coverage_enabled.set(True)
 
             if self.is_import_coverage:
@@ -259,6 +301,7 @@ class ModuleCodeCollector(ModuleWatchdog):
             # so also store in thread-local as a fallback for the hook.
             if _PY_GE_314:
                 _tls_coverage.covered = ctx_covered.get()[-1]
+                _tls_coverage.covered_files = ctx_covered_files.get()[-1]
 
             # For Python 3.12+, dynamically detect whether other sys.monitoring tools are
             # active and update the DISABLE optimisation flag accordingly.  Then re-enable
@@ -281,15 +324,19 @@ class ModuleCodeCollector(ModuleWatchdog):
 
         def __exit__(self, *args, **kwargs):
             covered_lines_stack = ctx_covered.get()
+            covered_files_stack = ctx_covered_files.get()
             covered_lines_stack.pop()
+            covered_files_stack.pop()
 
             # Stop coverage if we're exiting the last context
             if len(covered_lines_stack) == 0:
                 ctx_coverage_enabled.set(False)
                 if _PY_GE_314:
                     _tls_coverage.covered = None
+                    _tls_coverage.covered_files = None
             elif _PY_GE_314:
                 _tls_coverage.covered = covered_lines_stack[-1]
+                _tls_coverage.covered_files = covered_files_stack[-1]
 
         def get_covered_lines(self) -> dict[str, CoverageLines]:
             covered_lines = _get_ctx_covered_lines()
@@ -301,6 +348,7 @@ class ModuleCodeCollector(ModuleWatchdog):
     def start_coverage(cls):
         if cls._instance is None:
             return
+        cls._instance._covered_files.clear()
         cls._instance._coverage_enabled = True
 
     @classmethod

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -10,6 +10,7 @@ from types import CodeType
 from types import ModuleType
 import typing as t
 
+from ddtrace.internal.coverage.instrumentation import configure_file_level_coverage
 from ddtrace.internal.coverage.instrumentation import instrument_all_lines
 from ddtrace.internal.coverage.report import gen_json_report
 from ddtrace.internal.coverage.report import print_coverage_report
@@ -47,30 +48,31 @@ _tls_coverage = _threading.local()
 
 
 def _get_ctx_covered_lines() -> defaultdict[str, CoverageLines]:
-    # sys.monitoring callbacks are hot and Python 3.14+ callbacks cannot see ContextVar changes made in the current
-    # thread. Keep a thread-local pointer for every supported version: it is required on 3.14+ and is a cheaper fast
-    # path on 3.12/3.13.
-    tls_covered = getattr(_tls_coverage, "covered", None)
-    if tls_covered is not None:
-        return tls_covered
-
     if ctx_coverage_enabled.get():
         if context_stack := ctx_covered.get():
             return context_stack[-1]
         log.debug("_get_ctx_covered_lines() called but ctx_covered stack is empty")
 
+    # Fallback for Python 3.14+ where sys.monitoring callbacks can't see ContextVars.
+    if _PY_GE_314:
+        tls_covered = getattr(_tls_coverage, "covered", None)
+        if tls_covered is not None:
+            return tls_covered
+
     return defaultdict(CoverageLines)
 
 
 def _get_ctx_covered_files() -> set[str]:
-    tls_covered_files = getattr(_tls_coverage, "covered_files", None)
-    if tls_covered_files is not None:
-        return tls_covered_files
-
     if ctx_coverage_enabled.get():
         if context_stack := ctx_covered_files.get():
             return context_stack[-1]
         log.debug("_get_ctx_covered_files() called but ctx_covered_files stack is empty")
+
+    # Fallback for Python 3.14+ where sys.monitoring callbacks can't see ContextVars.
+    if _PY_GE_314:
+        tls_covered_files = getattr(_tls_coverage, "covered_files", None)
+        if tls_covered_files is not None:
+            return tls_covered_files
 
     return set()
 
@@ -123,6 +125,8 @@ class ModuleCodeCollector(ModuleWatchdog):
         if ModuleCodeCollector.is_installed():
             return
 
+        configure_file_level_coverage(file_level_coverage)
+
         super().install()
 
         if cls._instance is None:
@@ -150,7 +154,7 @@ class ModuleCodeCollector(ModuleWatchdog):
             self._covered_files.add(path)
             self.covered[path].add(0)
 
-        if ctx_coverage_enabled.get() or getattr(_tls_coverage, "covered", None) is not None:
+        if ctx_coverage_enabled.get() or (_PY_GE_314 and getattr(_tls_coverage, "covered", None) is not None):
             ctx_covered_file_paths = _get_ctx_covered_files()
             if path not in ctx_covered_file_paths:
                 ctx_covered_file_paths.add(path)
@@ -176,7 +180,7 @@ class ModuleCodeCollector(ModuleWatchdog):
             lines = self.covered[path]
             lines.add(line)
 
-        if ctx_coverage_enabled.get() or getattr(_tls_coverage, "covered", None) is not None:
+        if ctx_coverage_enabled.get() or (_PY_GE_314 and getattr(_tls_coverage, "covered", None) is not None):
             # Import-time contexts store their lines in a non-context variable to be aggregated on request when
             # reporting coverage
             ctx_lines = _get_ctx_covered_lines()[path]
@@ -304,12 +308,13 @@ class ModuleCodeCollector(ModuleWatchdog):
             if self.is_import_coverage:
                 ctx_is_import_coverage.set(self.is_import_coverage)
 
-            # sys.monitoring callbacks are hot. Store the active context in thread-local storage for a cheaper fast
-            # path on 3.12/3.13 and as a correctness fallback on 3.14+, where callbacks can't see ContextVar changes.
-            _tls_coverage.covered = ctx_covered.get()[-1]
-            _tls_coverage.covered_files = ctx_covered_files.get()[-1]
+            # Python 3.14+ sys.monitoring callbacks can't see ContextVar changes, so also store the active context in
+            # thread-local storage as a fallback for the hook.
+            if _PY_GE_314:
+                _tls_coverage.covered = ctx_covered.get()[-1]
+                _tls_coverage.covered_files = ctx_covered_files.get()[-1]
 
-            if _PY_GE_312:
+            if _PY_GE_314:
                 from ddtrace.internal.coverage.instrumentation_py3_12 import set_active_context_covered_files
 
                 set_active_context_covered_files(_tls_coverage.covered_files)
@@ -342,13 +347,14 @@ class ModuleCodeCollector(ModuleWatchdog):
             # Stop coverage if we're exiting the last context
             if len(covered_lines_stack) == 0:
                 ctx_coverage_enabled.set(False)
-                _tls_coverage.covered = None
-                _tls_coverage.covered_files = None
-            else:
+                if _PY_GE_314:
+                    _tls_coverage.covered = None
+                    _tls_coverage.covered_files = None
+            elif _PY_GE_314:
                 _tls_coverage.covered = covered_lines_stack[-1]
                 _tls_coverage.covered_files = covered_files_stack[-1]
 
-            if _PY_GE_312:
+            if _PY_GE_314:
                 from ddtrace.internal.coverage.instrumentation_py3_12 import set_active_context_covered_files
 
                 set_active_context_covered_files(_tls_coverage.covered_files)

--- a/ddtrace/internal/coverage/installer.py
+++ b/ddtrace/internal/coverage/installer.py
@@ -9,10 +9,12 @@ from ddtrace.internal.coverage.threading_coverage import _patch_threading
 def install(
     include_paths: t.Optional[list[Path]] = None,
     collect_import_time_coverage: bool = False,
+    file_level_coverage: bool = False,
 ) -> None:
     ModuleCodeCollector.install(
         include_paths=include_paths,
         collect_import_time_coverage=collect_import_time_coverage,
+        file_level_coverage=file_level_coverage,
     )
     _patch_multiprocessing()
     _patch_threading()

--- a/ddtrace/internal/coverage/instrumentation.py
+++ b/ddtrace/internal/coverage/instrumentation.py
@@ -2,9 +2,14 @@ import sys
 
 
 # Import are noqa'd otherwise some formatters will helpfully remove them
+def configure_file_level_coverage(enabled: object = None) -> None:
+    pass
+
+
 if sys.version_info >= (3, 16):
     from ddtrace.internal.coverage.instrumentation_py3_16 import instrument_all_lines  # noqa
 elif sys.version_info >= (3, 12):
+    from ddtrace.internal.coverage.instrumentation_py3_12 import configure_file_level_coverage  # noqa
     from ddtrace.internal.coverage.instrumentation_py3_12 import instrument_all_lines  # noqa
 elif sys.version_info >= (3, 11):
     from ddtrace.internal.coverage.instrumentation_py3_11 import instrument_all_lines  # noqa

--- a/ddtrace/internal/coverage/instrumentation_py3_12.py
+++ b/ddtrace/internal/coverage/instrumentation_py3_12.py
@@ -58,13 +58,25 @@ EVENT = sys.monitoring.events.PY_START if _USE_FILE_LEVEL_COVERAGE else sys.moni
 _DD_TOOL_ID: t.Optional[int] = None  # noqa: UP006
 _DD_CANDIDATE_SLOTS = (4, 3, 1)
 
-# Store: (hook, path, import_names_by_line, file_arg, import_args)
+# Store: (hook, path, import_names_by_line, file_arg, import_args, file_hook, import_hook)
 # IMPORTANT: Do not change t.Dict/t.Tuple to dict/tuple until minimum Python version is 3.11+
 # Module-level dict[...]/tuple[...] in Python 3.10 affects import timing. See packages.py for details.
-ImportNamesByLine = t.Dict[int, t.Tuple[str, t.Optional[t.Tuple[str]]]]  # noqa: UP006
-CoverageHookArg = t.Tuple[t.Optional[int], str, t.Optional[t.Tuple[str, t.Optional[t.Tuple[str]]]]]  # noqa: UP006
-CodeHookData = t.Tuple[HookType, str, ImportNamesByLine, CoverageHookArg, t.Tuple[CoverageHookArg, ...]]  # noqa: UP006
+ImportName = t.Tuple[str, t.Optional[t.Tuple[str]]]  # noqa: UP006
+ImportNamesByLine = t.Dict[int, ImportName]  # noqa: UP006
+CoverageHookArg = t.Tuple[t.Optional[int], str, t.Optional[ImportName]]  # noqa: UP006
+FileHookType = t.Optional[t.Callable[[str], None]]  # noqa: UP006
+ImportHookType = t.Optional[t.Callable[[str, ImportName], None]]  # noqa: UP006
+CodeHookData = t.Tuple[  # noqa: UP006
+    HookType,
+    str,
+    ImportNamesByLine,
+    CoverageHookArg,
+    t.Tuple[CoverageHookArg, ...],  # noqa: UP006
+    FileHookType,
+    ImportHookType,
+]
 _CODE_HOOKS: t.Dict[CodeType, CodeHookData] = {}  # noqa: UP006
+_IMPORTS_EMITTED: t.Set[CodeType] = set()  # noqa: UP006
 
 # NOTE: When True (default), _event_handler returns sys.monitoring.DISABLE after recording a
 # line so Python stops firing that event for this code location — a performance optimisation that
@@ -235,15 +247,25 @@ def _event_handler(code: CodeType, line: int) -> t.Optional[t.Literal[sys.monito
     if hook_data is None:
         return sys.monitoring.DISABLE
 
-    hook, path, import_names, file_arg, import_args = hook_data
+    hook, path, import_names, file_arg, import_args, file_hook, import_hook = hook_data
 
     if _USE_FILE_LEVEL_COVERAGE:
         # Report file-level coverage using line 0 as a sentinel value and emit this code object's pre-extracted import
         # dependency metadata. This keeps dependency tracking tied to executed code objects without parsing bytecode in
         # the hot callback.
-        hook(file_arg)  # type: ignore[arg-type]
-        for import_arg in import_args:
-            hook(import_arg)  # type: ignore[arg-type]
+        if file_hook is not None:
+            file_hook(path)
+        else:
+            hook(file_arg)  # type: ignore[arg-type]
+
+        if import_args and code not in _IMPORTS_EMITTED:
+            if import_hook is not None:
+                for import_arg in import_args:
+                    import_hook(path, import_arg[2])  # type: ignore[arg-type]
+            else:
+                for import_arg in import_args:
+                    hook(import_arg)  # type: ignore[arg-type]
+            _IMPORTS_EMITTED.add(code)
         if _use_disable_optimization:
             return sys.monitoring.DISABLE
     else:
@@ -274,10 +296,14 @@ def _instrument_with_monitoring(
         lines.update(nested_lines)
 
     # Register the hook and argument for the code object. Precompute file-level hook arguments so the callback does
-    # not allocate a set or tuples every time a code object starts executing.
+    # not allocate a set or tuples every time a code object starts executing. When the hook is ModuleCodeCollector.hook,
+    # also cache specialized file/import methods to avoid the generic tuple-dispatch path.
     file_arg = (0, path, None)
     import_args = tuple((None, path, import_name) for import_name in dict.fromkeys(import_names.values()))
-    _CODE_HOOKS[code] = (hook, path, import_names, file_arg, import_args)
+    hook_self = getattr(hook, "__self__", None)
+    file_hook = getattr(hook_self, "hook_file", None)
+    import_hook = getattr(hook_self, "hook_import", None)
+    _CODE_HOOKS[code] = (hook, path, import_names, file_arg, import_args, file_hook, import_hook)
 
     if _USE_FILE_LEVEL_COVERAGE:
         # Return CoverageLines with line 0 as sentinel to indicate file-level coverage

--- a/ddtrace/internal/coverage/instrumentation_py3_12.py
+++ b/ddtrace/internal/coverage/instrumentation_py3_12.py
@@ -10,6 +10,7 @@ The mode is controlled by the _DD_COVERAGE_FILE_LEVEL environment variable.
 
 import dis
 import sys
+import threading as _threading
 from types import CodeType
 import typing as t
 
@@ -77,6 +78,7 @@ CodeHookData = t.Tuple[  # noqa: UP006
 ]
 _CODE_HOOKS: t.Dict[CodeType, CodeHookData] = {}  # noqa: UP006
 _IMPORTS_EMITTED: t.Set[CodeType] = set()  # noqa: UP006
+_tls_context = _threading.local()
 
 # NOTE: When True (default), _event_handler returns sys.monitoring.DISABLE after recording a
 # line so Python stops firing that event for this code location — a performance optimisation that
@@ -96,6 +98,10 @@ _IMPORTS_EMITTED: t.Set[CodeType] = set()  # noqa: UP006
 # (see _rearm_all_events()'s docstring) to only affect our own tool's state, leaving any other
 # registered tool's disabled-event state untouched.
 _use_disable_optimization: bool = True
+
+
+def set_active_context_covered_files(covered_files: t.Optional[t.Set[str]]) -> None:  # noqa: UP006
+    _tls_context.covered_files = covered_files
 
 
 def has_other_monitoring_tools() -> bool:
@@ -253,10 +259,12 @@ def _event_handler(code: CodeType, line: int) -> t.Optional[t.Literal[sys.monito
         # Report file-level coverage using line 0 as a sentinel value and emit this code object's pre-extracted import
         # dependency metadata. This keeps dependency tracking tied to executed code objects without parsing bytecode in
         # the hot callback.
-        if file_hook is not None:
-            file_hook(path)
-        else:
-            hook(file_arg)  # type: ignore[arg-type]
+        active_covered_files = getattr(_tls_context, "covered_files", None)
+        if active_covered_files is None or path not in active_covered_files:
+            if file_hook is not None:
+                file_hook(path)
+            else:
+                hook(file_arg)  # type: ignore[arg-type]
 
         if import_args and code not in _IMPORTS_EMITTED:
             if import_hook is not None:

--- a/ddtrace/internal/coverage/instrumentation_py3_12.py
+++ b/ddtrace/internal/coverage/instrumentation_py3_12.py
@@ -235,20 +235,20 @@ def _event_handler(code: CodeType, line: int) -> t.Optional[t.Literal[sys.monito
     hook, path, import_names = hook_data
 
     if _USE_FILE_LEVEL_COVERAGE:
-        # Report file-level coverage using line 0 as a sentinel value
-        # Line 0 indicates "file was executed" without specific line information
+        # Report file-level coverage using line 0 as a sentinel value and emit this code object's pre-extracted import
+        # dependency metadata. This keeps dependency tracking tied to executed code objects without parsing bytecode in
+        # the hot callback.
         hook((0, path, None))
-
-        # Report any import dependencies (extracted at instrumentation time from bytecode)
-        # This ensures import tracking works even though we don't fire on individual lines
-        for line_num, import_name in import_names.items():
-            hook((line_num, path, import_name))
+        for import_name in set(import_names.values()):
+            hook((None, path, import_name))  # type: ignore[arg-type]
+        if _use_disable_optimization:
+            return sys.monitoring.DISABLE
     else:
         import_name = import_names.get(line, None)
         hook((line, path, import_name))
+        if _use_disable_optimization:
+            return sys.monitoring.DISABLE
 
-    if _use_disable_optimization:
-        return sys.monitoring.DISABLE
     return None
 
 

--- a/ddtrace/internal/coverage/instrumentation_py3_12.py
+++ b/ddtrace/internal/coverage/instrumentation_py3_12.py
@@ -58,10 +58,13 @@ EVENT = sys.monitoring.events.PY_START if _USE_FILE_LEVEL_COVERAGE else sys.moni
 _DD_TOOL_ID: t.Optional[int] = None  # noqa: UP006
 _DD_CANDIDATE_SLOTS = (4, 3, 1)
 
-# Store: (hook, path, import_names_by_line)
+# Store: (hook, path, import_names_by_line, file_arg, import_args)
 # IMPORTANT: Do not change t.Dict/t.Tuple to dict/tuple until minimum Python version is 3.11+
 # Module-level dict[...]/tuple[...] in Python 3.10 affects import timing. See packages.py for details.
-_CODE_HOOKS: t.Dict[CodeType, t.Tuple[HookType, str, t.Dict[int, t.Tuple[str, t.Optional[t.Tuple[str]]]]]] = {}  # noqa: UP006
+ImportNamesByLine = t.Dict[int, t.Tuple[str, t.Optional[t.Tuple[str]]]]  # noqa: UP006
+CoverageHookArg = t.Tuple[t.Optional[int], str, t.Optional[t.Tuple[str, t.Optional[t.Tuple[str]]]]]  # noqa: UP006
+CodeHookData = t.Tuple[HookType, str, ImportNamesByLine, CoverageHookArg, t.Tuple[CoverageHookArg, ...]]  # noqa: UP006
+_CODE_HOOKS: t.Dict[CodeType, CodeHookData] = {}  # noqa: UP006
 
 # NOTE: When True (default), _event_handler returns sys.monitoring.DISABLE after recording a
 # line so Python stops firing that event for this code location — a performance optimisation that
@@ -232,15 +235,15 @@ def _event_handler(code: CodeType, line: int) -> t.Optional[t.Literal[sys.monito
     if hook_data is None:
         return sys.monitoring.DISABLE
 
-    hook, path, import_names = hook_data
+    hook, path, import_names, file_arg, import_args = hook_data
 
     if _USE_FILE_LEVEL_COVERAGE:
         # Report file-level coverage using line 0 as a sentinel value and emit this code object's pre-extracted import
         # dependency metadata. This keeps dependency tracking tied to executed code objects without parsing bytecode in
         # the hot callback.
-        hook((0, path, None))
-        for import_name in set(import_names.values()):
-            hook((None, path, import_name))  # type: ignore[arg-type]
+        hook(file_arg)  # type: ignore[arg-type]
+        for import_arg in import_args:
+            hook(import_arg)  # type: ignore[arg-type]
         if _use_disable_optimization:
             return sys.monitoring.DISABLE
     else:
@@ -270,8 +273,11 @@ def _instrument_with_monitoring(
         _, nested_lines = instrument_all_lines(nested_code, hook, path, package)
         lines.update(nested_lines)
 
-    # Register the hook and argument for the code object
-    _CODE_HOOKS[code] = (hook, path, import_names)
+    # Register the hook and argument for the code object. Precompute file-level hook arguments so the callback does
+    # not allocate a set or tuples every time a code object starts executing.
+    file_arg = (0, path, None)
+    import_args = tuple((None, path, import_name) for import_name in dict.fromkeys(import_names.values()))
+    _CODE_HOOKS[code] = (hook, path, import_names, file_arg, import_args)
 
     if _USE_FILE_LEVEL_COVERAGE:
         # Return CoverageLines with line 0 as sentinel to indicate file-level coverage

--- a/ddtrace/internal/coverage/instrumentation_py3_12.py
+++ b/ddtrace/internal/coverage/instrumentation_py3_12.py
@@ -47,10 +47,21 @@ _IMPORT_NAME_ARG_SHIFT = 2 if sys.version_info >= (3, 15) else 0
 # Instead of hardcoding, just compile an empty module to get the expected bytes.
 EMPTY_MODULE_BYTES = compile("", "<empty>", "exec").co_code
 
-# Check if file-level coverage is requested
-_USE_FILE_LEVEL_COVERAGE = asbool(env.get("_DD_COVERAGE_FILE_LEVEL", "false"))
 
-EVENT = sys.monitoring.events.PY_START if _USE_FILE_LEVEL_COVERAGE else sys.monitoring.events.LINE
+def _get_file_level_coverage(default: t.Optional[bool] = None) -> bool:
+    if default is not None:
+        return default
+    return asbool(env.get("_DD_COVERAGE_FILE_LEVEL", "false"))
+
+
+def _event_for_file_level_coverage(enabled: bool) -> int:
+    return sys.monitoring.events.PY_START if enabled else sys.monitoring.events.LINE
+
+
+# Check if file-level coverage is requested
+_USE_FILE_LEVEL_COVERAGE = _get_file_level_coverage()
+
+EVENT = _event_for_file_level_coverage(_USE_FILE_LEVEL_COVERAGE)
 
 # NOTE: We try tool slots in priority order (4, 3, 1) to avoid colliding with other tools.
 # Slot 4 is preferred; slot 1 (COVERAGE_ID) is a last resort since other coverage tools may use it.
@@ -98,6 +109,23 @@ _tls_context = _threading.local()
 # (see _rearm_all_events()'s docstring) to only affect our own tool's state, leaving any other
 # registered tool's disabled-event state untouched.
 _use_disable_optimization: bool = True
+
+
+def configure_file_level_coverage(enabled: t.Optional[bool] = None) -> None:
+    """Configure the monitoring event used for coverage before sys.monitoring registration.
+
+    Production callers pass the already-resolved Test Optimization setting so the collector and backend agree on
+    line-level vs file-level mode. Tests may pass True/False directly without mutating environment variables.
+    """
+    global _USE_FILE_LEVEL_COVERAGE, EVENT
+
+    file_level_coverage = _get_file_level_coverage(enabled)
+    if _DD_TOOL_ID is not None and file_level_coverage != _USE_FILE_LEVEL_COVERAGE:
+        log.warning("Cannot change coverage mode after sys.monitoring registration")
+        return
+
+    _USE_FILE_LEVEL_COVERAGE = file_level_coverage
+    EVENT = _event_for_file_level_coverage(file_level_coverage)
 
 
 def set_active_context_covered_files(covered_files: t.Optional[t.Set[str]]) -> None:  # noqa: UP006

--- a/ddtrace/internal/coverage/instrumentation_py3_12.py
+++ b/ddtrace/internal/coverage/instrumentation_py3_12.py
@@ -8,6 +8,7 @@ This module supports two modes:
 The mode is controlled by the _DD_COVERAGE_FILE_LEVEL environment variable.
 """
 
+from contextvars import ContextVar
 import dis
 import sys
 import threading as _threading
@@ -89,6 +90,7 @@ CodeHookData = t.Tuple[  # noqa: UP006
 ]
 _CODE_HOOKS: t.Dict[CodeType, CodeHookData] = {}  # noqa: UP006
 _IMPORTS_EMITTED: t.Set[CodeType] = set()  # noqa: UP006
+_ctx_covered_files: ContextVar[t.Optional[t.Set[str]]] = ContextVar("ctx_covered_files", default=None)  # noqa: UP006
 _tls_context = _threading.local()
 
 # NOTE: When True (default), _event_handler returns sys.monitoring.DISABLE after recording a
@@ -129,7 +131,15 @@ def configure_file_level_coverage(enabled: t.Optional[bool] = None) -> None:
 
 
 def set_active_context_covered_files(covered_files: t.Optional[t.Set[str]]) -> None:  # noqa: UP006
-    _tls_context.covered_files = covered_files
+    _ctx_covered_files.set(covered_files)
+    if sys.version_info >= (3, 14):
+        _tls_context.covered_files = covered_files
+
+
+def _get_active_context_covered_files() -> t.Optional[t.Set[str]]:  # noqa: UP006
+    if sys.version_info >= (3, 14):
+        return getattr(_tls_context, "covered_files", None)
+    return _ctx_covered_files.get()
 
 
 def has_other_monitoring_tools() -> bool:
@@ -287,7 +297,7 @@ def _event_handler(code: CodeType, line: int) -> t.Optional[t.Literal[sys.monito
         # Report file-level coverage using line 0 as a sentinel value and emit this code object's pre-extracted import
         # dependency metadata. This keeps dependency tracking tied to executed code objects without parsing bytecode in
         # the hot callback.
-        active_covered_files = getattr(_tls_context, "covered_files", None)
+        active_covered_files = _get_active_context_covered_files()
         if active_covered_files is None or path not in active_covered_files:
             if file_hook is not None:
                 file_hook(path)

--- a/ddtrace/internal/coverage/multiprocessing_coverage.py
+++ b/ddtrace/internal/coverage/multiprocessing_coverage.py
@@ -107,7 +107,10 @@ class CoverageCollectingMultiprocess(BaseProcess):
             # Avoid circular import since the installer imports uses _patch_multiprocessing()
             from ddtrace.internal.coverage.installer import install
 
-            install(include_paths=self._dd_coverage_include_paths)
+            install(
+                include_paths=self._dd_coverage_include_paths,
+                file_level_coverage=self._dd_file_level_coverage,
+            )
             ModuleCodeCollector.start_coverage()
 
         # Call the original bootstrap method
@@ -130,6 +133,7 @@ class CoverageCollectingMultiprocess(BaseProcess):
 
     def __init__(self, *posargs, **kwargs) -> None:
         self._dd_coverage_enabled = False
+        self._dd_file_level_coverage = False
         self._dd_coverage_include_paths: list[Path] = []
 
         # If coverage is not enabled, the pipe used to communicate coverage data from child to parent is not needed
@@ -150,6 +154,7 @@ class CoverageCollectingMultiprocess(BaseProcess):
             self._dd_coverage_enabled = True
             if ModuleCodeCollector._instance is not None:
                 self._dd_coverage_include_paths = ModuleCodeCollector._instance._include_paths
+                self._dd_file_level_coverage = ModuleCodeCollector._instance._file_level_coverage
 
             # Capture context-level coverage dict if active (runs in the main thread)
             if ctx_coverage_enabled.get():
@@ -188,8 +193,14 @@ class Stowaway:
     ModuleCodeCollector in it leads to incomplete code coverage data.
     """
 
-    def __init__(self, include_paths: t.Optional[list[Path]] = None, dd_coverage_enabled: bool = True) -> None:
+    def __init__(
+        self,
+        include_paths: t.Optional[list[Path]] = None,
+        dd_coverage_enabled: bool = True,
+        file_level_coverage: bool = False,
+    ) -> None:
         self.dd_coverage_enabled: bool = dd_coverage_enabled
+        self.file_level_coverage: bool = file_level_coverage
         self.include_paths_strs: list[str] = []
         if include_paths is not None:
             self.include_paths_strs = [str(include_path) for include_path in include_paths]
@@ -198,15 +209,19 @@ class Stowaway:
         return {
             "include_paths_strs": json.dumps(self.include_paths_strs),
             "dd_coverage_enabled": self.dd_coverage_enabled,
+            "file_level_coverage": self.file_level_coverage,
         }
 
-    def __setstate__(self, state: dict[str, str]) -> None:
+    def __setstate__(self, state: dict[str, t.Any]) -> None:
         include_paths = [Path(include_path_str) for include_path_str in json.loads(state["include_paths_strs"])]
 
         if state["dd_coverage_enabled"]:
             from ddtrace.internal.coverage.installer import install
 
-            install(include_paths=include_paths)
+            install(
+                include_paths=include_paths,
+                file_level_coverage=state.get("file_level_coverage", False) is True,
+            )
             _patch_multiprocessing()
 
 
@@ -236,7 +251,10 @@ def _patch_multiprocessing():
             include_paths = (
                 [] if ModuleCodeCollector._instance is None else ModuleCodeCollector._instance._include_paths
             )
-            d["stowaway"] = Stowaway(include_paths=include_paths)
+            file_level_coverage = (
+                False if ModuleCodeCollector._instance is None else ModuleCodeCollector._instance._file_level_coverage
+            )
+            d["stowaway"] = Stowaway(include_paths=include_paths, file_level_coverage=file_level_coverage)
             return d
 
         spawn.get_preparation_data = get_preparation_data_with_stowaway

--- a/ddtrace/testing/internal/pytest/plugin.py
+++ b/ddtrace/testing/internal/pytest/plugin.py
@@ -1522,7 +1522,7 @@ def pytest_load_initial_conftests(
 
 def setup_coverage_collection() -> None:
     workspace_path = get_workspace_path()
-    install_coverage(workspace_path)
+    install_coverage(workspace_path, file_level_coverage=asbool(env.get("_DD_COVERAGE_FILE_LEVEL", "false")))
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/ddtrace/testing/internal/tracer_api/coverage.py
+++ b/ddtrace/testing/internal/tracer_api/coverage.py
@@ -18,7 +18,9 @@ from ddtrace.contrib.internal.coverage.utils import _is_coverage_invoked_by_cove
 from ddtrace.contrib.internal.coverage.utils import _is_coverage_patched
 from ddtrace.internal.coverage.code import ModuleCodeCollector
 import ddtrace.internal.coverage.installer
+from ddtrace.internal.settings import env
 from ddtrace.internal.test_visibility.coverage_lines import CoverageLines
+from ddtrace.internal.utils.formats import asbool
 from ddtrace.testing.internal.logging import catch_and_log_exceptions
 
 
@@ -32,6 +34,7 @@ def install_coverage(workspace_path: Path) -> None:
     ddtrace.internal.coverage.installer.install(
         include_paths=[workspace_path],
         collect_import_time_coverage=True,
+        file_level_coverage=asbool(env.get("_DD_COVERAGE_FILE_LEVEL", "false")),
     )
     ModuleCodeCollector.start_coverage()
 

--- a/ddtrace/testing/internal/tracer_api/coverage.py
+++ b/ddtrace/testing/internal/tracer_api/coverage.py
@@ -18,23 +18,18 @@ from ddtrace.contrib.internal.coverage.utils import _is_coverage_invoked_by_cove
 from ddtrace.contrib.internal.coverage.utils import _is_coverage_patched
 from ddtrace.internal.coverage.code import ModuleCodeCollector
 import ddtrace.internal.coverage.installer
-from ddtrace.internal.settings import env
 from ddtrace.internal.test_visibility.coverage_lines import CoverageLines
-from ddtrace.internal.utils.formats import asbool
 from ddtrace.testing.internal.logging import catch_and_log_exceptions
 
 
 log = logging.getLogger(__name__)
 
 
-log = logging.getLogger(__name__)
-
-
-def install_coverage(workspace_path: Path) -> None:
+def install_coverage(workspace_path: Path, file_level_coverage: bool = False) -> None:
     ddtrace.internal.coverage.installer.install(
         include_paths=[workspace_path],
         collect_import_time_coverage=True,
-        file_level_coverage=asbool(env.get("_DD_COVERAGE_FILE_LEVEL", "false")),
+        file_level_coverage=file_level_coverage,
     )
     ModuleCodeCollector.start_coverage()
 

--- a/tests/coverage/test_instrumentation_py312_disable.py
+++ b/tests/coverage/test_instrumentation_py312_disable.py
@@ -37,7 +37,7 @@ def test_event_handler_returns_disable():
         calls.append(line_info)
 
     # Register the code object with our hook
-    _CODE_HOOKS[code_obj] = (mock_hook, "/test/path.py", {})
+    _CODE_HOOKS[code_obj] = (mock_hook, "/test/path.py", {}, (0, "/test/path.py", None), ())
 
     # Pin the DISABLE optimisation on: this test is specifically about the DISABLE-returning
     # behavior, not about how the flag gets computed. Outside this test, the real coverage
@@ -229,7 +229,7 @@ def test_update_disable_optimization_rearmed_on_transition():
     # Set up a real code object and register it in _CODE_HOOKS
     code_obj = compile("x = 1", "<test_rearm>", "exec")
     calls: list[object] = []
-    _CODE_HOOKS[code_obj] = (lambda info: calls.append(info), "/test/rearm.py", {})
+    _CODE_HOOKS[code_obj] = (lambda info: calls.append(info), "/test/rearm.py", {}, (0, "/test/rearm.py", None), ())
     sys.monitoring.set_local_events(m._DD_TOOL_ID, code_obj, m.EVENT)
 
     # Start in DISABLE mode (default)
@@ -285,7 +285,7 @@ def test_event_handler_returns_none_when_other_tool_present():
     # Set up a code hook
     code_obj = compile("x = 1", "<test>", "exec")
     calls = []
-    _CODE_HOOKS[code_obj] = (lambda info: calls.append(info), "/test/path.py", {})
+    _CODE_HOOKS[code_obj] = (lambda info: calls.append(info), "/test/path.py", {}, (0, "/test/path.py", None), ())
 
     try:
         # Update the flag based on detected tools

--- a/tests/coverage/test_instrumentation_py312_disable.py
+++ b/tests/coverage/test_instrumentation_py312_disable.py
@@ -37,7 +37,7 @@ def test_event_handler_returns_disable():
         calls.append(line_info)
 
     # Register the code object with our hook
-    _CODE_HOOKS[code_obj] = (mock_hook, "/test/path.py", {}, (0, "/test/path.py", None), ())
+    _CODE_HOOKS[code_obj] = (mock_hook, "/test/path.py", {}, (0, "/test/path.py", None), (), None, None)
 
     # Pin the DISABLE optimisation on: this test is specifically about the DISABLE-returning
     # behavior, not about how the flag gets computed. Outside this test, the real coverage
@@ -77,6 +77,45 @@ def test_event_handler_returns_disable_for_missing_code():
 
     # Should still return DISABLE (graceful handling)
     assert result == sys.monitoring.DISABLE, f"Handler should return DISABLE even for missing code, got {result}"
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="Python 3.12+ monitoring API only")
+def test_file_event_handler_emits_import_dependencies_once():
+    """File-level callbacks should not resend global import dependency metadata on every execution."""
+    import ddtrace.internal.coverage.instrumentation_py3_12 as m
+    from ddtrace.internal.coverage.instrumentation_py3_12 import _CODE_HOOKS
+    from ddtrace.internal.coverage.instrumentation_py3_12 import _event_handler
+
+    code_obj = compile("x = 1", "<test_import_once>", "exec")
+    file_calls: list[str] = []
+    import_calls: list[object] = []
+
+    old_file_level = m._USE_FILE_LEVEL_COVERAGE
+    old_disable = m._use_disable_optimization
+    m._USE_FILE_LEVEL_COVERAGE = True
+    m._use_disable_optimization = False
+    m._IMPORTS_EMITTED.discard(code_obj)
+    _CODE_HOOKS[code_obj] = (
+        lambda info: None,
+        "/test/path.py",
+        {},
+        (0, "/test/path.py", None),
+        ((None, "/test/path.py", ("pkg", ("dep",))),),
+        lambda path: file_calls.append(path),
+        lambda path, import_name: import_calls.append((path, import_name)),
+    )
+
+    try:
+        assert _event_handler(code_obj, 0) is None
+        assert _event_handler(code_obj, 0) is None
+    finally:
+        _CODE_HOOKS.pop(code_obj, None)
+        m._IMPORTS_EMITTED.discard(code_obj)
+        m._USE_FILE_LEVEL_COVERAGE = old_file_level
+        m._use_disable_optimization = old_disable
+
+    assert file_calls == ["/test/path.py", "/test/path.py"]
+    assert import_calls == [("/test/path.py", ("pkg", ("dep",)))]
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Python 3.12+ monitoring API only")
@@ -229,7 +268,15 @@ def test_update_disable_optimization_rearmed_on_transition():
     # Set up a real code object and register it in _CODE_HOOKS
     code_obj = compile("x = 1", "<test_rearm>", "exec")
     calls: list[object] = []
-    _CODE_HOOKS[code_obj] = (lambda info: calls.append(info), "/test/rearm.py", {}, (0, "/test/rearm.py", None), ())
+    _CODE_HOOKS[code_obj] = (
+        lambda info: calls.append(info),
+        "/test/rearm.py",
+        {},
+        (0, "/test/rearm.py", None),
+        (),
+        None,
+        None,
+    )
     sys.monitoring.set_local_events(m._DD_TOOL_ID, code_obj, m.EVENT)
 
     # Start in DISABLE mode (default)
@@ -285,7 +332,15 @@ def test_event_handler_returns_none_when_other_tool_present():
     # Set up a code hook
     code_obj = compile("x = 1", "<test>", "exec")
     calls = []
-    _CODE_HOOKS[code_obj] = (lambda info: calls.append(info), "/test/path.py", {}, (0, "/test/path.py", None), ())
+    _CODE_HOOKS[code_obj] = (
+        lambda info: calls.append(info),
+        "/test/path.py",
+        {},
+        (0, "/test/path.py", None),
+        (),
+        None,
+        None,
+    )
 
     try:
         # Update the flag based on detected tools

--- a/tests/coverage/test_instrumentation_py312_disable.py
+++ b/tests/coverage/test_instrumentation_py312_disable.py
@@ -79,6 +79,62 @@ def test_event_handler_returns_disable_for_missing_code():
     assert result == sys.monitoring.DISABLE, f"Handler should return DISABLE even for missing code, got {result}"
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 12) or sys.version_info >= (3, 14), reason="Python 3.12-3.13 ContextVar path"
+)
+def test_contextvars_take_precedence_over_thread_local_fallback():
+    from collections import defaultdict
+
+    import ddtrace.internal.coverage.code as c
+    from ddtrace.internal.test_visibility.coverage_lines import CoverageLines
+
+    context_covered = defaultdict(CoverageLines)
+    tls_covered = defaultdict(CoverageLines)
+    context_covered_files = set()
+    tls_covered_files = set()
+
+    coverage_enabled_token = c.ctx_coverage_enabled.set(True)
+    covered_token = c.ctx_covered.set([context_covered])
+    covered_files_token = c.ctx_covered_files.set([context_covered_files])
+    old_tls_covered = getattr(c._tls_coverage, "covered", None)
+    old_tls_covered_files = getattr(c._tls_coverage, "covered_files", None)
+    c._tls_coverage.covered = tls_covered
+    c._tls_coverage.covered_files = tls_covered_files
+
+    try:
+        assert c._get_ctx_covered_lines() is context_covered
+        assert c._get_ctx_covered_files() is context_covered_files
+    finally:
+        c.ctx_coverage_enabled.reset(coverage_enabled_token)
+        c.ctx_covered.reset(covered_token)
+        c.ctx_covered_files.reset(covered_files_token)
+        c._tls_coverage.covered = old_tls_covered
+        c._tls_coverage.covered_files = old_tls_covered_files
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="Python 3.12+ monitoring API only")
+def test_configure_file_level_coverage_sets_monitoring_event():
+    import ddtrace.internal.coverage.instrumentation_py3_12 as m
+
+    old_file_level = m._USE_FILE_LEVEL_COVERAGE
+    old_event = m.EVENT
+    old_tool_id = m._DD_TOOL_ID
+    m._DD_TOOL_ID = None
+
+    try:
+        m.configure_file_level_coverage(True)
+        assert m._USE_FILE_LEVEL_COVERAGE is True
+        assert m.EVENT == sys.monitoring.events.PY_START
+
+        m.configure_file_level_coverage(False)
+        assert m._USE_FILE_LEVEL_COVERAGE is False
+        assert m.EVENT == sys.monitoring.events.LINE
+    finally:
+        m._USE_FILE_LEVEL_COVERAGE = old_file_level
+        m.EVENT = old_event
+        m._DD_TOOL_ID = old_tool_id
+
+
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Python 3.12+ monitoring API only")
 def test_file_event_handler_emits_import_dependencies_once():
     """File-level callbacks should not resend global import dependency metadata on every execution."""

--- a/tests/testing/internal/pytest/test_plugin.py
+++ b/tests/testing/internal/pytest/test_plugin.py
@@ -39,6 +39,20 @@ from tests.testing.mocks import session_manager_mock
 from tests.testing.mocks import test_report
 
 
+def test_setup_coverage_collection_passes_file_level_coverage(monkeypatch) -> None:
+    monkeypatch.setenv("_DD_COVERAGE_FILE_LEVEL", "true")
+
+    with (
+        patch("ddtrace.testing.internal.pytest.plugin.get_workspace_path", return_value=Path("/repo/path")),
+        patch("ddtrace.testing.internal.pytest.plugin.install_coverage") as mock_install_coverage,
+    ):
+        from ddtrace.testing.internal.pytest.plugin import setup_coverage_collection
+
+        setup_coverage_collection()
+
+    mock_install_coverage.assert_called_once_with(Path("/repo/path"), file_level_coverage=True)
+
+
 # =============================================================================
 # HIGH-LEVEL FEATURE TESTS (organized by feature)
 # =============================================================================

--- a/tests/testing/internal/test_coverage_api.py
+++ b/tests/testing/internal/test_coverage_api.py
@@ -6,14 +6,12 @@ from ddtrace.testing.internal.tracer_api.coverage import coverage_collection
 from ddtrace.testing.internal.tracer_api.coverage import install_coverage
 
 
-def test_install_coverage_passes_file_level_mode(monkeypatch) -> None:
-    monkeypatch.setenv("_DD_COVERAGE_FILE_LEVEL", "true")
-
+def test_install_coverage_passes_file_level_mode() -> None:
     with (
         mock.patch("ddtrace.internal.coverage.installer.install") as mock_install,
         mock.patch.object(ModuleCodeCollector, "start_coverage") as mock_start_coverage,
     ):
-        install_coverage(Path("/repo/path"))
+        install_coverage(Path("/repo/path"), file_level_coverage=True)
 
     mock_install.assert_called_once_with(
         include_paths=[Path("/repo/path")],

--- a/tests/testing/internal/test_coverage_api.py
+++ b/tests/testing/internal/test_coverage_api.py
@@ -3,6 +3,24 @@ from unittest import mock
 
 from ddtrace.internal.coverage.code import ModuleCodeCollector
 from ddtrace.testing.internal.tracer_api.coverage import coverage_collection
+from ddtrace.testing.internal.tracer_api.coverage import install_coverage
+
+
+def test_install_coverage_passes_file_level_mode(monkeypatch) -> None:
+    monkeypatch.setenv("_DD_COVERAGE_FILE_LEVEL", "true")
+
+    with (
+        mock.patch("ddtrace.internal.coverage.installer.install") as mock_install,
+        mock.patch.object(ModuleCodeCollector, "start_coverage") as mock_start_coverage,
+    ):
+        install_coverage(Path("/repo/path"))
+
+    mock_install.assert_called_once_with(
+        include_paths=[Path("/repo/path")],
+        collect_import_time_coverage=True,
+        file_level_coverage=True,
+    )
+    mock_start_coverage.assert_called_once_with()
 
 
 def test_get_coverage_bitmaps() -> None:


### PR DESCRIPTION
## Description

Optimize the Python 3.12+ file-level coverage callback path used by Test Optimization.

This PR focuses on the `sys.monitoring` / `PY_START` hot path:

- pass file-level coverage mode through the coverage install path
- precompute monitoring hook arguments
- use a faster file-level monitoring callback
- skip redundant file-level context hooks when a file is already marked covered

The goal is to make each file-level coverage callback cheaper while preserving runtime import-edge behavior and file attribution semantics.

Part 2 of the pytest/Test Optimization performance stack.

## Testing

Previously validated as part of the combined pytest performance branch with coverage and pytest focused tests updated by the commits.

## Risks

Medium. This changes coverage callback internals, but stays within file-level mode and keeps tests for coverage installation and monitoring behavior.