### PR TITLE
fix(llmobs): increase remote evaluator timeout

### DIFF
--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -382,6 +382,7 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
     AGENTLESS_BASE_URL = AGENTLESS_EXP_BASE_URL
     ENDPOINT = ""
     TIMEOUT = 10.0
+    REMOTE_EVALUATOR_TIMEOUT = 55.0
     BULK_UPLOAD_TIMEOUT = 60.0
     LIST_RECORDS_TIMEOUT = 20
     SUPPORTED_UPLOAD_EXTS = {"csv"}
@@ -402,6 +403,9 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
         until=lambda result: isinstance(result, Response) and result.status < 500,
     )
     def _request_with_retry(self, method: str, path: str, body: JSONType = None, timeout=TIMEOUT) -> Response:
+        return self._request_once(method, path, body, timeout)
+
+    def _request_once(self, method: str, path: str, body: JSONType = None, timeout=TIMEOUT) -> Response:
         headers = {
             "Content-Type": "application/json",
             "DD-API-KEY": self._api_key,
@@ -969,7 +973,9 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
         path = f"/api/unstable/llm-obs/v1/evaluators/{eval_name}/infer"
         body: JSONType = {"data": {"type": "evaluator_inference", "attributes": {"context": context}}}
 
-        resp = self.request("POST", path, body)
+        # Inference can legitimately take longer than ordinary experiment API calls. Keep this
+        # below the service's 60-second request deadline and avoid retrying this expensive call.
+        resp = self._request_once("POST", path, body, timeout=self.REMOTE_EVALUATOR_TIMEOUT)
         response_data = resp.get_json() or {}
 
         attributes = response_data.get("data", {}).get("attributes", {})

--- a/releasenotes/notes/increase-remote-evaluator-timeout-702ec9e017fcc482.yaml
+++ b/releasenotes/notes/increase-remote-evaluator-timeout-702ec9e017fcc482.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    LLM Observability: Fixes remote evaluators timing out after 10 seconds when an inference
+    takes longer to complete.

--- a/tests/llmobs/test_experiments.py
+++ b/tests/llmobs/test_experiments.py
@@ -3375,6 +3375,45 @@ def test_experiment_with_remote_evaluator(llmobs, test_dataset_one_record):
         assert result["assessment"] == "pass"
 
 
+def test_remote_evaluator_inference_uses_extended_timeout_without_retry():
+    from ddtrace.internal.utils.http import Response
+    from ddtrace.llmobs._writer import LLMObsExperimentsClient
+
+    client = LLMObsExperimentsClient(
+        interval=1.0,
+        timeout=5.0,
+        is_agentless=True,
+        _site="datadoghq.com",
+        _api_key="api-key",
+        _app_key="app-key",
+    )
+    response = Response(
+        status=200,
+        body=b'{"data":{"attributes":{"status":"OK","value":true,"assessment":"pass"}}}',
+    )
+
+    with (
+        mock.patch.object(client, "_request_once", return_value=response) as request_once,
+        mock.patch.object(client, "_request_with_retry") as request_with_retry,
+    ):
+        result = client.evaluator_infer("my-eval", {"span_input": "question", "span_output": "answer"})
+
+    request_once.assert_called_once_with(
+        "POST",
+        "/api/unstable/llm-obs/v1/evaluators/my-eval/infer",
+        {
+            "data": {
+                "type": "evaluator_inference",
+                "attributes": {"context": {"span_input": "question", "span_output": "answer"}},
+            }
+        },
+        timeout=client.REMOTE_EVALUATOR_TIMEOUT,
+    )
+    request_with_retry.assert_not_called()
+    assert result["value"] is True
+    assert result["assessment"] == "pass"
+
+
 def test_experiment_remote_evaluator_error_handling(llmobs, test_dataset_one_record):
     """Test that RemoteEvaluator errors are properly captured."""
     with mock.patch.object(


### PR DESCRIPTION
## Description

Give remote evaluator inference its own 55-second timeout instead of the experiments client general 10-second timeout. The inference request uses a single attempt so a slow or failed LLM call is not repeated.

This keeps ordinary experiment API requests at 10 seconds and leaves a small margin below the evaluator inference service 60-second request deadline.

## Testing

- Added a focused unit test that verifies the 55-second timeout and absence of retries.
- Focused formatting check passed for the changed Python files.
- Release-note spelling check passed.
- Release-note generation validation passed.
- The targeted LLMObs harness pulled its pinned runner successfully but remained in the Python 3.13 environment build before pytest execution; CI will run the repository suite.

## Risks

Low. The change is scoped to remote evaluator inference. A stalled inference can now hold a client connection longer, up to 55 seconds.

## Additional Notes

Includes a release note for the user-visible timeout fix.