### PR TITLE
chore(ci): make circular-import detection deterministic

### DIFF
--- a/scripts/import-analysis/cycles.py
+++ b/scripts/import-analysis/cycles.py
@@ -28,7 +28,15 @@ def _build_graph(root: Path) -> dict[str, set[str]]:
 
 
 def dfs(v: str, visited: set[str], stack: list[str], cycles: _CycleMap, g: dict[str, set[str]]) -> None:
-    for i in g.get(v, set()):
+    # Iterate neighbours in a stable (sorted) order. The graph stores neighbours in
+    # `set`s, whose iteration order depends on PYTHONHASHSEED and therefore varies
+    # between processes. Because this path-based traversal enumerates simple cycles in
+    # visitation order, an unstable order makes the set of discovered cycles
+    # non-deterministic across runs. The CI job analyses the base and PR trees in two
+    # separate processes and diffs the results, so that non-determinism surfaces as
+    # phantom "new" cycles even when no Python imports changed. Sorting makes both runs
+    # enumerate the same cycles.
+    for i in sorted(g.get(v, set())):
         if i not in visited:
             dfs(i, {*visited, v}, [*stack, v], cycles, g)
         elif i in stack:


### PR DESCRIPTION
## Description

The `detect_circular_imports` CI job intermittently reports large numbers of
phantom "new" circular imports on PRs that do not touch any Python module in
the `ddtrace/` import graph (e.g. a PR that only changes C++ / tests / release
notes was reported as introducing 2491 "new" cycles).

**Root cause.** The detector's `dfs` enumerates simple cycles by iterating over
the dependency graph's neighbour `set`s. Python randomizes string hashing per
process (`PYTHONHASHSEED`), so `set` iteration order differs from run to run.
Because this path-based traversal records cycles in visitation order, an
unstable neighbour order makes the *set of discovered cycles* non-deterministic:
in a dense strongly-connected component the traversal reaches different simple
cycles depending on order.

The CI job (`.gitlab-ci.yml` `detect_circular_imports`) analyses the base tree
and the PR tree in **two separate `uv run` processes** and diffs the results, so
this per-process non-determinism surfaces as phantom "new" cycles even when the
Python source is byte-identical between base and PR.

Verified locally: analysing an unchanged tree under different `PYTHONHASHSEED`
values produced a different cycle-set fingerprint every time. After sorting the
neighbour traversal, seeds `0`, `123456`, and `999999` all produce byte-identical
output, so a base-vs-PR diff on an unchanged tree correctly reports zero new
cycles.

## What changed

- `scripts/import-analysis/cycles.py`: iterate neighbours in sorted order in
  `dfs` so cycle enumeration is deterministic across processes.

## Testing

```
for seed in 0 123456 999999; do
  PYTHONHASHSEED=$seed uv run --script scripts/import-analysis/cycles.py analyze /tmp/fix_$seed.json
done
# all three /tmp/fix_*.json are now byte-identical (same shasum)
```

## Additional Notes

CI-only change with no user-facing impact; labelled `changelog/no-changelog`.
