### PR TITLE
Vlad/315 profiling release note

### DIFF
--- a/releasenotes/notes/profiling-python315-support-5910a6a4e623716b.yaml
+++ b/releasenotes/notes/profiling-python315-support-5910a6a4e623716b.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    profiling: The Continuous Profiler now supports Python 3.15 (GIL-enabled builds),
+    including the native stack profiler (Echion), lock profiler, memory profiler, and
+    asyncio task tracking.
+
+    Free-threading (``--disable-gil``) builds are not validated in this release.


### PR DESCRIPTION
**prev:** [#19258](https://github.com/DataDog/dd-trace-py/pull/19258) | **next:** —

## Summary

Customer-facing Reno fragment for profiling on 3.15 (GAP-02).


## Test plan

- [ ] `riot run reno` validates fragment
- [ ] Merge with PR that lifts profiling native gate for 3.15

