### PR TITLE
fix(ci_visibility): add ITR correlation ID [backport 4.12]

### DIFF
--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -205,6 +205,7 @@ class SessionManager:
             skipping_enabled=self.settings.skipping_enabled,
             skipping_level=self.itr_skipping_level,
         )
+        self.session.itr_correlation_id = self.itr_correlation_id
 
         # Propagate configuration errors to the session event and all child events.
         if self.configuration_errors:
@@ -227,10 +228,6 @@ class SessionManager:
                 "service.name": self.service,
             },
         )
-
-        if self.itr_correlation_id:
-            itr_event = "test" if self.itr_skipping_level == ITRSkippingLevel.TEST else "test_suite_end"
-            self.writer.add_metadata(itr_event, {"itr_correlation_id": self.itr_correlation_id})
 
         self.codeowners: t.Optional[Codeowners] = None
 

--- a/ddtrace/testing/internal/test_data.py
+++ b/ddtrace/testing/internal/test_data.py
@@ -384,6 +384,7 @@ class TestSession(TestItem[t.NoReturn, "TestModule"]):
     def __init__(self, name: str):
         super().__init__(name=name, parent=None)  # type: ignore
         self.tests_skipped_by_itr = 0
+        self.itr_correlation_id: t.Optional[str] = None
         self.itr_enabled = False
         self.itr_skipping_enabled = False
         self.itr_skipping_level = ITRSkippingLevel.TEST

--- a/ddtrace/testing/internal/writer.py
+++ b/ddtrace/testing/internal/writer.py
@@ -7,6 +7,7 @@ import typing as t
 import uuid
 
 from ddtrace.internal.settings import env
+from ddtrace.testing.internal.constants import ITRSkippingLevel
 from ddtrace.testing.internal.http import BackendConnectorSetup
 from ddtrace.testing.internal.http import FileAttachment
 from ddtrace.testing.internal.http import Subdomain
@@ -469,75 +470,75 @@ class PayloadFileCoverageWriter(TestCoverageWriter):
 
 
 def serialize_test_run(test_run: TestRun) -> Event:
-    return Event(
-        version=2,
-        type="test",
-        content={
-            "trace_id": test_run.trace_id,
-            "parent_id": 1,
-            "span_id": test_run.span_id,
-            "service": test_run.service,
-            "resource": test_run.name,
-            "name": "pytest.test",
-            "error": 1 if test_run.get_status() == TestStatus.FAIL else 0,
-            "start": test_run.start_ns,
-            "duration": test_run.duration_ns,
-            "meta": {
-                "span.kind": "test",
-                "test.module": test_run.module.name,
-                "test.module_path": test_run.module.module_path,
-                "test.name": test_run.name,
-                "test.status": test_run.get_status().value,
-                "test.suite": test_run.suite.name,
-                "type": "test",
-                **test_run.test.tags,
-                **test_run.tags,
-            },
-            "metrics": {
-                "_dd.py.partial_flush": 1,
-                "_dd.top_level": 1,
-                "_dd.tracer_kr": 1.0,
-                "_sampling_priority_v1": 1,
-                **test_run.metrics,
-            },
+    content = {
+        "trace_id": test_run.trace_id,
+        "parent_id": 1,
+        "span_id": test_run.span_id,
+        "service": test_run.service,
+        "resource": test_run.name,
+        "name": "pytest.test",
+        "error": 1 if test_run.get_status() == TestStatus.FAIL else 0,
+        "start": test_run.start_ns,
+        "duration": test_run.duration_ns,
+        "meta": {
+            "span.kind": "test",
+            "test.module": test_run.module.name,
+            "test.module_path": test_run.module.module_path,
+            "test.name": test_run.name,
+            "test.status": test_run.get_status().value,
+            "test.suite": test_run.suite.name,
             "type": "test",
-            "test_session_id": test_run.session.item_id,
-            "test_module_id": test_run.module.item_id,
-            "test_suite_id": test_run.suite.item_id,
+            **test_run.test.tags,
+            **test_run.tags,
         },
-    )
+        "metrics": {
+            "_dd.py.partial_flush": 1,
+            "_dd.top_level": 1,
+            "_dd.tracer_kr": 1.0,
+            "_sampling_priority_v1": 1,
+            **test_run.metrics,
+        },
+        "type": "test",
+        "test_session_id": test_run.session.item_id,
+        "test_module_id": test_run.module.item_id,
+        "test_suite_id": test_run.suite.item_id,
+    }
+    if test_run.session.itr_correlation_id and test_run.session.itr_skipping_level == ITRSkippingLevel.TEST:
+        content["itr_correlation_id"] = test_run.session.itr_correlation_id
+
+    return Event(version=2, type="test", content=content)
 
 
 def serialize_suite(suite: TestSuite) -> Event:
-    return Event(
-        version=1,
-        type="test_suite_end",
-        content={
-            "service": suite.service,
-            "resource": suite.name,
-            "name": "pytest.test_suite",
-            "error": 0,
-            "start": suite.start_ns,
-            "duration": suite.duration_ns,
-            "meta": {
-                "span.kind": "test",
-                "test.suite": suite.name,
-                "test.status": suite.get_status().value,
-                "type": "test_suite_end",
-                **suite.tags,
-            },
-            "metrics": {
-                "_dd.py.partial_flush": 1,
-                "_dd.tracer_kr": 1.0,
-                "_sampling_priority_v1": 1,
-                **suite.metrics,
-            },
+    content = {
+        "service": suite.service,
+        "resource": suite.name,
+        "name": "pytest.test_suite",
+        "error": 0,
+        "start": suite.start_ns,
+        "duration": suite.duration_ns,
+        "meta": {
+            "span.kind": "test",
+            "test.suite": suite.name,
+            "test.status": suite.get_status().value,
             "type": "test_suite_end",
-            "test_session_id": suite.session.item_id,
-            "test_module_id": suite.module.item_id,
-            "test_suite_id": suite.item_id,
+            **suite.tags,
         },
-    )
+        "metrics": {
+            "_dd.py.partial_flush": 1,
+            "_dd.tracer_kr": 1.0,
+            "_sampling_priority_v1": 1,
+            **suite.metrics,
+        },
+        "type": "test_suite_end",
+        "test_session_id": suite.session.item_id,
+        "test_module_id": suite.module.item_id,
+        "test_suite_id": suite.item_id,
+    }
+    if suite.session.itr_correlation_id and suite.session.itr_skipping_level == ITRSkippingLevel.SUITE:
+        content["itr_correlation_id"] = suite.session.itr_correlation_id
+
+    return Event(version=1, type="test_suite_end", content=content)
 
 
 def serialize_module(module: TestModule) -> Event:

--- a/releasenotes/notes/ci-visibility-itr-correlation-id-13e6e7d8deaf7b99.yaml
+++ b/releasenotes/notes/ci-visibility-itr-correlation-id-13e6e7d8deaf7b99.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    CI Visibility: This fix resolves an issue where the Datadog UI showed ``No extra information available`` when viewing details about why a test was skipped by Intelligent Test Runner, due to missing ITR correlation ID on test or suite events.

--- a/tests/testing/internal/test_session_manager.py
+++ b/tests/testing/internal/test_session_manager.py
@@ -186,6 +186,19 @@ class TestSessionManagerIsSkippableTest:
         assert session_manager.is_skippable_test(test_ref3) is True
 
 
+class TestSessionManagerITRCorrelationId:
+    def test_session_manager_propagates_itr_correlation_id_to_session(self) -> None:
+        session_manager = (
+            session_manager_mock()
+            .with_settings(MockDefaults.settings(itr_enabled=True, skipping_enabled=True))
+            .with_itr_correlation_id("itr-correlation-id")
+            .build_real_with_mocks(MockDefaults.test_environment())
+        )
+
+        assert session_manager.itr_correlation_id == "itr-correlation-id"
+        assert session_manager.session.itr_correlation_id == "itr-correlation-id"
+
+
 class TestSessionNameTest:
     def test_session_name_explicitly_from_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
         env = {"DD_TEST_SESSION_NAME": "the_name", "DD_API_KEY": "somekey", "DD_CIVISIBILITY_AGENTLESS_ENABLED": "true"}

--- a/tests/testing/internal/test_writer.py
+++ b/tests/testing/internal/test_writer.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 from unittest.mock import call
 from unittest.mock import patch
 
+from ddtrace.testing.internal.constants import ITRSkippingLevel
 from ddtrace.testing.internal.http import BackendConnectorAgentlessSetup
 from ddtrace.testing.internal.http import BackendResult
 from ddtrace.testing.internal.test_data import TestModule
@@ -367,7 +368,9 @@ class TestTestOptWriter:
         assert meta["unicode_meta"] == "é" * MAX_META_TAG_VALUE_LENGTH
         assert meta["numeric_meta"] == 123
         assert writer.metadata["*"]["long_metadata"] == long_metadata_value
-        assert event["content"]["meta"]["long_meta"] == long_event_meta_value
+        event_content = t.cast(dict[str, t.Any], event["content"])
+        event_meta = t.cast(dict[str, t.Any], event_content["meta"])
+        assert event_meta["long_meta"] == long_event_meta_value
 
     @patch("ddtrace.testing.internal.http.BackendConnector")
     def test_split_events(self, mock_backend_connector: Mock) -> None:
@@ -602,6 +605,31 @@ class TestSerializationFunctions:
         assert event["content"]["error"] == 1  # Fail = error
         assert event["content"]["meta"]["test.status"] == "fail"
 
+    def test_serialize_test_run_adds_correlation_id_to_content(self) -> None:
+        test_run = self.create_mock_test_run()
+        test_run.session.itr_correlation_id = "test-correlation-id"
+        test_run.session.itr_skipping_level = ITRSkippingLevel.TEST
+
+        event = serialize_test_run(test_run)
+
+        assert event["content"]["itr_correlation_id"] == "test-correlation-id"
+
+    def test_serialize_test_run_omits_missing_correlation_id_from_content(self) -> None:
+        test_run = self.create_mock_test_run()
+
+        event = serialize_test_run(test_run)
+
+        assert "itr_correlation_id" not in event["content"]
+
+    def test_serialize_test_run_omits_correlation_id_in_suite_skipping_mode(self) -> None:
+        test_run = self.create_mock_test_run()
+        test_run.session.itr_correlation_id = "test-correlation-id"
+        test_run.session.itr_skipping_level = ITRSkippingLevel.SUITE
+
+        event = serialize_test_run(test_run)
+
+        assert "itr_correlation_id" not in event["content"]
+
     def create_mock_test_suite(self) -> TestSuite:
         """Create a mock TestSuite."""
         suite_ref = TestDataFactory.create_suite_ref("test_module", "test_suite.py")
@@ -643,6 +671,31 @@ class TestSerializationFunctions:
         assert meta["test.status"] == "pass"
         assert meta["type"] == "test_suite_end"
         assert meta["suite.custom"] == "suite_value"
+
+    def test_serialize_suite_adds_correlation_id_to_content(self) -> None:
+        suite = self.create_mock_test_suite()
+        suite.session.itr_correlation_id = "suite-correlation-id"
+        suite.session.itr_skipping_level = ITRSkippingLevel.SUITE
+
+        event = serialize_suite(suite)
+
+        assert event["content"]["itr_correlation_id"] == "suite-correlation-id"
+
+    def test_serialize_suite_omits_missing_correlation_id_from_content(self) -> None:
+        suite = self.create_mock_test_suite()
+        suite.session.itr_skipping_level = ITRSkippingLevel.SUITE
+
+        event = serialize_suite(suite)
+
+        assert "itr_correlation_id" not in event["content"]
+
+    def test_serialize_suite_omits_correlation_id_in_test_skipping_mode(self) -> None:
+        suite = self.create_mock_test_suite()
+        suite.session.itr_correlation_id = "suite-correlation-id"
+
+        event = serialize_suite(suite)
+
+        assert "itr_correlation_id" not in event["content"]
 
     def create_mock_test_module(self) -> TestModule:
         """Create a mock TestModule."""

--- a/tests/testing/mocks.py
+++ b/tests/testing/mocks.py
@@ -110,6 +110,7 @@ class SessionManagerMockBuilder:
         self._test_properties: dict[TestRef, TestProperties] = {}
         self._known_tests: set[TestRef] = set()
         self._known_commits: list[str] = []
+        self._itr_correlation_id: t.Optional[str] = None
         self._workspace_path = "/fake/workspace"
         self._retry_handlers: list[Mock] = []
         self._env_tags: dict[str, str] = {}
@@ -146,6 +147,11 @@ class SessionManagerMockBuilder:
     def with_known_tests(self, tests: set[TestRef]) -> "SessionManagerMockBuilder":
         """Set known tests."""
         self._known_tests = tests
+        return self
+
+    def with_itr_correlation_id(self, correlation_id: str) -> "SessionManagerMockBuilder":
+        """Set the ITR correlation ID returned by the skippable tests endpoint."""
+        self._itr_correlation_id = correlation_id
         return self
 
     def with_workspace_path(self, path: str) -> "SessionManagerMockBuilder":
@@ -195,7 +201,7 @@ class SessionManagerMockBuilder:
             mock_client.get_test_management_properties.return_value = self._test_properties
             mock_client.get_known_commits.return_value = self._known_commits
             mock_client.send_git_pack_file.return_value = None
-            mock_client.get_skippable_tests.return_value = (self._skippable_items, None)
+            mock_client.get_skippable_tests.return_value = (self._skippable_items, self._itr_correlation_id)
             mock_client.configuration_errors = {}
             mock_api_client.return_value = mock_client
 


### PR DESCRIPTION
Backport #19141 to 4.12

## Description

Adds the ITR correlation ID to the `content.itr_correlation_id` field for `ddtrace.testing` citestcycle test/suite events when ITR is enabled and the skippable endpoint returns a correlation ID.

The correlation ID was parsed from the skippable response and emitted in citestcycle metadata. This change propagates it onto serialized event content instead, matching other tracers’ behavior where all test/suite events in an ITR-enabled session carry the session-wide correlation ID.

## Testing

- Added serializer coverage for:
  - test events with `content.itr_correlation_id`
  - suite events with `content.itr_correlation_id`
  - events without a session correlation ID omitting the field

## Risks

Low. The field is only added when a correlation ID was returned by the ITR skippable endpoint. Existing metadata emission is preserved.

## Additional Notes

Aligned with JavaScript and Java tracer behavior.
