### PR TITLE
chore(profiling): track max asyncio task count in one profile cycle

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
@@ -40,7 +40,8 @@ class ProfilerStats
     // Samples dropped because the cap was reached (cumulative over tracker lifetime)
     std::optional<size_t> heap_tracker_cap_drops;
 
-    // Number of asyncio tasks seen across sampled threads in the last sampling cycle
+    // Peak number of asyncio tasks seen across sampled threads in any single sampling
+    // cycle during the current profile period (see set_asyncio_task_count).
     std::optional<size_t> asyncio_task_count;
 
     // Number of greenlets currently tracked by the stack profiler

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
@@ -129,7 +129,11 @@ Datadog::ProfilerStats::get_heap_tracker_cap_drops() const
 void
 Datadog::ProfilerStats::set_asyncio_task_count(size_t count)
 {
-    asyncio_task_count = count;
+    // Track the peak (max) asyncio task count observed across sampling cycles
+    // within a profile period
+    if (!asyncio_task_count.has_value() || count > *asyncio_task_count) {
+        asyncio_task_count = count;
+    }
 }
 
 std::optional<size_t>

--- a/tests/profiling/collector/test_asyncio_task_count.py
+++ b/tests/profiling/collector/test_asyncio_task_count.py
@@ -52,3 +52,59 @@ def test_asyncio_task_count_present():
                 found_positive = True
 
     assert found_positive, "Expected at least one metadata file with asyncio_task_count > 0"
+
+
+@pytest.mark.subprocess(
+    env=dict(
+        DD_PROFILING_OUTPUT_PPROF="/tmp/test_asyncio_task_count_run_teardown",
+    ),
+    err=None,
+)
+def test_asyncio_task_count_survives_run_teardown():
+    """asyncio_task_count reflects the peak even after asyncio.run() tears down the loop.
+
+    There may be sampling cycles that observe 0 tasks when other samples in the same profiling interval
+    have a higher count. With a plain-assignment setter, the final 0 overwrote the real count captured while the
+    loop was live, so the uploaded profile reported asyncio_task_count: 0 when it should have been the peak.
+    """
+    import asyncio
+    import glob
+    import json
+    import os
+    import time
+
+    from ddtrace.profiling import profiler
+    from ddtrace.trace import tracer
+
+    NUM_WORKERS = 10
+    EXPECTED_PEAK = NUM_WORKERS + 1
+
+    async def worker():
+        await asyncio.sleep(0.5)
+
+    async def main():
+        tasks = [asyncio.create_task(worker(), name=f"worker-{i}") for i in range(NUM_WORKERS)]
+        await asyncio.gather(*tasks)
+
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+
+    # use the workload that calls asyncio.run() that clears the event loop on exit.
+    for _ in range(4):
+        asyncio.run(main())
+
+    # Keep profiling after the loop is gone so several idle cycles (0 tasks) fire.
+    time.sleep(1)
+    p.stop()
+
+    output_filename = os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid())
+    files = sorted(glob.glob(output_filename + ".*.internal_metadata.json"))
+    assert files, "Expected internal_metadata.json file"
+
+    peak = 0
+    for f in files:
+        with open(f) as fp:
+            metadata = json.load(fp)
+        peak = max(peak, metadata.get("asyncio_task_count", 0))
+
+    assert peak == EXPECTED_PEAK, f"Expected asyncio_task_count == {EXPECTED_PEAK}, found {peak}"


### PR DESCRIPTION
[PROF-14760](https://datadoghq.atlassian.net/jira/software/c/projects/PROF/boards/27442?selectedIssue=PROF-14760)

## Description

`asyncio.run()`/`Runner.close(`) calls `set_event_loop(None)`, which clears the tracked `asyncio_loop` for the thread. Following sampling cycles observe 0 tasks. With a plain-assignment setter, the final 0 overwrote the real count captured while the loop was live, so the uploaded profile reported `asyncio_task_count: 0` when it clearly did have tasks.

## Testing

Unit tests
## Risks

None
## Additional Notes

<!-- Any other information that would be helpful for reviewers -->


[PROF-14760]: https://datadoghq.atlassian.net/browse/PROF-14760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ