### PR TITLE
build(iast): harden native extension builds

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/CMakeLists.txt
+++ b/ddtrace/appsec/_iast/_taint_tracking/CMakeLists.txt
@@ -11,17 +11,86 @@ project(${APP_NAME})
 
 set(CMAKE_CXX_STANDARD 17)
 
-# -U_FORTIFY_SOURCE to fix a bug in alpine and pybind11 https://github.com/pybind/pybind11/issues/1650
-# https://gitlab.alpinelinux.org/alpine/aports/-/issues/8626
+# Direct CMake Debug builds use sanitizers by default. setup.py passes this option explicitly because DD_FAST_BUILD
+# keeps the release CMake build type.
+set(IAST_SANITIZERS_DEFAULT OFF)
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(IAST_SANITIZERS_DEFAULT ON)
+endif()
+option(IAST_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer" ${IAST_SANITIZERS_DEFAULT})
+option(IAST_ENABLE_HARDENING "Enable production-safe native hardening" ON)
+
+include(CheckCXXCompilerFlag)
+include(CheckCXXSourceCompiles)
+include(CheckLinkerFlag)
+include(CMakePushCheckState)
+
+# AIDEV-NOTE: Sanitizers provide fail-fast diagnostics in Debug/fast builds, while production hardening must not
+# introduce a sanitizer runtime dependency. Keep sanitizer and hardening flags target-scoped so vendored dependencies
+# retain their own build configuration.
+function(iast_add_supported_compile_option target option check_name)
+    check_cxx_compiler_flag("${option}" ${check_name})
+    if(${check_name})
+        target_compile_options(${target} PRIVATE "${option}")
+    endif()
+endfunction()
+
+function(iast_add_supported_link_option target option check_name)
+    check_linker_flag(CXX "${option}" ${check_name})
+    if(${check_name})
+        target_link_options(${target} PRIVATE "${option}")
+    endif()
+endfunction()
+
+function(iast_configure_native_target target)
+    if(IAST_ENABLE_SANITIZERS)
+        if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+            message(FATAL_ERROR "IAST sanitizers require a Clang or GCC-compatible compiler")
+        endif()
+
+        cmake_push_check_state(RESET)
+        set(CMAKE_REQUIRED_FLAGS "-fsanitize=address,undefined")
+        list(APPEND CMAKE_REQUIRED_LINK_OPTIONS "-fsanitize=address,undefined")
+        check_cxx_source_compiles("int main() { return 0; }" IAST_HAS_ADDRESS_UNDEFINED_SANITIZERS)
+        cmake_pop_check_state()
+        if(NOT IAST_HAS_ADDRESS_UNDEFINED_SANITIZERS)
+            message(FATAL_ERROR "The C++ compiler does not support the requested IAST ASan/UBSan profile")
+        endif()
+
+        target_compile_options(${target} PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer
+                                                 -fno-sanitize-recover=all)
+        target_link_options(${target} PRIVATE -fsanitize=address,undefined -fno-sanitize-recover=all)
+    endif()
+
+    if(IAST_ENABLE_HARDENING)
+        iast_add_supported_compile_option(${target} "-fstack-protector-strong" IAST_HAS_STACK_PROTECTOR_STRONG)
+        iast_add_supported_compile_option(${target} "-fno-omit-frame-pointer" IAST_HAS_FRAME_POINTERS)
+
+        if(NOT IAST_ENABLE_SANITIZERS)
+            iast_add_supported_compile_option(${target} "-ftrivial-auto-var-init=zero" IAST_HAS_AUTO_VAR_INIT_ZERO)
+        endif()
+
+        if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+            target_compile_definitions(${target} PRIVATE _GLIBCXX_ASSERTIONS)
+            if(NOT IAST_ENABLE_SANITIZERS)
+                target_compile_definitions(${target} PRIVATE _FORTIFY_SOURCE=2)
+            endif()
+            iast_add_supported_compile_option(${target} "-fstack-clash-protection" IAST_HAS_STACK_CLASH_PROTECTION)
+            iast_add_supported_compile_option(${target} "-fcf-protection=full" IAST_HAS_CONTROL_FLOW_PROTECTION)
+            iast_add_supported_link_option(${target} "-Wl,-z,relro" IAST_HAS_RELRO)
+            iast_add_supported_link_option(${target} "-Wl,-z,now" IAST_HAS_NOW)
+            iast_add_supported_link_option(${target} "-Wl,-z,noexecstack" IAST_HAS_NOEXECSTACK)
+        endif()
+    endif()
+endfunction()
+
 add_compile_options(
     -fPIC
     -fexceptions
     -fvisibility=hidden
-    -fpermissive
     -pthread
     -Wall
     -Wno-unknown-pragmas
-    -U_FORTIFY_SOURCE
     -g) # Add debug symbols always, it will be stripped in release/minsizerel by cmake
 
 if(BUILD_MACOS)
@@ -94,6 +163,13 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 pybind11_add_module(_native SHARED ${SOURCE_FILES} ${HEADER_FILES})
 get_filename_component(PARENT_DIR ${CMAKE_CURRENT_LIST_DIR} DIRECTORY)
 set_target_properties(_native PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
+iast_configure_native_target(_native)
+
+if(IAST_ENABLE_SANITIZERS)
+    message(STATUS "IAST native profile: ASan + UBSan with production hardening")
+else()
+    message(STATUS "IAST native profile: production hardening")
+endif()
 
 # target_link_libraries(_native PRIVATE ${ICU_LIBS})
 

--- a/ddtrace/appsec/_iast/_taint_tracking/tests/CMakeLists.txt
+++ b/ddtrace/appsec/_iast/_taint_tracking/tests/CMakeLists.txt
@@ -34,18 +34,18 @@ if(NOT MSVC AND NATIVE_TEST_COVERAGE)
 endif()
 
 target_link_libraries(native_tests ${NATIVE_TEST_LIBRARIES})
-
-# Enable ASan for native tests to detect memory errors at runtime. option(NATIVE_TEST_ASAN "Enable AddressSanitizer for
-# native tests" ON) if(NATIVE_TEST_ASAN AND NOT MSVC) target_compile_options(native_tests PRIVATE -fsanitize=address
-# -fno-omit-frame-pointer) target_link_options(native_tests PRIVATE -fsanitize=address) endif()
+iast_configure_native_target(native_tests)
 
 # Discover tests
 include(GoogleTest)
-gtest_discover_tests(native_tests)
-
-# replace gtest_discover_tests to use ASan for native tests to detect memory errors at runtime. gtest_discover_tests(
-# native_tests DISCOVERY_MODE PRE_TEST PROPERTIES ENVIRONMENT
-# "ASAN_OPTIONS=detect_leaks=0:halt_on_error=1:abort_on_error=1;LSAN_OPTIONS=verbosity=1:log_threads=1")
+if(IAST_ENABLE_SANITIZERS)
+    gtest_discover_tests(
+        native_tests DISCOVERY_MODE PRE_TEST
+        PROPERTIES ENVIRONMENT
+                   "ASAN_OPTIONS=detect_leaks=0:halt_on_error=1:abort_on_error=1;UBSAN_OPTIONS=halt_on_error=1")
+else()
+    gtest_discover_tests(native_tests)
+endif()
 
 add_custom_target(
     test_valgrind

--- a/docs/build_system.rst
+++ b/docs/build_system.rst
@@ -195,8 +195,10 @@ These environment variables modify aspects of the build process.
     default: False
 
     description: |
-        If set to 1, the tracer is compiled with minimal optimizations (`-g0`) and `DD_COMPILE_ABSEIL` is forced to 0. This is not recommended
-        for production due to reduced performance.
+        If set to 1, the tracer is compiled with minimal optimizations (`-O0`), `DD_COMPILE_ABSEIL` is forced to 0, and the IAST native
+        extension is instrumented with AddressSanitizer and UndefinedBehaviorSanitizer. The AddressSanitizer runtime must be loaded before
+        the Python interpreter (for example with `LD_PRELOAD` or `DYLD_INSERT_LIBRARIES`). This is not recommended for production due to
+        reduced performance.
 
     version_added:
         v3.3.0:

--- a/setup.py
+++ b/setup.py
@@ -347,6 +347,15 @@ class ExtensionHashes(build_ext):
                 # DEV: Make sure to include the rust features since changing them changes what gets built
                 for feature in rust_features:
                     sources_hash.update(feature.encode())
+                # CMake arguments and build modes can change the resulting
+                # binary without changing any source file. Include them so a
+                # production extension can never be restored into a
+                # Debug/DD_FAST_BUILD sanitizer build (or vice versa).
+                if isinstance(ext, CMakeExtension):
+                    sources_hash.update(ext.build_type.encode())
+                    sources_hash.update(str(FAST_BUILD).encode())
+                    for cmake_arg in ext.cmake_args:
+                        sources_hash.update(cmake_arg.encode())
                 for source in sorted(sources):
                     sources_hash.update(source.read_bytes())
                 hash_digest = sources_hash.hexdigest()
@@ -1586,6 +1595,11 @@ if not IS_PYSTON:
     ]
 
     if platform.system() not in ("Windows", ""):
+        # AIDEV-NOTE: DD_FAST_BUILD does not change CMAKE_BUILD_TYPE, so pass the
+        # sanitizer profile explicitly instead of relying on Debug detection in
+        # the IAST CMake project. Release builds keep sanitizers disabled because
+        # sanitizer runtimes are not suitable dependencies for production wheels.
+        iast_sanitizers_enabled = COMPILE_MODE.lower() == "debug" or FAST_BUILD
         ext_modules.append(
             Extension(
                 "ddtrace.appsec._shared._stacktrace",
@@ -1605,7 +1619,15 @@ if not IS_PYSTON:
             )
         )
         ext_modules.append(
-            CMakeExtension("ddtrace.appsec._iast._taint_tracking._native", source_dir=IAST_DIR, optional=False)
+            CMakeExtension(
+                "ddtrace.appsec._iast._taint_tracking._native",
+                source_dir=IAST_DIR,
+                cmake_args=[
+                    "-DIAST_ENABLE_SANITIZERS={}".format("ON" if iast_sanitizers_enabled else "OFF"),
+                    "-DIAST_ENABLE_HARDENING=ON",
+                ],
+                optional=False,
+            )
         )
 
     if CURRENT_OS in ("Linux", "Darwin") and is_64_bit_python() and sys.version_info < (3, 15):


### PR DESCRIPTION
## Description

Make IAST native memory-safety failures surface at their origin instead of silently continuing after undefined behavior:

- instrument `Debug` and `DD_FAST_BUILD` IAST builds with AddressSanitizer and UndefinedBehaviorSanitizer in fail-fast mode;
- apply runtime-free, feature-detected compiler and linker hardening to production IAST builds;
- remove the permissive/fortify-disabling flags from the IAST extension;
- include the CMake profile and arguments in extension cache hashes so sanitized and production artifacts cannot be mixed;
- apply the same sanitizer profile to the native GoogleTest target.

This deliberately improves detection and attribution, but it does not create a process-isolation boundary: an in-process native extension can still corrupt interpreter state before a hardening check detects it.

## Testing

- `scripts/lint checks`
- Linux aarch64, Python 3.14, GCC 14 debug build: 185 enabled native tests passed under ASan + UBSan (3 disabled)
- Linux production build: verified `BIND_NOW`, GNU RELRO, non-executable stack, stack protector, fortify, libstdc++ assertions, stack-clash protection, frame pointers, and zero initialization of automatic variables
- Verified the production extension has no ASan/UBSan runtime dependency
- macOS: compiled both production-hardened and debug sanitizer profiles

The local `rt run appsec_iast_native -p 3.14 --force-reinstall` environment could not download dependencies because DNS access was unavailable, so this draft PR is intended to exercise the full supported CI matrix.

## Risks

- Sanitized developer builds require the ASan runtime to load before Python (for example through `LD_PRELOAD` or `DYLD_INSERT_LIBRARIES`).
- Production hardening can expose latent native bugs as deterministic process termination. Compiler/linker flags are feature-detected to preserve toolchain portability.
- Frame pointers and the additional checks may have a small performance/code-size cost in the IAST native extension.

## Additional Notes

No release note: this is an internal build and diagnostics change with no public API change.