### PR TITLE
ci(benchmarks): add DCS Peformance team as code owners of .gitlab/benchmarks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -343,3 +343,6 @@ docker/Dockerfile.fuzz            @DataDog/chaos-engineering @DataDog/profiling-
 supported_versions.json                         @DataDog/apm-core-python @DataDog/apm-idm-python
 scripts/integration_registry/registry.yaml      @DataDog/apm-core-python @DataDog/apm-idm-python
 scripts/integration_registry/generate_supported_versions.py  @DataDog/apm-core-python @DataDog/apm-idm-python
+
+# Benchmarks CI setup
+/.gitlab/benchmarks             @DataDog/python-guild @DataDog/apm-core-python @DataDog/apm-ecosystems-performance


### PR DESCRIPTION
## Description

Performance team periodically miss the changes happening in dd-trace-py CI setup that we might need to provide input on. Having us in codeowners will ensure that we consistently receive notifications on code changes.

## Testing

PR jobs are green, no Github violations are shown.

## Risks

None