### PR TITLE
fix(gevent): preserve annotationlib during module cloning on Python 3.14

### DIFF
--- a/ddtrace/bootstrap/cloning.py
+++ b/ddtrace/bootstrap/cloning.py
@@ -69,6 +69,7 @@ def cleanup_loaded_modules() -> None:
             "concurrent",
             "importlib._bootstrap",  # special import that must not be unloaded
             "typing",
+            "annotationlib",  # owns the ForwardRef class aliased by typing on CPython >= 3.14
             "_operator",  # pickling issues with typing module
             "re",  # referenced by the typing module
             "sre_constants",  # imported by re at runtime

--- a/ddtrace/bootstrap/cloning.py
+++ b/ddtrace/bootstrap/cloning.py
@@ -70,6 +70,7 @@ def cleanup_loaded_modules() -> None:
             "importlib._bootstrap",  # special import that must not be unloaded
             "typing",
             "annotationlib",  # owns the ForwardRef class aliased by typing on CPython >= 3.14
+            "enum",  # annotationlib.Format is an IntEnum; keep enum so isinstance/issubclass hold
             "_operator",  # pickling issues with typing module
             "re",  # referenced by the typing module
             "sre_constants",  # imported by re at runtime

--- a/releasenotes/notes/fix-gevent-cloning-annotationlib-322065460b71078a.yaml
+++ b/releasenotes/notes/fix-gevent-cloning-annotationlib-322065460b71078a.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    gevent: Fixes an issue where running an application with ``ddtrace-run``
+    (or single-step instrumentation) could raise a
+    ``PydanticSchemaGenerationError`` at import time for models that use forward
+    references, when ``gevent`` is installed and the application runs on CPython
+    3.14 or later. The ``annotationlib`` module, which now owns the
+    ``ForwardRef`` class on CPython 3.14, is preserved during module cloning so
+    that ``pydantic`` resolves forward references correctly.


### PR DESCRIPTION
## Description

Module cloning keeps only `KEEP_MODULES` intact after bootstrap. On CPython 3.14 the `ForwardRef` class moved to the `annotationlib` module, which `typing` now aliases. Because `annotationlib` was not preserved, cloning left a stale `typing.ForwardRef` distinct from the re-imported `annotationlib.ForwardRef`, so pydantic's `isinstance` checks failed and raised `PydanticSchemaGenerationError` for valid forward references at class-definition time.

Cloning auto-enables whenever `gevent` is installed, even as an unused transitive dependency, so applications hit this without importing or using gevent.

Add `annotationlib` to `KEEP_MODULES`, mirroring the `_operator` fix in #12723 (which addressed the same class of breakage when Python 3.12 made `typing` depend on `_operator`).

## Testing

Reproduced on CPython 3.14.2 with ddtrace 4.10.4, pydantic 2.13.4, and gevent
installed:
- `python repro.py` → passes (`typing.ForwardRef is annotationlib.ForwardRef` is True)
- `ddtrace-run python repro.py` → crashes with `PydanticSchemaGenerationError`
- with this change (cloning still on, gevent installed) → passes

## Risks

Low. Adds a single module to the keep-list. `annotationlib` only exists on CPython 3.14+, so this is a no-op on earlier versions, and it only affects the gevent module-cloning path. No public API change.

## Additional Notes

Reported by a customer running under SSI on Python 3.14; internal ref APMS-20155.