### PR TITLE
fix(llmobs): surface OpenRouter BYOK upstream cost

### DIFF
--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -241,10 +241,6 @@ def get_openrouter_cost_metrics(token_usage: Any) -> dict[str, float]:
         if isinstance(upstream_cost, (int, float)):
             total_cost += float(upstream_cost)
     metrics: dict[str, float] = {TOTAL_COST_METRIC_KEY: total_cost}
-    # Only emit the input/output breakdown when it reconciles with the total: the
-    # upstream_inference_* costs are wholesale and can diverge from `cost` (e.g. a BYOK fee on top
-    # of upstream). Reconcile at nanodollar precision (how the backend stores cost) so binary-float
-    # noise in the decimal components doesn't spuriously reject a breakdown that sums to the total.
     input_cost = _get_attr(cost_details, "upstream_inference_prompt_cost", None)
     output_cost = _get_attr(cost_details, "upstream_inference_completions_cost", None)
     if (

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -239,7 +239,7 @@ def get_openrouter_cost_metrics(token_usage: Any) -> dict[str, float]:
     if _get_attr(token_usage, "is_byok", False):
         upstream_cost = _get_attr(cost_details, "upstream_inference_cost", None)
         if isinstance(upstream_cost, (int, float)):
-            total_cost += float(upstream_cost)
+            total_cost += upstream_cost
     metrics: dict[str, float] = {TOTAL_COST_METRIC_KEY: total_cost}
     input_cost = _get_attr(cost_details, "upstream_inference_prompt_cost", None)
     output_cost = _get_attr(cost_details, "upstream_inference_completions_cost", None)

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -223,17 +223,28 @@ def get_openrouter_cost_metrics(token_usage: Any) -> dict[str, float]:
 
     OpenRouter returns billed cost on ``usage.cost`` (with a ``usage.cost_details`` breakdown) in
     every response. Returns an empty dict for responses without a cost (e.g. other providers).
+
+    BYOK (bring-your-own-key): when the customer calls the provider with their own credentials,
+    OpenRouter's billed ``cost`` covers only its own fee (often 0) while the provider inference
+    cost is incurred upstream and reported under ``cost_details.upstream_inference_cost``. In that
+    case (flagged by ``usage.is_byok``) add the upstream cost so the span reflects the cost the
+    customer actually incurred. For non-BYOK responses ``cost`` already includes the provider cost,
+    so the upstream figure is not added.
     """
     cost = _get_attr(token_usage, "cost", None)
     if not isinstance(cost, (int, float)):
         return {}
     total_cost = float(cost)
-    metrics: dict[str, float] = {TOTAL_COST_METRIC_KEY: total_cost}
-    # Only emit the input/output breakdown when it reconciles with the billed total: the
-    # upstream_inference_* costs are wholesale and can diverge from `cost` (e.g. BYOK surcharge).
-    # Reconcile at nanodollar precision (how the backend stores cost) so binary-float noise in the
-    # decimal components doesn't spuriously reject a breakdown that actually sums to the total.
     cost_details = _get_attr(token_usage, "cost_details", {}) or {}
+    if _get_attr(token_usage, "is_byok", False):
+        upstream_cost = _get_attr(cost_details, "upstream_inference_cost", None)
+        if isinstance(upstream_cost, (int, float)):
+            total_cost += float(upstream_cost)
+    metrics: dict[str, float] = {TOTAL_COST_METRIC_KEY: total_cost}
+    # Only emit the input/output breakdown when it reconciles with the total: the
+    # upstream_inference_* costs are wholesale and can diverge from `cost` (e.g. a BYOK fee on top
+    # of upstream). Reconcile at nanodollar precision (how the backend stores cost) so binary-float
+    # noise in the decimal components doesn't spuriously reject a breakdown that sums to the total.
     input_cost = _get_attr(cost_details, "upstream_inference_prompt_cost", None)
     output_cost = _get_attr(cost_details, "upstream_inference_completions_cost", None)
     if (

--- a/releasenotes/notes/llmobs-openrouter-byok-upstream-cost-a70e8d0083d04505.yaml
+++ b/releasenotes/notes/llmobs-openrouter-byok-upstream-cost-a70e8d0083d04505.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    LLM Observability: Resolves an issue where the OpenAI and LiteLLM integrations reported zero cost for OpenRouter requests using a BYOK (bring-your-own-key) setup. This cost is now surfaced on the span's cost metrics.
+    LLM Observability: Resolves an issue where the OpenAI and LiteLLM integrations reported zero cost for OpenRouter requests using a bring-your-own-key setup.

--- a/releasenotes/notes/llmobs-openrouter-byok-upstream-cost-a70e8d0083d04505.yaml
+++ b/releasenotes/notes/llmobs-openrouter-byok-upstream-cost-a70e8d0083d04505.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    LLM Observability: Resolves an issue where the OpenAI and LiteLLM integrations reported zero cost for OpenRouter requests using a BYOK (bring-your-own-key) setup. OpenRouter bills ``0`` for these requests and reports the provider inference cost under ``usage.cost_details.upstream_inference_cost`` (flagged by ``usage.is_byok``); this cost is now surfaced on the span's cost metrics.

--- a/releasenotes/notes/llmobs-openrouter-byok-upstream-cost-a70e8d0083d04505.yaml
+++ b/releasenotes/notes/llmobs-openrouter-byok-upstream-cost-a70e8d0083d04505.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    LLM Observability: Resolves an issue where the OpenAI and LiteLLM integrations reported zero cost for OpenRouter requests using a BYOK (bring-your-own-key) setup. OpenRouter bills ``0`` for these requests and reports the provider inference cost under ``usage.cost_details.upstream_inference_cost`` (flagged by ``usage.is_byok``); this cost is now surfaced on the span's cost metrics.
+    LLM Observability: Resolves an issue where the OpenAI and LiteLLM integrations reported zero cost for OpenRouter requests using a BYOK (bring-your-own-key) setup. This cost is now surfaced on the span's cost metrics.

--- a/tests/contrib/litellm/cassettes/completion_openrouter_byok.yaml
+++ b/tests/contrib/litellm/cassettes/completion_openrouter_byok.yaml
@@ -1,0 +1,87 @@
+interactions:
+- request:
+    body: '{"model": "anthropic/claude-opus-5", "messages": [{"content": "What is
+      the capital of France?", "role": "user"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '113'
+      Content-Type:
+      - application/json
+      HTTP-Referer:
+      - https://litellm.ai
+      Host:
+      - openrouter.ai
+      User-Agent:
+      - litellm/1.65.4
+      X-Title:
+      - liteLLM
+    method: POST
+    uri: https://openrouter.ai/api/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/+JSgAEuAAAAAP//4kIwAQAAAP//QmICAAAA//9CYgIAAAD//0JiAgAAAP//QmIC
+        AAAA//9CYgIAAAD//0JiAgAAAP//QmICAAAA///VVdly4jgU/RWXX7ongQSzJ1X9wB4IS9hCh6ku
+        SpZlWyBLjiSbpYsPmE+Z7+gfmytCmvRU17zPAyW46zl347tNPfveDgjPOpVqyakWysVidjt/KQwn
+        ejpSnd7ubvucdFlqZ2zhrgnWYI5DpG+wiGJGNBUcVFgSpAmEukTJ2JHwCANzxHUoRUzxLWYo8UhW
+        xInKlsAtliKlHpFgVHs3ArHaK02ilU95QGQsKYekPGEMNESmFJOVpicnj/goYdoACAXIlX3/J1Di
+        HtnZ97mMzUQAKVz17g4RqQpXAFYB7HtbaRGDM0eapmT1by3h3kon0vCLiFIoIPb9d1sKRgwppajS
+        QM0kF1wTA9KehcTCKKYaMUv4VlsijolFlXV19YQkVVdXN1ZXf1KWNoYi4Vru4RdDMiBKW5jqvYW4
+        Z1GtrFgwqilGLGMRyCAiijMnJQbKiYQMGJISmbGYwKb6FuWnuFxIHWaN0hjFSGqD5UNGCzHBg5Nk
+        Sign1gToyxvrBNGgDUVELC0AF/ciJDeAkG7IyaFFfZ8waya2JrOR9EWSSvIGbSi0JNkmAvcGAqUn
+        DXykrC1hzLzGQcGsvCNqS8JxaAUCAPAIIGeABWaJR88Af/zF9urH3wTAMQS1/GyEsSQK5oabSp6/
+        YvLHDbRCEj9RiL03/K2XEOvcmwQGyBBEamMSIEtBjWgQal/ILZKe9ZpAH2CmLeSKRJ8bCFnOTc1Y
+        SljdT8DlPLonjB6VsBhQAAVFuX8rI/TZlJt5FvLgY7n0xPk0Kjt9Dr8N99BqCM+FRi4jlpCn1isa
+        cOpD7yH5G6szjZVHNKLsbc71PjaT+FN5YyKD9en5X/MFdBHSH09H9nw6UgfUlwU3jgiWwdShUetO
+        y7XuY7htdVv1oPG4aXqojr/GXxee8jlxG9HOfbrm/cmhfkhm1+kM9ebt5cOuWB3scslC5m8PrOCM
+        goekEqd+H7/0nihb3I4Cvbjd+jVV4e5T52tlEDhrt9N2lp25dgt1B+9zzqjWbjQeJgItShI+fEHH
+        ucF6XljONvvh1GHwlvqzCbyBHi0G+QHNFZez+WF4aOWXzfl+0BxMm8NoTPhdb7Sellt9PK7UxaDl
+        Oc6wVGg1POdxm3fC7rpRDx5YPB2NOjWMO3Q07l/fodum7DyqZrfXCCu5er3R2fF6mcYyj9vOrLNZ
+        dIZj8VQ8jIKB//K6Hrd2tcdBqVBdqvErXrhBCpZbPMCl6rLyFO94IaiyXi9xKrUnmhau1zPWCvBy
+        Vlr0eBCg13p+vCHR3e3w4HbKKnX718+PD70FxGSeegxraXt/GGz8cXogc9o8oPJkRnJiOel7qRrP
+        opzLHnxvHrilh2d3+LzZHyjPkfVd786/u54McE85SW/YjMUiRDCFafn5BbtugAeLdj4/FS+18Zcv
+        9vHb8fgtYyfvVxnGM4r1SosN4bAdTtFc5fc/qIu4DHINs8cuokrVmCp9mieqVu5ebOx7LROS+TXq
+        Zfe+2xhhOG4/g4DnSbLaSqrJRzEMLRUfBWaJPgiOb8k/xk5iWFKCohXlPjHnkazO+G5yuaJTyfzO
+        4oz0YpjL/d7wUhX1S9jjbwr2EdXlBL1jL5ahXhHU/z/4Ho/HfwCTvKixxggAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-RAY:
+      - a21e58b10ae07d47-BOS
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jul 2026 20:20:46 GMT
+      Permissions-Policy:
+      - payment=(self "https://checkout.stripe.com" "https://connect-js.stripe.com"
+        "https://js.stripe.com" "https://*.js.stripe.com" "https://hooks.stripe.com")
+      Referrer-Policy:
+      - no-referrer, strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Generation-Id:
+      - gen-1785183644-wUY3NRtSOsGJx9wVuIlv
+      access-control-expose-headers:
+      - X-Generation-Id,X-Provider-Name,cf-ray
+      set-cookie:
+      - __cf_bm=NVrO2N0nUnol6efzP_eG_SUO9OIVVwPWPQj_hFWliKA-1785183644.3233423-1.0.1.1-y7g7a2cJ6a9IgX060d8qW9TkWBkAxeRpuby2nsaFW5.GnJ6Tq_mo2Ra2gV2vKt.ZRgEp.7mh.La9iwOhMIfXR8.rANeophYC6U7kLRvQp8sDRumbZiEpN9OA3zHzEcOe;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=openrouter.ai; Expires=Mon,
+        27 Jul 2026 20:50:46 GMT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/contrib/litellm/test_litellm_llmobs.py
+++ b/tests/contrib/litellm/test_litellm_llmobs.py
@@ -4,6 +4,7 @@ import pytest
 from ddtrace._monkey import patch
 from ddtrace.contrib.internal.litellm.patch import get_version
 from ddtrace.internal.utils.version import parse_version
+from ddtrace.llmobs._utils import _get_attr
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import get_llmobs_input_messages
 from ddtrace.llmobs._utils import get_llmobs_metrics
@@ -1049,6 +1050,33 @@ def test_completion_openrouter_cost(litellm, request_vcr, litellm_llmobs, test_s
     assert len(spans) == 1
     metrics = get_llmobs_metrics(spans[0])
     assert "total_cost" in metrics
+    assert metrics["total_cost"] > 0
+    if "input_cost" in metrics or "output_cost" in metrics:
+        assert round((metrics["input_cost"] + metrics["output_cost"]) * 1e9) == round(metrics["total_cost"] * 1e9)
+
+
+def test_completion_openrouter_byok_cost(litellm, request_vcr, litellm_llmobs, test_spans):
+    """OpenRouter BYOK (bring-your-own-key) upstream cost is surfaced on the span's cost metrics.
+
+    With BYOK, OpenRouter bills ``usage.cost=0`` (the customer pays the provider directly with their
+    own key) and reports the real provider cost under ``usage.cost_details.upstream_inference_cost``,
+    flagged by ``usage.is_byok=True``. The integration should surface that upstream cost as
+    ``total_cost`` rather than the billed 0.
+    """
+    with request_vcr.use_cassette("completion_openrouter_byok.yaml"):
+        resp = litellm.completion(
+            model="openrouter/anthropic/claude-opus-5",
+            messages=[{"content": "What is the capital of France?", "role": "user"}],
+        )
+
+    assert _get_attr(resp.usage, "is_byok", None) is True
+    assert _get_attr(resp.usage, "cost", None) == 0
+    cost_details = _get_attr(resp.usage, "cost_details", {})
+    assert _get_attr(cost_details, "upstream_inference_cost", 0) > 0
+    spans = [s for trace in test_spans.pop_traces() for s in trace]
+    assert len(spans) == 1
+    metrics = get_llmobs_metrics(spans[0])
+    # BYOK bills cost=0; the upstream inference cost must still be surfaced as a non-zero total_cost.
     assert metrics["total_cost"] > 0
     if "input_cost" in metrics or "output_cost" in metrics:
         assert round((metrics["input_cost"] + metrics["output_cost"]) * 1e9) == round(metrics["total_cost"] * 1e9)

--- a/tests/contrib/openai/cassettes/v1/chat_completion_openrouter_byok.yaml
+++ b/tests/contrib/openai/cassettes/v1/chat_completion_openrouter_byok.yaml
@@ -1,0 +1,80 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": "What is the capital of France?"}],
+      "model": "openai/gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '108'
+      content-type:
+      - application/json
+      host:
+      - openrouter.ai
+      user-agent:
+      - OpenAI/Python 1.0.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.0.0
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://openrouter.ai/api/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/+JSgAEuAAAAAP//4kIwAQAAAP//fFFNj5swEP0ryGeSLvkgKbfdQ6Xtoe2hUg9V
+        ZTl4gGnAtjxD2tWK/94hWVIipeWC9Ob5fcy8KrSqUDW4Rbbbb7P9+n2WLzbrPNvu8m+H+uO2/HR8
+        Wj3bSqXKH35CyUIvG8PL0nehBUbvZFRGMAwi9VclVZ230ArdB3AG39WBFxu/6NChvAjRn9BClPln
+        mT8+C0YvxNDpCl0NMUR0o1kV9NbubZZluTEjCeIJS9CM42PXt63YN14gUsV3KeQs/FbFQ6paX4vL
+        gSaW6CI1WqKShC4UsQ8i6AzjCfQ/ph0QmRpU8aqib+WvDBESGwknxt4xnGN+bSApTUA2beKr5EM0
+        roQEKfliItJSuBGqnkw7pbkYSdULMAw/UtVPVpK7C6zZH8FJ/mwzWk37vsK7VLEXwyuwykYe8bk+
+        kj68+KMqOPaQ3kpqC2ywpdGrNGUD9qohL8+I/hWRYQ6b3qKfA+MBZ8BwMZ9r94FYinYaXQURZCX6
+        Ld/yYfzydXqP85b1hjp2uys3rYVu+ZvVcGdp83DXC8w7YScn+E/rYRj+AAAA//8DAAoKOUhLAwAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-RAY:
+      - a21e5f546e333762-BOS
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jul 2026 20:25:17 GMT
+      Permissions-Policy:
+      - payment=(self "https://checkout.stripe.com" "https://connect-js.stripe.com"
+        "https://js.stripe.com" "https://*.js.stripe.com" "https://hooks.stripe.com")
+      Referrer-Policy:
+      - no-referrer, strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Generation-Id:
+      - gen-1785183916-4361576WbgJ5cNkB2Idf
+      access-control-expose-headers:
+      - X-Generation-Id,X-Provider-Name,cf-ray
+      set-cookie:
+      - __cf_bm=NZ0Y5k64Ioch0gNAuNxkvJShQrenMFVeHyL1Zxce1SY-1785183916.2236412-1.0.1.1-COb0Kicvi5fBX2HIJbc_htwYgHw9LOlqMS9JwNUzYDBe_D81xzc8Q0cD.fQfWg04ZEJCxOcbI6C0lVuHq2Li24G7lioB7jaM2w00EoVsMKxfss1jjZ4jN0WoTDvTCnfv;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=openrouter.ai; Expires=Mon,
+        27 Jul 2026 20:55:17 GMT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/contrib/openai/test_openai_llmobs.py
+++ b/tests/contrib/openai/test_openai_llmobs.py
@@ -7,6 +7,7 @@ import pytest
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs._integrations.utils import _est_tokens
+from ddtrace.llmobs._utils import _get_attr
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import get_llmobs_input_messages
 from ddtrace.llmobs._utils import get_llmobs_metadata
@@ -3268,5 +3269,31 @@ class TestLLMObsOpenAIOpenRouter:
         assert "total_cost" in metrics
         assert metrics["total_cost"] > 0
         # input_cost/output_cost are present only when they sum to total_cost; if present, verify that.
+        if "input_cost" in metrics or "output_cost" in metrics:
+            assert round((metrics["input_cost"] + metrics["output_cost"]) * 1e9) == round(metrics["total_cost"] * 1e9)
+
+    def test_chat_completion_openrouter_byok_cost(self, openai, openai_llmobs, test_spans):
+        """OpenRouter BYOK upstream cost is surfaced on the span's cost metrics.
+
+        With BYOK, OpenRouter bills ``usage.cost=0`` and reports the real provider cost under
+        ``usage.cost_details.upstream_inference_cost`` (flagged by ``usage.is_byok=True``). The
+        integration should surface that upstream cost as ``total_cost`` rather than the billed 0.
+        """
+        with get_openai_vcr(subdirectory_name="v1").use_cassette("chat_completion_openrouter_byok.yaml"):
+            client = openai.OpenAI(base_url="https://openrouter.ai/api/v1")
+            resp = client.chat.completions.create(
+                model="openai/gpt-4o-mini",
+                messages=[{"role": "user", "content": "What is the capital of France?"}],
+            )
+
+        assert _get_attr(resp.usage, "is_byok", None) is True
+        assert _get_attr(resp.usage, "cost", None) == 0
+        cost_details = _get_attr(resp.usage, "cost_details", {})
+        assert _get_attr(cost_details, "upstream_inference_cost", 0) > 0
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        assert len(spans) == 1
+        metrics = get_llmobs_metrics(spans[0])
+        # BYOK bills cost=0; the upstream inference cost must still be surfaced as a non-zero total_cost.
+        assert metrics["total_cost"] > 0
         if "input_cost" in metrics or "output_cost" in metrics:
             assert round((metrics["input_cost"] + metrics["output_cost"]) * 1e9) == round(metrics["total_cost"] * 1e9)

--- a/tests/llmobs/test_integrations_utils.py
+++ b/tests/llmobs/test_integrations_utils.py
@@ -17,7 +17,6 @@ from ddtrace.llmobs._integrations.utils import _extract_content_parts
 from ddtrace.llmobs._integrations.utils import _normalize_prompt_variables
 from ddtrace.llmobs._integrations.utils import _openai_parse_input_response_messages
 from ddtrace.llmobs._integrations.utils import format_image_part
-from ddtrace.llmobs._integrations.utils import get_openrouter_cost_metrics
 from ddtrace.llmobs._integrations.utils import openai_construct_message_from_streamed_chunks
 from ddtrace.llmobs._integrations.utils import openai_set_meta_tags_from_chat
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
@@ -631,75 +630,3 @@ class TestOpenAIConstructMessageFromStreamedChunks:
         message = openai_construct_message_from_streamed_chunks(chunks)
         assert message["reasoning_content"] == "r"
         assert message["content"] == "c"
-
-
-class TestGetOpenRouterCostMetrics:
-    """Tests for get_openrouter_cost_metrics, including OpenRouter BYOK upstream cost handling."""
-
-    def test_no_cost_returns_empty(self):
-        # A response without a numeric cost (e.g. a non-OpenRouter provider) yields no metrics.
-        assert get_openrouter_cost_metrics(SimpleNamespace(prompt_tokens=10)) == {}
-        assert get_openrouter_cost_metrics(SimpleNamespace(cost=None)) == {}
-
-    def test_standard_cost_with_reconciling_breakdown(self):
-        usage = SimpleNamespace(
-            cost=0.00197,
-            cost_details=SimpleNamespace(
-                upstream_inference_prompt_cost=0.00117,
-                upstream_inference_completions_cost=0.0008,
-            ),
-        )
-        metrics = get_openrouter_cost_metrics(usage)
-        assert metrics["total_cost"] == 0.00197
-        assert metrics["input_cost"] == 0.00117
-        assert metrics["output_cost"] == 0.0008
-
-    def test_standard_cost_breakdown_omitted_when_not_reconciling(self):
-        # When the upstream breakdown doesn't sum to the billed cost, only total_cost is emitted.
-        usage = SimpleNamespace(
-            cost=0.005,
-            cost_details=SimpleNamespace(
-                upstream_inference_prompt_cost=0.00117,
-                upstream_inference_completions_cost=0.0008,
-            ),
-        )
-        metrics = get_openrouter_cost_metrics(usage)
-        assert metrics == {"total_cost": 0.005}
-
-    def test_byok_uses_upstream_cost(self):
-        # BYOK: OpenRouter bills cost=0, but the real (provider) cost lives in
-        # cost_details.upstream_inference_cost and must be surfaced as total_cost.
-        usage = SimpleNamespace(
-            cost=0,
-            is_byok=True,
-            cost_details=SimpleNamespace(
-                upstream_inference_cost=0.00197,
-                upstream_inference_prompt_cost=0.00117,
-                upstream_inference_completions_cost=0.0008,
-            ),
-        )
-        metrics = get_openrouter_cost_metrics(usage)
-        assert metrics["total_cost"] == 0.00197
-        assert metrics["input_cost"] == 0.00117
-        assert metrics["output_cost"] == 0.0008
-
-    def test_byok_without_upstream_cost_falls_back_to_billed_cost(self):
-        # is_byok True but no upstream figure present: fall back to the billed cost unchanged.
-        usage = SimpleNamespace(cost=0, is_byok=True, cost_details=SimpleNamespace())
-        assert get_openrouter_cost_metrics(usage) == {"total_cost": 0.0}
-
-    def test_dict_usage_is_supported(self):
-        # token_usage may be a plain dict rather than an SDK object.
-        usage = {
-            "cost": 0,
-            "is_byok": True,
-            "cost_details": {
-                "upstream_inference_cost": 0.00159,
-                "upstream_inference_prompt_cost": 0.000222,
-                "upstream_inference_completions_cost": 0.001368,
-            },
-        }
-        metrics = get_openrouter_cost_metrics(usage)
-        assert metrics["total_cost"] == 0.00159
-        assert metrics["input_cost"] == 0.000222
-        assert metrics["output_cost"] == 0.001368

--- a/tests/llmobs/test_integrations_utils.py
+++ b/tests/llmobs/test_integrations_utils.py
@@ -17,6 +17,7 @@ from ddtrace.llmobs._integrations.utils import _extract_content_parts
 from ddtrace.llmobs._integrations.utils import _normalize_prompt_variables
 from ddtrace.llmobs._integrations.utils import _openai_parse_input_response_messages
 from ddtrace.llmobs._integrations.utils import format_image_part
+from ddtrace.llmobs._integrations.utils import get_openrouter_cost_metrics
 from ddtrace.llmobs._integrations.utils import openai_construct_message_from_streamed_chunks
 from ddtrace.llmobs._integrations.utils import openai_set_meta_tags_from_chat
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
@@ -630,3 +631,75 @@ class TestOpenAIConstructMessageFromStreamedChunks:
         message = openai_construct_message_from_streamed_chunks(chunks)
         assert message["reasoning_content"] == "r"
         assert message["content"] == "c"
+
+
+class TestGetOpenRouterCostMetrics:
+    """Tests for get_openrouter_cost_metrics, including OpenRouter BYOK upstream cost handling."""
+
+    def test_no_cost_returns_empty(self):
+        # A response without a numeric cost (e.g. a non-OpenRouter provider) yields no metrics.
+        assert get_openrouter_cost_metrics(SimpleNamespace(prompt_tokens=10)) == {}
+        assert get_openrouter_cost_metrics(SimpleNamespace(cost=None)) == {}
+
+    def test_standard_cost_with_reconciling_breakdown(self):
+        usage = SimpleNamespace(
+            cost=0.00197,
+            cost_details=SimpleNamespace(
+                upstream_inference_prompt_cost=0.00117,
+                upstream_inference_completions_cost=0.0008,
+            ),
+        )
+        metrics = get_openrouter_cost_metrics(usage)
+        assert metrics["total_cost"] == 0.00197
+        assert metrics["input_cost"] == 0.00117
+        assert metrics["output_cost"] == 0.0008
+
+    def test_standard_cost_breakdown_omitted_when_not_reconciling(self):
+        # When the upstream breakdown doesn't sum to the billed cost, only total_cost is emitted.
+        usage = SimpleNamespace(
+            cost=0.005,
+            cost_details=SimpleNamespace(
+                upstream_inference_prompt_cost=0.00117,
+                upstream_inference_completions_cost=0.0008,
+            ),
+        )
+        metrics = get_openrouter_cost_metrics(usage)
+        assert metrics == {"total_cost": 0.005}
+
+    def test_byok_uses_upstream_cost(self):
+        # BYOK: OpenRouter bills cost=0, but the real (provider) cost lives in
+        # cost_details.upstream_inference_cost and must be surfaced as total_cost.
+        usage = SimpleNamespace(
+            cost=0,
+            is_byok=True,
+            cost_details=SimpleNamespace(
+                upstream_inference_cost=0.00197,
+                upstream_inference_prompt_cost=0.00117,
+                upstream_inference_completions_cost=0.0008,
+            ),
+        )
+        metrics = get_openrouter_cost_metrics(usage)
+        assert metrics["total_cost"] == 0.00197
+        assert metrics["input_cost"] == 0.00117
+        assert metrics["output_cost"] == 0.0008
+
+    def test_byok_without_upstream_cost_falls_back_to_billed_cost(self):
+        # is_byok True but no upstream figure present: fall back to the billed cost unchanged.
+        usage = SimpleNamespace(cost=0, is_byok=True, cost_details=SimpleNamespace())
+        assert get_openrouter_cost_metrics(usage) == {"total_cost": 0.0}
+
+    def test_dict_usage_is_supported(self):
+        # token_usage may be a plain dict rather than an SDK object.
+        usage = {
+            "cost": 0,
+            "is_byok": True,
+            "cost_details": {
+                "upstream_inference_cost": 0.00159,
+                "upstream_inference_prompt_cost": 0.000222,
+                "upstream_inference_completions_cost": 0.001368,
+            },
+        }
+        metrics = get_openrouter_cost_metrics(usage)
+        assert metrics["total_cost"] == 0.00159
+        assert metrics["input_cost"] == 0.000222
+        assert metrics["output_cost"] == 0.001368


### PR DESCRIPTION
## Description

For OpenRouter **BYOK** (bring-your-own-key) setups, the customer calls the underlying provider with their own credentials. OpenRouter therefore bills `cost = 0` and reports the actual provider inference cost under `usage.cost_details.upstream_inference_cost`, flagging the response with `usage.is_byok = True`.

`get_openrouter_cost_metrics` previously read only the top-level `usage.cost`, so BYOK spans showed **zero cost** in LLM Observability even though the customer incurred real cost. This affects both the LiteLLM and OpenAI integrations (they share this helper).

Fix: when `usage.is_byok` is set, add `cost_details.upstream_inference_cost` to the total so the span reflects the cost actually incurred. Non-BYOK behavior is unchanged (`cost` already includes the provider cost). The input/output breakdown still only emits when `upstream_inference_prompt_cost + upstream_inference_completions_cost` reconciles with the total at nanodollar precision.

Example BYOK payload (Opus 5) that previously produced `total_cost = 0`, now `0.00197`:
```
'cost': 0, 'is_byok': True, 'cost_details': {'upstream_inference_cost': 0.00197,
 'upstream_inference_prompt_cost': 0.00117, 'upstream_inference_completions_cost': 0.0008}
```

## Testing

Integration tests exercise both integrations against live-recorded BYOK VCR cassettes. Each test first guards the precondition — that the recorded response is genuinely a BYOK response (`is_byok is True`, `cost == 0`, `upstream_inference_cost > 0`) — so a future non-BYOK re-recording can't make the test pass trivially. It then asserts the span surfaces a non-zero `total_cost` (with the `input_cost`/`output_cost` breakdown reconciling when present).

- `tests/contrib/litellm/test_litellm_llmobs.py::test_completion_openrouter_byok_cost` — LiteLLM path, Anthropic BYOK (`openrouter/anthropic/claude-opus-5`).
- `tests/contrib/openai/test_openai_llmobs.py::TestLLMObsOpenAIOpenRouter::test_chat_completion_openrouter_byok_cost` — OpenAI-SDK-against-OpenRouter path, OpenAI BYOK (`openai/gpt-4o-mini`).

Both cassettes were recorded against a live OpenRouter BYOK account and confirmed to carry `is_byok: true`, `cost: 0`, and a non-zero `upstream_inference_cost`. Also reproduced end to end with a local repro script confirming the cost appears on the span in the UI.

### Repro script provided by customer
```
import dspy  # noqa: E402  (imported after enable so ddtrace can instrument it)

lm = dspy.LM(
    "openrouter/anthropic/claude-opus-5",
    api_key=os.environ["OPENROUTER_API_KEY"],
    cache=False,
)
dspy.configure(lm=lm, cache=False, track_usage=True)

answer_agent = dspy.Predict("question->answer")
answer = answer_agent(question="What is the capital of Brazil? Answer")
print("Answer:", answer.answer)

print(f"Token usage: {answer.get_lm_usage()}")

LLMObs.flush()
```

### Before
[Trace](https://app.datadoghq.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40is_root_span%3Atrue&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&is_llm_session=false&refresh_mode=sliding&selectedTab=overview&sidepanelContextScopeKind=llm&sp=%5B%7B%22p%22%3A%7B%22eventId%22%3A%22AwAAAZ-lSjqz2DVELwAAABhBWi1sU2pxekFBQzBZaFdTRE9oN0FBQUEAAAAkZjE5ZmE1NGEtYTc3My00NWM4LWE3YjMtNDJkYTlmZGI1MGM3AAAkCA%22%7D%2C%22i%22%3A%22llm-obs-panel%22%7D%5D&spanId=2726099381201312506&start=1785183778285&end=1785184678285&paused=false)
<img width="1526" height="713" alt="Screenshot 2026-07-27 at 4 38 34 PM" src="https://github.com/user-attachments/assets/15a6d330-9e62-4023-bd17-2dce992c9549" />

### After
[Trace](https://app.datadoghq.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40is_root_span%3Atrue&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&is_llm_session=false&refresh_mode=sliding&selectedTab=overview&sidepanelContextScopeKind=llm&sp=%5B%7B%22p%22%3A%7B%22eventId%22%3A%22AwAAAZ-lR9WKuAxmswAAABhBWi1sUjlXS0FBQlJuSURVcG9uaEFBQUEAAAAkZjE5ZmE1NGItNDcyYS00YmIyLThlZmYtZTgxMjllZTMzN2FiAAAdog%22%7D%2C%22i%22%3A%22llm-obs-panel%22%7D%5D&spanId=17812846719156687862&start=1785183778285&end=1785184678285&paused=false)
<img width="1535" height="710" alt="Screenshot 2026-07-27 at 4 39 00 PM" src="https://github.com/user-attachments/assets/eb5e3015-09d4-45ae-b370-861be0f5a701" />

## Risks

Low. The change is confined to a single pure helper. The new behavior is gated on `usage.is_byok`, so non-BYOK OpenRouter responses (and all non-OpenRouter providers) are unaffected.

## Additional Notes

Reported by a prospect via support. Fixes the case where BYOK usage reported zero cost in the OpenRouter integration.

Claude session: \`3b93fe65-18d2-413f-b53e-2d95f370e1ed\`
Resume: \`claude --resume 3b93fe65-18d2-413f-b53e-2d95f370e1ed\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)