### PR TITLE
fix(profiling): fix overcounting of heap-live-size upon exceeding capacity (PROF-11496)

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -1,6 +1,8 @@
 #include <cassert>
 #include <cmath>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <memory>
 #include <random>
 #include <vector>
@@ -111,8 +113,9 @@ class heap_tracker_t
     /* Track an allocation that we decided to sample. This updates shared state and
      * must be called with the GIL held and without making any C Python API calls.
      * If an allocation at the same address is already tracked, the old traceback
-     * is deleted internally. */
-    void add_sample_no_cpython(void* ptr, std::unique_ptr<traceback_t> tb);
+     * is deleted internally. ``domain`` is recorded only for the track/untrack
+     * balance instrumentation. */
+    void add_sample_no_cpython(void* ptr, PyMemAllocatorDomain domain, std::unique_ptr<traceback_t> tb);
 
     void export_heap_no_cpython();
 
@@ -134,8 +137,10 @@ class heap_tracker_t
   private:
     uint32_t next_sample_size_no_cpython(uint32_t sample_size);
 
-    /* This function is called from heap_tracker_t::postfork_child() as part of
-       the fork handler to reset the sampling state. */
+    /* Reset the byte accumulator and draw the next sampling target. Called after a
+       sample is taken, when a candidate sample is dropped at the cap (so the bytes
+       allocated while saturated are not carried into the next sample's weight), and
+       from heap_tracker_t::postfork_child() as part of the fork handler. */
     void reset_sampling_state_no_cpython();
 
     /* Heap profiler sampling interval */
@@ -155,10 +160,20 @@ class heap_tracker_t
     /* Bytes allocated since the last sample was collected */
     uint64_t allocated_memory;
 
-    /* Number of samples silently dropped because allocs_m hit the cap.
-     * Accumulated across the lifetime of this tracker instance and surfaced
-     * via ProfilerStats so the backend / user can detect data loss. */
+    /* Number of candidate samples dropped because allocs_m was at capacity.
+     * Surfaced via ProfilerStats (heap_tracker_cap_drops) so the backend / user can
+     * detect that the live set is saturated (heap-space under-reports past this
+     * point, since we can no longer track additional live allocations). */
     size_t cap_drops{ 0 };
+
+    /* Track/untrack balance instrumentation. A persistently growing
+     * (track_count_obj + track_count_mem - untrack_count) with the map pinned near
+     * the cap pinpoints which domain's frees are bypassing the untrack hook (the
+     * ghost-accumulation root cause). Logged from export when
+     * _DD_MEMALLOC_HEAP_DEBUG_STATS is set. */
+    size_t track_count_obj{ 0 };
+    size_t track_count_mem{ 0 };
+    size_t untrack_count{ 0 };
 
     /* Debug guard to assert that GIL-protected critical sections are maintained
      * while accessing the profiler's state */
@@ -241,6 +256,7 @@ heap_tracker_t::untrack_no_cpython(void* ptr)
 
     auto node = allocs_m.extract(ptr);
     if (!node.empty()) {
+        ++untrack_count;
         pool_put_no_cpython(std::move(node.mapped()));
     }
 }
@@ -257,9 +273,21 @@ heap_tracker_t::should_sample_no_cpython(size_t size, uint64_t* allocated_memory
         return false;
     }
 
-    /* This cap bounds memory use but creates blind spots: once allocs_m is full,
-     * new allocations are not sampled. cap_drops tracks how often this happens
-     * so we can observe whether the limit is ever reached in practice. */
+    /* At capacity: we cannot track another live allocation, so drop this
+     * candidate sample. Crucially, we must ALSO reset the sampling state here.
+     *
+     * `allocated_memory` doubles as the weight assigned to the next sample (it is
+     * the count of bytes allocated since the last sample). It is only reset when a
+     * sample is actually taken (add_sample) or dropped here. If we returned false
+     * WITHOUT resetting, `allocated_memory` would keep accumulating every
+     * allocation for the entire time the map stays saturated; the first sample
+     * taken once a slot frees up would then inherit that enormous accumulated
+     * weight. That is the phantom heap-live-size inflation: a handful of
+     * post-saturation samples each weighted with GiB/TiB of dropped-allocation
+     * bytes, decoupling heap-space from real memory (see
+     * mem_domain_heap_live_size_bug.md). Resetting bounds every sample's weight to
+     * ~one sampling interval, so at worst heap-space *under*-reports while
+     * saturated (a safe failure mode) instead of exploding. */
     if (allocs_m.size() >= TRACEBACK_ARRAY_MAX_COUNT) {
         ++cap_drops;
         reset_sampling_state_no_cpython();
@@ -270,9 +298,20 @@ heap_tracker_t::should_sample_no_cpython(size_t size, uint64_t* allocated_memory
 }
 
 void
-heap_tracker_t::add_sample_no_cpython(void* ptr, std::unique_ptr<traceback_t> tb)
+heap_tracker_t::add_sample_no_cpython(void* ptr, PyMemAllocatorDomain domain, std::unique_ptr<traceback_t> tb)
 {
     memalloc_gil_debug_guard_t guard(gil_guard);
+
+#ifdef _PY312_AND_LATER
+    if (domain == PYMEM_DOMAIN_MEM) {
+        ++track_count_mem;
+    } else {
+        ++track_count_obj;
+    }
+#else
+    (void)domain;
+    ++track_count_obj;
+#endif
 
     auto [it, inserted] = allocs_m.insert_or_assign(ptr, std::move(tb));
     (void)it; // Unused, but needed for structured binding
@@ -298,6 +337,21 @@ heap_tracker_t::export_heap_no_cpython()
     auto& stats = Datadog::Sample::profile_borrow().stats();
     stats.set_heap_tracker_size(allocs_m.size());
     stats.set_heap_tracker_cap_drops(cap_drops);
+
+    /* Diagnostic surfaced only when _DD_MEMALLOC_HEAP_DEBUG_STATS is set (silent in
+     * production). track/untrack must stay balanced (track_obj + track_mem -
+     * untrack == live); a large `drops` with `live` pinned at the cap means the
+     * live set is saturated and heap-space is under-reporting. */
+    static const bool debug_stats = (std::getenv("_DD_MEMALLOC_HEAP_DEBUG_STATS") != nullptr);
+    if (debug_stats) {
+        std::fprintf(stderr,
+                     "[memalloc-heap] live=%zu track_obj=%zu track_mem=%zu untrack=%zu drops=%zu\n",
+                     allocs_m.size(),
+                     track_count_obj,
+                     track_count_mem,
+                     untrack_count,
+                     cap_drops);
+    }
 }
 
 void
@@ -326,6 +380,9 @@ heap_tracker_t::postfork_child()
     allocs_m.clear();
 
     cap_drops = 0;
+    track_count_obj = 0;
+    track_count_mem = 0;
+    untrack_count = 0;
 
     // Reset the sampling state to start fresh after fork.
     reset_sampling_state_no_cpython();
@@ -369,7 +426,6 @@ memalloc_heap_untrack_no_cpython(void* ptr)
 void
 memalloc_heap_track_invokes_cpython(uint16_t max_nframe, void* ptr, size_t size, PyMemAllocatorDomain domain)
 {
-    (void)domain; // Parameter kept for API consistency but not currently used
     if (!heap_tracker_t::instance) {
         return;
     }
@@ -447,7 +503,7 @@ memalloc_heap_track_invokes_cpython(uint16_t max_nframe, void* ptr, size_t size,
 
     // Check that instance is still valid after GIL release in constructor
     if (heap_tracker_t::instance) {
-        heap_tracker_t::instance->add_sample_no_cpython(ptr, std::move(tb));
+        heap_tracker_t::instance->add_sample_no_cpython(ptr, domain, std::move(tb));
     }
     // If instance is gone, tb's unique_ptr automatically deletes the traceback
 }

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -342,7 +342,7 @@ heap_tracker_t::export_heap_no_cpython()
      * production). track/untrack must stay balanced (track_obj + track_mem -
      * untrack == live); a large `drops` with `live` pinned at the cap means the
      * live set is saturated and heap-space is under-reporting. */
-    static const bool debug_stats = (std::getenv("_DD_MEMALLOC_HEAP_DEBUG_STATS") != nullptr);
+    const bool debug_stats = (std::getenv("_DD_MEMALLOC_HEAP_DEBUG_STATS") != nullptr);
     if (debug_stats) {
         std::fprintf(stderr,
                      "[memalloc-heap] live=%zu track_obj=%zu track_mem=%zu untrack=%zu drops=%zu\n",

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -1,7 +1,6 @@
 #include <cassert>
 #include <cmath>
 #include <cstdint>
-#include <cstdio>
 #include <cstdlib>
 #include <memory>
 #include <random>
@@ -87,6 +86,24 @@ using HeapMapType = std::unordered_map<K, V>;
    formula if more testing shows us to be too inaccurate.
  */
 
+/* Live-sample map capacity, default TRACEBACK_ARRAY_MAX_COUNT. The internal,
+ * test-only env var _DD_MEMALLOC_HEAP_MAX_SAMPLE_COUNT overrides it (clamped to
+ * [1, TRACEBACK_ARRAY_MAX_COUNT]) so tests can saturate the cap cheaply. */
+static size_t
+heap_max_sample_count_from_env()
+{
+    const char* raw = std::getenv("_DD_MEMALLOC_HEAP_MAX_SAMPLE_COUNT");
+    if (raw == nullptr || raw[0] == '\0') {
+        return TRACEBACK_ARRAY_MAX_COUNT;
+    }
+    char* end = nullptr;
+    unsigned long long parsed = std::strtoull(raw, &end, 10);
+    if (end == raw || parsed == 0ULL || parsed > static_cast<unsigned long long>(TRACEBACK_ARRAY_MAX_COUNT)) {
+        return TRACEBACK_ARRAY_MAX_COUNT;
+    }
+    return static_cast<size_t>(parsed);
+}
+
 class heap_tracker_t
 {
   public:
@@ -113,9 +130,8 @@ class heap_tracker_t
     /* Track an allocation that we decided to sample. This updates shared state and
      * must be called with the GIL held and without making any C Python API calls.
      * If an allocation at the same address is already tracked, the old traceback
-     * is deleted internally. ``domain`` is recorded only for the track/untrack
-     * balance instrumentation. */
-    void add_sample_no_cpython(void* ptr, PyMemAllocatorDomain domain, std::unique_ptr<traceback_t> tb);
+     * is deleted internally. */
+    void add_sample_no_cpython(void* ptr, std::unique_ptr<traceback_t> tb);
 
     void export_heap_no_cpython();
 
@@ -160,20 +176,15 @@ class heap_tracker_t
     /* Bytes allocated since the last sample was collected */
     uint64_t allocated_memory;
 
+    /* Cap on allocs_m. Read once at construction from
+     * _DD_MEMALLOC_HEAP_MAX_SAMPLE_COUNT; defaults to TRACEBACK_ARRAY_MAX_COUNT. */
+    size_t max_sample_count;
+
     /* Number of candidate samples dropped because allocs_m was at capacity.
      * Surfaced via ProfilerStats (heap_tracker_cap_drops) so the backend / user can
      * detect that the live set is saturated (heap-space under-reports past this
      * point, since we can no longer track additional live allocations). */
     size_t cap_drops{ 0 };
-
-    /* Track/untrack balance instrumentation. A persistently growing
-     * (track_count_obj + track_count_mem - untrack_count) with the map pinned near
-     * the cap pinpoints which domain's frees are bypassing the untrack hook (the
-     * ghost-accumulation root cause). Logged from export when
-     * _DD_MEMALLOC_HEAP_DEBUG_STATS is set. */
-    size_t track_count_obj{ 0 };
-    size_t track_count_mem{ 0 };
-    size_t untrack_count{ 0 };
 
     /* Debug guard to assert that GIL-protected critical sections are maintained
      * while accessing the profiler's state */
@@ -242,6 +253,7 @@ heap_tracker_t::heap_tracker_t(uint32_t sample_size_val)
   , rng(sample_size_val != 0U ? sample_size_val : 0x9e3779b9U) // 2^32 / phi (golden ratio)
   , current_sample_size(next_sample_size_no_cpython(sample_size_val))
   , allocated_memory(0)
+  , max_sample_count(heap_max_sample_count_from_env())
 {
     // Pre-allocate pool capacity to avoid reallocations
     pool.reserve(POOL_CAPACITY);
@@ -256,7 +268,6 @@ heap_tracker_t::untrack_no_cpython(void* ptr)
 
     auto node = allocs_m.extract(ptr);
     if (!node.empty()) {
-        ++untrack_count;
         pool_put_no_cpython(std::move(node.mapped()));
     }
 }
@@ -288,7 +299,7 @@ heap_tracker_t::should_sample_no_cpython(size_t size, uint64_t* allocated_memory
      * mem_domain_heap_live_size_bug.md). Resetting bounds every sample's weight to
      * ~one sampling interval, so at worst heap-space *under*-reports while
      * saturated (a safe failure mode) instead of exploding. */
-    if (allocs_m.size() >= TRACEBACK_ARRAY_MAX_COUNT) {
+    if (allocs_m.size() >= max_sample_count) {
         ++cap_drops;
         reset_sampling_state_no_cpython();
         return false;
@@ -298,20 +309,9 @@ heap_tracker_t::should_sample_no_cpython(size_t size, uint64_t* allocated_memory
 }
 
 void
-heap_tracker_t::add_sample_no_cpython(void* ptr, PyMemAllocatorDomain domain, std::unique_ptr<traceback_t> tb)
+heap_tracker_t::add_sample_no_cpython(void* ptr, std::unique_ptr<traceback_t> tb)
 {
     memalloc_gil_debug_guard_t guard(gil_guard);
-
-#ifdef _PY312_AND_LATER
-    if (domain == PYMEM_DOMAIN_MEM) {
-        ++track_count_mem;
-    } else {
-        ++track_count_obj;
-    }
-#else
-    (void)domain;
-    ++track_count_obj;
-#endif
 
     auto [it, inserted] = allocs_m.insert_or_assign(ptr, std::move(tb));
     (void)it; // Unused, but needed for structured binding
@@ -337,21 +337,6 @@ heap_tracker_t::export_heap_no_cpython()
     auto& stats = Datadog::Sample::profile_borrow().stats();
     stats.set_heap_tracker_size(allocs_m.size());
     stats.set_heap_tracker_cap_drops(cap_drops);
-
-    /* Diagnostic surfaced only when _DD_MEMALLOC_HEAP_DEBUG_STATS is set (silent in
-     * production). track/untrack must stay balanced (track_obj + track_mem -
-     * untrack == live); a large `drops` with `live` pinned at the cap means the
-     * live set is saturated and heap-space is under-reporting. */
-    const bool debug_stats = (std::getenv("_DD_MEMALLOC_HEAP_DEBUG_STATS") != nullptr);
-    if (debug_stats) {
-        std::fprintf(stderr,
-                     "[memalloc-heap] live=%zu track_obj=%zu track_mem=%zu untrack=%zu drops=%zu\n",
-                     allocs_m.size(),
-                     track_count_obj,
-                     track_count_mem,
-                     untrack_count,
-                     cap_drops);
-    }
 }
 
 void
@@ -380,9 +365,6 @@ heap_tracker_t::postfork_child()
     allocs_m.clear();
 
     cap_drops = 0;
-    track_count_obj = 0;
-    track_count_mem = 0;
-    untrack_count = 0;
 
     // Reset the sampling state to start fresh after fork.
     reset_sampling_state_no_cpython();
@@ -426,6 +408,7 @@ memalloc_heap_untrack_no_cpython(void* ptr)
 void
 memalloc_heap_track_invokes_cpython(uint16_t max_nframe, void* ptr, size_t size, PyMemAllocatorDomain domain)
 {
+    (void)domain; // Parameter kept for API consistency but not currently used
     if (!heap_tracker_t::instance) {
         return;
     }
@@ -503,7 +486,7 @@ memalloc_heap_track_invokes_cpython(uint16_t max_nframe, void* ptr, size_t size,
 
     // Check that instance is still valid after GIL release in constructor
     if (heap_tracker_t::instance) {
-        heap_tracker_t::instance->add_sample_no_cpython(ptr, domain, std::move(tb));
+        heap_tracker_t::instance->add_sample_no_cpython(ptr, std::move(tb));
     }
     // If instance is gone, tb's unique_ptr automatically deletes the traceback
 }

--- a/releasenotes/notes/fix-mem-domain-heap-live-size-overcount-61bcf35621509035.yaml
+++ b/releasenotes/notes/fix-mem-domain-heap-live-size-overcount-61bcf35621509035.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    profiling: fixed a bug where the reported heap live size (``heap-space``)
+    could be inflated by orders of magnitude once the heap profiler's
+    live-sample map reached its internal cap, producing a phantom "growing"
+    live heap while real memory usage stayed flat. Sample weights are now
+    reset when a sample is dropped at the cap.

--- a/releasenotes/notes/fix-mem-domain-heap-live-size-overcount-61bcf35621509035.yaml
+++ b/releasenotes/notes/fix-mem-domain-heap-live-size-overcount-61bcf35621509035.yaml
@@ -1,8 +1,6 @@
 ---
 fixes:
   - |
-    profiling: fixed a bug where the reported heap live size (``heap-space``)
-    could be inflated by orders of magnitude once the heap profiler's
-    live-sample map reached its internal cap, producing a phantom "growing"
-    live heap while real memory usage stayed flat. Sample weights are now
-    reset when a sample is dropped at the cap.
+    profiling: fixes a bug in heap profiler where the reported heap live size (``heap-space``)
+    could be inflated by orders of magnitude once live-sample map reached its internal cap.
+    As a result, a phantom "growing" live heap would be presented while real memory usage stayed flat. 

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -1733,22 +1733,19 @@ def test_mem_domain_mem_overhead() -> None:
         objs = [_make_mem_domain_object(size) for _ in range(200)]
         del objs
 
-    def time_obj_only() -> float:
+    def time_churn(mem_domain_enabled: bool) -> float:
+        # Run the *same* MEM-domain churn in both cases so the only difference is
+        # whether the MEM-domain hooks are installed. This isolates the overhead of
+        # enabling ``mem_domain_enabled`` rather than conflating it with a different
+        # workload.
         t0 = time.perf_counter()
         for _ in range(rounds):
-            with memalloc.MemoryCollector(heap_sample_size=256 * 1024, mem_domain_enabled=False):
-                _allocate_1k()
-        return time.perf_counter() - t0
-
-    def time_mem_on() -> float:
-        t0 = time.perf_counter()
-        for _ in range(rounds):
-            with memalloc.MemoryCollector(heap_sample_size=256 * 1024, mem_domain_enabled=True):
+            with memalloc.MemoryCollector(heap_sample_size=256 * 1024, mem_domain_enabled=mem_domain_enabled):
                 churn_mem_domain()
         return time.perf_counter() - t0
 
-    obj_elapsed = time_obj_only()
-    mem_elapsed = time_mem_on()
+    obj_elapsed = time_churn(mem_domain_enabled=False)
+    mem_elapsed = time_churn(mem_domain_enabled=True)
 
     # Generous ceiling: MEM hooks should not exceed 10× OBJ-only on this micro-bench.
     assert mem_elapsed < 10 * max(obj_elapsed, 1e-9), (

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -1571,3 +1571,186 @@ def test_obj_and_mem_domain_coexist(tmp_path: Path) -> None:
     samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
     assert len(samples) > 0, "OBJ + MEM coexistence test: expected heap-space samples"
     del d, lst
+
+
+def _measure_live_churn_samples(mc: "memalloc.MemoryCollector", output_filename: str, n_iter: int, size: int) -> int:
+    """Churn ``n_iter`` MEM-domain allocations (allocate then immediately free each),
+    flush CPython free lists, then return the number of live heap-space samples still
+    attributed to ``_make_mem_domain_object``.
+
+    Every object is unreferenced and ``gc.collect()`` is called before measuring, so a
+    correct heap tracker must report ~0 live samples for the churned allocations. If
+    freed MEM-domain allocations are not untracked (the ai_gateway staging bug), they
+    linger as "ghost" entries and this count grows roughly linearly with ``n_iter``.
+    """
+    for _ in range(n_iter):
+        obj = _make_mem_domain_object(size)
+        # Force a real, non-trivial free through the MEM free hook rather than letting
+        # CPython reuse the same block: mutate then drop the last reference.
+        if isinstance(obj, bytearray):
+            obj[-1:] = b"\x00"
+        del obj
+    # Flush type-specific free lists so cached-but-dead objects don't masquerade as live.
+    gc.collect()
+    mc.snapshot()
+    ddup.upload()
+    profile = pprof_utils.parse_newest_profile(output_filename)
+    heap_samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
+    return _count_heap_samples_with_function(profile, heap_samples, "_make_mem_domain_object")
+
+
+@pytest.mark.skipif(not PY_312_OR_ABOVE, reason="MEM-domain hooks are only installed on Python 3.12+")
+def test_mem_domain_churn_does_not_inflate_live_heap(tmp_path: Path) -> None:
+    """Regression guard for MEM-domain heap-live-size churn (ai_gateway context).
+
+    Enabling ``mem_domain_enabled=True`` was suspected of inflating heap-live-size
+    without bound via freed-but-not-untracked "ghost" entries. Local investigation
+    (see ``mem_domain_heap_live_size_bug.md``) could NOT reproduce that: the
+    MEM-domain free path untracks symmetrically, so ``track == untrack`` and the
+    cap is never approached. This test is therefore a **regression guard**, not a
+    bug-demonstrating (pre-fix-failing) test -- it passes on HEAD as well as with
+    any tracker changes, and would only start failing if a future change actually
+    broke MEM-domain untracking.
+
+    Invariant: after churning N MEM-domain allocations where every object is freed
+    (+ ``gc.collect()``), the live *sample count* attributed to the churn (an
+    RSS-independent proxy) must stay bounded and must NOT scale with N.
+    """
+    output_filename: str = _setup_profiling_prelude(tmp_path, "test_mem_domain_churn")
+    # 64 KiB sampling interval so 256 KiB churn objects are reliably sampled (~4 samples
+    # each while live); every one must disappear from the live set once freed.
+    mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=64 * 1024, mem_domain_enabled=True)
+    size: int = 256 * 1024
+
+    with mc:
+        # Warm-up churn establishes a baseline for the steady-state live count.
+        live_baseline: int = _measure_live_churn_samples(mc, output_filename, n_iter=200, size=size)
+        # 5x the churn. A correct tracker untracks every freed allocation, so the live
+        # count stays flat; a leaking tracker accumulates ~5x more ghosts.
+        live_heavy: int = _measure_live_churn_samples(mc, output_filename, n_iter=1000, size=size)
+
+    # Absolute bound: all 1000 heavy-churn objects are freed, so almost none may remain
+    # live. Ghost accumulation would leave hundreds/thousands of sampled entries here.
+    assert live_heavy < 50, (
+        f"Live heap-space samples for freed MEM-domain churn did not drop: {live_heavy} "
+        f"entries remain live after freeing 1000 allocations + gc.collect() "
+        f"(baseline after 200 was {live_baseline}). This is the ghost-accumulation bug: "
+        f"freed MEM-domain allocations are not being untracked, so heap-live-size inflates."
+    )
+    # Scaling bound: 5x the work must not produce ~5x the live entries. Allow generous
+    # slack for sampling jitter and objects still resident in free lists.
+    assert live_heavy <= live_baseline + 25, (
+        f"Live heap-space samples scale with churn volume "
+        f"(baseline={live_baseline}, heavy={live_heavy}); freed MEM-domain allocations "
+        f"are accumulating as ghost entries in the heap tracker."
+    )
+
+
+@pytest.mark.skipif(not PY_312_OR_ABOVE, reason="MEM-domain hooks are only installed on Python 3.12+")
+def test_mem_domain_cap_saturation_does_not_inflate_live_heap(tmp_path: Path) -> None:
+    """Regression for the ai_gateway phantom heap-live-size inflation at the cap.
+
+    The heap tracker bounds its live-sample map at ``TRACEBACK_ARRAY_MAX_COUNT``
+    (65,536). Pre-fix, once the map was saturated the sampler dropped candidate
+    samples WITHOUT resetting ``allocated_memory`` -- the byte accumulator that
+    doubles as each sample's weight. While saturated it therefore kept summing the
+    size of *every* allocation, so the first sample taken once a slot freed up
+    inherited that huge accumulated weight. A handful of such post-saturation
+    samples, each weighted with the entire churn volume, made reported
+    ``heap-space`` explode to many GiB/TiB while real memory stayed flat -- the
+    phantom leak. The fix resets the sampling state on a cap-drop, bounding every
+    sample's weight to ~one sampling interval.
+
+    This test saturates the cap with a large bounded working set, then churns hard
+    (rotating the working set + transient allocate/free) so the buggy path is
+    exercised, and asserts reported heap-space stays bounded by the real tracked
+    working set rather than scaling with the churned-allocation volume.
+    """
+    output_filename: str = _setup_profiling_prelude(tmp_path, "test_mem_domain_cap_saturation")
+    sample_interval: int = 256  # small R so each ~1 KiB object is reliably sampled
+    obj_size: int = 1024
+    # >65,536 reliably-sampled live objects guarantees the map saturates.
+    n_held: int = 70_000
+    n_rounds: int = 60
+    pile_per_round: int = 10_000
+    mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=sample_interval, mem_domain_enabled=True)
+    held: list[object] = []
+    with mc:
+        # Phase 1: fill the working set to saturate the live-sample cap.
+        for _ in range(n_held):
+            held.append(_make_mem_domain_object(obj_size))
+        # Phase 2: each round (a) piles up dropped-allocation bytes while the map is
+        # fully saturated -- transient allocations are dropped at the cap and their
+        # frees do NOT open a slot (they were never tracked), so pre-fix the
+        # `allocated_memory` accumulator grows without bound -- then (b) frees one
+        # retained entry to open a single slot and immediately allocates a *retained*
+        # replacement. Pre-fix, that replacement is the first allocation after the
+        # slot opens, so it captures the entire piled-up weight and keeps it live,
+        # inflating heap-space. Post-fix, every cap-drop resets the accumulator, so
+        # the replacement's weight is ~one sampling interval.
+        for r in range(n_rounds):
+            for _ in range(pile_per_round):
+                tmp = _make_mem_domain_object(obj_size * 4)
+                del tmp
+            idx = r % n_held
+            held[idx] = None
+            held[idx] = _make_mem_domain_object(obj_size)
+        mc.snapshot()
+    ddup.upload()
+
+    profile = pprof_utils.parse_newest_profile(output_filename)
+    heap_space_idx = pprof_utils.get_sample_type_index(profile, "heap-space")
+    assert heap_space_idx >= 0, "heap-space sample type not found in profile"
+    total_heap_space: int = sum(s.value[heap_space_idx] for s in profile.sample if s.value[heap_space_idx] > 0)
+
+    # Upper bound on genuinely-live MEM bytes we ever hold. Reported heap-space must
+    # stay within a small multiple of this (post-fix it is ~cap * R, which is below
+    # this bound). Pre-fix it scales with the churn volume and blows past it by
+    # orders of magnitude (GiB+).
+    real_working_set: int = n_held * obj_size
+    assert 0 < total_heap_space < 4 * real_working_set, (
+        f"heap-space {total_heap_space:,} B is not bounded by the real working set "
+        f"({real_working_set:,} B). At the live-sample cap the byte accumulator is "
+        f"leaking into sample weights -> phantom heap-live-size inflation."
+    )
+    del held
+
+
+@pytest.mark.skipif(not PY_312_OR_ABOVE, reason="MEM-domain hooks are only installed on Python 3.12+")
+def test_mem_domain_mem_overhead() -> None:
+    """Sanity-check MEM-domain hook overhead on PyMem_Malloc churn.
+
+    Not a stored perf gate; documents that enabling ``mem_domain_enabled`` on MEM
+    allocations stays within a modest multiple of OBJ-only tracking. See
+    ``mem_domain_ga_checklist.md`` for service-level perf gates.
+    """
+    import time
+
+    size = 4096
+    rounds = 5
+
+    def churn_mem_domain() -> None:
+        objs = [_make_mem_domain_object(size) for _ in range(200)]
+        del objs
+
+    def time_obj_only() -> float:
+        t0 = time.perf_counter()
+        for _ in range(rounds):
+            with memalloc.MemoryCollector(heap_sample_size=256 * 1024, mem_domain_enabled=False):
+                _allocate_1k()
+        return time.perf_counter() - t0
+
+    def time_mem_on() -> float:
+        t0 = time.perf_counter()
+        for _ in range(rounds):
+            with memalloc.MemoryCollector(heap_sample_size=256 * 1024, mem_domain_enabled=True):
+                churn_mem_domain()
+        return time.perf_counter() - t0
+
+    obj_elapsed = time_obj_only()
+    mem_elapsed = time_mem_on()
+
+    # Generous ceiling: MEM hooks should not exceed 10× OBJ-only on this micro-bench.
+    assert mem_elapsed < 10 * max(obj_elapsed, 1e-9), (
+        f"MEM-domain churn took {mem_elapsed:.4f}s vs OBJ-only {obj_elapsed:.4f}s (>{10 * obj_elapsed:.4f}s ceiling)"
+    )

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -1647,47 +1647,41 @@ def test_mem_domain_churn_does_not_inflate_live_heap(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(not PY_312_OR_ABOVE, reason="MEM-domain hooks are only installed on Python 3.12+")
-def test_mem_domain_cap_saturation_does_not_inflate_live_heap(tmp_path: Path) -> None:
+def test_mem_domain_cap_saturation_does_not_inflate_live_heap(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Regression for the ai_gateway phantom heap-live-size inflation at the cap.
 
-    The heap tracker bounds its live-sample map at ``TRACEBACK_ARRAY_MAX_COUNT``
-    (65,536). Pre-fix, once the map was saturated the sampler dropped candidate
-    samples WITHOUT resetting ``allocated_memory`` -- the byte accumulator that
-    doubles as each sample's weight. While saturated it therefore kept summing the
-    size of *every* allocation, so the first sample taken once a slot freed up
-    inherited that huge accumulated weight. A handful of such post-saturation
-    samples, each weighted with the entire churn volume, made reported
-    ``heap-space`` explode to many GiB/TiB while real memory stayed flat -- the
-    phantom leak. The fix resets the sampling state on a cap-drop, bounding every
-    sample's weight to ~one sampling interval.
+    ``allocated_memory`` is the running byte accumulator that also weights the next
+    sample. Pre-fix, once the live-sample map saturated the sampler dropped
+    candidates WITHOUT resetting it, so it kept summing every dropped allocation; the
+    first sample taken once a slot freed inherited that whole weight, exploding
+    ``heap-space`` while RSS stayed flat. The fix resets on a cap-drop.
 
-    This test saturates the cap with a large bounded working set, then churns hard
-    (rotating the working set + transient allocate/free) so the buggy path is
-    exercised, and asserts reported heap-space stays bounded by the real tracked
-    working set rather than scaling with the churned-allocation volume.
+    To saturate cheaply we shrink the cap via ``_DD_MEMALLOC_HEAP_MAX_SAMPLE_COUNT``
+    instead of allocating 65,536+ objects, then churn to run the drop-at-cap path and
+    assert ``heap-space`` stays bounded by the real working set (not the churn
+    volume). Fails pre-fix, passes post-fix.
     """
+    # Set before the collector starts; the tracker reads the cap once at construction.
+    max_sample_count: int = 512
+    monkeypatch.setenv("_DD_MEMALLOC_HEAP_MAX_SAMPLE_COUNT", str(max_sample_count))
+
     output_filename: str = _setup_profiling_prelude(tmp_path, "test_mem_domain_cap_saturation")
     sample_interval: int = 256  # small R so each ~1 KiB object is reliably sampled
     obj_size: int = 1024
-    # >65,536 reliably-sampled live objects guarantees the map saturates.
-    n_held: int = 70_000
-    n_rounds: int = 60
-    pile_per_round: int = 10_000
+    # More reliably-sampled objects than the (small) cap, so the map saturates.
+    n_held: int = 1_500
+    n_rounds: int = 20
+    pile_per_round: int = 2_000
     mc: memalloc.MemoryCollector = memalloc.MemoryCollector(heap_sample_size=sample_interval, mem_domain_enabled=True)
     held: list[object] = []
     with mc:
         # Phase 1: fill the working set to saturate the live-sample cap.
         for _ in range(n_held):
             held.append(_make_mem_domain_object(obj_size))
-        # Phase 2: each round (a) piles up dropped-allocation bytes while the map is
-        # fully saturated -- transient allocations are dropped at the cap and their
-        # frees do NOT open a slot (they were never tracked), so pre-fix the
-        # `allocated_memory` accumulator grows without bound -- then (b) frees one
-        # retained entry to open a single slot and immediately allocates a *retained*
-        # replacement. Pre-fix, that replacement is the first allocation after the
-        # slot opens, so it captures the entire piled-up weight and keeps it live,
-        # inflating heap-space. Post-fix, every cap-drop resets the accumulator, so
-        # the replacement's weight is ~one sampling interval.
+        # Phase 2: each round piles dropped-allocation bytes while saturated (transient
+        # allocs are dropped at the cap; their frees open no slot), then frees one
+        # retained entry and replaces it. Pre-fix the replacement captures the whole
+        # piled-up weight; post-fix each cap-drop resets the accumulator.
         for r in range(n_rounds):
             for _ in range(pile_per_round):
                 tmp = _make_mem_domain_object(obj_size * 4)
@@ -1703,10 +1697,8 @@ def test_mem_domain_cap_saturation_does_not_inflate_live_heap(tmp_path: Path) ->
     assert heap_space_idx >= 0, "heap-space sample type not found in profile"
     total_heap_space: int = sum(s.value[heap_space_idx] for s in profile.sample if s.value[heap_space_idx] > 0)
 
-    # Upper bound on genuinely-live MEM bytes we ever hold. Reported heap-space must
-    # stay within a small multiple of this (post-fix it is ~cap * R, which is below
-    # this bound). Pre-fix it scales with the churn volume and blows past it by
-    # orders of magnitude (GiB+).
+    # Post-fix heap-space is ~cap * R, well under this bound; pre-fix it scales with
+    # the churn volume (hundreds of MiB) and blows past it by orders of magnitude.
     real_working_set: int = n_held * obj_size
     assert 0 < total_heap_space < 4 * real_working_set, (
         f"heap-space {total_heap_space:,} B is not bounded by the real working set "


### PR DESCRIPTION
## Description

When the heap profiler's live-sample map exceeds its capacity (`TRACEBACK_ARRAY_MAX_COUNT` = 65,536), the `heap-live-size` metric can explode to many GiB/TiB > real container RSS, which is obviously wrong.

**Root cause.** 
* `allocated_memory` is a running byte accumulator that doubles as the *weight* assigned to the next sample, and is reset only when a sample is actually taken. 
* At capacity, `should_sample_no_cpython` dropped the candidate sample and returned `false` **without resetting** `allocated_memory`
* ==> so while saturated it kept summing the size of *every* dropped allocation AND the first sample taken once a slot freed up inherited that entire accumulated weight. 

**Example**
* [AB-experiment](https://ddstaging.datadoghq.com/profiling/comparison?query=service%3Arapid-td-ab-codecache-ai-b%20version%3Aab-b-664eb7bc39e5%20env%3Astaging&compare_end_A=1785167332180&compare_query_A=service%3Arapid-td-ab-codecache-ai-a%20version%3Aab-a-3cd14d5a6f52%20env%3Astaging&compare_query_B=service%3Arapid-td-ab-codecache-ai-b%20version%3Aab-b-664eb7bc39e5%20env%3Astaging&compare_start_A=1785156532180&compareValuesMode=relative&comparisonViz=table&group_by=line&my_code=disabled&profile_type=ebpf-cpu-time&from_ts=1785156532180&to_ts=1785167332180&live=false)

<img width="647" height="308" alt="Screenshot 2026-07-27 at 12 34 14 PM" src="https://github.com/user-attachments/assets/546135dc-091b-4dcf-90f0-6a4147a2d3e5" />

**Fix**
* Call `reset_sampling_state_no_cpython()` on a cap-drop, so bytes accumulated while saturated aren't carried into the next sample's weight. 

## Testing

* New unit test `test_mem_domain_cap_saturation_does_not_inflate_live_heap` shrinks the cap to 512 via `_DD_MEMALLOC_HEAP_MAX_SAMPLE_COUNT` and quickly saturates it

| Build | Result | reported heap-space |
|---|---|---|
| cap-reset removed (bug) | ❌ fail | 110,326,499 B (~105 MiB) vs 1.5 MiB real working set (~72×) |
| cap-reset present (fix) | ✅ pass | bounded (< 4× working set) |