### PR TITLE
feat(pydantic_ai): propagate conversation_id as LLMObs session_id

### DIFF
--- a/ddtrace/contrib/internal/pydantic_ai/patch.py
+++ b/ddtrace/contrib/internal/pydantic_ai/patch.py
@@ -42,6 +42,7 @@ def traced_agent_run_stream(func, instance, args, kwargs):
         model=getattr(instance, "model", None),
         kind="agent",
     )
+    integration.set_session_id(span, kwargs.get("conversation_id"))
 
     result = func(*args, **kwargs)
     kwargs["instance"] = instance
@@ -61,6 +62,7 @@ def traced_agent_iter(func, instance, args, kwargs):
         model=getattr(instance, "model", None),
         kind="agent",
     )
+    integration.set_session_id(span, kwargs.get("conversation_id"))
 
     result = func(*args, **kwargs)
     kwargs["instance"] = instance

--- a/ddtrace/llmobs/_integrations/pydantic_ai.py
+++ b/ddtrace/llmobs/_integrations/pydantic_ai.py
@@ -35,6 +35,26 @@ class PydanticAIIntegration(BaseLLMIntegration):
             _annotate_llmobs_span_data(span, kind=kind)
         return span
 
+    def set_session_id(self, span: Span, conversation_id: Optional[str]) -> None:
+        """Set the caller-provided ``conversation_id`` as the LLMObs session for this span.
+
+        Two values are intentionally ignored rather than propagated as-is:
+
+        - ``None`` (the default): most calls don't pass ``conversation_id`` explicitly, so this
+          is just the common no-op case — nothing to propagate.
+        - ``"new"``: pydantic-ai documents this as a sentinel on ``conversation_id`` meaning
+          "fork a fresh conversation off the supplied history", which it replaces internally
+          with a freshly generated id we have no access to here. Setting the session id to the
+          literal string ``"new"`` would silently group every unrelated fresh conversation
+          under one shared session, which is worse than not setting a session id at all.
+
+        Called at agent-span creation, before any child tool spans are created, so the session
+        id propagates to them.
+        """
+        if not self.llmobs_enabled or not conversation_id or conversation_id == "new":
+            return
+        _annotate_llmobs_span_data(span, session_id=conversation_id)
+
     def _set_base_span_tags(self, span: Span, model: Optional[Any] = None, **kwargs) -> None:
         if model:
             model_name, provider = self._get_model_and_provider(model)

--- a/releasenotes/notes/pydantic-ai-session-id-from-conversation-id-9dc7b53452b453ed.yaml
+++ b/releasenotes/notes/pydantic-ai-session-id-from-conversation-id-9dc7b53452b453ed.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    LLM Observability: The Pydantic AI integration now propagates the explicit
+    ``conversation_id`` passed to ``Agent.run``/``run_stream``/``iter`` as the LLMObs
+    ``session_id``.

--- a/tests/contrib/pydantic_ai/test_pydantic_ai_llmobs.py
+++ b/tests/contrib/pydantic_ai/test_pydantic_ai_llmobs.py
@@ -501,6 +501,113 @@ class TestLLMObsPydanticAISpanLinks:
         assert second_llm_span_data["span_links"][0]["attributes"] == {"from": "output", "to": "input"}
 
 
+@pytest.mark.parametrize(
+    "ddtrace_global_config",
+    [dict(_llmobs_enabled=True, _llmobs_ml_app="<ml-app-name>")],
+)
+class TestLLMObsPydanticAISessionId:
+    """The raw `conversation_id` kwarg passed to run/run_stream/iter is propagated as the
+    LLMObs `session_id`, except when it's `None` (omitted) or the `'new'` sentinel — see
+    `PydanticAIIntegration.set_session_id` for why those two values are skipped rather than
+    propagated as-is.
+    """
+
+    async def test_agent_run_with_conversation_id(self, pydantic_ai, request_vcr, pydantic_ai_llmobs, test_spans):
+        with request_vcr.use_cassette("agent_iter.yaml"):
+            agent = pydantic_ai.Agent(model="gpt-4o", name="test_agent")
+            result = await agent.run("Hello, world!", conversation_id="test-conversation")
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="agent",
+            name="test_agent",
+            input_value="Hello, world!",
+            output_value=result.output,
+            metadata=expected_agent_metadata(),
+            tags={**PYDANTIC_AI_TAGS, "session_id": "test-conversation"},
+        )
+
+    async def test_agent_run_stream_with_conversation_id(
+        self, pydantic_ai, request_vcr, pydantic_ai_llmobs, test_spans
+    ):
+        output = ""
+        with request_vcr.use_cassette("agent_run_stream.yaml"):
+            agent = pydantic_ai.Agent(model="gpt-4o", name="test_agent")
+            async with agent.run_stream("Hello, world!", conversation_id="test-conversation") as result:
+                async for chunk in result.stream(debounce_by=None):
+                    output = chunk
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="agent",
+            name="test_agent",
+            input_value="Hello, world!",
+            output_value=output,
+            metadata=expected_agent_metadata(),
+            tags={**PYDANTIC_AI_TAGS, "session_id": "test-conversation"},
+        )
+
+    async def test_agent_iter_with_conversation_id(self, pydantic_ai, request_vcr, pydantic_ai_llmobs, test_spans):
+        with request_vcr.use_cassette("agent_iter.yaml"):
+            agent = pydantic_ai.Agent(model="gpt-4o", name="test_agent")
+            async with agent.iter("Hello, world!", conversation_id="test-conversation") as agent_run:
+                async for _ in agent_run:
+                    pass
+                output = agent_run.result.output
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(spans[0]),
+            span_kind="agent",
+            name="test_agent",
+            input_value="Hello, world!",
+            output_value=output,
+            metadata=expected_agent_metadata(),
+            tags={**PYDANTIC_AI_TAGS, "session_id": "test-conversation"},
+        )
+
+    async def test_agent_run_with_conversation_id_new_sentinel_is_not_propagated(
+        self, pydantic_ai, request_vcr, pydantic_ai_llmobs, test_spans
+    ):
+        """`conversation_id='new'` tells pydantic-ai to fork a fresh conversation off the
+        supplied history; pydantic-ai replaces it internally with a generated UUID7 we have no
+        access to at span-creation time. Propagating the literal string `'new'` would silently
+        group every unrelated fresh conversation under one shared session, so it must be
+        skipped entirely rather than used as the session id."""
+        with request_vcr.use_cassette("agent_iter.yaml"):
+            agent = pydantic_ai.Agent(model="gpt-4o", name="test_agent")
+            await agent.run("Hello, world!", conversation_id="new")
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        tags = _get_llmobs_data_metastruct(spans[0])["tags"]
+        assert "session_id" not in tags
+
+    async def test_agent_run_with_conversation_id_omitted_is_not_propagated(
+        self, pydantic_ai, request_vcr, pydantic_ai_llmobs, test_spans
+    ):
+        """When `conversation_id` isn't passed explicitly, we don't attempt to reconstruct the
+        id pydantic-ai resolves internally (e.g. inherited from `message_history`, or a fresh
+        UUID7) — only an explicit `conversation_id` kwarg is propagated as the session id."""
+        from pydantic_ai.messages import ModelRequest
+        from pydantic_ai.messages import UserPromptPart
+
+        message_history = [
+            ModelRequest(
+                parts=[UserPromptPart(content="Hello from history!")],
+                conversation_id="conversation-from-history",
+            )
+        ]
+        with request_vcr.use_cassette("agent_iter.yaml"):
+            agent = pydantic_ai.Agent(model="gpt-4o", name="test_agent")
+            await agent.run(message_history=message_history)
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        tags = _get_llmobs_data_metastruct(spans[0])["tags"]
+        assert "session_id" not in tags
+
+
 class _UnserializableSentinel:
     """Stand-in for provider sentinels such as OpenAI's ``Omit`` / ``NOT_GIVEN``."""
 


### PR DESCRIPTION
## Summary

- Propagates the explicit `conversation_id` kwarg passed to `Agent.run`/`run_stream`/`iter` as the LLMObs `session_id`, mirroring the pattern already used by the `google_adk` integration (`PydanticAIIntegration.set_session_id`, called right after span creation).
- `conversation_id=None` (the default, i.e. not passed explicitly) and the `'new'` sentinel are intentionally **not** propagated:
  - `None` is just the common no-op case (most calls don't pass it).
  - `'new'` tells pydantic-ai to fork a fresh conversation into an id generated internally (a fresh UUID7) that isn't available to the integration at span-creation time. Propagating the literal string `'new'` would incorrectly group every unrelated fresh conversation under one shared session.
- Only the raw kwarg is used, not pydantic-ai's internally resolved id (e.g. `AgentRun.conversation_id`, which also accounts for inheritance from `message_history`) — resolving it would require entering the run before the session id could be set, which is after child tool spans already need it.

## Test plan

- [x] Added `TestLLMObsPydanticAISessionId` to `tests/contrib/pydantic_ai/test_pydantic_ai_llmobs.py`, covering: explicit `conversation_id` via `run`/`run_stream`/`iter`, the `'new'` sentinel being skipped, and an omitted-but-inherited-from-`message_history` case also being skipped (documenting the raw-kwarg-only design choice).

Closes #19237