### PR TITLE
Vlad/315 lib injection ssi

### DIFF
--- a/lib-injection/dl_wheels.py
+++ b/lib-injection/dl_wheels.py
@@ -42,7 +42,7 @@ if pip_version < MIN_PIP_VERSION:
     )
 
 # Supported Python versions lists all python versions that can install at least one version of the ddtrace library.
-supported_versions = ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+supported_versions = ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
 supported_arches = ["aarch64", "x86_64", "i686"]
 supported_platforms = ["musllinux_1_2", "manylinux2014"]
 supported_flavors = ["", "slim"]

--- a/lib-injection/sources/sitecustomize.py
+++ b/lib-injection/sources/sitecustomize.py
@@ -43,7 +43,7 @@ SCRIPT_DIR = os.path.dirname(__file__)
 RUNTIMES_ALLOW_LIST = {
     "cpython": {
         "min": Version(version=(3, 9), constraint=""),
-        "max": Version(version=(3, 15), constraint=""),
+        "max": Version(version=(3, 16), constraint=""),
     }
 }
 


### PR DESCRIPTION
**prev:** [#19260](https://github.com/DataDog/dd-trace-py/pull/19260) | **next:** [#19259](https://github.com/DataDog/dd-trace-py/pull/19259)

## Summary

SSI allow-list + wheel download for 3.15 auto-instrumentation (GAP-01). Closes #17813.


## Test plan

- [ ] lib-injection CI green

