### PR TITLE
feat(tracing): republish otel thread context on gevent greenlet switching

### DIFF
--- a/ddtrace/contrib/internal/gevent/greenlet.py
+++ b/ddtrace/contrib/internal/gevent/greenlet.py
@@ -1,23 +1,30 @@
+from typing import Any
+
 import gevent
 
-from ddtrace._trace.provider import _DD_CONTEXTVAR
+from ddtrace.internal import core
+from ddtrace.trace import tracer
 
 
 GEVENT_VERSION = gevent.version_info[0:3]
 
 
+def _context_switch_trace(event: str, args: Any) -> None:
+    if event in {"switch", "throw"}:
+        core.dispatch(
+            "ddtrace.context_provider.activate",
+            (tracer.context_provider, tracer.context_provider.active()),
+        )
+
+
 class TracingMixin(object):
     def __init__(self, *args, **kwargs):
-        # Storse the current Datadog context.
-        # This is necessary to ensure tracing context is passed to greenlets.
-        # Avoids setting Greenlet.gr_context, setting field could introduce
-        # unintended side-effects in third party libraries.
-        self.trace_context = _DD_CONTEXTVAR.get()
+        # Avoid changing gr_context, which may affect third-party libraries.
+        self.trace_context = tracer.context_provider.active()
         super(TracingMixin, self).__init__(*args, **kwargs)
 
     def run(self):
-        # Propagates Datadog context to spawned greenlets
-        _DD_CONTEXTVAR.set(self.trace_context)
+        tracer.context_provider.activate(self.trace_context)
         super(TracingMixin, self).run()
 
 

--- a/ddtrace/contrib/internal/gevent/patch.py
+++ b/ddtrace/contrib/internal/gevent/patch.py
@@ -1,9 +1,13 @@
 import gevent
 import gevent.pool
 
+from ddtrace.internal._greenlet import register_trace
+from ddtrace.internal._greenlet import unregister_trace
+
 from .greenlet import TracedGreenlet
 from .greenlet import TracedIMap
 from .greenlet import TracedIMapUnordered
+from .greenlet import _context_switch_trace
 
 
 __Greenlet = gevent.Greenlet
@@ -33,6 +37,7 @@ def patch():
     gevent.__datadog_patch = True
 
     _replace(TracedGreenlet, TracedIMap, TracedIMapUnordered)
+    register_trace(_context_switch_trace)
 
 
 def unpatch():
@@ -45,6 +50,7 @@ def unpatch():
         return
     gevent.__datadog_patch = False
 
+    unregister_trace(_context_switch_trace)
     _replace(__Greenlet, __IMap, __IMapUnordered)
 
 

--- a/ddtrace/internal/_greenlet.py
+++ b/ddtrace/internal/_greenlet.py
@@ -1,0 +1,60 @@
+from typing import Any
+from typing import Callable
+from typing import Optional
+
+from greenlet import gettrace
+from greenlet import settrace
+
+from ddtrace.internal.logger import get_logger
+
+
+log = get_logger(__name__)
+
+
+GreenletTraceCallback = Callable[[str, Any], None]
+
+
+class _Trace:
+    """Compose callbacks through the current thread's greenlet trace hook."""
+
+    def __init__(self, original: Optional[GreenletTraceCallback]) -> None:
+        self._original = original
+        self._subscribers: list[GreenletTraceCallback] = []
+
+    def __call__(self, event: str, args: Any) -> None:
+        for subscriber in tuple(self._subscribers):
+            try:
+                subscriber(event, args)
+            except Exception:
+                log.debug("greenlet trace subscriber %r raised", subscriber, exc_info=True)
+        if self._original is not None:
+            self._original(event, args)
+
+
+def register_trace(subscriber: GreenletTraceCallback) -> None:
+    current_trace = gettrace()
+    if isinstance(current_trace, _Trace):
+        trace = current_trace
+    else:
+        trace = _Trace(current_trace)
+        settrace(trace)
+
+    if subscriber in trace._subscribers:
+        return
+    trace._subscribers.append(subscriber)
+
+
+def unregister_trace(subscriber: GreenletTraceCallback) -> None:
+    trace = gettrace()
+    if not isinstance(trace, _Trace):
+        return
+
+    try:
+        trace._subscribers.remove(subscriber)
+    except ValueError:
+        return
+
+    if trace._subscribers:
+        return
+
+    settrace(trace._original)

--- a/ddtrace/profiling/_gevent.py
+++ b/ddtrace/profiling/_gevent.py
@@ -7,8 +7,9 @@ import gevent.greenlet
 from gevent.greenlet import Greenlet as _Greenlet
 import gevent.hub
 from greenlet import greenlet
-from greenlet import settrace
 
+from ddtrace.internal._greenlet import register_trace
+from ddtrace.internal._greenlet import unregister_trace
 from ddtrace.internal.datadog.profiling import stack
 
 
@@ -20,7 +21,6 @@ _gevent_iwait: t.Callable[..., t.Any] = gevent.iwait
 
 # Global package state
 _tracked_greenlets: set[int] = set()
-_original_greenlet_tracer: t.Optional[t.Callable[[str, t.Any], None]] = None
 _greenlet_parent_map: dict[int, int] = {}
 _parent_greenlet_count: dict[int, int] = {}
 
@@ -143,9 +143,6 @@ def greenlet_tracer(event: str, args: t.Any) -> None:
         except Exception:  # nosec B110
             pass
 
-    if _original_greenlet_tracer is not None:
-        _original_greenlet_tracer(event, args)
-
 
 def _untrack_greenlet_by_id(greenlet_id: int) -> None:
     """Untrack a greenlet by its ID. Idempotent."""
@@ -261,8 +258,6 @@ def get_current_greenlet_task() -> tuple[t.Optional[int], t.Optional[str], t.Opt
 
 
 def patch() -> None:
-    global _original_greenlet_tracer
-
     # Patch the spawn method to track greenlets.
     gevent.Greenlet = gevent.greenlet.Greenlet = Greenlet
     gevent.spawn = Greenlet.spawn
@@ -273,7 +268,7 @@ def patch() -> None:
 
     gevent.hub.spawn_raw = wrap_spawn(_gevent_hub_spawn_raw)
 
-    _original_greenlet_tracer = t.cast(t.Callable[[str, t.Any], None], settrace(greenlet_tracer))
+    register_trace(greenlet_tracer)
 
 
 def unpatch() -> None:
@@ -287,4 +282,4 @@ def unpatch() -> None:
 
     gevent.hub.spawn_raw = _gevent_hub_spawn_raw
 
-    settrace(_original_greenlet_tracer)
+    unregister_trace(greenlet_tracer)

--- a/releasenotes/notes/gevent-otel-thread-context-b5b5f18890e4f0be.yaml
+++ b/releasenotes/notes/gevent-otel-thread-context-b5b5f18890e4f0be.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    tracing: Ensures that OpenTelemetry thread context is republished on gevent task switches.
+    This enables compatible host profiling and security tools to correlate samples with the active
+    trace and span in applications using gevent.

--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -1,19 +1,37 @@
+from contextlib import contextmanager
 import subprocess  # noqa:I001
+import sys
 import threading
 
 import gevent
 import gevent.pool
+import pytest
 
-
-from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import _SAMPLING_PRIORITY_KEY
+from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import USER_KEEP
-from ddtrace.trace import Context
 from ddtrace.contrib.internal.gevent.patch import patch
 from ddtrace.contrib.internal.gevent.patch import unpatch
+from ddtrace.internal import core
+from ddtrace.trace import Context
 from tests.utils import TracerTestCase
 
 from .utils import silence_errors
+
+
+@contextmanager
+def _activation_events(provider):
+    events = []
+
+    def record(event_provider, context):
+        if event_provider is provider:
+            events.append(context)
+
+    core.on("ddtrace.context_provider.activate", record)
+    try:
+        yield events
+    finally:
+        core.reset_listeners("ddtrace.context_provider.activate", record)
 
 
 class TestGeventTracer(TracerTestCase):
@@ -55,6 +73,44 @@ class TestGeventTracer(TracerTestCase):
         assert 1 == len(traces[0])
         assert "greenlet" == traces[0][0].name
         assert "base" == traces[0][0].resource
+
+    @pytest.mark.skipif(sys.platform != "linux", reason="OTel thread context is Linux-only")
+    def test_otel_thread_ctx_follows_greenlet_switches(self):
+        with _activation_events(self.tracer.context_provider) as activated:
+            with self.tracer.trace("parent") as parent:
+                activated.clear()
+
+                def greenlet() -> None:
+                    assert activated[-1] is parent
+                    with self.tracer.trace("child") as child:
+                        activated.clear()
+                        gevent.sleep(0)
+                        assert activated[-1] is child
+
+                gevent.spawn(greenlet).join()
+                assert activated[-1] is parent
+
+    @pytest.mark.skipif(sys.platform != "linux", reason="OTel thread context is Linux-only")
+    def test_otel_thread_ctx_follows_raw_greenlet_switches_and_throw(self):
+        from greenlet import greenlet
+
+        with _activation_events(self.tracer.context_provider) as activated:
+            with self.tracer.trace("parent") as parent:
+                activated.clear()
+
+                def child():
+                    assert activated[-1] is None
+                    with self.tracer.trace("raw") as raw_span:
+                        activated.clear()
+                        try:
+                            greenlet.getcurrent().parent.switch()
+                        except RuntimeError:
+                            assert activated[-1] is raw_span
+
+                raw = greenlet(child)
+                raw.switch()
+                assert activated[-1] is parent
+                raw.throw(RuntimeError("expected"))
 
     def test_trace_greenlet_twice(self):
         # a greenlet can be traced using the trace API
@@ -391,3 +447,51 @@ class TestGeventTracer(TracerTestCase):
         assert p.returncode == 0, f"stdout: {stdout.decode()}\n\nstderr: {stderr.decode()}"
         assert b"Test success" in stdout, stdout.decode()
         assert b"RecursionError" not in stderr, stderr.decode()
+
+
+def test_greenlet_trace_multiplexer_preserves_callbacks():
+    from greenlet import gettrace
+    from greenlet import greenlet
+    from greenlet import settrace
+
+    from ddtrace.internal._greenlet import register_trace
+    from ddtrace.internal._greenlet import unregister_trace
+
+    events = []
+
+    def customer(event, args):
+        events.append(("customer", event))
+
+    def tracing(event, args):
+        events.append(("tracing", event))
+
+    def profiling(event, args):
+        events.append(("profiling", event))
+
+    def replacement(event, args):
+        pass
+
+    original = settrace(customer)
+    try:
+        register_trace(tracing)
+        register_trace(profiling)
+        greenlet(lambda: None).switch()
+
+        unregister_trace(tracing)
+        assert gettrace() is not customer
+        greenlet(lambda: None).switch()
+
+        unregister_trace(profiling)
+        assert gettrace() is customer
+
+        register_trace(tracing)
+        settrace(replacement)
+        unregister_trace(tracing)
+        assert gettrace() is replacement
+    finally:
+        unregister_trace(tracing)
+        unregister_trace(profiling)
+        settrace(original)
+
+    assert {name for name, _ in events[:6]} == {"customer", "tracing", "profiling"}
+    assert {name for name, _ in events[6:]} == {"customer", "profiling"}


### PR DESCRIPTION
## Description

This PR triggers the activation signal on greenlet switch under gevent. This ensures that the OTel thread context is actualized around those tasks. 


To avoid clashing with profiling's settrace handler and avoid concurrency issues when unpatching, I added a centralized dispatcher for such hooks that both tracing and profiling can then reuse.

## Testing

- added unit tests

## Risks

- Low: this adds a little bit of overhead (core event dispatch + active span lookup) on each greenlet task switch => small performance regression

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
