### PR TITLE
chore: raise RSS SLO for tracing-profiling-enabled scenario

### DIFF
--- a/.gitlab/benchmarks/bp-runner.macrobenchmarks.fail-on-breach.yml
+++ b/.gitlab/benchmarks/bp-runner.macrobenchmarks.fail-on-breach.yml
@@ -43,7 +43,7 @@ experiments:
           - name: normal_operation/tracing-profiling-enabled/python-server-utilization
             thresholds:
               - cpu_usage_percentage < 220 %
-              - rss < 1040 MB
+              - rss < 1080 MB
           - name: high_load/tracing-profiling-enabled
             thresholds:
               - throughput > 30.0 op/s


### PR DESCRIPTION
## Description

The changes in PR https://github.com/DataDog/dd-trace-py/pull/18332 increased RSS usage by ~+30MB for profiler on normal_operation/tracing-profiling-enabled. This PRs fixes the SLOs breach caused by the above mentioned PR, because this is the expected tradeoff.

Quoting Thomas Kowalski:
> The PR made it such that we take more samples than we used to => mechanically use more memory

## Testing

Check `check-slo-breaches` CI job on Gitlab. It must be green after this PR. 

## Risks

None, this is chore PR to reflect change in SLO.
