### PR TITLE
feat(llmobs): real tool spans for the OpenAI Realtime integration

### DIFF
--- a/ddtrace/contrib/internal/openai/_realtime.py
+++ b/ddtrace/contrib/internal/openai/_realtime.py
@@ -35,6 +35,7 @@ Known limitations (deferred by design):
 """
 
 import importlib
+import time
 from types import ModuleType
 from types import SimpleNamespace
 from typing import Any
@@ -162,6 +163,22 @@ class _ResponseTurn:
         self.tool_results: list[ToolResult] = []
 
 
+class _PendingToolSpan:
+    """A tool-kind child span opened for a single function/MCP call, awaiting its result.
+
+    The span is parented under the emitting turn's span and started at the wall-clock moment the
+    call was first observed, so its duration reflects real tool-execution latency. ``arguments`` is
+    the parsed call input (backfilled from ``function_call_arguments.done`` or the item on
+    ``response.done`` when the earlier events didn't carry it).
+    """
+
+    def __init__(self, span: Any, turn: "_ResponseTurn", name: str) -> None:
+        self.span = span
+        self.turn = turn
+        self.name = name
+        self.arguments: Any = None
+
+
 class _RealtimeState:
     """Drives per-turn LLMObs spans (grouped by session_id) off the realtime event stream."""
 
@@ -185,6 +202,9 @@ class _RealtimeState:
         self._input_transcripts: dict[str, str] = {}
         # call_id -> function name, so a later function_call_output can be labeled with its tool name.
         self._tool_call_names: dict[str, str] = {}
+        # call_id -> open tool-kind child span, from when the call is first observed until its result
+        # lands (function_call_output for client calls, inline output for server MCP calls).
+        self._pending_tool_spans: dict[str, _PendingToolSpan] = {}
         # Turns whose response is done but whose input transcription hasn't arrived yet.
         self._awaiting: list[Any] = []
         self._closed = False
@@ -260,6 +280,21 @@ class _RealtimeState:
         turn = self._responses.get(_get_attr(event, "response_id", None))
         if turn is None:
             return
+        # Tool-call lifecycle: open a tool span when the call is first seen, capture its arguments.
+        if event_type == "response.output_item.added":
+            self._maybe_start_tool_span(turn, _get_attr(event, "item", None))
+            return
+        if event_type == "response.function_call_arguments.delta":
+            # First delta is a fallback start signal when output_item.added wasn't observed.
+            self._ensure_tool_span(turn, str(_get_attr(event, "call_id", "") or ""), "")
+            return
+        if event_type == "response.function_call_arguments.done":
+            call_id = str(_get_attr(event, "call_id", "") or "")
+            pending = self._ensure_tool_span(turn, call_id, "")
+            args = _get_attr(event, "arguments", None)
+            if pending is not None and args is not None:
+                pending.arguments = safe_load_json(str(args))
+            return
         if normalized == "response.audio.delta":
             delta = _get_attr(event, "delta", None)
             if delta:
@@ -272,6 +307,80 @@ class _RealtimeState:
             turn.text += str(_get_attr(event, "delta", "") or "")
         elif normalized == "response.text.done":
             turn.text = str(_get_attr(event, "text", turn.text) or "")
+
+    # -- tool span lifecycle ------------------------------------------------
+
+    def _maybe_start_tool_span(self, turn: "_ResponseTurn", item: Any) -> None:
+        """Open a tool span for a function_call/mcp_call output item as soon as it's observed."""
+        if item is None:
+            return
+        item_type = _get_attr(item, "type", None)
+        if item_type not in ("function_call", "mcp_call"):
+            return
+        call_id = str(_get_attr(item, "call_id", "") or _get_attr(item, "id", "") or "")
+        name = str(_get_attr(item, "name", "") or "")
+        pending = self._ensure_tool_span(turn, call_id, name)
+        if pending is not None and pending.arguments is None:
+            args = _get_attr(item, "arguments", None)
+            if args:
+                pending.arguments = safe_load_json(str(args))
+
+    def _ensure_tool_span(
+        self, turn: "_ResponseTurn", call_id: str, name: str, start_ns: Optional[int] = None
+    ) -> Optional["_PendingToolSpan"]:
+        """Return the open tool span for ``call_id``, creating it (parented under the turn) if new.
+
+        The span's start time is the wall-clock moment the call was first observed so its duration
+        measures real tool-execution latency; a lazily-created span (its start event was never seen)
+        falls back to the turn span's start.
+        """
+        if not call_id or turn is None or turn.span is None:
+            return None
+        pending = self._pending_tool_spans.get(call_id)
+        if pending is not None:
+            if name and not pending.name:
+                pending.name = name
+            return pending
+        try:
+            # Parent under the emitting turn's span (APM child_of) and back-date to when the call was
+            # observed. The turn span may finish (at response.done) before this tool span does — that
+            # is expected; the child simply finishes afterward.
+            tool_span = self._integration.trace(
+                "createRealtimeToolCall",
+                submit_to_llmobs=True,
+                instance=SimpleNamespace(_client=self._client),
+                activate=False,
+                parent_context=turn.span,
+            )
+            tool_span.start_ns = int(start_ns if start_ns is not None else time.time_ns())
+        except Exception:
+            log.debug("error starting realtime tool span", exc_info=True)
+            return None
+        pending = _PendingToolSpan(tool_span, turn, name)
+        self._pending_tool_spans[call_id] = pending
+        return pending
+
+    def _finish_tool_span(self, call_id: str, result: Any, error: Any = None) -> None:
+        """Finalize and finish the tool span for ``call_id`` with its result/error."""
+        pending = self._pending_tool_spans.pop(call_id, None)
+        if pending is None or pending.span is None:
+            return
+        try:
+            output = result if result is not None else error
+            self._integration._llmobs_set_tags_from_realtime_tool(
+                pending.span,
+                pending.turn.span,
+                name=pending.name,
+                call_id=call_id,
+                arguments=pending.arguments,
+                result=output,
+                session_id=self._session_id,
+                error=result is None and error is not None,
+            )
+        except Exception:
+            log.debug("error tagging realtime tool span", exc_info=True)
+        finally:
+            pending.span.finish()
 
     # -- span lifecycle -----------------------------------------------------
 
@@ -306,12 +415,30 @@ class _RealtimeState:
         turn.model = _get_attr(response, "model", None) or turn.model or self._model
         turn.status = _get_attr(response, "status", None)
         turn.tool_calls, turn.tool_results = _extract_response_tools(response)
-        # Remember each function call's name so the function_call_output the app returns later can be
-        # labeled with it (the output event itself only carries the call_id).
+        # Backfill each call's name/arguments onto its open tool span (earlier events may not have
+        # carried them), then handle the two result paths. Client function_call spans stay open until
+        # the app returns a function_call_output; server MCP calls carry their result inline here.
+        mcp_results = {tr.get("tool_id"): tr.get("result") for tr in turn.tool_results}
         for tool_call in turn.tool_calls:
             call_id = tool_call.get("tool_id")
-            if call_id and tool_call.get("type") == "function":
-                self._tool_call_names[call_id] = tool_call.get("name", "")
+            if not call_id:
+                continue
+            name = tool_call.get("name", "")
+            call_type = tool_call.get("type")
+            if call_type == "mcp_call":
+                # Ensure a span exists even if output_item.added was never seen, then finish inline.
+                self._ensure_tool_span(turn, call_id, name, start_ns=turn.span.start_ns if turn.span else None)
+            pending = self._pending_tool_spans.get(call_id)
+            if pending is not None:
+                if not pending.name and name:
+                    pending.name = name
+                if pending.arguments is None:
+                    pending.arguments = tool_call.get("arguments")
+            if call_type == "function":
+                # Label the eventual function_call_output with this call's tool name.
+                self._tool_call_names[call_id] = name
+            elif call_type == "mcp_call":
+                self._finish_tool_span(call_id, mcp_results.get(call_id))
         if not turn.input.transcript and turn.input.item_id is not None:
             turn.input.transcript = self._input_transcripts.get(turn.input.item_id, "")
         # Hold the span open for a late input transcription ONLY when transcription is actually
@@ -338,9 +465,14 @@ class _RealtimeState:
             if not turn.input.transcript and turn.input.item_id is not None:
                 turn.input.transcript = self._input_transcripts.get(turn.input.item_id, "")
             self._finalize_turn(turn)
+        # Finish any tool spans whose result never arrived (client call still in flight at close) so
+        # none leak — submitted with whatever arguments we captured and an empty result.
+        for call_id in list(self._pending_tool_spans):
+            self._finish_tool_span(call_id, "")
         self._responses.clear()
         self._input_transcripts.clear()
         self._tool_call_names.clear()
+        self._pending_tool_spans.clear()
 
     # -- tagging helpers ----------------------------------------------------
 
@@ -498,6 +630,9 @@ class _RealtimeState:
             if name:
                 result["name"] = name
             self._pending_input.tool_results.append(result)
+            # This is the real tool-execution result for the open function_call span: finish it now,
+            # giving the child span a duration that spans the actual tool call.
+            self._finish_tool_span(call_id, str(output) if output is not None else "")
             return
         # Only user items contribute to the input turn; skip assistant/system items.
         role = _get_attr(item, "role", None)

--- a/ddtrace/contrib/internal/openai/_realtime.py
+++ b/ddtrace/contrib/internal/openai/_realtime.py
@@ -417,8 +417,13 @@ class _RealtimeState:
         turn.tool_calls, turn.tool_results = _extract_response_tools(response)
         # Backfill each call's name/arguments onto its open tool span (earlier events may not have
         # carried them), then handle the two result paths. Client function_call spans stay open until
-        # the app returns a function_call_output; server MCP calls carry their result inline here.
-        mcp_results = {tr.get("tool_id"): tr.get("result") for tr in turn.tool_results}
+        # the app returns a function_call_output; server MCP calls carry their result (or error)
+        # inline here. Keep MCP output and error apart so a failed call marks its span errored.
+        mcp_io = {
+            str(_get_attr(item, "id", "") or ""): (_get_attr(item, "output", None), _get_attr(item, "error", None))
+            for item in (_get_attr(response, "output", None) or [])
+            if _get_attr(item, "type", "") == "mcp_call"
+        }
         for tool_call in turn.tool_calls:
             call_id = tool_call.get("tool_id")
             if not call_id:
@@ -438,7 +443,12 @@ class _RealtimeState:
                 # Label the eventual function_call_output with this call's tool name.
                 self._tool_call_names[call_id] = name
             elif call_type == "mcp_call":
-                self._finish_tool_span(call_id, mcp_results.get(call_id))
+                output, mcp_error = mcp_io.get(call_id, (None, None))
+                self._finish_tool_span(
+                    call_id,
+                    str(output) if output is not None else None,
+                    error=str(mcp_error) if mcp_error is not None else None,
+                )
         if not turn.input.transcript and turn.input.item_id is not None:
             turn.input.transcript = self._input_transcripts.get(turn.input.item_id, "")
         # Hold the span open for a late input transcription ONLY when transcription is actually

--- a/ddtrace/contrib/internal/openai/_realtime.py
+++ b/ddtrace/contrib/internal/openai/_realtime.py
@@ -35,6 +35,7 @@ Known limitations (deferred by design):
 """
 
 import importlib
+import threading
 import time
 from types import ModuleType
 from types import SimpleNamespace
@@ -186,6 +187,11 @@ class _RealtimeState:
         self._integration = integration
         self._client = client
         self._model = model
+        # All state below is shared between the two entry points, which run on different threads in
+        # the common sync-connection pattern (recv() looping on a background thread while send() runs
+        # on the main thread). Every mutation funnels through on_client_event / on_server_event /
+        # finish_session, so a single lock held across each of those serializes all access.
+        self._lock = threading.Lock()
         # Per-connection id used to group every turn span into one conversation in the UI.
         self._session_id = uuid.uuid4().hex
         self._session_config: dict[str, Any] = {}
@@ -213,65 +219,67 @@ class _RealtimeState:
 
     def on_client_event(self, event: Any) -> None:
         try:
-            event_type = _event_type(event)
-            if event_type == "session.update":
-                self._update_session_config(_get_attr(event, "session", None))
-            elif event_type == "input_audio_buffer.append":
-                audio = _get_attr(event, "audio", None)
-                if audio:
-                    self._pending_input.audio.append(audio)
-            elif event_type == "input_audio_buffer.clear":
-                # Discarded input audio must not be attributed to the next response.
-                self._pending_input.audio.clear()
-            elif event_type == "conversation.item.create":
-                self._absorb_input_item(_get_attr(event, "item", None))
+            with self._lock:
+                event_type = _event_type(event)
+                if event_type == "session.update":
+                    self._update_session_config(_get_attr(event, "session", None))
+                elif event_type == "input_audio_buffer.append":
+                    audio = _get_attr(event, "audio", None)
+                    if audio:
+                        self._pending_input.audio.append(audio)
+                elif event_type == "input_audio_buffer.clear":
+                    # Discarded input audio must not be attributed to the next response.
+                    self._pending_input.audio.clear()
+                elif event_type == "conversation.item.create":
+                    self._absorb_input_item(_get_attr(event, "item", None))
         except Exception:
             log.debug("error handling realtime client event", exc_info=True)
 
     def on_server_event(self, event: Any) -> None:
         try:
-            event_type = _event_type(event)
-            if event_type in ("session.created", "session.updated"):
-                self._update_session_config(_get_attr(event, "session", None))
-                return
-            if event_type == "input_audio_buffer.committed":
-                self._pending_input.item_id = _get_attr(event, "item_id", None)
-                return
-            if event_type == "input_audio_buffer.cleared":
-                self._pending_input.audio.clear()
-                return
-            if event_type == "conversation.item.input_audio_transcription.completed":
-                item_id = _get_attr(event, "item_id", None)
-                transcript = str(_get_attr(event, "transcript", "") or "")
-                if item_id is not None:
-                    self._input_transcripts[item_id] = transcript
-                if self._pending_input.item_id == item_id and not self._pending_input.transcript:
-                    self._pending_input.transcript = transcript
-                # A finished turn may have been waiting on exactly this transcript — finalize it now.
-                for turn in [t for t in self._awaiting if t.input.item_id == item_id]:
-                    turn.input.transcript = turn.input.transcript or transcript
-                    self._awaiting.remove(turn)
-                    self._finalize_turn(turn)
-                return
-            if event_type == "conversation.item.input_audio_transcription.failed":
-                # Transcription won't arrive for this item; finalize any turn waiting on it so its
-                # span doesn't hang (would otherwise wait until the next turn or close).
-                item_id = _get_attr(event, "item_id", None)
-                for turn in [t for t in self._awaiting if t.input.item_id == item_id]:
-                    self._awaiting.remove(turn)
-                    self._finalize_turn(turn)
-                return
-            if event_type == "response.created":
-                response = _get_attr(event, "response", None)
-                self._start_response(_get_attr(response, "id", None) or _get_attr(event, "response_id", None))
-                return
-            if event_type == "response.done":
-                response = _get_attr(event, "response", None)
-                self._finish_response(
-                    _get_attr(response, "id", None) or _get_attr(event, "response_id", None), response
-                )
-                return
-            self._handle_response_delta(event, event_type)
+            with self._lock:
+                event_type = _event_type(event)
+                if event_type in ("session.created", "session.updated"):
+                    self._update_session_config(_get_attr(event, "session", None))
+                    return
+                if event_type == "input_audio_buffer.committed":
+                    self._pending_input.item_id = _get_attr(event, "item_id", None)
+                    return
+                if event_type == "input_audio_buffer.cleared":
+                    self._pending_input.audio.clear()
+                    return
+                if event_type == "conversation.item.input_audio_transcription.completed":
+                    item_id = _get_attr(event, "item_id", None)
+                    transcript = str(_get_attr(event, "transcript", "") or "")
+                    if item_id is not None:
+                        self._input_transcripts[item_id] = transcript
+                    if self._pending_input.item_id == item_id and not self._pending_input.transcript:
+                        self._pending_input.transcript = transcript
+                    # A finished turn may have been waiting on exactly this transcript — finalize now.
+                    for turn in [t for t in self._awaiting if t.input.item_id == item_id]:
+                        turn.input.transcript = turn.input.transcript or transcript
+                        self._awaiting.remove(turn)
+                        self._finalize_turn(turn)
+                    return
+                if event_type == "conversation.item.input_audio_transcription.failed":
+                    # Transcription won't arrive for this item; finalize any turn waiting on it so its
+                    # span doesn't hang (would otherwise wait until the next turn or close).
+                    item_id = _get_attr(event, "item_id", None)
+                    for turn in [t for t in self._awaiting if t.input.item_id == item_id]:
+                        self._awaiting.remove(turn)
+                        self._finalize_turn(turn)
+                    return
+                if event_type == "response.created":
+                    response = _get_attr(event, "response", None)
+                    self._start_response(_get_attr(response, "id", None) or _get_attr(event, "response_id", None))
+                    return
+                if event_type == "response.done":
+                    response = _get_attr(event, "response", None)
+                    self._finish_response(
+                        _get_attr(response, "id", None) or _get_attr(event, "response_id", None), response
+                    )
+                    return
+                self._handle_response_delta(event, event_type)
         except Exception:
             log.debug("error handling realtime server event", exc_info=True)
 
@@ -468,24 +476,25 @@ class _RealtimeState:
         self._awaiting = []
 
     def finish_session(self) -> None:
-        if self._closed:
-            return
-        self._closed = True
-        # Finalize anything still open: turns awaiting a transcription, plus in-flight turns that
-        # never saw ``response.done`` (closed mid-turn). Whatever partial data we have is submitted.
-        self._flush_awaiting()
-        for turn in list(self._responses.values()):
-            if not turn.input.transcript and turn.input.item_id is not None:
-                turn.input.transcript = self._input_transcripts.get(turn.input.item_id, "")
-            self._finalize_turn(turn)
-        # Finish any tool spans whose result never arrived (client call still in flight at close) so
-        # none leak — submitted with whatever arguments we captured and an empty result.
-        for call_id in list(self._pending_tool_spans):
-            self._finish_tool_span(call_id, "")
-        self._responses.clear()
-        self._input_transcripts.clear()
-        self._tool_call_names.clear()
-        self._pending_tool_spans.clear()
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            # Finalize anything still open: turns awaiting a transcription, plus in-flight turns that
+            # never saw ``response.done`` (closed mid-turn). Whatever partial data we have is submitted.
+            self._flush_awaiting()
+            for turn in list(self._responses.values()):
+                if not turn.input.transcript and turn.input.item_id is not None:
+                    turn.input.transcript = self._input_transcripts.get(turn.input.item_id, "")
+                self._finalize_turn(turn)
+            # Finish any tool spans whose result never arrived (client call still in flight at close)
+            # so none leak — submitted with whatever arguments we captured and an empty result.
+            for call_id in list(self._pending_tool_spans):
+                self._finish_tool_span(call_id, "")
+            self._responses.clear()
+            self._input_transcripts.clear()
+            self._tool_call_names.clear()
+            self._pending_tool_spans.clear()
 
     # -- tagging helpers ----------------------------------------------------
 

--- a/ddtrace/contrib/internal/openai/_realtime.py
+++ b/ddtrace/contrib/internal/openai/_realtime.py
@@ -430,9 +430,12 @@ class _RealtimeState:
                 continue
             name = tool_call.get("name", "")
             call_type = tool_call.get("type")
-            if call_type == "mcp_call":
-                # Ensure a span exists even if output_item.added was never seen, then finish inline.
-                self._ensure_tool_span(turn, call_id, name, start_ns=turn.span.start_ns if turn.span else None)
+            # Ensure a span exists even if the streaming start events (output_item.added /
+            # function_call_arguments.*) were never observed — some transports deliver only
+            # response.done. A newly-created span back-dates to the turn's start; an existing one
+            # (opened during streaming) keeps its earlier start. The MCP span is finished inline
+            # below; a function span stays open until its function_call_output.
+            self._ensure_tool_span(turn, call_id, name, start_ns=turn.span.start_ns if turn.span else None)
             pending = self._pending_tool_spans.get(call_id)
             if pending is not None:
                 if not pending.name and name:

--- a/ddtrace/llmobs/_integrations/openai.py
+++ b/ddtrace/llmobs/_integrations/openai.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs._constants import CACHE_READ_INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import CACHE_WRITE_INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import INPUT_TOKENS_METRIC_KEY
@@ -21,6 +22,7 @@ from ddtrace.llmobs._integrations.utils import openai_set_meta_tags_from_complet
 from ddtrace.llmobs._integrations.utils import openai_set_meta_tags_from_response
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _get_attr
+from ddtrace.llmobs._utils import get_llmobs_trace_id
 from ddtrace.llmobs._utils import safe_json
 from ddtrace.llmobs.types import Document
 from ddtrace.trace import Span
@@ -210,6 +212,42 @@ class OpenAIIntegration(BaseLLMIntegration):
             self._apply_shadow_metrics(span, metrics, "llm", model_name=model_name, model_provider=model_provider)
         except Exception:
             log.debug("Error applying shadow metrics for realtime span %s", span, exc_info=True)
+
+    def _llmobs_set_tags_from_realtime_tool(
+        self,
+        span: Span,
+        parent_span: Optional[Span],
+        name: str,
+        call_id: str,
+        arguments: Any,
+        result: Any,
+        session_id: Optional[str] = None,
+        error: bool = False,
+    ) -> None:
+        """Tag a tool-kind child span for a single Realtime function/MCP call.
+
+        The span is nested under its emitting turn's span via an explicit LLMObs ``parent_id`` /
+        ``trace_id`` (stamped here rather than relying on the active context, which has already moved
+        on by the time a client tool result lands). Input is the call arguments, output the result.
+        """
+        if error:
+            span.error = 1
+        parent_id = str(parent_span.span_id) if parent_span is not None else None
+        trace_id = None
+        if parent_span is not None:
+            trace_id = get_llmobs_trace_id(parent_span) or format_trace_id(parent_span.trace_id)
+        _annotate_llmobs_span_data(
+            span,
+            name=name or "tool",
+            kind="tool",
+            parent_id=parent_id,
+            trace_id=trace_id,
+            session_id=session_id,
+            # Pass raw values; _annotate_llmobs_span_data serializes them (avoid double-encoding).
+            input_value=arguments if arguments is not None else "",
+            output_value=result if result is not None else "",
+            metadata={"tool_id": call_id} if call_id else None,
+        )
 
     def _set_apm_shadow_tags(self, span, args, kwargs, response=None, operation=""):
         span_kind = (

--- a/releasenotes/notes/llmobs-realtime-tool-spans-afa1fb6011dbb8af.yaml
+++ b/releasenotes/notes/llmobs-realtime-tool-spans-afa1fb6011dbb8af.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    LLM Observability: The OpenAI Realtime API integration now emits a dedicated ``tool`` span for
+    each function or MCP call the model makes, nested under its turn span and recording the call's
+    arguments and result.

--- a/tests/contrib/openai/test_openai_realtime.py
+++ b/tests/contrib/openai/test_openai_realtime.py
@@ -362,7 +362,8 @@ def test_realtime_state_mcp_call_captured():
 def test_realtime_state_function_call_emits_tool_span():
     """A client function_call emits a real tool-kind child span, opened when the call is observed
     (output_item.added) and finished when the app returns the result (function_call_output), parented
-    under the emitting turn's span with a duration spanning the real tool execution."""
+    under the emitting turn's span with a duration spanning the real tool execution.
+    """
     integration, state = _new_state()
     state.on_server_event(_session_created(transcription=False))
     # Turn 1: the model emits a function call. The span opens on output_item.added and its arguments
@@ -389,7 +390,9 @@ def test_realtime_state_function_call_emits_tool_span():
             response=_ns(
                 id="r1",
                 status="completed",
-                output=[_ns(type="function_call", name="get_weather", arguments='{"city": "Denver"}', call_id="call_1")],
+                output=[
+                    _ns(type="function_call", name="get_weather", arguments='{"city": "Denver"}', call_id="call_1")
+                ],
             ),
         )
     )
@@ -421,7 +424,8 @@ def test_realtime_state_function_call_emits_tool_span():
 
 def test_realtime_state_mcp_call_emits_tool_span():
     """A server MCP call emits a tool span opened on output_item.added and finished inline at
-    response.done with the server-side result (no app round-trip)."""
+    response.done with the server-side result (no app round-trip).
+    """
     integration, state = _new_state()
     state.on_server_event(_session_created(transcription=False))
     state.on_server_event(_ns(type="response.created", response=_ns(id="r1")))
@@ -439,7 +443,14 @@ def test_realtime_state_mcp_call_emits_tool_span():
                 id="r1",
                 status="completed",
                 output=[
-                    _ns(type="mcp_call", id="mcp_1", name="search", arguments='{"q": "x"}', output="result text", error=None)
+                    _ns(
+                        type="mcp_call",
+                        id="mcp_1",
+                        name="search",
+                        arguments='{"q": "x"}',
+                        output="result text",
+                        error=None,
+                    )
                 ],
             ),
         )
@@ -453,6 +464,40 @@ def test_realtime_state_mcp_call_emits_tool_span():
     assert tool["parent_span"] is integration.responses[0]["span"]
     assert tool["span"].finished is True
     assert tool["span"].start_ns is not None and tool["span"].start_ns <= tool["span"].finish_ns
+    assert not state._pending_tool_spans
+
+
+def test_realtime_state_mcp_call_error_marks_span_error():
+    """A server MCP call that fails (error set, no output) marks its tool span errored, and carries
+    the error text as the span's output rather than being reported as a successful call.
+    """
+    integration, state = _new_state()
+    state.on_server_event(_session_created(transcription=False))
+    state.on_server_event(_ns(type="response.created", response=_ns(id="r1")))
+    state.on_server_event(
+        _ns(
+            type="response.output_item.added",
+            response_id="r1",
+            item=_ns(type="mcp_call", id="mcp_1", name="search"),
+        )
+    )
+    state.on_server_event(
+        _ns(
+            type="response.done",
+            response=_ns(
+                id="r1",
+                status="completed",
+                output=[
+                    _ns(type="mcp_call", id="mcp_1", name="search", arguments='{"q": "x"}', output=None, error="boom")
+                ],
+            ),
+        )
+    )
+    assert len(integration.tools) == 1
+    tool = integration.tools[0]
+    assert tool["error"] is True
+    assert tool["result"] == "boom"
+    assert tool["span"].finished is True
     assert not state._pending_tool_spans
 
 
@@ -511,7 +556,9 @@ def test_realtime_state_tool_span_started_on_arguments_delta():
             response=_ns(
                 id="r1",
                 status="completed",
-                output=[_ns(type="function_call", name="get_weather", arguments='{"city": "Denver"}', call_id="call_1")],
+                output=[
+                    _ns(type="function_call", name="get_weather", arguments='{"city": "Denver"}', call_id="call_1")
+                ],
             ),
         )
     )
@@ -1066,7 +1113,8 @@ def test_realtime_integration_tool_call(openai, openai_llmobs, test_spans):
 @pytest.mark.skipif(RealtimeConnection is None, reason="openai realtime API not available")
 def test_realtime_integration_mcp_tool_span(openai, openai_llmobs, test_spans):
     """A server MCP call emits a real tool-kind child span, nested under the turn span (real
-    integration): opened on output_item.added, finished inline at response.done with its result."""
+    integration): opened on output_item.added, finished inline at response.done with its result.
+    """
     messages = [
         json.dumps(
             {"type": "session.created", "event_id": "e0", "session": {"type": "realtime", "model": "gpt-realtime"}}

--- a/tests/contrib/openai/test_openai_realtime.py
+++ b/tests/contrib/openai/test_openai_realtime.py
@@ -7,6 +7,7 @@ patched ``RealtimeConnection`` backed by a fake websocket (integration test).
 
 import base64
 import json
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -47,9 +48,16 @@ class _FakeSpan:
         self.resource = resource
         self.error = 0
         self.finished = False
+        # Set by the state machine for tool spans (back-dated to when the call was observed); a real
+        # ddtrace Span exposes the same attribute. finish() stamps a wall-clock finish for ordering.
+        self.start_ns = None
+        self.finish_ns = None
+        self.span_id = id(self)
+        self.trace_id = 1
 
     def finish(self):
         self.finished = True
+        self.finish_ns = time.time_ns()
 
 
 class _RecordingIntegration:
@@ -57,6 +65,7 @@ class _RecordingIntegration:
 
     def __init__(self):
         self.responses = []
+        self.tools = []
 
     def trace(self, operation_id, **kwargs):
         return _FakeSpan(operation_id)
@@ -73,6 +82,22 @@ class _RecordingIntegration:
                 "metadata": metadata,
                 "metrics": metrics,
                 "session_id": session_id,
+            }
+        )
+
+    def _llmobs_set_tags_from_realtime_tool(
+        self, span, parent_span, name, call_id, arguments, result, session_id=None, error=False
+    ):
+        self.tools.append(
+            {
+                "span": span,
+                "parent_span": parent_span,
+                "name": name,
+                "call_id": call_id,
+                "arguments": arguments,
+                "result": result,
+                "session_id": session_id,
+                "error": error,
             }
         )
 
@@ -332,6 +357,175 @@ def test_realtime_state_mcp_call_captured():
     assert out["tool_results"] == [
         {"name": "search", "result": "result text", "tool_id": "mcp_1", "type": "mcp_tool_result"}
     ]
+
+
+def test_realtime_state_function_call_emits_tool_span():
+    """A client function_call emits a real tool-kind child span, opened when the call is observed
+    (output_item.added) and finished when the app returns the result (function_call_output), parented
+    under the emitting turn's span with a duration spanning the real tool execution."""
+    integration, state = _new_state()
+    state.on_server_event(_session_created(transcription=False))
+    # Turn 1: the model emits a function call. The span opens on output_item.added and its arguments
+    # are captured from function_call_arguments.done; the turn finishes at response.done.
+    state.on_server_event(_ns(type="response.created", response=_ns(id="r1")))
+    state.on_server_event(
+        _ns(
+            type="response.output_item.added",
+            response_id="r1",
+            item=_ns(type="function_call", name="get_weather", call_id="call_1"),
+        )
+    )
+    state.on_server_event(
+        _ns(
+            type="response.function_call_arguments.done",
+            response_id="r1",
+            call_id="call_1",
+            arguments='{"city": "Denver"}',
+        )
+    )
+    state.on_server_event(
+        _ns(
+            type="response.done",
+            response=_ns(
+                id="r1",
+                status="completed",
+                output=[_ns(type="function_call", name="get_weather", arguments='{"city": "Denver"}', call_id="call_1")],
+            ),
+        )
+    )
+    # No tool span is finished yet — the app hasn't returned the result.
+    assert integration.tools == []
+    turn_span = integration.responses[0]["span"]
+
+    # The app returns the tool result -> the tool span is finished now.
+    state.on_client_event(
+        {
+            "type": "conversation.item.create",
+            "item": {"type": "function_call_output", "call_id": "call_1", "output": "72F and sunny"},
+        }
+    )
+    assert len(integration.tools) == 1
+    tool = integration.tools[0]
+    assert tool["name"] == "get_weather"
+    assert tool["call_id"] == "call_1"
+    assert tool["arguments"] == {"city": "Denver"}
+    assert tool["result"] == "72F and sunny"
+    assert tool["session_id"] == state._session_id
+    assert tool["error"] is False
+    # Parented under the turn that emitted the call, finished after it, with a sane duration.
+    assert tool["parent_span"] is turn_span
+    assert tool["span"].finished is True
+    assert tool["span"].start_ns is not None and tool["span"].start_ns <= tool["span"].finish_ns
+    assert not state._pending_tool_spans  # nothing left open
+
+
+def test_realtime_state_mcp_call_emits_tool_span():
+    """A server MCP call emits a tool span opened on output_item.added and finished inline at
+    response.done with the server-side result (no app round-trip)."""
+    integration, state = _new_state()
+    state.on_server_event(_session_created(transcription=False))
+    state.on_server_event(_ns(type="response.created", response=_ns(id="r1")))
+    state.on_server_event(
+        _ns(
+            type="response.output_item.added",
+            response_id="r1",
+            item=_ns(type="mcp_call", id="mcp_1", name="search"),
+        )
+    )
+    state.on_server_event(
+        _ns(
+            type="response.done",
+            response=_ns(
+                id="r1",
+                status="completed",
+                output=[
+                    _ns(type="mcp_call", id="mcp_1", name="search", arguments='{"q": "x"}', output="result text", error=None)
+                ],
+            ),
+        )
+    )
+    assert len(integration.tools) == 1
+    tool = integration.tools[0]
+    assert tool["name"] == "search"
+    assert tool["call_id"] == "mcp_1"
+    assert tool["arguments"] == {"q": "x"}
+    assert tool["result"] == "result text"
+    assert tool["parent_span"] is integration.responses[0]["span"]
+    assert tool["span"].finished is True
+    assert tool["span"].start_ns is not None and tool["span"].start_ns <= tool["span"].finish_ns
+    assert not state._pending_tool_spans
+
+
+def test_realtime_state_open_tool_span_finalized_on_close():
+    """A function_call whose result never arrives is still finished on session close (no leak)."""
+    integration, state = _new_state()
+    state.on_server_event(_session_created(transcription=False))
+    state.on_server_event(_ns(type="response.created", response=_ns(id="r1")))
+    state.on_server_event(
+        _ns(
+            type="response.output_item.added",
+            response_id="r1",
+            item=_ns(type="function_call", name="get_weather", call_id="call_1"),
+        )
+    )
+    state.on_server_event(
+        _ns(
+            type="response.done",
+            response=_ns(
+                id="r1",
+                status="completed",
+                output=[_ns(type="function_call", name="get_weather", arguments="{}", call_id="call_1")],
+            ),
+        )
+    )
+    # Result never returned; the span is still open.
+    assert integration.tools == []
+    assert "call_1" in state._pending_tool_spans
+
+    state.finish_session()
+    assert len(integration.tools) == 1
+    assert integration.tools[0]["span"].finished is True
+    assert not state._pending_tool_spans
+
+
+def test_realtime_state_tool_span_started_on_arguments_delta():
+    """When output_item.added isn't observed, the first function_call_arguments.delta opens the span."""
+    integration, state = _new_state()
+    state.on_server_event(_session_created(transcription=False))
+    state.on_server_event(_ns(type="response.created", response=_ns(id="r1")))
+    state.on_server_event(
+        _ns(type="response.function_call_arguments.delta", response_id="r1", call_id="call_1", delta='{"ci')
+    )
+    assert "call_1" in state._pending_tool_spans
+    state.on_server_event(
+        _ns(
+            type="response.function_call_arguments.done",
+            response_id="r1",
+            call_id="call_1",
+            arguments='{"city": "Denver"}',
+        )
+    )
+    state.on_server_event(
+        _ns(
+            type="response.done",
+            response=_ns(
+                id="r1",
+                status="completed",
+                output=[_ns(type="function_call", name="get_weather", arguments='{"city": "Denver"}', call_id="call_1")],
+            ),
+        )
+    )
+    state.on_client_event(
+        {
+            "type": "conversation.item.create",
+            "item": {"type": "function_call_output", "call_id": "call_1", "output": "cold"},
+        }
+    )
+    assert len(integration.tools) == 1
+    # Name backfilled from response.done (the delta events carried no name), args from the done event.
+    assert integration.tools[0]["name"] == "get_weather"
+    assert integration.tools[0]["arguments"] == {"city": "Denver"}
+    assert integration.tools[0]["result"] == "cold"
 
 
 def test_realtime_state_unwrappable_audio_fallback_marker():
@@ -867,6 +1061,74 @@ def test_realtime_integration_tool_call(openai, openai_llmobs, test_spans):
     assert out["tool_calls"] == [
         {"name": "get_weather", "arguments": {"city": "Paris"}, "tool_id": "call_1", "type": "function"}
     ]
+
+
+@pytest.mark.skipif(RealtimeConnection is None, reason="openai realtime API not available")
+def test_realtime_integration_mcp_tool_span(openai, openai_llmobs, test_spans):
+    """A server MCP call emits a real tool-kind child span, nested under the turn span (real
+    integration): opened on output_item.added, finished inline at response.done with its result."""
+    messages = [
+        json.dumps(
+            {"type": "session.created", "event_id": "e0", "session": {"type": "realtime", "model": "gpt-realtime"}}
+        ),
+        json.dumps({"type": "response.created", "event_id": "rc", "response": {"id": "r1"}}),
+        json.dumps(
+            {
+                "type": "response.output_item.added",
+                "event_id": "oi",
+                "response_id": "r1",
+                "item": {"type": "mcp_call", "id": "mcp_1", "name": "search"},
+            }
+        ),
+        json.dumps(
+            {
+                "type": "response.done",
+                "event_id": "rd",
+                "response": {
+                    "id": "r1",
+                    "status": "completed",
+                    "output": [
+                        {
+                            "type": "mcp_call",
+                            "id": "mcp_1",
+                            "name": "search",
+                            "arguments": '{"q": "x"}',
+                            "output": "result text",
+                        }
+                    ],
+                },
+            }
+        ),
+    ]
+    conn = RealtimeConnection(_FakeWebSocket(messages))
+    client = openai.OpenAI()
+    _realtime._attach_session(SimpleNamespace(_dd_client=client, _dd_model="gpt-realtime"), conn)
+    for _ in range(len(messages)):
+        conn.recv()
+    conn.close()
+
+    from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
+    by_resource = {s.resource: s for s in spans}
+    assert set(by_resource) == {"createRealtimeResponse", "createRealtimeToolCall"}
+
+    turn_span = by_resource["createRealtimeResponse"]
+    tool_span = by_resource["createRealtimeToolCall"]
+    turn_data = _get_llmobs_data_metastruct(turn_span)
+    tool_data = _get_llmobs_data_metastruct(tool_span)
+
+    # The tool span is a real tool-kind span nested under the turn (same LLMObs trace) and grouped by
+    # the same session_id.
+    assert tool_data["meta"]["span"]["kind"] == "tool"
+    assert tool_data["name"] == "search"
+    assert tool_data["parent_id"] == str(turn_span.span_id)
+    assert tool_data["trace_id"] == turn_data["trace_id"]
+    assert tool_data["session_id"] == turn_data["session_id"]
+    assert json.loads(tool_data["meta"]["input"]["value"]) == {"q": "x"}
+    assert json.loads(tool_data["meta"]["output"]["value"]) == "result text"
+    # Back-dated to when the call was observed, and finishes no earlier than it started.
+    assert tool_span.start_ns <= tool_span.start_ns + (tool_span.duration_ns or 0)
 
 
 @pytest.mark.skipif(RealtimeConnection is None, reason="openai realtime API not available")

--- a/tests/contrib/openai/test_openai_realtime.py
+++ b/tests/contrib/openai/test_openai_realtime.py
@@ -616,6 +616,79 @@ def test_realtime_state_function_call_only_in_response_done_emits_tool_span():
     assert not state._pending_tool_spans
 
 
+def test_realtime_state_concurrent_send_recv_is_thread_safe():
+    """Server events (recv thread) and client events (send thread) run concurrently — the common
+    sync-connection pattern. The state lock must keep the shared dicts consistent so every function
+    call still yields exactly one finished tool span carrying its own result, with none lost or leaked.
+
+    A stress test over the concurrent path rather than a deterministic race detector: it drives many
+    overlapping turns from two threads and asserts end-state integrity.
+    """
+    import queue
+    import threading
+
+    integration, state = _new_state()
+    state.on_server_event(_session_created(transcription=False))
+
+    n = 60
+    ready: "queue.Queue[str]" = queue.Queue()
+
+    def drive_server():
+        # recv thread: create each function call and complete its turn, then hand the call_id off.
+        for i in range(n):
+            rid, cid, args = "r%d" % i, "call_%d" % i, '{"i": %d}' % i
+            state.on_server_event(_ns(type="response.created", response=_ns(id=rid)))
+            state.on_server_event(
+                _ns(
+                    type="response.output_item.added",
+                    response_id=rid,
+                    item=_ns(type="function_call", name="get_weather", call_id=cid),
+                )
+            )
+            state.on_server_event(
+                _ns(type="response.function_call_arguments.done", response_id=rid, call_id=cid, arguments=args)
+            )
+            state.on_server_event(
+                _ns(
+                    type="response.done",
+                    response=_ns(
+                        id=rid,
+                        status="completed",
+                        output=[_ns(type="function_call", name="get_weather", arguments=args, call_id=cid)],
+                    ),
+                )
+            )
+            ready.put(cid)
+
+    def drive_client():
+        # send thread: return each tool result once its call has been observed by the server thread.
+        for _ in range(n):
+            cid = ready.get()
+            state.on_client_event(
+                {
+                    "type": "conversation.item.create",
+                    "item": {"type": "function_call_output", "call_id": cid, "output": "res-%s" % cid},
+                }
+            )
+
+    threads = [threading.Thread(target=drive_server), threading.Thread(target=drive_client)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    state.finish_session()
+
+    # Every call produced exactly one finished tool span with its own result; none lost, none leaked.
+    assert not state._pending_tool_spans
+    by_call = {t["call_id"]: t for t in integration.tools}
+    assert len(integration.tools) == n and len(by_call) == n
+    for i in range(n):
+        cid = "call_%d" % i
+        assert by_call[cid]["result"] == "res-%s" % cid
+        assert by_call[cid]["error"] is False
+        assert by_call[cid]["span"].finished is True
+
+
 def test_realtime_state_unwrappable_audio_fallback_marker():
     """Audio in a format we can't wrap (not PCM16/G.711) with no transcript surfaces an [audio] marker."""
     integration, state = _new_state(model="gpt-realtime")

--- a/tests/contrib/openai/test_openai_realtime.py
+++ b/tests/contrib/openai/test_openai_realtime.py
@@ -575,6 +575,47 @@ def test_realtime_state_tool_span_started_on_arguments_delta():
     assert integration.tools[0]["result"] == "cold"
 
 
+def test_realtime_state_function_call_only_in_response_done_emits_tool_span():
+    """A function_call observed ONLY at response.done (no output_item.added / arguments streaming
+    events, as some transports deliver) still gets a tool span, lazily created at response.done and
+    finished when the app returns the result.
+    """
+    integration, state = _new_state()
+    state.on_server_event(_session_created(transcription=False))
+    state.on_server_event(_ns(type="response.created", response=_ns(id="r1")))
+    # No output_item.added / function_call_arguments.* — the call first appears in response.done.
+    state.on_server_event(
+        _ns(
+            type="response.done",
+            response=_ns(
+                id="r1",
+                status="completed",
+                output=[
+                    _ns(type="function_call", name="get_weather", arguments='{"city": "Denver"}', call_id="call_1")
+                ],
+            ),
+        )
+    )
+    # Span was created lazily at response.done and is still open (awaiting the result).
+    assert "call_1" in state._pending_tool_spans
+    assert integration.tools == []
+
+    state.on_client_event(
+        {
+            "type": "conversation.item.create",
+            "item": {"type": "function_call_output", "call_id": "call_1", "output": "72F and sunny"},
+        }
+    )
+    assert len(integration.tools) == 1
+    tool = integration.tools[0]
+    assert tool["name"] == "get_weather"
+    assert tool["arguments"] == {"city": "Denver"}
+    assert tool["result"] == "72F and sunny"
+    assert tool["error"] is False
+    assert tool["span"].finished is True
+    assert not state._pending_tool_spans
+
+
 def test_realtime_state_unwrappable_audio_fallback_marker():
     """Audio in a format we can't wrap (not PCM16/G.711) with no transcript surfaces an [audio] marker."""
     integration, state = _new_state(model="gpt-realtime")
@@ -1068,7 +1109,10 @@ def test_realtime_integration_multi_turn_with_output_audio(openai, openai_llmobs
 
 @pytest.mark.skipif(RealtimeConnection is None, reason="openai realtime API not available")
 def test_realtime_integration_tool_call(openai, openai_llmobs, test_spans):
-    """A function_call in response.done is captured as a tool_call on the turn span (real integration)."""
+    """A function_call in response.done is captured as a tool_call on the turn span AND emits its own
+    tool span (real integration). No function_call_output arrives here, so the tool span is finished
+    at session close.
+    """
     messages = [
         json.dumps(
             {"type": "session.created", "event_id": "e0", "session": {"type": "realtime", "model": "gpt-realtime"}}
@@ -1103,11 +1147,19 @@ def test_realtime_integration_tool_call(openai, openai_llmobs, test_spans):
     from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 
     spans = [s for trace in test_spans.pop_traces() for s in trace]
-    assert [s.resource for s in spans] == ["createRealtimeResponse"]
-    out = _get_llmobs_data_metastruct(spans[0])["meta"]["output"]["messages"][0]
+    by_resource = {s.resource: s for s in spans}
+    assert set(by_resource) == {"createRealtimeResponse", "createRealtimeToolCall"}
+    turn_span = by_resource["createRealtimeResponse"]
+    out = _get_llmobs_data_metastruct(turn_span)["meta"]["output"]["messages"][0]
     assert out["tool_calls"] == [
         {"name": "get_weather", "arguments": {"city": "Paris"}, "tool_id": "call_1", "type": "function"}
     ]
+    # The function call also gets its own tool-kind span, nested under the turn, even though only
+    # response.done (no output_item.added / arguments streaming) carried it.
+    tool_data = _get_llmobs_data_metastruct(by_resource["createRealtimeToolCall"])
+    assert tool_data["meta"]["span"]["kind"] == "tool"
+    assert tool_data["name"] == "get_weather"
+    assert tool_data["parent_id"] == str(turn_span.span_id)
 
 
 @pytest.mark.skipif(RealtimeConnection is None, reason="openai realtime API not available")

--- a/tests/contrib/openai/test_openai_realtime.py
+++ b/tests/contrib/openai/test_openai_realtime.py
@@ -1173,8 +1173,10 @@ def test_realtime_integration_mcp_tool_span(openai, openai_llmobs, test_spans):
     assert tool_data["parent_id"] == str(turn_span.span_id)
     assert tool_data["trace_id"] == turn_data["trace_id"]
     assert tool_data["session_id"] == turn_data["session_id"]
+    # input is the parsed-dict arguments (JSON-serialized); output is the raw result string
+    # (safe_json leaves strings as-is, so it is stored verbatim rather than JSON-encoded).
     assert json.loads(tool_data["meta"]["input"]["value"]) == {"q": "x"}
-    assert json.loads(tool_data["meta"]["output"]["value"]) == "result text"
+    assert tool_data["meta"]["output"]["value"] == "result text"
     # Back-dated to when the call was observed, and finishes no earlier than it started.
     assert tool_span.start_ns <= tool_span.start_ns + (tool_span.duration_ns or 0)
 


### PR DESCRIPTION
## What

Each `function_call` / `mcp_call` the realtime model makes now becomes a **real `tool`-kind LLMObs span**, nested under the emitting turn's `createRealtimeResponse` span — instead of only living as `tool_calls` attributes on the turn. So realtime tool calls get the full tool-span product experience (detail view, evals, etc.) and a real start time for timeline placement.

This is the tool-spans change from #19197, cherry-picked to apply **directly on top of `main`** (the OpenAI Realtime audio instrumentation is already merged) so it can land independently of the audio-timing branch it was originally stacked on. The only addition over the original commit is `import time` in `_realtime.py`, which had been provided by the audio-timing branch and is required here now that this stands alone.

## Lifecycle
- **Open** on `response.output_item.added` for a `function_call`/`mcp_call` (fallback: first `response.function_call_arguments.delta`).
- **Arguments** captured from `response.function_call_arguments.done` / the item on `response.done`.
- **Finish**: client `function_call` → when the app returns `function_call_output` (matched by `call_id`); server `mcp_call` → inline output at `response.done`. Duration = real tool-execution latency.
- Parented under the emitting turn; carries the same `session_id` as the turn (so the UI groups it). Open spans finalized at session close so none leak.

## Tests / validation
- 4 new state-machine unit tests (function_call, MCP inline, close-fallback, args-delta start), plus a full MCP integration test.
- Static validation on `main`: files compile, lint passes, and every symbol the cherry-picked code references resolves against `main` (this surfaced the missing `import time`, now added). The Docker-backed test suite could not run locally in this environment and will run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
