### PR TITLE
perf(ci_visibility): file level coverage collection improvements

### DIFF
--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -419,7 +419,11 @@ class ModuleCodeCollector(ModuleWatchdog):
             return covered_lines
 
         def get_covered_file_paths(self) -> t.AbstractSet[str]:
-            covered_file_paths = _get_ctx_covered_files()
+            # Python < 3.12 and injected child-process coverage may only update the line-oriented
+            # context data. Merge those keys into the file set so file-level uploads still include
+            # every file that would have been emitted by get_covered_lines().
+            covered_file_paths = set(_get_ctx_covered_files())
+            covered_file_paths.update(_get_ctx_covered_lines())
             if global_instance := ModuleCodeCollector._instance:
                 return global_instance._get_covered_file_paths_with_imports(covered_file_paths)
             return covered_file_paths

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -168,6 +168,17 @@ class ModuleCodeCollector(ModuleWatchdog):
                 ctx_covered_file_paths.add(path)
                 _get_ctx_covered_lines()[path].add(0)
 
+    def hook_line(self, path: str, line: int) -> None:
+        if self._coverage_enabled:
+            lines = self.covered[path]
+            lines.add(line)
+
+        if ctx_coverage_enabled.get() or (_PY_GE_314 and getattr(_tls_coverage, "covered", None) is not None):
+            # Import-time contexts store their lines in a non-context variable to be aggregated on request when
+            # reporting coverage
+            ctx_lines = _get_ctx_covered_lines()[path]
+            ctx_lines.add(line)
+
     def hook(self, arg: tuple[int, str, t.Optional[tuple[str, tuple[str, ...]]]]):
         line: int
         path: str
@@ -177,15 +188,7 @@ class ModuleCodeCollector(ModuleWatchdog):
         if self._file_level_coverage and line == 0:
             self.hook_file(path)
         else:
-            if self._coverage_enabled:
-                lines = self.covered[path]
-                lines.add(line)
-
-            if ctx_coverage_enabled.get() or (_PY_GE_314 and getattr(_tls_coverage, "covered", None) is not None):
-                # Import-time contexts store their lines in a non-context variable to be aggregated on request when
-                # reporting coverage
-                ctx_lines = _get_ctx_covered_lines()[path]
-                ctx_lines.add(line)
+            self.hook_line(path, line)
 
         if import_name is not None:
             self.hook_import(path, import_name)

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -106,6 +106,9 @@ class ModuleCodeCollector(ModuleWatchdog):
         self._import_time_contexts: dict[str, "ModuleCodeCollector.CollectInContext"] = {}
         self._import_time_name_to_path: dict[str, str] = {}
         self._import_names_by_path: dict[str, set[tuple[str, tuple[str, ...]]]] = defaultdict(set)
+        # AIDEV-NOTE: Import metadata can grow during late/dynamic imports. Clear this cache whenever import coverage
+        # metadata changes so per-test import-time augmentation does not miss newly discovered dependencies.
+        self._import_time_dependency_paths_cache: dict[str, frozenset[str]] = {}
 
         # Replace the built-in exec function with our own in the pytest globals
         try:
@@ -145,6 +148,11 @@ class ModuleCodeCollector(ModuleWatchdog):
                 lambda x: True, cls._instance._exit_context_on_exception_hook
             )
 
+    def hook_import(self, path: str, import_name: tuple[str, tuple[str, ...]]) -> None:
+        if self._collect_import_coverage and import_name not in self._import_names_by_path[path]:
+            self._import_names_by_path[path].add(import_name)
+            self._import_time_dependency_paths_cache.clear()
+
     def hook_file(self, path: str) -> None:
         if self._coverage_enabled and path not in self._covered_files:
             self._covered_files.add(path)
@@ -175,8 +183,8 @@ class ModuleCodeCollector(ModuleWatchdog):
                 ctx_lines = _get_ctx_covered_lines()[path]
                 ctx_lines.add(line)
 
-        if import_name is not None and self._collect_import_coverage:
-            self._import_names_by_path[path].add(import_name)
+        if import_name is not None:
+            self.hook_import(path, import_name)
 
     @classmethod
     def inject_coverage(
@@ -240,10 +248,14 @@ class ModuleCodeCollector(ModuleWatchdog):
 
         return covered_lines
 
-    def _add_import_time_lines(self, covered_lines):
-        """Modify given covered_lines in place and add lines that were covered at import time"""
+    def _get_import_time_dependency_paths(self, root_path: str) -> frozenset[str]:
+        cached_dependency_paths = self._import_time_dependency_paths_cache.get(root_path)
+        if cached_dependency_paths is not None:
+            return cached_dependency_paths
+
+        dependency_paths = set()
         visited_paths = set()
-        to_visit_paths = set(covered_lines.keys())
+        to_visit_paths = {root_path}
 
         while to_visit_paths:
             path = to_visit_paths.pop()
@@ -256,8 +268,7 @@ class ModuleCodeCollector(ModuleWatchdog):
             if path not in self._import_time_covered:
                 continue
 
-            imported_module_lines = self._import_time_covered[path]
-            covered_lines[path].update(imported_module_lines)
+            dependency_paths.add(path)
 
             # Queue up dependencies of current path, if they exist, have valid paths, and haven't been visited yet
             for dependencies in self._import_names_by_path.get(path, set()):
@@ -284,15 +295,36 @@ class ModuleCodeCollector(ModuleWatchdog):
                             break
                         parent_package = parent_package[:-1]
 
+        cached_dependency_paths = frozenset(dependency_paths)
+        self._import_time_dependency_paths_cache[root_path] = cached_dependency_paths
+        return cached_dependency_paths
+
+    def _add_import_time_lines(self, covered_lines):
+        """Modify given covered_lines in place and add lines that were covered at import time"""
+        processed_paths = set()
+        if self._file_level_coverage:
+            for root_path in tuple(covered_lines.keys()):
+                for dependency_path in self._get_import_time_dependency_paths(root_path):
+                    if dependency_path not in processed_paths:
+                        processed_paths.add(dependency_path)
+                        covered_lines[dependency_path].add(0)
+            return
+
+        for root_path in tuple(covered_lines.keys()):
+            for path in self._get_import_time_dependency_paths(root_path):
+                if path not in processed_paths:
+                    processed_paths.add(path)
+                    imported_module_lines = self._import_time_covered[path]
+                    covered_lines[path].update(imported_module_lines)
+
     def _get_covered_file_paths_with_imports(self, covered_file_paths: set[str]) -> t.AbstractSet[str]:
         if not covered_file_paths:
             return covered_file_paths
 
-        covered_lines: defaultdict[str, CoverageLines] = defaultdict(CoverageLines)
-        for path in covered_file_paths:
-            covered_lines[path].add(0)
-        self._add_import_time_lines(covered_lines)
-        return set(covered_lines)
+        paths = set(covered_file_paths)
+        for root_path in tuple(covered_file_paths):
+            paths.update(self._get_import_time_dependency_paths(root_path))
+        return paths
 
     class CollectInContext:
         def __init__(self, is_import_coverage: bool = False):
@@ -460,6 +492,7 @@ class ModuleCodeCollector(ModuleWatchdog):
 
         if self._collect_import_coverage:
             self._import_time_name_to_path[_module.__name__] = code.co_filename
+            self._import_time_dependency_paths_cache.clear()
             module_context = self.CollectInContext(is_import_coverage=True)
             module_context.__enter__()
             self._import_time_contexts[code.co_filename] = module_context
@@ -481,6 +514,7 @@ class ModuleCodeCollector(ModuleWatchdog):
             collector.__exit__()
             if covered_lines[_module.__file__]:
                 self._import_time_covered[_module.__file__].update(covered_lines[_module.__file__])
+                self._import_time_dependency_paths_cache.clear()
 
             del self._import_time_contexts[_module.__file__]
 
@@ -494,6 +528,7 @@ class ModuleCodeCollector(ModuleWatchdog):
             collector.__exit__()
             if covered_lines[_module.__file__]:
                 self._import_time_covered[_module.__file__].update(covered_lines[_module.__file__])
+                self._import_time_dependency_paths_cache.clear()
 
             del self._import_time_contexts[_module.__file__]
 

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -20,7 +20,9 @@ from ddtrace.internal.packages import platlib_path
 from ddtrace.internal.packages import platstdlib_path
 from ddtrace.internal.packages import purelib_path
 from ddtrace.internal.packages import stdlib_path
+from ddtrace.internal.settings import env
 from ddtrace.internal.test_visibility.coverage_lines import CoverageLines
+from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.inspection import resolved_code_origin
 
 
@@ -37,6 +39,7 @@ _PY_GE_313 = sys.version_info >= (3, 13)
 _PY_GE_314 = sys.version_info >= (3, 14)
 
 ctx_covered: ContextVar[list[defaultdict[str, CoverageLines]]] = ContextVar("ctx_covered", default=[])
+ctx_covered_files: ContextVar[list[set[str]]] = ContextVar("ctx_covered_files", default=[])
 ctx_is_import_coverage = ContextVar("ctx_is_import_coverage", default=False)
 ctx_coverage_enabled = ContextVar("ctx_coverage_enabled", default=False)
 
@@ -60,6 +63,20 @@ def _get_ctx_covered_lines() -> defaultdict[str, CoverageLines]:
     return defaultdict(CoverageLines)
 
 
+def _get_ctx_covered_files() -> set[str]:
+    if ctx_coverage_enabled.get():
+        if context_stack := ctx_covered_files.get():
+            return context_stack[-1]
+        log.debug("_get_ctx_covered_files() called but ctx_covered_files stack is empty")
+
+    if _PY_GE_314:
+        tls_covered_files = getattr(_tls_coverage, "covered_files", None)
+        if tls_covered_files is not None:
+            return tls_covered_files
+
+    return set()
+
+
 class ModuleCodeCollector(ModuleWatchdog):
     _instance: t.Optional["ModuleCodeCollector"] = None
 
@@ -76,11 +93,13 @@ class ModuleCodeCollector(ModuleWatchdog):
         self._exclude_paths.append(Path(__file__).resolve().parent)
 
         self._coverage_enabled: bool = False
+        self._file_level_coverage: bool = False
         self.seen: set[tuple[CodeType, str]] = set()
 
         # Data structures for coverage data
         self.lines: defaultdict[str, CoverageLines] = defaultdict(CoverageLines)
         self.covered: defaultdict[str, CoverageLines] = defaultdict(CoverageLines)
+        self._covered_files: set[str] = set()
 
         # Import-time coverage data
         self._import_time_covered: defaultdict[str, CoverageLines] = defaultdict(CoverageLines)
@@ -101,6 +120,7 @@ class ModuleCodeCollector(ModuleWatchdog):
         cls,
         include_paths: t.Optional[list[Path]] = None,
         collect_import_time_coverage: bool = False,
+        file_level_coverage: t.Optional[bool] = None,
     ):
         if ModuleCodeCollector.is_installed():
             return
@@ -116,11 +136,25 @@ class ModuleCodeCollector(ModuleWatchdog):
 
         cls._instance._include_paths = include_paths
         cls._instance._collect_import_coverage = collect_import_time_coverage
+        cls._instance._file_level_coverage = (
+            asbool(env.get("_DD_COVERAGE_FILE_LEVEL", "false")) if file_level_coverage is None else file_level_coverage
+        )
 
         if collect_import_time_coverage:
             ModuleCodeCollector.register_import_exception_hook(
                 lambda x: True, cls._instance._exit_context_on_exception_hook
             )
+
+    def hook_file(self, path: str) -> None:
+        if self._coverage_enabled and path not in self._covered_files:
+            self._covered_files.add(path)
+            self.covered[path].add(0)
+
+        if ctx_coverage_enabled.get() or (_PY_GE_314 and getattr(_tls_coverage, "covered", None) is not None):
+            ctx_covered_file_paths = _get_ctx_covered_files()
+            if path not in ctx_covered_file_paths:
+                ctx_covered_file_paths.add(path)
+                _get_ctx_covered_lines()[path].add(0)
 
     def hook(self, arg: tuple[int, str, t.Optional[tuple[str, tuple[str, ...]]]]):
         line: int
@@ -128,15 +162,18 @@ class ModuleCodeCollector(ModuleWatchdog):
         import_name: t.Optional[tuple[str, tuple[str, ...]]]
         line, path, import_name = arg
 
-        if self._coverage_enabled:
-            lines = self.covered[path]
-            lines.add(line)
+        if self._file_level_coverage and line == 0:
+            self.hook_file(path)
+        else:
+            if self._coverage_enabled:
+                lines = self.covered[path]
+                lines.add(line)
 
-        if ctx_coverage_enabled.get() or (_PY_GE_314 and getattr(_tls_coverage, "covered", None) is not None):
-            # Import-time contexts store their lines in a non-context variable to be aggregated on request when
-            # reporting coverage
-            ctx_lines = _get_ctx_covered_lines()[path]
-            ctx_lines.add(line)
+            if ctx_coverage_enabled.get() or (_PY_GE_314 and getattr(_tls_coverage, "covered", None) is not None):
+                # Import-time contexts store their lines in a non-context variable to be aggregated on request when
+                # reporting coverage
+                ctx_lines = _get_ctx_covered_lines()[path]
+                ctx_lines.add(line)
 
         if import_name is not None and self._collect_import_coverage:
             self._import_names_by_path[path].add(import_name)
@@ -161,11 +198,16 @@ class ModuleCodeCollector(ModuleWatchdog):
             for path, path_lines in lines.items():
                 instance.lines[path].update(path_lines)
         if covered:
+            ctx_covered_file_paths = _get_ctx_covered_files() if ctx_coverage_enabled.get() else None
             for path, path_covered in covered.items():
                 if instance._coverage_enabled:
                     instance.covered[path].update(path_covered)
+                    if instance._file_level_coverage:
+                        instance._covered_files.add(path)
                 if ctx_coverage_enabled.get() and ctx_covered_lines is not None:
                     ctx_covered_lines[path].update(path_covered)
+                    if instance._file_level_coverage and ctx_covered_file_paths is not None:
+                        ctx_covered_file_paths.add(path)
 
     @classmethod
     def report(cls, workspace_path: Path, ignore_nocover: bool = False):
@@ -242,14 +284,27 @@ class ModuleCodeCollector(ModuleWatchdog):
                             break
                         parent_package = parent_package[:-1]
 
+    def _get_covered_file_paths_with_imports(self, covered_file_paths: set[str]) -> t.AbstractSet[str]:
+        if not covered_file_paths:
+            return covered_file_paths
+
+        covered_lines: defaultdict[str, CoverageLines] = defaultdict(CoverageLines)
+        for path in covered_file_paths:
+            covered_lines[path].add(0)
+        self._add_import_time_lines(covered_lines)
+        return set(covered_lines)
+
     class CollectInContext:
         def __init__(self, is_import_coverage: bool = False):
             self.is_import_coverage = is_import_coverage
             if ctx_covered.get() is None:
                 ctx_covered.set([])
+            if ctx_covered_files.get() is None:
+                ctx_covered_files.set([])
 
         def __enter__(self):
             ctx_covered.get().append(defaultdict(CoverageLines))
+            ctx_covered_files.get().append(set())
             ctx_coverage_enabled.set(True)
 
             if self.is_import_coverage:
@@ -259,6 +314,7 @@ class ModuleCodeCollector(ModuleWatchdog):
             # so also store in thread-local as a fallback for the hook.
             if _PY_GE_314:
                 _tls_coverage.covered = ctx_covered.get()[-1]
+                _tls_coverage.covered_files = ctx_covered_files.get()[-1]
 
             # For Python 3.12+, dynamically detect whether other sys.monitoring tools are
             # active and update the DISABLE optimisation flag accordingly.  Then re-enable
@@ -281,15 +337,19 @@ class ModuleCodeCollector(ModuleWatchdog):
 
         def __exit__(self, *args, **kwargs):
             covered_lines_stack = ctx_covered.get()
+            covered_files_stack = ctx_covered_files.get()
             covered_lines_stack.pop()
+            covered_files_stack.pop()
 
             # Stop coverage if we're exiting the last context
             if len(covered_lines_stack) == 0:
                 ctx_coverage_enabled.set(False)
                 if _PY_GE_314:
                     _tls_coverage.covered = None
+                    _tls_coverage.covered_files = None
             elif _PY_GE_314:
                 _tls_coverage.covered = covered_lines_stack[-1]
+                _tls_coverage.covered_files = covered_files_stack[-1]
 
         def get_covered_lines(self) -> dict[str, CoverageLines]:
             covered_lines = _get_ctx_covered_lines()
@@ -297,10 +357,21 @@ class ModuleCodeCollector(ModuleWatchdog):
                 global_instance._add_import_time_lines(covered_lines)
             return covered_lines
 
+        def get_covered_file_paths(self) -> t.AbstractSet[str]:
+            covered_file_paths = _get_ctx_covered_files()
+            if global_instance := ModuleCodeCollector._instance:
+                return global_instance._get_covered_file_paths_with_imports(covered_file_paths)
+            return covered_file_paths
+
+    @classmethod
+    def file_level_coverage_enabled(cls):
+        return cls._instance is not None and cls._instance._file_level_coverage
+
     @classmethod
     def start_coverage(cls):
         if cls._instance is None:
             return
+        cls._instance._covered_files.clear()
         cls._instance._coverage_enabled = True
 
     @classmethod

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -341,7 +341,7 @@ class ModuleCodeCollector(ModuleWatchdog):
         cache_key = frozenset(covered_file_paths)
         cached_paths = self._file_level_covered_paths_cache.get(cache_key)
         if cached_paths is not None:
-            return set(cached_paths)
+            return cached_paths
 
         paths = set(covered_file_paths)
         for root_path in cache_key:

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -318,6 +318,13 @@ class ModuleCodeCollector(ModuleWatchdog):
                     covered_lines[path].update(imported_module_lines)
 
     def _get_covered_file_paths_with_imports(self, covered_file_paths: set[str]) -> t.AbstractSet[str]:
+        """Return file-level covered paths with import-time dependencies added.
+
+        This is the file-level equivalent of _add_import_time_lines(), but avoids
+        allocating and mutating one CoverageLines object per covered file for every
+        test. File-level coverage only needs path membership because every covered
+        file emits the same line-0 sentinel bitmap.
+        """
         if not covered_file_paths:
             return covered_file_paths
 

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from collections import defaultdict
 from contextvars import ContextVar
 from copy import deepcopy
@@ -37,6 +38,7 @@ _EMPTY_MODULE_BYTES = compile("", "<empty>", "exec").co_code
 _PY_GE_312 = sys.version_info >= (3, 12)
 _PY_GE_313 = sys.version_info >= (3, 13)
 _PY_GE_314 = sys.version_info >= (3, 14)
+_FILE_LEVEL_COVERED_PATHS_CACHE_MAX_SIZE = 4096
 
 ctx_covered: ContextVar[list[defaultdict[str, CoverageLines]]] = ContextVar("ctx_covered", default=[])
 ctx_covered_files: ContextVar[list[set[str]]] = ContextVar("ctx_covered_files", default=[])
@@ -110,7 +112,7 @@ class ModuleCodeCollector(ModuleWatchdog):
         # metadata changes so per-test import-time augmentation does not miss newly discovered dependencies.
         self._direct_import_time_dependency_paths_cache: dict[str, frozenset[str]] = {}
         self._import_time_dependency_paths_cache: dict[str, frozenset[str]] = {}
-        self._file_level_covered_paths_cache: dict[frozenset[str], frozenset[str]] = {}
+        self._file_level_covered_paths_cache: OrderedDict[frozenset[str], frozenset[str]] = OrderedDict()
 
         # Replace the built-in exec function with our own in the pytest globals
         try:
@@ -344,6 +346,7 @@ class ModuleCodeCollector(ModuleWatchdog):
         cache_key = frozenset(covered_file_paths)
         cached_paths = self._file_level_covered_paths_cache.get(cache_key)
         if cached_paths is not None:
+            self._file_level_covered_paths_cache.move_to_end(cache_key)
             return cached_paths
 
         paths = set(covered_file_paths)
@@ -353,6 +356,8 @@ class ModuleCodeCollector(ModuleWatchdog):
                 paths.update(self._get_import_time_dependency_paths(root_path))
 
         self._file_level_covered_paths_cache[cache_key] = frozenset(paths)
+        if len(self._file_level_covered_paths_cache) > _FILE_LEVEL_COVERED_PATHS_CACHE_MAX_SIZE:
+            self._file_level_covered_paths_cache.popitem(last=False)
         return paths
 
     class CollectInContext:

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -344,8 +344,10 @@ class ModuleCodeCollector(ModuleWatchdog):
             return cached_paths
 
         paths = set(covered_file_paths)
+        import_time_covered = self._import_time_covered
         for root_path in cache_key:
-            paths.update(self._get_import_time_dependency_paths(root_path))
+            if root_path in import_time_covered:
+                paths.update(self._get_import_time_dependency_paths(root_path))
 
         self._file_level_covered_paths_cache[cache_key] = frozenset(paths)
         return paths

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -108,7 +108,9 @@ class ModuleCodeCollector(ModuleWatchdog):
         self._import_names_by_path: dict[str, set[tuple[str, tuple[str, ...]]]] = defaultdict(set)
         # AIDEV-NOTE: Import metadata can grow during late/dynamic imports. Clear this cache whenever import coverage
         # metadata changes so per-test import-time augmentation does not miss newly discovered dependencies.
+        self._direct_import_time_dependency_paths_cache: dict[str, frozenset[str]] = {}
         self._import_time_dependency_paths_cache: dict[str, frozenset[str]] = {}
+        self._file_level_covered_paths_cache: dict[frozenset[str], frozenset[str]] = {}
 
         # Replace the built-in exec function with our own in the pytest globals
         try:
@@ -151,7 +153,9 @@ class ModuleCodeCollector(ModuleWatchdog):
     def hook_import(self, path: str, import_name: tuple[str, tuple[str, ...]]) -> None:
         if self._collect_import_coverage and import_name not in self._import_names_by_path[path]:
             self._import_names_by_path[path].add(import_name)
+            self._direct_import_time_dependency_paths_cache.pop(path, None)
             self._import_time_dependency_paths_cache.clear()
+            self._file_level_covered_paths_cache.clear()
 
     def hook_file(self, path: str) -> None:
         if self._coverage_enabled and path not in self._covered_files:
@@ -248,6 +252,36 @@ class ModuleCodeCollector(ModuleWatchdog):
 
         return covered_lines
 
+    def _get_direct_import_time_dependency_paths(self, path: str) -> frozenset[str]:
+        cached_dependency_paths = self._direct_import_time_dependency_paths_cache.get(path)
+        if cached_dependency_paths is not None:
+            return cached_dependency_paths
+
+        dependency_paths = set()
+        for dependencies in self._import_names_by_path.get(path, set()):
+            package, modules = dependencies
+            for module in modules:
+                dep_fqdn = f"{package}.{module}" if package else module
+                dep_name = dep_fqdn if dep_fqdn in self._import_time_name_to_path else module
+                if dep_name in self._import_time_name_to_path:
+                    dependency_paths.add(self._import_time_name_to_path[dep_name])
+
+                # Since modules can import from packages below them in the hierarchy, we may also need to find
+                # packages that were imported (eg: identifying __init__.py files). We do this by working our way
+                # from the module name to the package name "one dot at a time"
+                parent_package = dep_fqdn.split(".")[:-1]
+                while parent_package:
+                    parent_package_str = ".".join(parent_package)
+                    if parent_package_str in self._import_time_name_to_path:
+                        dependency_paths.add(self._import_time_name_to_path[parent_package_str])
+                    if parent_package_str == package:
+                        break
+                    parent_package = parent_package[:-1]
+
+        cached_dependency_paths = frozenset(dependency_paths)
+        self._direct_import_time_dependency_paths_cache[path] = cached_dependency_paths
+        return cached_dependency_paths
+
     def _get_import_time_dependency_paths(self, root_path: str) -> frozenset[str]:
         cached_dependency_paths = self._import_time_dependency_paths_cache.get(root_path)
         if cached_dependency_paths is not None:
@@ -269,31 +303,7 @@ class ModuleCodeCollector(ModuleWatchdog):
                 continue
 
             dependency_paths.add(path)
-
-            # Queue up dependencies of current path, if they exist, have valid paths, and haven't been visited yet
-            for dependencies in self._import_names_by_path.get(path, set()):
-                package, modules = dependencies
-                for module in modules:
-                    dep_fqdn = f"{package}.{module}" if package else module
-                    dep_name = dep_fqdn if dep_fqdn in self._import_time_name_to_path else module
-                    if dep_name in self._import_time_name_to_path:
-                        dependency_path = self._import_time_name_to_path[dep_name]
-                        if dependency_path not in visited_paths:
-                            to_visit_paths.add(dependency_path)
-
-                    # Since modules can import from packages below them in the hierarchy, we may also need to find
-                    # packages that were imported (eg: identifying __init__.py files). We do this by working our way
-                    # from the module name to the package name "one dot at a time"
-                    parent_package = dep_fqdn.split(".")[:-1]
-                    while parent_package:
-                        parent_package_str = ".".join(parent_package)
-                        if parent_package_str in self._import_time_name_to_path:
-                            dependency_path = self._import_time_name_to_path[parent_package_str]
-                            if dependency_path not in visited_paths:
-                                to_visit_paths.add(dependency_path)
-                        if parent_package_str == package:
-                            break
-                        parent_package = parent_package[:-1]
+            to_visit_paths.update(self._get_direct_import_time_dependency_paths(path) - visited_paths)
 
         cached_dependency_paths = frozenset(dependency_paths)
         self._import_time_dependency_paths_cache[root_path] = cached_dependency_paths
@@ -328,9 +338,16 @@ class ModuleCodeCollector(ModuleWatchdog):
         if not covered_file_paths:
             return covered_file_paths
 
+        cache_key = frozenset(covered_file_paths)
+        cached_paths = self._file_level_covered_paths_cache.get(cache_key)
+        if cached_paths is not None:
+            return set(cached_paths)
+
         paths = set(covered_file_paths)
-        for root_path in tuple(covered_file_paths):
+        for root_path in cache_key:
             paths.update(self._get_import_time_dependency_paths(root_path))
+
+        self._file_level_covered_paths_cache[cache_key] = frozenset(paths)
         return paths
 
     class CollectInContext:
@@ -499,7 +516,9 @@ class ModuleCodeCollector(ModuleWatchdog):
 
         if self._collect_import_coverage:
             self._import_time_name_to_path[_module.__name__] = code.co_filename
+            self._direct_import_time_dependency_paths_cache.clear()
             self._import_time_dependency_paths_cache.clear()
+            self._file_level_covered_paths_cache.clear()
             module_context = self.CollectInContext(is_import_coverage=True)
             module_context.__enter__()
             self._import_time_contexts[code.co_filename] = module_context
@@ -522,6 +541,7 @@ class ModuleCodeCollector(ModuleWatchdog):
             if covered_lines[_module.__file__]:
                 self._import_time_covered[_module.__file__].update(covered_lines[_module.__file__])
                 self._import_time_dependency_paths_cache.clear()
+                self._file_level_covered_paths_cache.clear()
 
             del self._import_time_contexts[_module.__file__]
 
@@ -536,6 +556,7 @@ class ModuleCodeCollector(ModuleWatchdog):
             if covered_lines[_module.__file__]:
                 self._import_time_covered[_module.__file__].update(covered_lines[_module.__file__])
                 self._import_time_dependency_paths_cache.clear()
+                self._file_level_covered_paths_cache.clear()
 
             del self._import_time_contexts[_module.__file__]
 

--- a/ddtrace/internal/coverage/installer.py
+++ b/ddtrace/internal/coverage/installer.py
@@ -9,10 +9,12 @@ from ddtrace.internal.coverage.threading_coverage import _patch_threading
 def install(
     include_paths: t.Optional[list[Path]] = None,
     collect_import_time_coverage: bool = False,
+    file_level_coverage: t.Optional[bool] = None,
 ) -> None:
     ModuleCodeCollector.install(
         include_paths=include_paths,
         collect_import_time_coverage=collect_import_time_coverage,
+        file_level_coverage=file_level_coverage,
     )
     _patch_multiprocessing()
     _patch_threading()

--- a/ddtrace/internal/coverage/instrumentation_py3_12.py
+++ b/ddtrace/internal/coverage/instrumentation_py3_12.py
@@ -58,10 +58,16 @@ EVENT = sys.monitoring.events.PY_START if _USE_FILE_LEVEL_COVERAGE else sys.moni
 _DD_TOOL_ID: t.Optional[int] = None  # noqa: UP006
 _DD_CANDIDATE_SLOTS = (4, 3, 1)
 
-# Store: (hook, path, import_names_by_line)
+# Store: (hook, path, import_names_by_line, line_hook, file_hook, import_hook)
 # IMPORTANT: Do not change t.Dict/t.Tuple to dict/tuple until minimum Python version is 3.11+
 # Module-level dict[...]/tuple[...] in Python 3.10 affects import timing. See packages.py for details.
-_CODE_HOOKS: t.Dict[CodeType, t.Tuple[HookType, str, t.Dict[int, t.Tuple[str, t.Optional[t.Tuple[str]]]]]] = {}  # noqa: UP006
+ImportName = t.Tuple[str, t.Optional[t.Tuple[str]]]  # noqa: UP006
+ImportNamesByLine = t.Dict[int, ImportName]  # noqa: UP006
+LineHookType = t.Optional[t.Callable[[str, int], None]]  # noqa: UP006
+FileHookType = t.Optional[t.Callable[[str], None]]  # noqa: UP006
+ImportHookType = t.Optional[t.Callable[[str, ImportName], None]]  # noqa: UP006
+CodeHookData = t.Tuple[HookType, str, ImportNamesByLine, LineHookType, FileHookType, ImportHookType]  # noqa: UP006
+_CODE_HOOKS: t.Dict[CodeType, CodeHookData] = {}  # noqa: UP006
 
 # NOTE: When True (default), _event_handler returns sys.monitoring.DISABLE after recording a
 # line so Python stops firing that event for this code location — a performance optimisation that
@@ -232,20 +238,34 @@ def _event_handler(code: CodeType, line: int) -> t.Optional[t.Literal[sys.monito
     if hook_data is None:
         return sys.monitoring.DISABLE
 
-    hook, path, import_names = hook_data
+    hook, path, import_names, line_hook, file_hook, import_hook = hook_data
 
     if _USE_FILE_LEVEL_COVERAGE:
-        # Report file-level coverage using line 0 as a sentinel value
-        # Line 0 indicates "file was executed" without specific line information
-        hook((0, path, None))
+        # Report file-level coverage using a dedicated hook. File-level coverage only means "this file executed";
+        # import metadata is emitted separately below.
+        if file_hook is not None:
+            file_hook(path)
+        else:
+            hook((0, path, None))
 
-        # Report any import dependencies (extracted at instrumentation time from bytecode)
-        # This ensures import tracking works even though we don't fire on individual lines
-        for line_num, import_name in import_names.items():
-            hook((line_num, path, import_name))
+        # Report any import dependencies (extracted at instrumentation time from bytecode). This keeps import tracking
+        # tied to executed code objects even though file-level mode does not fire on individual lines.
+        for import_name in import_names.values():
+            if import_hook is not None:
+                import_hook(path, import_name)
+            else:
+                hook((0, path, import_name))
     else:
-        import_name = import_names.get(line, None)
-        hook((line, path, import_name))
+        if line_hook is not None:
+            line_hook(path, line)
+            if import_name := import_names.get(line, None):
+                if import_hook is not None:
+                    import_hook(path, import_name)
+                else:
+                    hook((line, path, import_name))
+        else:
+            import_name = import_names.get(line, None)
+            hook((line, path, import_name))
 
     if _use_disable_optimization:
         return sys.monitoring.DISABLE
@@ -270,8 +290,14 @@ def _instrument_with_monitoring(
         _, nested_lines = instrument_all_lines(nested_code, hook, path, package)
         lines.update(nested_lines)
 
-    # Register the hook and argument for the code object
-    _CODE_HOOKS[code] = (hook, path, import_names)
+    # Register the generic hook plus specialized hooks when the collector provides them. Keeping file-, line-, and
+    # import-level operations separate makes the two coverage modes easier to follow and avoids tuple dispatch in the
+    # common ModuleCodeCollector path.
+    hook_self = getattr(hook, "__self__", None)
+    line_hook = getattr(hook_self, "hook_line", None)
+    file_hook = getattr(hook_self, "hook_file", None)
+    import_hook = getattr(hook_self, "hook_import", None)
+    _CODE_HOOKS[code] = (hook, path, import_names, line_hook, file_hook, import_hook)
 
     if _USE_FILE_LEVEL_COVERAGE:
         # Return CoverageLines with line 0 as sentinel to indicate file-level coverage

--- a/ddtrace/testing/internal/pytest/plugin.py
+++ b/ddtrace/testing/internal/pytest/plugin.py
@@ -1522,7 +1522,7 @@ def pytest_load_initial_conftests(
 
 def setup_coverage_collection() -> None:
     workspace_path = get_workspace_path()
-    install_coverage(workspace_path)
+    install_coverage(workspace_path, file_level_coverage=asbool(env.get("_DD_COVERAGE_FILE_LEVEL", "false")))
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/ddtrace/testing/internal/tracer_api/coverage.py
+++ b/ddtrace/testing/internal/tracer_api/coverage.py
@@ -56,7 +56,7 @@ _FILE_LEVEL_BITMAP = bytes(CoverageLines.from_list([0]).to_bytes())
 class CoverageData:
     def __init__(self) -> None:
         self._covered_lines: t.Optional[dict[str, CoverageLines]] = None
-        self._covered_file_paths: t.Optional[set[str]] = None
+        self._covered_file_paths: t.Optional[t.Iterable[str]] = None
 
     def get_coverage_bitmaps(self, relative_to: Path) -> t.Iterable[tuple[str, bytes]]:
         relative_to_str = str(relative_to)

--- a/ddtrace/testing/internal/tracer_api/coverage.py
+++ b/ddtrace/testing/internal/tracer_api/coverage.py
@@ -28,10 +28,11 @@ log = logging.getLogger(__name__)
 log = logging.getLogger(__name__)
 
 
-def install_coverage(workspace_path: Path) -> None:
+def install_coverage(workspace_path: Path, file_level_coverage: bool = False) -> None:
     ddtrace.internal.coverage.installer.install(
         include_paths=[workspace_path],
         collect_import_time_coverage=True,
+        file_level_coverage=file_level_coverage,
     )
     ModuleCodeCollector.start_coverage()
 

--- a/ddtrace/testing/internal/tracer_api/coverage.py
+++ b/ddtrace/testing/internal/tracer_api/coverage.py
@@ -50,15 +50,27 @@ def _relative_coverage_path(absolute_path: str, relative_to: str) -> t.Optional[
         return None  # covered file does not belong to current repo
 
 
+_FILE_LEVEL_BITMAP = bytes(CoverageLines.from_list([0]).to_bytes())
+
+
 class CoverageData:
     def __init__(self) -> None:
         self._covered_lines: t.Optional[dict[str, CoverageLines]] = None
+        self._covered_file_paths: t.Optional[set[str]] = None
 
     def get_coverage_bitmaps(self, relative_to: Path) -> t.Iterable[tuple[str, bytes]]:
+        relative_to_str = str(relative_to)
+
+        if self._covered_file_paths is not None:
+            for absolute_path in self._covered_file_paths:
+                path_str = _relative_coverage_path(absolute_path, relative_to_str)
+                if path_str is not None:
+                    yield path_str, _FILE_LEVEL_BITMAP
+            return
+
         if not self._covered_lines:
             return
 
-        relative_to_str = str(relative_to)
         for absolute_path, covered_lines in self._covered_lines.items():
             path_str = _relative_coverage_path(absolute_path, relative_to_str)
             if path_str is not None:
@@ -70,7 +82,10 @@ def coverage_collection() -> t.Generator[CoverageData, None, None]:
     with ModuleCodeCollector.CollectInContext() as coverage_collector:
         coverage_data = CoverageData()
         yield coverage_data
-        coverage_data._covered_lines = coverage_collector.get_covered_lines()
+        if ModuleCodeCollector.file_level_coverage_enabled():
+            coverage_data._covered_file_paths = coverage_collector.get_covered_file_paths()
+        else:
+            coverage_data._covered_lines = coverage_collector.get_covered_lines()
 
 
 def install_coverage_percentage():

--- a/ddtrace/testing/internal/tracer_api/coverage.py
+++ b/ddtrace/testing/internal/tracer_api/coverage.py
@@ -6,6 +6,7 @@ coverage data.
 """
 
 import contextlib
+import functools
 import logging
 from pathlib import Path
 import typing as t
@@ -41,6 +42,14 @@ def uninstall_coverage() -> None:
     ModuleCodeCollector.uninstall()
 
 
+@functools.lru_cache(maxsize=65536)
+def _relative_coverage_path(absolute_path: str, relative_to: str) -> t.Optional[str]:
+    try:
+        return f"/{Path(absolute_path).relative_to(relative_to)}"
+    except ValueError:
+        return None  # covered file does not belong to current repo
+
+
 class CoverageData:
     def __init__(self) -> None:
         self._covered_lines: t.Optional[dict[str, CoverageLines]] = None
@@ -49,14 +58,11 @@ class CoverageData:
         if not self._covered_lines:
             return
 
+        relative_to_str = str(relative_to)
         for absolute_path, covered_lines in self._covered_lines.items():
-            try:
-                relative_path = Path(absolute_path).relative_to(relative_to)
-            except ValueError:
-                continue  # covered file does not belong to current repo
-
-            path_str = f"/{relative_path}"
-            yield path_str, covered_lines.to_bytes()
+            path_str = _relative_coverage_path(absolute_path, relative_to_str)
+            if path_str is not None:
+                yield path_str, covered_lines.to_bytes()
 
 
 @contextlib.contextmanager

--- a/tests/coverage/included_path/covered_then_dynamic_import.py
+++ b/tests/coverage/included_path/covered_then_dynamic_import.py
@@ -1,0 +1,8 @@
+def cover_file_without_import():
+    return "covered"
+
+
+def import_preimported_dependency():
+    from tests.coverage.included_path.preimported_dependency import dependency_function
+
+    return dependency_function()

--- a/tests/coverage/included_path/preimported_dependency.py
+++ b/tests/coverage/included_path/preimported_dependency.py
@@ -1,0 +1,5 @@
+VALUE = 42
+
+
+def dependency_function():
+    return VALUE

--- a/tests/coverage/test_file_level_fast_path_regressions.py
+++ b/tests/coverage/test_file_level_fast_path_regressions.py
@@ -52,3 +52,93 @@ def test_same_file_fast_path_preserves_late_dynamic_import_dependency():
 
     assert covered_file in with_dynamic_import
     assert dependency_file in with_dynamic_import, "late dynamic import dependency must merge import-time coverage"
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="Test specific to Python 3.12+ monitoring API")
+@pytest.mark.subprocess(parametrize={"_DD_COVERAGE_FILE_LEVEL": ["true"]})
+def test_file_level_path_fast_path_preserves_late_dynamic_import_dependency():
+    """File-level get_covered_file_paths() must include dependency edges discovered after an earlier cache hit.
+
+    The first context covers ``covered_then_dynamic_import.py`` without executing its dynamic import, then asks for
+    file paths. That populates the file-level covered-path cache for the singleton covered-file set. The second context
+    covers the same file set but also executes the dynamic import. If dynamic import metadata does not invalidate the
+    file-level cache, the preimported dependency would be omitted.
+    """
+    import os
+    from pathlib import Path
+
+    def relpath_set(rootpath, paths):
+        root = Path(rootpath)
+        return {str(Path(path).relative_to(root)) for path in paths}
+
+    from ddtrace.internal.coverage.code import ModuleCodeCollector
+    from ddtrace.internal.coverage.installer import install
+
+    cwd_path = os.getcwd()
+    include_path = Path(cwd_path + "/tests/coverage/included_path/")
+
+    install(include_paths=[include_path], collect_import_time_coverage=True)
+
+    # Imported before the test contexts: later contexts only include it through import-time dependency expansion.
+    from tests.coverage.included_path import preimported_dependency  # noqa:F401
+    from tests.coverage.included_path.covered_then_dynamic_import import cover_file_without_import
+    from tests.coverage.included_path.covered_then_dynamic_import import import_preimported_dependency
+
+    with ModuleCodeCollector.CollectInContext() as context_without_dynamic_import:
+        assert cover_file_without_import() == "covered"
+        without_dynamic_import = relpath_set(cwd_path, context_without_dynamic_import.get_covered_file_paths())
+
+    with ModuleCodeCollector.CollectInContext() as context_with_dynamic_import:
+        assert cover_file_without_import() == "covered"
+        assert import_preimported_dependency() == 42
+        with_dynamic_import = relpath_set(cwd_path, context_with_dynamic_import.get_covered_file_paths())
+
+    covered_file = "tests/coverage/included_path/covered_then_dynamic_import.py"
+    dependency_file = "tests/coverage/included_path/preimported_dependency.py"
+
+    assert covered_file in without_dynamic_import
+    assert dependency_file not in without_dynamic_import, "import-time coverage should not leak into unrelated contexts"
+
+    assert covered_file in with_dynamic_import
+    assert dependency_file in with_dynamic_import, "late dynamic import dependency must invalidate cached file paths"
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="Test specific to Python 3.12+ monitoring API")
+@pytest.mark.subprocess(parametrize={"_DD_COVERAGE_FILE_LEVEL": ["true"]})
+def test_file_level_path_fast_path_preserves_nested_dynamic_import_dependencies():
+    """Nested dynamic imports should be represented in file-level path output across contexts."""
+    import os
+    from pathlib import Path
+
+    def relpath_set(rootpath, paths):
+        root = Path(rootpath)
+        return {str(Path(path).relative_to(root)) for path in paths}
+
+    from ddtrace.internal.coverage.code import ModuleCodeCollector
+    from ddtrace.internal.coverage.installer import install
+
+    cwd_path = os.getcwd()
+    include_path = Path(cwd_path + "/tests/coverage/included_path/")
+
+    install(include_paths=[include_path], collect_import_time_coverage=True)
+
+    from tests.coverage.included_path.nested_fixture import fixture_dynamic_path
+    from tests.coverage.included_path.nested_fixture import fixture_toplevel_path
+
+    with ModuleCodeCollector.CollectInContext() as context_toplevel:
+        fixture_toplevel_path(5)
+        toplevel_files = relpath_set(cwd_path, context_toplevel.get_covered_file_paths())
+
+    with ModuleCodeCollector.CollectInContext() as context_dynamic:
+        fixture_dynamic_path(10)
+        dynamic_files = relpath_set(cwd_path, context_dynamic.get_covered_file_paths())
+
+    assert "tests/coverage/included_path/nested_fixture.py" in toplevel_files
+    assert "tests/coverage/included_path/layer2_toplevel.py" in toplevel_files
+    assert "tests/coverage/included_path/layer2_dynamic.py" not in toplevel_files
+
+    assert "tests/coverage/included_path/nested_fixture.py" in dynamic_files
+    assert "tests/coverage/included_path/layer2_dynamic.py" in dynamic_files
+    assert "tests/coverage/included_path/layer3_toplevel.py" in dynamic_files
+    assert "tests/coverage/included_path/layer3_dynamic.py" in dynamic_files
+    assert "tests/coverage/included_path/constants_dynamic.py" in dynamic_files

--- a/tests/coverage/test_file_level_fast_path_regressions.py
+++ b/tests/coverage/test_file_level_fast_path_regressions.py
@@ -1,0 +1,54 @@
+import sys
+
+import pytest
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="Test specific to Python 3.12+ monitoring API")
+@pytest.mark.subprocess(parametrize={"_DD_COVERAGE_FILE_LEVEL": ["true", "false"]})
+def test_same_file_fast_path_preserves_late_dynamic_import_dependency():
+    """Guard against skipping same-file PY_START events too aggressively.
+
+    File-level optimizations may want to stop doing work once a file is already
+    covered in the current context. That is only safe if later code objects in
+    that same file can still publish their import dependency metadata. Here the
+    dependency module is imported before the test contexts, so the second
+    context only gets that module's import-time coverage if the dynamic import
+    dependency edge from ``covered_then_dynamic_import.py`` is preserved.
+    """
+    import os
+    from pathlib import Path
+
+    from ddtrace.internal.coverage.code import ModuleCodeCollector
+    from ddtrace.internal.coverage.installer import install
+    from tests.coverage.utils import _get_relpath_dict
+
+    cwd_path = os.getcwd()
+    include_path = Path(cwd_path + "/tests/coverage/included_path/")
+
+    install(include_paths=[include_path], collect_import_time_coverage=True)
+
+    # Imported before the test contexts: later contexts should only include it
+    # when dependency tracking proves the executed code imported it.
+    from tests.coverage.included_path import preimported_dependency  # noqa:F401
+    from tests.coverage.included_path.covered_then_dynamic_import import cover_file_without_import
+    from tests.coverage.included_path.covered_then_dynamic_import import import_preimported_dependency
+
+    with ModuleCodeCollector.CollectInContext() as context_without_dynamic_import:
+        assert cover_file_without_import() == "covered"
+        without_dynamic_import = _get_relpath_dict(cwd_path, context_without_dynamic_import.get_covered_lines())
+
+    with ModuleCodeCollector.CollectInContext() as context_with_dynamic_import:
+        # Cover the file first. A too-aggressive file-level fast path would be tempted to suppress the rest of the
+        # file's PY_START callbacks after this point.
+        assert cover_file_without_import() == "covered"
+        assert import_preimported_dependency() == 42
+        with_dynamic_import = _get_relpath_dict(cwd_path, context_with_dynamic_import.get_covered_lines())
+
+    covered_file = "tests/coverage/included_path/covered_then_dynamic_import.py"
+    dependency_file = "tests/coverage/included_path/preimported_dependency.py"
+
+    assert covered_file in without_dynamic_import
+    assert dependency_file not in without_dynamic_import, "import-time coverage should not leak into unrelated contexts"
+
+    assert covered_file in with_dynamic_import
+    assert dependency_file in with_dynamic_import, "late dynamic import dependency must merge import-time coverage"

--- a/tests/coverage/test_file_level_fast_path_regressions.py
+++ b/tests/coverage/test_file_level_fast_path_regressions.py
@@ -3,6 +3,26 @@ import sys
 import pytest
 
 
+def test_file_level_covered_paths_cache_is_bounded(monkeypatch):
+    from collections import OrderedDict
+
+    import ddtrace.internal.coverage.code as coverage_code
+    from ddtrace.internal.coverage.code import ModuleCodeCollector
+
+    collector = object.__new__(ModuleCodeCollector)
+    collector._file_level_covered_paths_cache = OrderedDict()
+    collector._import_time_covered = {}
+
+    monkeypatch.setattr(coverage_code, "_FILE_LEVEL_COVERED_PATHS_CACHE_MAX_SIZE", 2)
+
+    collector._get_covered_file_paths_with_imports({"/repo/one.py"})
+    collector._get_covered_file_paths_with_imports({"/repo/two.py"})
+    collector._get_covered_file_paths_with_imports({"/repo/three.py"})
+
+    assert len(collector._file_level_covered_paths_cache) == 2
+    assert frozenset({"/repo/one.py"}) not in collector._file_level_covered_paths_cache
+
+
 def test_file_level_paths_include_line_only_context_coverage():
     """File-level path snapshots must preserve files only present in the line coverage context.
 
@@ -13,19 +33,11 @@ def test_file_level_paths_include_line_only_context_coverage():
     from ddtrace.internal.coverage.code import _get_ctx_covered_files
     from ddtrace.internal.coverage.code import _get_ctx_covered_lines
 
-    old_instance = ModuleCodeCollector._instance
-    collector = ModuleCodeCollector()
-    collector._file_level_coverage = True
-    ModuleCodeCollector._instance = collector
+    with ModuleCodeCollector.CollectInContext() as context_collector:
+        _get_ctx_covered_files().add("/repo/parent.py")
+        _get_ctx_covered_lines()["/repo/child.py"].add(0)
 
-    try:
-        with ModuleCodeCollector.CollectInContext() as context_collector:
-            _get_ctx_covered_files().add("/repo/parent.py")
-            _get_ctx_covered_lines()["/repo/child.py"].add(0)
-
-            assert context_collector.get_covered_file_paths() == {"/repo/parent.py", "/repo/child.py"}
-    finally:
-        ModuleCodeCollector._instance = old_instance
+        assert context_collector.get_covered_file_paths() == {"/repo/parent.py", "/repo/child.py"}
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Test specific to Python 3.12+ monitoring API")

--- a/tests/coverage/test_file_level_fast_path_regressions.py
+++ b/tests/coverage/test_file_level_fast_path_regressions.py
@@ -3,6 +3,31 @@ import sys
 import pytest
 
 
+def test_file_level_paths_include_line_only_context_coverage():
+    """File-level path snapshots must preserve files only present in the line coverage context.
+
+    Python < 3.12 records file-level coverage through line hooks, and multiprocessing child coverage is merged back
+    into the parent line dictionary. In both cases, the file-level upload path must include those line-dict keys.
+    """
+    from ddtrace.internal.coverage.code import ModuleCodeCollector
+    from ddtrace.internal.coverage.code import _get_ctx_covered_files
+    from ddtrace.internal.coverage.code import _get_ctx_covered_lines
+
+    old_instance = ModuleCodeCollector._instance
+    collector = ModuleCodeCollector()
+    collector._file_level_coverage = True
+    ModuleCodeCollector._instance = collector
+
+    try:
+        with ModuleCodeCollector.CollectInContext() as context_collector:
+            _get_ctx_covered_files().add("/repo/parent.py")
+            _get_ctx_covered_lines()["/repo/child.py"].add(0)
+
+            assert context_collector.get_covered_file_paths() == {"/repo/parent.py", "/repo/child.py"}
+    finally:
+        ModuleCodeCollector._instance = old_instance
+
+
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Test specific to Python 3.12+ monitoring API")
 @pytest.mark.subprocess(parametrize={"_DD_COVERAGE_FILE_LEVEL": ["true", "false"]})
 def test_same_file_fast_path_preserves_late_dynamic_import_dependency():

--- a/tests/coverage/test_instrumentation_py312_disable.py
+++ b/tests/coverage/test_instrumentation_py312_disable.py
@@ -37,7 +37,7 @@ def test_event_handler_returns_disable():
         calls.append(line_info)
 
     # Register the code object with our hook
-    _CODE_HOOKS[code_obj] = (mock_hook, "/test/path.py", {})
+    _CODE_HOOKS[code_obj] = (mock_hook, "/test/path.py", {}, None, None, None)
 
     # Pin the DISABLE optimisation on: this test is specifically about the DISABLE-returning
     # behavior, not about how the flag gets computed. Outside this test, the real coverage
@@ -229,7 +229,7 @@ def test_update_disable_optimization_rearmed_on_transition():
     # Set up a real code object and register it in _CODE_HOOKS
     code_obj = compile("x = 1", "<test_rearm>", "exec")
     calls: list[object] = []
-    _CODE_HOOKS[code_obj] = (lambda info: calls.append(info), "/test/rearm.py", {})
+    _CODE_HOOKS[code_obj] = (lambda info: calls.append(info), "/test/rearm.py", {}, None, None, None)
     sys.monitoring.set_local_events(m._DD_TOOL_ID, code_obj, m.EVENT)
 
     # Start in DISABLE mode (default)
@@ -285,7 +285,7 @@ def test_event_handler_returns_none_when_other_tool_present():
     # Set up a code hook
     code_obj = compile("x = 1", "<test>", "exec")
     calls = []
-    _CODE_HOOKS[code_obj] = (lambda info: calls.append(info), "/test/path.py", {})
+    _CODE_HOOKS[code_obj] = (lambda info: calls.append(info), "/test/path.py", {}, None, None, None)
 
     try:
         # Update the flag based on detected tools

--- a/tests/coverage/test_instrumentation_py312_disable.py
+++ b/tests/coverage/test_instrumentation_py312_disable.py
@@ -80,6 +80,78 @@ def test_event_handler_returns_disable_for_missing_code():
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Python 3.12+ monitoring API only")
+def test_event_handler_uses_specialized_file_and_import_hooks():
+    import ddtrace.internal.coverage.instrumentation_py3_12 as m
+
+    code_obj = compile("x = 1", "<test_file_hooks>", "exec")
+    generic_calls = []
+    file_calls = []
+    import_calls = []
+    import_name = ("tests.coverage", ("included_path",))
+
+    old_file_level = m._USE_FILE_LEVEL_COVERAGE
+    old_disable = m._use_disable_optimization
+    m._USE_FILE_LEVEL_COVERAGE = True
+    m._use_disable_optimization = False
+    m._CODE_HOOKS[code_obj] = (
+        lambda info: generic_calls.append(info),
+        "/test/path.py",
+        {10: import_name},
+        lambda path, line: None,
+        lambda path: file_calls.append(path),
+        lambda path, name: import_calls.append((path, name)),
+    )
+
+    try:
+        assert m._event_handler(code_obj, 0) is None
+    finally:
+        m._CODE_HOOKS.pop(code_obj, None)
+        m._USE_FILE_LEVEL_COVERAGE = old_file_level
+        m._use_disable_optimization = old_disable
+
+    assert generic_calls == []
+    assert file_calls == ["/test/path.py"]
+    assert import_calls == [("/test/path.py", import_name)]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="Python 3.12+ monitoring API only")
+def test_event_handler_uses_specialized_line_and_import_hooks():
+    import ddtrace.internal.coverage.instrumentation_py3_12 as m
+
+    code_obj = compile("x = 1", "<test_line_hooks>", "exec")
+    generic_calls = []
+    line_calls = []
+    file_calls = []
+    import_calls = []
+    import_name = ("tests.coverage", ("included_path",))
+
+    old_file_level = m._USE_FILE_LEVEL_COVERAGE
+    old_disable = m._use_disable_optimization
+    m._USE_FILE_LEVEL_COVERAGE = False
+    m._use_disable_optimization = False
+    m._CODE_HOOKS[code_obj] = (
+        lambda info: generic_calls.append(info),
+        "/test/path.py",
+        {7: import_name},
+        lambda path, line: line_calls.append((path, line)),
+        lambda path: file_calls.append(path),
+        lambda path, name: import_calls.append((path, name)),
+    )
+
+    try:
+        assert m._event_handler(code_obj, 7) is None
+    finally:
+        m._CODE_HOOKS.pop(code_obj, None)
+        m._USE_FILE_LEVEL_COVERAGE = old_file_level
+        m._use_disable_optimization = old_disable
+
+    assert generic_calls == []
+    assert line_calls == [("/test/path.py", 7)]
+    assert file_calls == []
+    assert import_calls == [("/test/path.py", import_name)]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="Python 3.12+ monitoring API only")
 def test_ensure_registered_claims_a_candidate_slot():
     """Test that _ensure_registered() claims a slot from _DD_CANDIDATE_SLOTS (4, 3, 1)."""
     import sys


### PR DESCRIPTION
## Description

Optimize Test Optimization file-level coverage payload construction by using file path sets directly instead of line-oriented coverage data structures where possible.

This PR keeps the main performance win focused on file-level coverage data flow:

- collect file-level coverage as covered file paths instead of line-oriented `CoverageLines` objects where possible
- emit a shared line-0 bitmap for file-level coverage payloads
- cache repo-relative coverage path conversion
- cache import-time dependency path expansion
- cache expanded file coverage path sets
- skip import expansion for files that have no import-time coverage metadata
- keep dynamic import dependency invalidation so late imports are not missed
- split Python 3.12+ monitoring dispatch into explicit file, line, and import hooks for readability

In local benchmarks, this reduced wall time by about 36.6% against the `ddtrace==4.11.1` baseline when running both versions with ITR file-level coverage enabled.

## Testing

Added regression tests for:

- file-level fast path preserving late dynamic import dependencies
- file-level fast path preserving nested dynamic import dependencies
- import dependency cache invalidation after late dynamic imports
- specialized Python 3.12+ monitoring hook dispatch for file-level and line-level modes

## Risks

Medium. This changes internal file-level coverage data flow and import dependency expansion. The main risk is missing or misattributing a covered file, which would affect Test Impact Analysis correctness. The added dynamic import and nested import regression tests are intended to guard those cases.

Line-level coverage behavior is intended to remain unchanged.

## Additional Notes

The implementation intentionally focuses on the file-level coverage data model and payload path, where benchmarks showed the clearest gains, while avoiding broader callback hot-path changes.