### PR TITLE
fix(profiling): omit oversized provenance versions

### DIFF
--- a/ddtrace/internal/datadog/profiling/code_provenance.py
+++ b/ddtrace/internal/datadog/profiling/code_provenance.py
@@ -15,6 +15,26 @@ from ddtrace.internal.packages import _package_for_root_module_mapping
 from ddtrace.internal.settings import env
 
 
+_MAX_BACKEND_VERSION = 2**31 - 1
+
+
+def _backend_compatible_version(version: str) -> str:
+    """Return an RFC-compatible version that older backends can parse."""
+    if version.isascii() and version.isdecimal():
+        try:
+            if int(version) > _MAX_BACKEND_VERSION:
+                # The code-provenance RFC requires `version` to be a string,
+                # and an empty string is already used for the synthetic native
+                # library. Do not truncate an oversized version, because that
+                # would report an inaccurate dependency version.
+                return ""
+        except ValueError:
+            # Python rejects decimal strings that exceed its integer conversion
+            # limit. Such a value also cannot be represented by the backend.
+            return ""
+    return version
+
+
 class Library:
     def __init__(
         self,
@@ -25,7 +45,7 @@ class Library:
     ) -> None:
         self.kind = kind
         self.name = name
-        self.version = version
+        self.version = _backend_compatible_version(version)
         self.paths = paths
 
     def to_dict(self) -> dict[str, t.Any]:

--- a/releasenotes/notes/profiling-code-provenance-version-overflow-897119e848649bec.yaml
+++ b/releasenotes/notes/profiling-code-provenance-version-overflow-897119e848649bec.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    profiling: Fixes an issue where aggregated profiles become unavailable when an installed package has an oversized numeric version.

--- a/tests/profiling/test_code_provenance.py
+++ b/tests/profiling/test_code_provenance.py
@@ -144,6 +144,25 @@ class TestCodeProvenance:
         assert native[0]["kind"] == "library"
         assert native[0]["paths"] == ["<native>"]
 
+    def test_oversized_library_version_is_omitted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from ddtrace.internal.datadog.profiling import code_provenance
+        from ddtrace.internal.packages import Distribution
+
+        monkeypatch.setattr(
+            code_provenance,
+            "_package_for_root_module_mapping",
+            lambda: {"inference_service/rpc_pb2.py": Distribution(name="inference-service", version="202503311822")},
+        )
+
+        libraries = code_provenance.CodeProvenance().to_dict()["v1"]
+        library = next(library for library in libraries if library["name"] == "inference-service")
+
+        # The RFC requires `version` to be a string. An empty version preserves
+        # that schema while avoiding a numeric component that legacy backends
+        # cannot parse as a signed 32-bit integer.
+        assert library["version"] == ""
+        assert is_valid_json(json.dumps({"v1": [library]}))
+
     @pytest.mark.subprocess(
         env=dict(DD_MAIN_PACKAGE="ddtrace"),
     )


### PR DESCRIPTION
## Description

Fixes SCP-1306 by preventing code provenance from reporting a package version with a backend-parsed numeric component larger than a signed 32-bit integer. The code-provenance RFC requires `version` to be a JSON string but defines no numeric bound. For an oversized component, this change sends the existing empty-string version sentinel rather than an inaccurate truncated value.

This preserves the manifest schema and library path attribution while avoiding aggregation failures in backend versions that parse version components as signed 32-bit integers. A backend-side defensive fix remains necessary for profiles already stored with an oversized version.

## Testing

- Added a regression test for the customer-reported `202503311822` package version and validated that the emitted library entry remains RFC-schema-valid.
- Added focused coverage for oversized major, minor, patch, `v`-prefixed, and old-style Java version components, plus signed 32-bit boundary cases.
- Passed `scripts/run-tests --venv 9710280 -- -- -k 'test_oversized_backend_version_component_is_omitted or test_backend_version_component_within_limit_is_preserved or test_oversized_library_version_is_omitted'` on Python 3.13, with 12 selected tests passing in both profiling configurations.
- Passed the full Python 3.13 profiling suite in both configurations, with 366 passed, 34 skipped, and 2 expected failures in each.
- Passed `scripts/lint fmt -- ddtrace/internal/datadog/profiling/code_provenance.py tests/profiling/test_code_provenance.py`.
- Passed `scripts/lint typing -- ddtrace/internal/datadog/profiling/code_provenance.py tests/profiling/test_code_provenance.py`.

## Risks

Affected packages are reported with an empty version when a numeric component parsed by the affected backend cannot be represented as a signed 32-bit integer. This loses that package's version metadata but preserves code provenance JSON validity and prevents the aggregated profile from becoming unavailable.

## Additional Notes

Includes a customer-facing profiling release note.
