### PR TITLE
feat(tracing): republish the otel thread context on asyncio task switches

### DIFF
--- a/ddtrace/contrib/internal/asyncio/patch.py
+++ b/ddtrace/contrib/internal/asyncio/patch.py
@@ -1,5 +1,8 @@
 import asyncio
+from contextvars import Context
 from typing import Any
+from typing import Callable
+from typing import NoReturn
 
 from ddtrace._trace.pin import Pin
 from ddtrace.internal import core
@@ -27,6 +30,7 @@ def patch():
     asyncio._datadog_patch = True
     Pin().onto(asyncio)
     wrap(asyncio.BaseEventLoop.create_task, _wrapped_create_task)
+    wrap(asyncio.Handle._run, _wrapped_run_handle)
 
 
 def unpatch():
@@ -36,6 +40,25 @@ def unpatch():
         return
     asyncio._datadog_patch = False
     unwrap(asyncio.BaseEventLoop.create_task, _wrapped_create_task)
+    unwrap(asyncio.Handle._run, _wrapped_run_handle)
+
+
+def _activate_context() -> None:
+    core.dispatch(
+        "ddtrace.context_provider.activate",
+        (tracer.context_provider, tracer.context_provider.active()),
+    )
+
+
+def _wrapped_run_handle(
+    wrapped: Callable[[asyncio.Handle], None], args: tuple[asyncio.Handle], kwargs: dict[str, NoReturn]
+) -> None:
+    ctx: Context = args[0]._context  # type: ignore[attr-defined]
+    ctx.run(_activate_context)
+    try:
+        return wrapped(*args, **kwargs)
+    finally:
+        ctx.run(_activate_context)
 
 
 def _wrapped_create_task(wrapped, args, kwargs):

--- a/ddtrace/contrib/internal/asyncio/patch.py
+++ b/ddtrace/contrib/internal/asyncio/patch.py
@@ -53,12 +53,15 @@ def _activate_context() -> None:
 def _wrapped_run_handle(
     wrapped: Callable[[asyncio.Handle], None], args: tuple[asyncio.Handle], kwargs: dict[str, NoReturn]
 ) -> None:
+    if not core.has_listeners("ddtrace.context_provider.activate"):
+        return wrapped(*args, **kwargs)
+
     ctx: Context = args[0]._context  # type: ignore[attr-defined]
     ctx.run(_activate_context)
     try:
         return wrapped(*args, **kwargs)
     finally:
-        ctx.run(_activate_context)
+        _activate_context()
 
 
 def _wrapped_create_task(wrapped, args, kwargs):

--- a/releasenotes/notes/asyncio-otel-thread-context-252661e4b2b5141f.yaml
+++ b/releasenotes/notes/asyncio-otel-thread-context-252661e4b2b5141f.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    tracing: Ensure that OpenTelemetry thread context is republished on asyncio task switches

--- a/releasenotes/notes/asyncio-otel-thread-context-252661e4b2b5141f.yaml
+++ b/releasenotes/notes/asyncio-otel-thread-context-252661e4b2b5141f.yaml
@@ -1,4 +1,6 @@
 ---
 features:
   - |
-    tracing: Ensure that OpenTelemetry thread context is republished on asyncio task switches
+    tracing: Ensures that OpenTelemetry thread context is republished on asyncio task switches.
+    This enables compatible host profiling and security tools to correlate samples with the active
+    trace and span in async functions.

--- a/releasenotes/notes/asyncio-otel-thread-context-252661e4b2b5141f.yaml
+++ b/releasenotes/notes/asyncio-otel-thread-context-252661e4b2b5141f.yaml
@@ -3,4 +3,4 @@ features:
   - |
     tracing: Ensures that OpenTelemetry thread context is republished on asyncio task switches.
     This enables compatible host profiling and security tools to correlate samples with the active
-    trace and span in async functions.
+    trace and span in async functions when using the builtin asyncio event loops.

--- a/tests/contrib/asyncio/test_propagation.py
+++ b/tests/contrib/asyncio/test_propagation.py
@@ -10,6 +10,7 @@ from ddtrace.trace import Context
 
 
 _orig_create_task = asyncio.BaseEventLoop.create_task
+_orig_handle_run = asyncio.Handle._run
 
 
 def test_event_loop_unpatch(tracer):
@@ -18,6 +19,7 @@ def test_event_loop_unpatch(tracer):
     unpatch()
     assert isinstance(tracer.context_provider, DefaultContextProvider)
     assert asyncio.BaseEventLoop.create_task == _orig_create_task
+    assert asyncio.Handle._run == _orig_handle_run
 
 
 @pytest.mark.asyncio

--- a/tests/tracer/test_otel_thread_context.py
+++ b/tests/tracer/test_otel_thread_context.py
@@ -1,3 +1,4 @@
+import asyncio
 import concurrent.futures
 import ctypes
 import os
@@ -8,6 +9,8 @@ import pytest
 
 from ddtrace._trace.provider import DefaultContextProvider
 from ddtrace._trace.tracer import Tracer
+from ddtrace.contrib.internal.asyncio.patch import patch as patch_asyncio
+from ddtrace.contrib.internal.asyncio.patch import unpatch as unpatch_asyncio
 
 
 pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="OTel thread context is only published on Linux")
@@ -66,6 +69,62 @@ def test_only_installed_context_provider_updates_thread_context(tracer: Tracer):
         uninstalled_provider.activate(None)
 
         assert _published_span_id() == span.span_id
+
+
+def test_span_context_tracks_asyncio_task_switches(tracer: Tracer):
+    was_patched = getattr(asyncio, "_datadog_patch", False)
+    patch_asyncio()
+
+    async def run_tasks() -> None:
+        first_started = asyncio.Event()
+        resume_first = asyncio.Event()
+        first_resumed = asyncio.Event()
+
+        async def first() -> None:
+            with tracer.trace("first") as span:
+                first_started.set()
+                await resume_first.wait()
+                assert _published_span_id() == span.span_id
+                first_resumed.set()
+
+        async def second() -> None:
+            await first_started.wait()
+            with tracer.trace("second"):
+                resume_first.set()
+                await first_resumed.wait()
+
+        await asyncio.gather(first(), second())
+
+    try:
+        asyncio.run(run_tasks())
+    finally:
+        if not was_patched:
+            unpatch_asyncio()
+
+
+def test_span_context_skips_finished_span_captured_by_asyncio_handle(tracer: Tracer):
+    was_patched = getattr(asyncio, "_datadog_patch", False)
+    patch_asyncio()
+
+    async def run_callback() -> None:
+        loop = asyncio.get_running_loop()
+        callback_finished = loop.create_future()
+
+        with tracer.trace("parent") as parent:
+            with tracer.trace("child"):
+
+                def callback() -> None:
+                    callback_finished.set_result(_published_span_id())
+
+                loop.call_soon(callback)
+
+            assert await callback_finished == parent.span_id
+
+    try:
+        asyncio.run(run_callback())
+    finally:
+        if not was_patched:
+            unpatch_asyncio()
 
 
 def test_span_context_is_reactivated_after_fork(tracer: Tracer):

--- a/tests/tracer/test_otel_thread_context.py
+++ b/tests/tracer/test_otel_thread_context.py
@@ -96,7 +96,11 @@ def test_span_context_tracks_asyncio_task_switches(tracer: Tracer):
         await asyncio.gather(first(), second())
 
     try:
-        asyncio.run(run_tasks())
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(run_tasks())
+        finally:
+            loop.close()
     finally:
         if not was_patched:
             unpatch_asyncio()
@@ -121,7 +125,11 @@ def test_span_context_skips_finished_span_captured_by_asyncio_handle(tracer: Tra
             assert await callback_finished == parent.span_id
 
     try:
-        asyncio.run(run_callback())
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(run_callback())
+        finally:
+            loop.close()
     finally:
         if not was_patched:
             unpatch_asyncio()


### PR DESCRIPTION
## Description

This PR triggers the activation signal on async task switch on the asyncio builtin event loops. This ensures that the OTel thread context is actualized around those tasks.  

## Testing

- added unit tests

## Risks

- Low: this adds a little bit of overhead (core event dispatch + active span lookup) on each asyncio task switch => small performance regression

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
