### PR TITLE
docs(releasenotes): profiling Python 3.15 support note

### DIFF
--- a/releasenotes/notes/profiling-python315-support-5910a6a4e623716b.yaml
+++ b/releasenotes/notes/profiling-python315-support-5910a6a4e623716b.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    profiling: The Continuous Profiler now supports Python 3.15 (GIL-enabled builds),
+    including the native stack profiler (Echion), lock profiler, memory profiler, and
+    asyncio task tracking.
+
+    Free-threading (``--disable-gil``) builds are not validated in this release.


### PR DESCRIPTION
**prev:** [#19274](https://github.com/DataDog/dd-trace-py/pull/19274) | **next:** [#19254](https://github.com/DataDog/dd-trace-py/pull/19254)

## Summary

Customer-facing Reno fragment for profiling on 3.15. Replaces merged #19259.

## Test plan

- [ ] CI green on this branch
- [ ] Stack merges cleanly into the next PR's base branch

## Tracker

- Contributes to #17817
- Contributes to #17809
