### PR TITLE
ci: remove pinned image override on notify-slo-breaches job

### DIFF
--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -426,7 +426,5 @@ notify-slo-breaches:
   stage: notify
   needs: ["check-slo-breaches"]
   when: always
-  # Temporary override while benchmarking platform updates their template
-  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:6845f3c7
   variables:
     CHANNEL: "apm-python-release"


### PR DESCRIPTION
## Description

#19217 added a temporary `image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:6845f3c7` override to the `notify-slo-breaches` job to work around a `latest`-tag denial on `check-slo-breaches`. That override image doesn't carry the dependencies `notify-slo-breaches` needs (e.g. `postmessage`), so the job now fails:

```
postmessage: command not found
```
https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1885560137

This reverts the override on `notify-slo-breaches` only. `check-slo-breaches` (both macro- and micro-benchmarks) keeps its pin, since that's the job the original fix targeted and isn't affected by this failure.

## Testing

CI: the next pipeline's `notify-slo-breaches` job should run with the default (template-provided) image and no longer fail on `postmessage`.

## Risks

None — reverts to the job's previous, working image resolution.

## Additional Notes

None