### PR TITLE
perf(coverage): use file path sets for file-level coverage

### DIFF
--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -331,7 +331,7 @@ class ModuleCodeCollector(ModuleWatchdog):
                     imported_module_lines = self._import_time_covered[path]
                     covered_lines[path].update(imported_module_lines)
 
-    def _get_covered_file_paths_with_imports(self, covered_file_paths: set[str]) -> set[str]:
+    def _get_covered_file_paths_with_imports(self, covered_file_paths: set[str]) -> t.AbstractSet[str]:
         """Return file-level covered paths with import-time dependencies added.
 
         This is the file-level equivalent of _add_import_time_lines(), but avoids
@@ -345,7 +345,7 @@ class ModuleCodeCollector(ModuleWatchdog):
         cache_key = frozenset(covered_file_paths)
         cached_paths = self._file_level_covered_paths_cache.get(cache_key)
         if cached_paths is not None:
-            return set(cached_paths)
+            return cached_paths
 
         paths = set(covered_file_paths)
         for root_path in cache_key:
@@ -427,7 +427,7 @@ class ModuleCodeCollector(ModuleWatchdog):
                 global_instance._add_import_time_lines(covered_lines)
             return covered_lines
 
-        def get_covered_file_paths(self) -> set[str]:
+        def get_covered_file_paths(self) -> t.AbstractSet[str]:
             covered_file_paths = _get_ctx_covered_files()
             if global_instance := ModuleCodeCollector._instance:
                 return global_instance._get_covered_file_paths_with_imports(covered_file_paths)

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -125,12 +125,12 @@ class ModuleCodeCollector(ModuleWatchdog):
         cls,
         include_paths: t.Optional[list[Path]] = None,
         collect_import_time_coverage: bool = False,
-        file_level_coverage: bool = False,
+        file_level_coverage: t.Optional[bool] = None,
     ):
         if ModuleCodeCollector.is_installed():
             return
 
-        configure_file_level_coverage(file_level_coverage)
+        file_level_coverage = configure_file_level_coverage(file_level_coverage)
 
         super().install()
 

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -106,6 +106,9 @@ class ModuleCodeCollector(ModuleWatchdog):
         self._import_time_contexts: dict[str, "ModuleCodeCollector.CollectInContext"] = {}
         self._import_time_name_to_path: dict[str, str] = {}
         self._import_names_by_path: dict[str, set[tuple[str, tuple[str, ...]]]] = defaultdict(set)
+        # AIDEV-NOTE: Import metadata can grow during late/dynamic imports. Clear this cache whenever import coverage
+        # metadata changes so per-test import-time augmentation does not miss newly discovered dependencies.
+        self._import_time_dependency_paths_cache: dict[str, frozenset[str]] = {}
 
         # Replace the built-in exec function with our own in the pytest globals
         try:
@@ -146,8 +149,9 @@ class ModuleCodeCollector(ModuleWatchdog):
             )
 
     def hook_import(self, path: str, import_name: tuple[str, tuple[str, ...]]) -> None:
-        if self._collect_import_coverage:
+        if self._collect_import_coverage and import_name not in self._import_names_by_path[path]:
             self._import_names_by_path[path].add(import_name)
+            self._import_time_dependency_paths_cache.clear()
 
     def hook_file(self, path: str) -> None:
         if self._coverage_enabled and path not in self._covered_files:
@@ -248,10 +252,14 @@ class ModuleCodeCollector(ModuleWatchdog):
 
         return covered_lines
 
-    def _add_import_time_lines(self, covered_lines):
-        """Modify given covered_lines in place and add lines that were covered at import time"""
+    def _get_import_time_dependency_paths(self, root_path: str) -> frozenset[str]:
+        cached_dependency_paths = self._import_time_dependency_paths_cache.get(root_path)
+        if cached_dependency_paths is not None:
+            return cached_dependency_paths
+
+        dependency_paths = set()
         visited_paths = set()
-        to_visit_paths = set(covered_lines.keys())
+        to_visit_paths = {root_path}
 
         while to_visit_paths:
             path = to_visit_paths.pop()
@@ -264,8 +272,7 @@ class ModuleCodeCollector(ModuleWatchdog):
             if path not in self._import_time_covered:
                 continue
 
-            imported_module_lines = self._import_time_covered[path]
-            covered_lines[path].update(imported_module_lines)
+            dependency_paths.add(path)
 
             # Queue up dependencies of current path, if they exist, have valid paths, and haven't been visited yet
             for dependencies in self._import_names_by_path.get(path, set()):
@@ -291,6 +298,28 @@ class ModuleCodeCollector(ModuleWatchdog):
                         if parent_package_str == package:
                             break
                         parent_package = parent_package[:-1]
+
+        cached_dependency_paths = frozenset(dependency_paths)
+        self._import_time_dependency_paths_cache[root_path] = cached_dependency_paths
+        return cached_dependency_paths
+
+    def _add_import_time_lines(self, covered_lines):
+        """Modify given covered_lines in place and add lines that were covered at import time"""
+        processed_paths = set()
+        if self._file_level_coverage:
+            for root_path in tuple(covered_lines.keys()):
+                for dependency_path in self._get_import_time_dependency_paths(root_path):
+                    if dependency_path not in processed_paths:
+                        processed_paths.add(dependency_path)
+                        covered_lines[dependency_path].add(0)
+            return
+
+        for root_path in tuple(covered_lines.keys()):
+            for path in self._get_import_time_dependency_paths(root_path):
+                if path not in processed_paths:
+                    processed_paths.add(path)
+                    imported_module_lines = self._import_time_covered[path]
+                    covered_lines[path].update(imported_module_lines)
 
     class CollectInContext:
         def __init__(self, is_import_coverage: bool = False):
@@ -458,6 +487,7 @@ class ModuleCodeCollector(ModuleWatchdog):
 
         if self._collect_import_coverage:
             self._import_time_name_to_path[_module.__name__] = code.co_filename
+            self._import_time_dependency_paths_cache.clear()
             module_context = self.CollectInContext(is_import_coverage=True)
             module_context.__enter__()
             self._import_time_contexts[code.co_filename] = module_context
@@ -479,6 +509,7 @@ class ModuleCodeCollector(ModuleWatchdog):
             collector.__exit__()
             if covered_lines[_module.__file__]:
                 self._import_time_covered[_module.__file__].update(covered_lines[_module.__file__])
+                self._import_time_dependency_paths_cache.clear()
 
             del self._import_time_contexts[_module.__file__]
 
@@ -492,6 +523,7 @@ class ModuleCodeCollector(ModuleWatchdog):
             collector.__exit__()
             if covered_lines[_module.__file__]:
                 self._import_time_covered[_module.__file__].update(covered_lines[_module.__file__])
+                self._import_time_dependency_paths_cache.clear()
 
             del self._import_time_contexts[_module.__file__]
 

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -348,8 +348,10 @@ class ModuleCodeCollector(ModuleWatchdog):
             return cached_paths
 
         paths = set(covered_file_paths)
+        import_time_covered = self._import_time_covered
         for root_path in cache_key:
-            paths.update(self._get_import_time_dependency_paths(root_path))
+            if root_path in import_time_covered:
+                paths.update(self._get_import_time_dependency_paths(root_path))
 
         self._file_level_covered_paths_cache[cache_key] = frozenset(paths)
         return paths

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -108,7 +108,9 @@ class ModuleCodeCollector(ModuleWatchdog):
         self._import_names_by_path: dict[str, set[tuple[str, tuple[str, ...]]]] = defaultdict(set)
         # AIDEV-NOTE: Import metadata can grow during late/dynamic imports. Clear this cache whenever import coverage
         # metadata changes so per-test import-time augmentation does not miss newly discovered dependencies.
+        self._direct_import_time_dependency_paths_cache: dict[str, frozenset[str]] = {}
         self._import_time_dependency_paths_cache: dict[str, frozenset[str]] = {}
+        self._file_level_covered_paths_cache: dict[frozenset[str], frozenset[str]] = {}
 
         # Replace the built-in exec function with our own in the pytest globals
         try:
@@ -151,7 +153,9 @@ class ModuleCodeCollector(ModuleWatchdog):
     def hook_import(self, path: str, import_name: tuple[str, tuple[str, ...]]) -> None:
         if self._collect_import_coverage and import_name not in self._import_names_by_path[path]:
             self._import_names_by_path[path].add(import_name)
+            self._direct_import_time_dependency_paths_cache.pop(path, None)
             self._import_time_dependency_paths_cache.clear()
+            self._file_level_covered_paths_cache.clear()
 
     def hook_file(self, path: str) -> None:
         if self._coverage_enabled and path not in self._covered_files:
@@ -252,6 +256,36 @@ class ModuleCodeCollector(ModuleWatchdog):
 
         return covered_lines
 
+    def _get_direct_import_time_dependency_paths(self, path: str) -> frozenset[str]:
+        cached_dependency_paths = self._direct_import_time_dependency_paths_cache.get(path)
+        if cached_dependency_paths is not None:
+            return cached_dependency_paths
+
+        dependency_paths = set()
+        for dependencies in self._import_names_by_path.get(path, set()):
+            package, modules = dependencies
+            for module in modules:
+                dep_fqdn = f"{package}.{module}" if package else module
+                dep_name = dep_fqdn if dep_fqdn in self._import_time_name_to_path else module
+                if dep_name in self._import_time_name_to_path:
+                    dependency_paths.add(self._import_time_name_to_path[dep_name])
+
+                # Since modules can import from packages below them in the hierarchy, we may also need to find
+                # packages that were imported (eg: identifying __init__.py files). We do this by working our way
+                # from the module name to the package name "one dot at a time"
+                parent_package = dep_fqdn.split(".")[:-1]
+                while parent_package:
+                    parent_package_str = ".".join(parent_package)
+                    if parent_package_str in self._import_time_name_to_path:
+                        dependency_paths.add(self._import_time_name_to_path[parent_package_str])
+                    if parent_package_str == package:
+                        break
+                    parent_package = parent_package[:-1]
+
+        cached_dependency_paths = frozenset(dependency_paths)
+        self._direct_import_time_dependency_paths_cache[path] = cached_dependency_paths
+        return cached_dependency_paths
+
     def _get_import_time_dependency_paths(self, root_path: str) -> frozenset[str]:
         cached_dependency_paths = self._import_time_dependency_paths_cache.get(root_path)
         if cached_dependency_paths is not None:
@@ -273,31 +307,7 @@ class ModuleCodeCollector(ModuleWatchdog):
                 continue
 
             dependency_paths.add(path)
-
-            # Queue up dependencies of current path, if they exist, have valid paths, and haven't been visited yet
-            for dependencies in self._import_names_by_path.get(path, set()):
-                package, modules = dependencies
-                for module in modules:
-                    dep_fqdn = f"{package}.{module}" if package else module
-                    dep_name = dep_fqdn if dep_fqdn in self._import_time_name_to_path else module
-                    if dep_name in self._import_time_name_to_path:
-                        dependency_path = self._import_time_name_to_path[dep_name]
-                        if dependency_path not in visited_paths:
-                            to_visit_paths.add(dependency_path)
-
-                    # Since modules can import from packages below them in the hierarchy, we may also need to find
-                    # packages that were imported (eg: identifying __init__.py files). We do this by working our way
-                    # from the module name to the package name "one dot at a time"
-                    parent_package = dep_fqdn.split(".")[:-1]
-                    while parent_package:
-                        parent_package_str = ".".join(parent_package)
-                        if parent_package_str in self._import_time_name_to_path:
-                            dependency_path = self._import_time_name_to_path[parent_package_str]
-                            if dependency_path not in visited_paths:
-                                to_visit_paths.add(dependency_path)
-                        if parent_package_str == package:
-                            break
-                        parent_package = parent_package[:-1]
+            to_visit_paths.update(self._get_direct_import_time_dependency_paths(path) - visited_paths)
 
         cached_dependency_paths = frozenset(dependency_paths)
         self._import_time_dependency_paths_cache[root_path] = cached_dependency_paths
@@ -332,9 +342,16 @@ class ModuleCodeCollector(ModuleWatchdog):
         if not covered_file_paths:
             return covered_file_paths
 
+        cache_key = frozenset(covered_file_paths)
+        cached_paths = self._file_level_covered_paths_cache.get(cache_key)
+        if cached_paths is not None:
+            return set(cached_paths)
+
         paths = set(covered_file_paths)
-        for root_path in tuple(covered_file_paths):
+        for root_path in cache_key:
             paths.update(self._get_import_time_dependency_paths(root_path))
+
+        self._file_level_covered_paths_cache[cache_key] = frozenset(paths)
         return paths
 
     class CollectInContext:
@@ -513,7 +530,9 @@ class ModuleCodeCollector(ModuleWatchdog):
 
         if self._collect_import_coverage:
             self._import_time_name_to_path[_module.__name__] = code.co_filename
+            self._direct_import_time_dependency_paths_cache.clear()
             self._import_time_dependency_paths_cache.clear()
+            self._file_level_covered_paths_cache.clear()
             module_context = self.CollectInContext(is_import_coverage=True)
             module_context.__enter__()
             self._import_time_contexts[code.co_filename] = module_context
@@ -536,6 +555,7 @@ class ModuleCodeCollector(ModuleWatchdog):
             if covered_lines[_module.__file__]:
                 self._import_time_covered[_module.__file__].update(covered_lines[_module.__file__])
                 self._import_time_dependency_paths_cache.clear()
+                self._file_level_covered_paths_cache.clear()
 
             del self._import_time_contexts[_module.__file__]
 
@@ -550,6 +570,7 @@ class ModuleCodeCollector(ModuleWatchdog):
             if covered_lines[_module.__file__]:
                 self._import_time_covered[_module.__file__].update(covered_lines[_module.__file__])
                 self._import_time_dependency_paths_cache.clear()
+                self._file_level_covered_paths_cache.clear()
 
             del self._import_time_contexts[_module.__file__]
 

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -321,6 +321,22 @@ class ModuleCodeCollector(ModuleWatchdog):
                     imported_module_lines = self._import_time_covered[path]
                     covered_lines[path].update(imported_module_lines)
 
+    def _get_covered_file_paths_with_imports(self, covered_file_paths: set[str]) -> set[str]:
+        """Return file-level covered paths with import-time dependencies added.
+
+        This is the file-level equivalent of _add_import_time_lines(), but avoids
+        allocating and mutating one CoverageLines object per covered file for every
+        test. File-level coverage only needs path membership because every covered
+        file emits the same line-0 sentinel bitmap.
+        """
+        if not covered_file_paths:
+            return covered_file_paths
+
+        paths = set(covered_file_paths)
+        for root_path in tuple(covered_file_paths):
+            paths.update(self._get_import_time_dependency_paths(root_path))
+        return paths
+
     class CollectInContext:
         def __init__(self, is_import_coverage: bool = False):
             self.is_import_coverage = is_import_coverage
@@ -393,6 +409,16 @@ class ModuleCodeCollector(ModuleWatchdog):
             if global_instance := ModuleCodeCollector._instance:
                 global_instance._add_import_time_lines(covered_lines)
             return covered_lines
+
+        def get_covered_file_paths(self) -> set[str]:
+            covered_file_paths = _get_ctx_covered_files()
+            if global_instance := ModuleCodeCollector._instance:
+                return global_instance._get_covered_file_paths_with_imports(covered_file_paths)
+            return covered_file_paths
+
+    @classmethod
+    def file_level_coverage_enabled(cls):
+        return cls._instance is not None and cls._instance._file_level_coverage
 
     @classmethod
     def start_coverage(cls):

--- a/ddtrace/internal/coverage/installer.py
+++ b/ddtrace/internal/coverage/installer.py
@@ -9,7 +9,7 @@ from ddtrace.internal.coverage.threading_coverage import _patch_threading
 def install(
     include_paths: t.Optional[list[Path]] = None,
     collect_import_time_coverage: bool = False,
-    file_level_coverage: bool = False,
+    file_level_coverage: t.Optional[bool] = None,
 ) -> None:
     ModuleCodeCollector.install(
         include_paths=include_paths,

--- a/ddtrace/internal/coverage/instrumentation.py
+++ b/ddtrace/internal/coverage/instrumentation.py
@@ -2,8 +2,8 @@ import sys
 
 
 # Import are noqa'd otherwise some formatters will helpfully remove them
-def configure_file_level_coverage(enabled: object = None) -> None:
-    pass
+def configure_file_level_coverage(enabled: object = None) -> bool:
+    return bool(enabled)
 
 
 if sys.version_info >= (3, 16):

--- a/ddtrace/internal/coverage/instrumentation_py3_12.py
+++ b/ddtrace/internal/coverage/instrumentation_py3_12.py
@@ -113,7 +113,7 @@ _tls_context = _threading.local()
 _use_disable_optimization: bool = True
 
 
-def configure_file_level_coverage(enabled: t.Optional[bool] = None) -> None:
+def configure_file_level_coverage(enabled: t.Optional[bool] = None) -> bool:
     """Configure the monitoring event used for coverage before sys.monitoring registration.
 
     Production callers pass the already-resolved Test Optimization setting so the collector and backend agree on
@@ -124,10 +124,11 @@ def configure_file_level_coverage(enabled: t.Optional[bool] = None) -> None:
     file_level_coverage = _get_file_level_coverage(enabled)
     if _DD_TOOL_ID is not None and file_level_coverage != _USE_FILE_LEVEL_COVERAGE:
         log.warning("Cannot change coverage mode after sys.monitoring registration")
-        return
+        return _USE_FILE_LEVEL_COVERAGE
 
     _USE_FILE_LEVEL_COVERAGE = file_level_coverage
     EVENT = _event_for_file_level_coverage(file_level_coverage)
+    return file_level_coverage
 
 
 def set_active_context_covered_files(covered_files: t.Optional[t.Set[str]]) -> None:  # noqa: UP006

--- a/ddtrace/testing/internal/tracer_api/coverage.py
+++ b/ddtrace/testing/internal/tracer_api/coverage.py
@@ -53,7 +53,7 @@ _FILE_LEVEL_BITMAP = bytes(CoverageLines.from_list([0]).to_bytes())
 class CoverageData:
     def __init__(self) -> None:
         self._covered_lines: t.Optional[dict[str, CoverageLines]] = None
-        self._covered_file_paths: t.Optional[set[str]] = None
+        self._covered_file_paths: t.Optional[t.Iterable[str]] = None
 
     def get_coverage_bitmaps(self, relative_to: Path) -> t.Iterable[tuple[str, bytes]]:
         relative_to_str = str(relative_to)

--- a/ddtrace/testing/internal/tracer_api/coverage.py
+++ b/ddtrace/testing/internal/tracer_api/coverage.py
@@ -47,15 +47,27 @@ def _relative_coverage_path(absolute_path: str, relative_to: str) -> t.Optional[
         return None  # covered file does not belong to current repo
 
 
+_FILE_LEVEL_BITMAP = bytes(CoverageLines.from_list([0]).to_bytes())
+
+
 class CoverageData:
     def __init__(self) -> None:
         self._covered_lines: t.Optional[dict[str, CoverageLines]] = None
+        self._covered_file_paths: t.Optional[set[str]] = None
 
     def get_coverage_bitmaps(self, relative_to: Path) -> t.Iterable[tuple[str, bytes]]:
+        relative_to_str = str(relative_to)
+
+        if self._covered_file_paths is not None:
+            for absolute_path in self._covered_file_paths:
+                path_str = _relative_coverage_path(absolute_path, relative_to_str)
+                if path_str is not None:
+                    yield path_str, _FILE_LEVEL_BITMAP
+            return
+
         if not self._covered_lines:
             return
 
-        relative_to_str = str(relative_to)
         for absolute_path, covered_lines in self._covered_lines.items():
             path_str = _relative_coverage_path(absolute_path, relative_to_str)
             if path_str is not None:
@@ -67,7 +79,10 @@ def coverage_collection() -> t.Generator[CoverageData, None, None]:
     with ModuleCodeCollector.CollectInContext() as coverage_collector:
         coverage_data = CoverageData()
         yield coverage_data
-        coverage_data._covered_lines = coverage_collector.get_covered_lines()
+        if ModuleCodeCollector.file_level_coverage_enabled():
+            coverage_data._covered_file_paths = coverage_collector.get_covered_file_paths()
+        else:
+            coverage_data._covered_lines = coverage_collector.get_covered_lines()
 
 
 def install_coverage_percentage():

--- a/ddtrace/testing/internal/tracer_api/coverage.py
+++ b/ddtrace/testing/internal/tracer_api/coverage.py
@@ -6,6 +6,7 @@ coverage data.
 """
 
 import contextlib
+import functools
 import logging
 from pathlib import Path
 import typing as t
@@ -38,6 +39,14 @@ def uninstall_coverage() -> None:
     ModuleCodeCollector.uninstall()
 
 
+@functools.lru_cache(maxsize=65536)
+def _relative_coverage_path(absolute_path: str, relative_to: str) -> t.Optional[str]:
+    try:
+        return f"/{Path(absolute_path).relative_to(relative_to)}"
+    except ValueError:
+        return None  # covered file does not belong to current repo
+
+
 class CoverageData:
     def __init__(self) -> None:
         self._covered_lines: t.Optional[dict[str, CoverageLines]] = None
@@ -46,14 +55,11 @@ class CoverageData:
         if not self._covered_lines:
             return
 
+        relative_to_str = str(relative_to)
         for absolute_path, covered_lines in self._covered_lines.items():
-            try:
-                relative_path = Path(absolute_path).relative_to(relative_to)
-            except ValueError:
-                continue  # covered file does not belong to current repo
-
-            path_str = f"/{relative_path}"
-            yield path_str, covered_lines.to_bytes()
+            path_str = _relative_coverage_path(absolute_path, relative_to_str)
+            if path_str is not None:
+                yield path_str, covered_lines.to_bytes()
 
 
 @contextlib.contextmanager

--- a/tests/coverage/included_path/covered_then_dynamic_import.py
+++ b/tests/coverage/included_path/covered_then_dynamic_import.py
@@ -1,0 +1,8 @@
+def cover_file_without_import():
+    return "covered"
+
+
+def import_preimported_dependency():
+    from tests.coverage.included_path.preimported_dependency import dependency_function
+
+    return dependency_function()

--- a/tests/coverage/included_path/preimported_dependency.py
+++ b/tests/coverage/included_path/preimported_dependency.py
@@ -1,0 +1,5 @@
+VALUE = 42
+
+
+def dependency_function():
+    return VALUE

--- a/tests/coverage/test_file_level_fast_path_regressions.py
+++ b/tests/coverage/test_file_level_fast_path_regressions.py
@@ -52,3 +52,93 @@ def test_same_file_fast_path_preserves_late_dynamic_import_dependency():
 
     assert covered_file in with_dynamic_import
     assert dependency_file in with_dynamic_import, "late dynamic import dependency must merge import-time coverage"
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="Test specific to Python 3.12+ monitoring API")
+@pytest.mark.subprocess(parametrize={"_DD_COVERAGE_FILE_LEVEL": ["true"]})
+def test_file_level_path_fast_path_preserves_late_dynamic_import_dependency():
+    """File-level get_covered_file_paths() must include dependency edges discovered after an earlier cache hit.
+
+    The first context covers ``covered_then_dynamic_import.py`` without executing its dynamic import, then asks for
+    file paths. That populates the file-level covered-path cache for the singleton covered-file set. The second context
+    covers the same file set but also executes the dynamic import. If dynamic import metadata does not invalidate the
+    file-level cache, the preimported dependency would be omitted.
+    """
+    import os
+    from pathlib import Path
+
+    def relpath_set(rootpath, paths):
+        root = Path(rootpath)
+        return {str(Path(path).relative_to(root)) for path in paths}
+
+    from ddtrace.internal.coverage.code import ModuleCodeCollector
+    from ddtrace.internal.coverage.installer import install
+
+    cwd_path = os.getcwd()
+    include_path = Path(cwd_path + "/tests/coverage/included_path/")
+
+    install(include_paths=[include_path], collect_import_time_coverage=True)
+
+    # Imported before the test contexts: later contexts only include it through import-time dependency expansion.
+    from tests.coverage.included_path import preimported_dependency  # noqa:F401
+    from tests.coverage.included_path.covered_then_dynamic_import import cover_file_without_import
+    from tests.coverage.included_path.covered_then_dynamic_import import import_preimported_dependency
+
+    with ModuleCodeCollector.CollectInContext() as context_without_dynamic_import:
+        assert cover_file_without_import() == "covered"
+        without_dynamic_import = relpath_set(cwd_path, context_without_dynamic_import.get_covered_file_paths())
+
+    with ModuleCodeCollector.CollectInContext() as context_with_dynamic_import:
+        assert cover_file_without_import() == "covered"
+        assert import_preimported_dependency() == 42
+        with_dynamic_import = relpath_set(cwd_path, context_with_dynamic_import.get_covered_file_paths())
+
+    covered_file = "tests/coverage/included_path/covered_then_dynamic_import.py"
+    dependency_file = "tests/coverage/included_path/preimported_dependency.py"
+
+    assert covered_file in without_dynamic_import
+    assert dependency_file not in without_dynamic_import, "import-time coverage should not leak into unrelated contexts"
+
+    assert covered_file in with_dynamic_import
+    assert dependency_file in with_dynamic_import, "late dynamic import dependency must invalidate cached file paths"
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="Test specific to Python 3.12+ monitoring API")
+@pytest.mark.subprocess(parametrize={"_DD_COVERAGE_FILE_LEVEL": ["true"]})
+def test_file_level_path_fast_path_preserves_nested_dynamic_import_dependencies():
+    """Nested dynamic imports should be represented in file-level path output across contexts."""
+    import os
+    from pathlib import Path
+
+    def relpath_set(rootpath, paths):
+        root = Path(rootpath)
+        return {str(Path(path).relative_to(root)) for path in paths}
+
+    from ddtrace.internal.coverage.code import ModuleCodeCollector
+    from ddtrace.internal.coverage.installer import install
+
+    cwd_path = os.getcwd()
+    include_path = Path(cwd_path + "/tests/coverage/included_path/")
+
+    install(include_paths=[include_path], collect_import_time_coverage=True)
+
+    from tests.coverage.included_path.nested_fixture import fixture_dynamic_path
+    from tests.coverage.included_path.nested_fixture import fixture_toplevel_path
+
+    with ModuleCodeCollector.CollectInContext() as context_toplevel:
+        fixture_toplevel_path(5)
+        toplevel_files = relpath_set(cwd_path, context_toplevel.get_covered_file_paths())
+
+    with ModuleCodeCollector.CollectInContext() as context_dynamic:
+        fixture_dynamic_path(10)
+        dynamic_files = relpath_set(cwd_path, context_dynamic.get_covered_file_paths())
+
+    assert "tests/coverage/included_path/nested_fixture.py" in toplevel_files
+    assert "tests/coverage/included_path/layer2_toplevel.py" in toplevel_files
+    assert "tests/coverage/included_path/layer2_dynamic.py" not in toplevel_files
+
+    assert "tests/coverage/included_path/nested_fixture.py" in dynamic_files
+    assert "tests/coverage/included_path/layer2_dynamic.py" in dynamic_files
+    assert "tests/coverage/included_path/layer3_toplevel.py" in dynamic_files
+    assert "tests/coverage/included_path/layer3_dynamic.py" in dynamic_files
+    assert "tests/coverage/included_path/constants_dynamic.py" in dynamic_files

--- a/tests/coverage/test_file_level_fast_path_regressions.py
+++ b/tests/coverage/test_file_level_fast_path_regressions.py
@@ -1,0 +1,54 @@
+import sys
+
+import pytest
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="Test specific to Python 3.12+ monitoring API")
+@pytest.mark.subprocess(parametrize={"_DD_COVERAGE_FILE_LEVEL": ["true", "false"]})
+def test_same_file_fast_path_preserves_late_dynamic_import_dependency():
+    """Guard against skipping same-file PY_START events too aggressively.
+
+    File-level optimizations may want to stop doing work once a file is already
+    covered in the current context. That is only safe if later code objects in
+    that same file can still publish their import dependency metadata. Here the
+    dependency module is imported before the test contexts, so the second
+    context only gets that module's import-time coverage if the dynamic import
+    dependency edge from ``covered_then_dynamic_import.py`` is preserved.
+    """
+    import os
+    from pathlib import Path
+
+    from ddtrace.internal.coverage.code import ModuleCodeCollector
+    from ddtrace.internal.coverage.installer import install
+    from tests.coverage.utils import _get_relpath_dict
+
+    cwd_path = os.getcwd()
+    include_path = Path(cwd_path + "/tests/coverage/included_path/")
+
+    install(include_paths=[include_path], collect_import_time_coverage=True)
+
+    # Imported before the test contexts: later contexts should only include it
+    # when dependency tracking proves the executed code imported it.
+    from tests.coverage.included_path import preimported_dependency  # noqa:F401
+    from tests.coverage.included_path.covered_then_dynamic_import import cover_file_without_import
+    from tests.coverage.included_path.covered_then_dynamic_import import import_preimported_dependency
+
+    with ModuleCodeCollector.CollectInContext() as context_without_dynamic_import:
+        assert cover_file_without_import() == "covered"
+        without_dynamic_import = _get_relpath_dict(cwd_path, context_without_dynamic_import.get_covered_lines())
+
+    with ModuleCodeCollector.CollectInContext() as context_with_dynamic_import:
+        # Cover the file first. A too-aggressive file-level fast path would be tempted to suppress the rest of the
+        # file's PY_START callbacks after this point.
+        assert cover_file_without_import() == "covered"
+        assert import_preimported_dependency() == 42
+        with_dynamic_import = _get_relpath_dict(cwd_path, context_with_dynamic_import.get_covered_lines())
+
+    covered_file = "tests/coverage/included_path/covered_then_dynamic_import.py"
+    dependency_file = "tests/coverage/included_path/preimported_dependency.py"
+
+    assert covered_file in without_dynamic_import
+    assert dependency_file not in without_dynamic_import, "import-time coverage should not leak into unrelated contexts"
+
+    assert covered_file in with_dynamic_import
+    assert dependency_file in with_dynamic_import, "late dynamic import dependency must merge import-time coverage"


### PR DESCRIPTION
## Description

Use a file-path-set fast path for Test Optimization file-level coverage and cache expensive path/dependency expansion work.

This PR changes the file-level coverage path to better match the data we need to emit:

- cache repo-relative coverage path conversion
- collect file-level coverage as covered file path sets instead of line-oriented structures
- cache import-time dependency path expansion
- cache expanded file coverage path sets
- skip dependency expansion for files with no import-time coverage metadata
- add regression coverage for dynamic imports and dependency attribution

The goal is to avoid repeatedly allocating `CoverageLines`, converting paths, and walking import dependency graphs for every test when file-level coverage only needs filename attribution.

Part 3 of the pytest/Test Optimization performance stack. Stacked on #19231.

## Testing

Previously validated as part of the combined pytest performance branch, including mockdog `citestcov` parity checks and dynamic import regression tests.

## Risks

Medium/high. This is the main data-model optimization for file-level coverage. The added regression tests guard against missing dynamic import dependency files.