### PR TITLE
perf(profiling): reuse exporter across upload cycles

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/constants.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/constants.hpp
@@ -23,6 +23,11 @@ constexpr std::string_view g_runtime_name = "CPython";
 // Name of the language we support
 constexpr std::string_view g_language_name = "python";
 
+// Profile family — generally different from `g_language_name` (e.g. an eBPF
+// profiler may run in family `native` while sampling `python` code), but for
+// this profiler they happen to coincide.
+constexpr std::string_view g_family_name = "python";
+
 // Name of the library
 constexpr std::string_view g_library_name = "dd-trace-py";
 

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_state.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_state.hpp
@@ -101,15 +101,17 @@ class ProfilerState
     std::atomic<ddog_CancellationToken> upload_cancel{ { .inner = nullptr } };
     std::atomic<uint64_t> upload_seq{ 0 };
 
-    // Cached profile exporter, reused across upload cycles. Each construction
-    // allocates a tokio runtime, TLS connector and HTTP client on the Rust side
-    // (~10-15 native allocations), so we build it once and keep it.
-    // Lifetime: created lazily on first upload, dropped in prefork() (parent side,
-    // while tokio threads are still alive) and in cleanup(). Always accessed under
-    // upload_lock — except in cleanup(), which runs single-threaded at exit.
-    // Config snapshot: baked from ProfilerState at first build; later set_* calls
-    // do not retroactively update it.
-    ddog_prof_ProfileExporter cached_exporter{ .inner = nullptr };
+    // Profile exporter, reused across upload cycles. Each construction allocates
+    // a tokio runtime, TLS connector and HTTP client on the Rust side (~10-15
+    // native allocations), so we build it once and keep it.
+    // Lifetime: created lazily on first upload, dropped in prefork (parent side,
+    // while tokio threads are still alive) and in cleanup. Always accessed under
+    // upload_lock — except in cleanup, which runs single-threaded at exit.
+    // The exporter bakes the endpoint (URL + timeout) and the static identity
+    // tags (env, service, version, runtime_id, process_id, etc.). Per-upload
+    // user tags are passed via optional_additional_tags on send instead of
+    // being baked here, so they can change without rebuilding the exporter.
+    ddog_prof_ProfileExporter exporter{ .inner = nullptr };
     void drop_exporter();
 
     // ========================================================================

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_state.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_state.hpp
@@ -101,6 +101,17 @@ class ProfilerState
     std::atomic<ddog_CancellationToken> upload_cancel{ { .inner = nullptr } };
     std::atomic<uint64_t> upload_seq{ 0 };
 
+    // Cached profile exporter, reused across upload cycles. Each construction
+    // allocates a tokio runtime, TLS connector and HTTP client on the Rust side
+    // (~10-15 native allocations), so we build it once and keep it.
+    // Lifetime: created lazily on first upload, dropped in prefork() (parent side,
+    // while tokio threads are still alive) and in cleanup(). Always accessed under
+    // upload_lock — except in cleanup(), which runs single-threaded at exit.
+    // Config snapshot: baked from ProfilerState at first build; later set_* calls
+    // do not retroactively update it.
+    ddog_prof_ProfileExporter cached_exporter{ .inner = nullptr };
+    void drop_exporter();
+
     // ========================================================================
     // Interned string caches
     // ========================================================================

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader.hpp
@@ -13,7 +13,7 @@ namespace Datadog {
 
 // Uploader handles uploading encoded profiles to the Datadog backend.
 // The ddog_prof_ProfileExporter is owned by ProfilerState and reused across
-// upload cycles (see ProfilerState::cached_exporter).
+// upload cycles (see ProfilerState::exporter).
 // Upload state (lock, cancellation token, sequence number) is stored in the ProfilerState singleton.
 class Uploader
 {

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader.hpp
@@ -12,13 +12,14 @@ extern "C"
 namespace Datadog {
 
 // Uploader handles uploading encoded profiles to the Datadog backend.
+// The ddog_prof_ProfileExporter is owned by ProfilerState and reused across
+// upload cycles (see ProfilerState::cached_exporter).
 // Upload state (lock, cancellation token, sequence number) is stored in the ProfilerState singleton.
 class Uploader
 {
   private:
     std::string errmsg;
     std::string output_filename;
-    ddog_prof_ProfileExporter ddog_exporter{ .inner = nullptr };
     ddog_prof_EncodedProfile encoded_profile{};
     Datadog::ProfilerStats profiler_stats;
     std::string process_tags;
@@ -32,34 +33,19 @@ class Uploader
     static void lock();
     static void unlock();
 
-    Uploader(std::string_view _url,
-             ddog_prof_ProfileExporter ddog_exporter,
+    Uploader(std::string_view _output_filename,
              ddog_prof_EncodedProfile encoded,
              Datadog::ProfilerStats stats,
              std::string_view _process_tags);
     ~Uploader();
 
-    // Disable copy constructor and copy assignment operator to avoid double-free
-    // of ddog_exporter
+    // Disable copy to avoid double-free of encoded_profile.
     Uploader(const Uploader&) = delete;
     Uploader& operator=(const Uploader&) = delete;
 
-    // In move constructor and move assignment operator, we clear inner pointer
-    // of ddog_exporter in other to avoid double-free from the destructor.
-    // These were added as we started to calling ddog_prof_Exporter_drop()
-    // function in the destructor.
-    // We initially observed the double free error as we created a temporary
-    // object which then moved to std::variant. A simplified example and possible
-    // solution using std::variant constructor is here:
-    // https://gist.github.com/taegyunkim/9191e643e315be55e78e383ccc498713
-    // We also update the move constructor and move assignment operator to set
-    // the inner pointer to nullptr to avoid double-free. At the time of writing,
-    // we don't have code that uses move constructor and move assignment operator,
-    // but we add them to avoid any potential issues.
+    // Move clears the source's encoded_profile so the destructor only drops it once.
     Uploader(Uploader&& other) noexcept
     {
-        ddog_exporter = other.ddog_exporter;
-        other.ddog_exporter = { .inner = nullptr };
         encoded_profile = other.encoded_profile;
         other.encoded_profile = { .inner = nullptr };
         profiler_stats = other.profiler_stats;
@@ -71,10 +57,7 @@ class Uploader
     Uploader& operator=(Uploader&& other) noexcept
     {
         if (this != &other) {
-            ddog_prof_Exporter_drop(&ddog_exporter);
             ddog_prof_EncodedProfile_drop(&encoded_profile);
-            ddog_exporter = other.ddog_exporter;
-            other.ddog_exporter = { .inner = nullptr };
             encoded_profile = other.encoded_profile;
             other.encoded_profile = { .inner = nullptr };
             profiler_stats = other.profiler_stats;

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader_builder.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader_builder.hpp
@@ -14,9 +14,6 @@ namespace Datadog {
 // Configuration state is stored in the ProfilerState singleton.
 class UploaderBuilder
 {
-    static constexpr std::string_view language{ g_language_name };
-    static constexpr std::string_view family{ g_language_name };
-
   public:
     static void set_env(std::string_view _dd_env);
     static void set_service(std::string_view _service);

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader_builder.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/uploader_builder.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <string_view>
 #include <variant>
+#include <vector>
 
 namespace Datadog {
 
@@ -32,6 +33,12 @@ class UploaderBuilder
     static void set_max_timeout_ms(uint64_t _max_timeout_ms);
 
     static std::variant<Uploader, std::string> build();
+
+    // Build a tag vector from ProfilerState::user_tags, for use as
+    // optional_additional_tags on send. Caller owns the returned vector and
+    // must drop it with ddog_Vec_Tag_drop. Tags that fail validation are
+    // omitted and their reason appended to `reasons`.
+    static ddog_Vec_Tag build_user_tag_vec(std::vector<std::string>& reasons);
 };
 
 } // namespace Datadog

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_state.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_state.cpp
@@ -136,9 +136,9 @@ ProfilerState::start()
 void
 ProfilerState::drop_exporter()
 {
-    if (cached_exporter.inner != nullptr) {
-        ddog_prof_Exporter_drop(&cached_exporter);
-        cached_exporter = { .inner = nullptr };
+    if (exporter.inner != nullptr) {
+        ddog_prof_Exporter_drop(&exporter);
+        exporter = { .inner = nullptr };
     }
 }
 
@@ -176,12 +176,12 @@ ProfilerState::prefork()
     }
     // upload_lock is now held - will be released in postfork_parent/child
 
-    // Drop the cached exporter while we are still in the parent. The exporter
-    // owns Rust state (tokio runtime, TLS, HTTP client) whose worker threads
-    // do not survive fork(); dropping it post-fork in the child can deadlock or
-    // touch dead-thread state. Dropping it here — under upload_lock with no
-    // upload in flight — is safe. Parent and child both re-create it lazily on
-    // the next upload via UploaderBuilder::build().
+    // Drop the exporter while we are still in the parent. It owns Rust state
+    // (tokio runtime, TLS, HTTP client) whose worker threads do not survive
+    // fork; dropping post-fork in the child can deadlock or touch dead-thread
+    // state. Dropping here — under upload_lock with no upload in flight — is
+    // safe. Parent and child both re-create it lazily on the next upload via
+    // UploaderBuilder::build.
     drop_exporter();
 
     // Lock the profile mutex so the sampling thread cannot be mid-allocation

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_state.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_state.cpp
@@ -134,6 +134,15 @@ ProfilerState::start()
 }
 
 void
+ProfilerState::drop_exporter()
+{
+    if (cached_exporter.inner != nullptr) {
+        ddog_prof_Exporter_drop(&cached_exporter);
+        cached_exporter = { .inner = nullptr };
+    }
+}
+
+void
 ProfilerState::cleanup()
 {
     // Clear the profile, decreasing the refcount on the Profiles Dictionary
@@ -141,6 +150,9 @@ ProfilerState::cleanup()
 
     // Decrease the refcount on the Profiles Dictionary
     release_profiles_dictionary();
+
+    // atexit runs single-threaded, so no lock is required here.
+    drop_exporter();
 }
 
 void
@@ -163,6 +175,14 @@ ProfilerState::prefork()
         std::this_thread::sleep_for(std::chrono::microseconds(50));
     }
     // upload_lock is now held - will be released in postfork_parent/child
+
+    // Drop the cached exporter while we are still in the parent. The exporter
+    // owns Rust state (tokio runtime, TLS, HTTP client) whose worker threads
+    // do not survive fork(); dropping it post-fork in the child can deadlock or
+    // touch dead-thread state. Dropping it here — under upload_lock with no
+    // upload in flight — is safe. Parent and child both re-create it lazily on
+    // the next upload via UploaderBuilder::build().
+    drop_exporter();
 
     // Lock the profile mutex so the sampling thread cannot be mid-allocation
     // inside ddog_prof_Profile_add2 when the child calls ddog_prof_Profile_drop.

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
@@ -13,12 +13,10 @@
 using namespace Datadog;
 
 Datadog::Uploader::Uploader(std::string_view _output_filename,
-                            ddog_prof_ProfileExporter _ddog_exporter,
                             ddog_prof_EncodedProfile _encoded_profile,
                             Datadog::ProfilerStats _stats,
                             std::string_view _process_tags)
   : output_filename{ _output_filename }
-  , ddog_exporter{ _ddog_exporter }
   , encoded_profile{ _encoded_profile }
   , profiler_stats{ _stats }
   , process_tags{ _process_tags }
@@ -30,10 +28,8 @@ Datadog::Uploader::Uploader(std::string_view _output_filename,
 
 Datadog::Uploader::~Uploader()
 {
-    // We need to call _drop() on the exporter and the cancellation token,
-    // as their inner pointers are allocated on the Rust side. And since
-    // there could be a request in flight, we first need to cancel it. Then,
-    // we drop the exporter and the cancellation token.
+    // Cancel any request still in flight before dropping the encoded profile.
+    // The exporter itself is owned by ProfilerState and outlives the Uploader.
     auto current_cancel = ProfilerState::get().upload_cancel.exchange({ .inner = nullptr });
 
     if (current_cancel.inner != nullptr) {
@@ -41,7 +37,6 @@ Datadog::Uploader::~Uploader()
         ddog_CancellationToken_drop(&current_cancel);
     }
 
-    ddog_prof_Exporter_drop(&ddog_exporter);
     ddog_prof_EncodedProfile_drop(&encoded_profile);
 }
 
@@ -141,8 +136,13 @@ Datadog::Uploader::upload_unlocked()
         .len = static_cast<uintptr_t>(to_compress_files.size()),
     };
 
+    // The exporter is owned by ProfilerState and reused across uploads.
+    // Caller holds upload_lock, so this access is serialized with prefork/cleanup
+    // (the only places that drop the exporter).
+    auto& cached_exporter = ProfilerState::get().cached_exporter;
+
     // Build and send the request in one call
-    auto init_runtime_res = ddog_prof_Exporter_init_runtime(&ddog_exporter);
+    auto init_runtime_res = ddog_prof_Exporter_init_runtime(&cached_exporter);
     if (init_runtime_res.tag != DDOG_VOID_RESULT_OK) {
         std::cerr << "Error initializing runtime: " << err_to_msg(&init_runtime_res.err, "Error initializing runtime")
                   << std::endl;
@@ -165,7 +165,7 @@ Datadog::Uploader::upload_unlocked()
         ddog_CancellationToken_drop(&current_cancel);
     }
 
-    auto res = ddog_prof_Exporter_send_blocking(&ddog_exporter,
+    auto res = ddog_prof_Exporter_send_blocking(&cached_exporter,
                                                 &encoded_profile,
                                                 files_to_compress,
                                                 nullptr, // optional_additional_tags
@@ -183,7 +183,7 @@ Datadog::Uploader::upload_unlocked()
         ret = false;
     }
     ddog_CancellationToken_drop(&new_cancel_clone_for_request);
-    ddog_prof_Exporter_drop(&ddog_exporter);
+    // cached_exporter intentionally NOT dropped: it is reused across uploads.
 
     return ret;
 }

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader.cpp
@@ -4,6 +4,7 @@
 #include "libdatadog_helpers.hpp"
 #include "profiler_state.hpp"
 #include "profiler_stats.hpp"
+#include "uploader_builder.hpp"
 
 #include <fstream>  // ofstream
 #include <sstream>  // ostringstream
@@ -138,15 +139,30 @@ Datadog::Uploader::upload_unlocked()
 
     // The exporter is owned by ProfilerState and reused across uploads.
     // Caller holds upload_lock, so this access is serialized with prefork/cleanup
-    // (the only places that drop the exporter).
-    auto& cached_exporter = ProfilerState::get().cached_exporter;
+    // (the only places that drop the exporter) and with other uploads.
+    auto& exporter = ProfilerState::get().exporter;
 
-    // Build and send the request in one call
-    auto init_runtime_res = ddog_prof_Exporter_init_runtime(&cached_exporter);
+    // User-defined tags can change between uploads (e.g. manual Profiler usage
+    // setting per-task tags), so we build them per-send rather than baking
+    // them into the long-lived exporter.
+    std::vector<std::string> tag_reasons;
+    ddog_Vec_Tag user_tag_vec = UploaderBuilder::build_user_tag_vec(tag_reasons);
+    if (!tag_reasons.empty()) {
+        std::cerr << "Bad user tag(s); skipping upload: ";
+        for (const auto& r : tag_reasons) {
+            std::cerr << r << "; ";
+        }
+        std::cerr << std::endl;
+        ddog_Vec_Tag_drop(user_tag_vec);
+        return false;
+    }
+
+    auto init_runtime_res = ddog_prof_Exporter_init_runtime(&exporter);
     if (init_runtime_res.tag != DDOG_VOID_RESULT_OK) {
         std::cerr << "Error initializing runtime: " << err_to_msg(&init_runtime_res.err, "Error initializing runtime")
                   << std::endl;
         ddog_Error_drop(&init_runtime_res.err);
+        ddog_Vec_Tag_drop(user_tag_vec);
         return false;
     }
 
@@ -165,10 +181,10 @@ Datadog::Uploader::upload_unlocked()
         ddog_CancellationToken_drop(&current_cancel);
     }
 
-    auto res = ddog_prof_Exporter_send_blocking(&cached_exporter,
+    auto res = ddog_prof_Exporter_send_blocking(&exporter,
                                                 &encoded_profile,
                                                 files_to_compress,
-                                                nullptr, // optional_additional_tags
+                                                &user_tag_vec,
                                                 optional_process_tags_ptr,
                                                 &internal_metadata_json_slice,
                                                 optional_info_json_ptr,
@@ -183,7 +199,7 @@ Datadog::Uploader::upload_unlocked()
         ret = false;
     }
     ddog_CancellationToken_drop(&new_cancel_clone_for_request);
-    // cached_exporter intentionally NOT dropped: it is reused across uploads.
+    ddog_Vec_Tag_drop(user_tag_vec);
 
     return ret;
 }

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader_builder.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader_builder.cpp
@@ -179,9 +179,9 @@ ensure_exporter(ProfilerState& state)
     }
 
     ddog_prof_ProfileExporter_Result res = ddog_prof_Exporter_new(
-      to_slice("dd-trace-py"),
+      to_slice(g_library_name),
       to_slice(state.profiler_version),
-      to_slice(g_language_name),
+      to_slice(g_family_name),
       &tags,
       ddog_prof_Endpoint_agent(to_slice(state.url), state.max_timeout_ms, /*use_system_resolver=*/false));
     ddog_Vec_Tag_drop(tags);

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader_builder.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader_builder.cpp
@@ -216,6 +216,14 @@ Datadog::UploaderBuilder::build_user_tag_vec(std::vector<std::string>& reasons)
 std::variant<Datadog::Uploader, std::string>
 Datadog::UploaderBuilder::build()
 {
+    // AIDEV-NOTE: UploaderBuilder reaches into ProfilerState via the singleton
+    // here and in build_user_tag_vec / every set_* method. This is consistent
+    // with the rest of UploaderBuilder, but it is a hidden dependency. The
+    // clean fix is to thread only the fields actually needed (env, service,
+    // version, runtime, runtime_id, ..., user_tags, exporter) through an
+    // explicit config struct, decoupling UploaderBuilder from ProfilerState
+    // entirely. Deferred to a follow-up to keep this PR focused on the
+    // exporter-reuse behavior change.
     auto& state = ProfilerState::get();
 
     // Lazily create the exporter on first build. Subsequent builds reuse it.

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader_builder.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader_builder.cpp
@@ -5,6 +5,7 @@
 #include "sample.hpp"
 
 #include <numeric>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unistd.h>
@@ -130,43 +131,44 @@ join(const std::vector<std::string>& vec, const std::string& delim)
                            });
 }
 
-std::variant<Datadog::Uploader, std::string>
-Datadog::UploaderBuilder::build()
-{
-    auto& state = ProfilerState::get();
+namespace {
 
-    // Setup the ddog_Exporter
+// Create the cached exporter if it does not already exist.
+// Caller must hold ProfilerState::upload_lock.
+std::optional<std::string>
+ensure_cached_exporter(Datadog::ProfilerState& state)
+{
+    if (state.cached_exporter.inner != nullptr) {
+        return std::nullopt;
+    }
+
     ddog_Vec_Tag tags = ddog_Vec_Tag_new();
 
-    // Add the tags.  In the average case, the user has a structural problem with
-    // one of their tags, but it's really annoying to have to iteratively fix several
-    // tags, so we'll just collect all the reasons and report them all at once.
+    // Add the tags. We collect all errors so the user can fix them in one pass.
     std::vector<std::string> reasons{};
-    const std::vector<std::pair<ExportTagKey, std::string_view>> tag_data = {
-        { ExportTagKey::dd_env, state.dd_env },
-        { ExportTagKey::service, state.service },
-        { ExportTagKey::version, state.version },
-        { ExportTagKey::language, language },
-        { ExportTagKey::runtime, state.runtime },
-        { ExportTagKey::runtime_id, state.runtime_id },
-        { ExportTagKey::runtime_version, state.runtime_version },
-        { ExportTagKey::profiler_version, state.profiler_version },
-        { ExportTagKey::process_id, state.process_id }
+    const std::vector<std::pair<Datadog::ExportTagKey, std::string_view>> tag_data = {
+        { Datadog::ExportTagKey::dd_env, state.dd_env },
+        { Datadog::ExportTagKey::service, state.service },
+        { Datadog::ExportTagKey::version, state.version },
+        { Datadog::ExportTagKey::language, g_language_name },
+        { Datadog::ExportTagKey::runtime, state.runtime },
+        { Datadog::ExportTagKey::runtime_id, state.runtime_id },
+        { Datadog::ExportTagKey::runtime_version, state.runtime_version },
+        { Datadog::ExportTagKey::profiler_version, state.profiler_version },
+        { Datadog::ExportTagKey::process_id, state.process_id }
     };
 
     for (const auto& [tag, data] : tag_data) {
         if (!data.empty()) {
             std::string errmsg;
-            if (!add_tag(tags, tag, data, errmsg)) {
-                reasons.push_back(std::string(to_string(tag)) + ": " + errmsg);
+            if (!Datadog::add_tag(tags, tag, data, errmsg)) {
+                reasons.push_back(std::string(Datadog::to_string(tag)) + ": " + errmsg);
             }
         }
     }
-
-    // Add the user-defined tags, if any.
     for (const auto& tag : state.user_tags) {
         std::string errmsg;
-        if (!add_tag(tags, tag.first, tag.second, errmsg)) {
+        if (!Datadog::add_tag(tags, tag.first, tag.second, errmsg)) {
             reasons.push_back(std::string(tag.first) + ": " + errmsg);
         }
     }
@@ -176,23 +178,38 @@ Datadog::UploaderBuilder::build()
         return "Error initializing exporter, missing or bad configuration: " + join(reasons, ", ");
     }
 
-    // If we're here, the tags are good, so we can initialize the exporter
     ddog_prof_ProfileExporter_Result res = ddog_prof_Exporter_new(
-      to_slice("dd-trace-py"),
-      to_slice(state.profiler_version),
-      to_slice(family),
+      Datadog::to_slice("dd-trace-py"),
+      Datadog::to_slice(state.profiler_version),
+      Datadog::to_slice(g_language_name),
       &tags,
-      ddog_prof_Endpoint_agent(to_slice(state.url), state.max_timeout_ms, /*use_system_resolver=*/false));
+      ddog_prof_Endpoint_agent(Datadog::to_slice(state.url), state.max_timeout_ms, /*use_system_resolver=*/false));
     ddog_Vec_Tag_drop(tags);
 
     if (res.tag == DDOG_PROF_PROFILE_EXPORTER_RESULT_ERR_HANDLE_PROFILE_EXPORTER) {
         auto& err = res.err;
         std::string errmsg = Datadog::err_to_msg(&err, "Error initializing exporter");
-        ddog_Error_drop(&err); // errmsg contains a copy of err.message
+        ddog_Error_drop(&err);
         return errmsg;
     }
 
-    auto* ddog_exporter = &res.ok;
+    state.cached_exporter = res.ok;
+    return std::nullopt;
+}
+
+} // namespace
+
+std::variant<Datadog::Uploader, std::string>
+Datadog::UploaderBuilder::build()
+{
+    auto& state = ProfilerState::get();
+
+    // Lazily create the exporter on first build. Subsequent builds reuse it.
+    // The caller (ddup_upload) holds upload_lock, so this is serialized with
+    // prefork() / cleanup() — the only places that drop the exporter.
+    if (auto err = ensure_cached_exporter(state)) {
+        return std::move(*err);
+    }
 
     // Perform profile encoding before creating the Uploader
     // Also take the Profiler Stats and reset the one being written to
@@ -213,22 +230,12 @@ Datadog::UploaderBuilder::build()
             auto err = encoded.err;
             std::string errmsg = Datadog::err_to_msg(&err, "Error serializing profile");
             ddog_Error_drop(&err);
-            ddog_prof_Exporter_drop(ddog_exporter);
+            // cached_exporter is intentionally kept; encoding failure is not the exporter's fault.
             return errmsg;
         }
     }
 
-    // We create a std::variant here instead of creating a temporary Uploader object.
-    // i.e. return Datadog::Uploader{ output_filename, *ddog_exporter, encoded.ok, std::move(stats) }
-    // because above code creates a temporary Uploader object, moves it into the
-    // variant, and then the destructor of the temporary Uploader object is called
-    // when the temporary Uploader object goes out of scope.
-    // This was necessary to avoid double-free from calling ddog_prof_Exporter_drop()
-    // in the destructor of Uploader. See comments in uploader.hpp for more details.
-    return std::variant<Datadog::Uploader, std::string>{ std::in_place_type<Datadog::Uploader>,
-                                                         state.output_filename,
-                                                         *ddog_exporter,
-                                                         encoded.ok,
-                                                         stats,
-                                                         state.process_tags };
+    return std::variant<Datadog::Uploader, std::string>{
+        std::in_place_type<Datadog::Uploader>, state.output_filename, encoded.ok, stats, state.process_tags
+    };
 }

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader_builder.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/uploader_builder.cpp
@@ -132,44 +132,44 @@ join(const std::vector<std::string>& vec, const std::string& delim)
 }
 
 namespace {
+using namespace Datadog;
 
-// Create the cached exporter if it does not already exist.
+// Create the exporter if it does not already exist.
 // Caller must hold ProfilerState::upload_lock.
+//
+// Only the static identity tags (env, service, version, language, runtime,
+// runtime_id, runtime_version, profiler_version, process_id) are baked into
+// the exporter here. User-defined tags are passed per-send via
+// optional_additional_tags so they can change without rebuilding the exporter.
 std::optional<std::string>
-ensure_cached_exporter(Datadog::ProfilerState& state)
+ensure_exporter(ProfilerState& state)
 {
-    if (state.cached_exporter.inner != nullptr) {
+    if (state.exporter.inner != nullptr) {
         return std::nullopt;
     }
 
     ddog_Vec_Tag tags = ddog_Vec_Tag_new();
 
-    // Add the tags. We collect all errors so the user can fix them in one pass.
+    // Collect all tag errors so the user can fix them in one pass.
     std::vector<std::string> reasons{};
-    const std::vector<std::pair<Datadog::ExportTagKey, std::string_view>> tag_data = {
-        { Datadog::ExportTagKey::dd_env, state.dd_env },
-        { Datadog::ExportTagKey::service, state.service },
-        { Datadog::ExportTagKey::version, state.version },
-        { Datadog::ExportTagKey::language, g_language_name },
-        { Datadog::ExportTagKey::runtime, state.runtime },
-        { Datadog::ExportTagKey::runtime_id, state.runtime_id },
-        { Datadog::ExportTagKey::runtime_version, state.runtime_version },
-        { Datadog::ExportTagKey::profiler_version, state.profiler_version },
-        { Datadog::ExportTagKey::process_id, state.process_id }
+    const std::vector<std::pair<ExportTagKey, std::string_view>> tag_data = {
+        { ExportTagKey::dd_env, state.dd_env },
+        { ExportTagKey::service, state.service },
+        { ExportTagKey::version, state.version },
+        { ExportTagKey::language, g_language_name },
+        { ExportTagKey::runtime, state.runtime },
+        { ExportTagKey::runtime_id, state.runtime_id },
+        { ExportTagKey::runtime_version, state.runtime_version },
+        { ExportTagKey::profiler_version, state.profiler_version },
+        { ExportTagKey::process_id, state.process_id }
     };
 
     for (const auto& [tag, data] : tag_data) {
         if (!data.empty()) {
             std::string errmsg;
-            if (!Datadog::add_tag(tags, tag, data, errmsg)) {
-                reasons.push_back(std::string(Datadog::to_string(tag)) + ": " + errmsg);
+            if (!add_tag(tags, tag, data, errmsg)) {
+                reasons.push_back(std::string(to_string(tag)) + ": " + errmsg);
             }
-        }
-    }
-    for (const auto& tag : state.user_tags) {
-        std::string errmsg;
-        if (!Datadog::add_tag(tags, tag.first, tag.second, errmsg)) {
-            reasons.push_back(std::string(tag.first) + ": " + errmsg);
         }
     }
 
@@ -179,25 +179,39 @@ ensure_cached_exporter(Datadog::ProfilerState& state)
     }
 
     ddog_prof_ProfileExporter_Result res = ddog_prof_Exporter_new(
-      Datadog::to_slice("dd-trace-py"),
-      Datadog::to_slice(state.profiler_version),
-      Datadog::to_slice(g_language_name),
+      to_slice("dd-trace-py"),
+      to_slice(state.profiler_version),
+      to_slice(g_language_name),
       &tags,
-      ddog_prof_Endpoint_agent(Datadog::to_slice(state.url), state.max_timeout_ms, /*use_system_resolver=*/false));
+      ddog_prof_Endpoint_agent(to_slice(state.url), state.max_timeout_ms, /*use_system_resolver=*/false));
     ddog_Vec_Tag_drop(tags);
 
     if (res.tag == DDOG_PROF_PROFILE_EXPORTER_RESULT_ERR_HANDLE_PROFILE_EXPORTER) {
         auto& err = res.err;
-        std::string errmsg = Datadog::err_to_msg(&err, "Error initializing exporter");
+        std::string errmsg = err_to_msg(&err, "Error initializing exporter");
         ddog_Error_drop(&err);
         return errmsg;
     }
 
-    state.cached_exporter = res.ok;
+    state.exporter = res.ok;
     return std::nullopt;
 }
 
 } // namespace
+
+ddog_Vec_Tag
+Datadog::UploaderBuilder::build_user_tag_vec(std::vector<std::string>& reasons)
+{
+    auto& state = ProfilerState::get();
+    ddog_Vec_Tag tags = ddog_Vec_Tag_new();
+    for (const auto& tag : state.user_tags) {
+        std::string errmsg;
+        if (!add_tag(tags, tag.first, tag.second, errmsg)) {
+            reasons.push_back(std::string(tag.first) + ": " + errmsg);
+        }
+    }
+    return tags;
+}
 
 std::variant<Datadog::Uploader, std::string>
 Datadog::UploaderBuilder::build()
@@ -206,8 +220,8 @@ Datadog::UploaderBuilder::build()
 
     // Lazily create the exporter on first build. Subsequent builds reuse it.
     // The caller (ddup_upload) holds upload_lock, so this is serialized with
-    // prefork() / cleanup() — the only places that drop the exporter.
-    if (auto err = ensure_cached_exporter(state)) {
+    // prefork / cleanup — the only places that drop the exporter.
+    if (auto err = ensure_exporter(state)) {
         return std::move(*err);
     }
 
@@ -230,7 +244,7 @@ Datadog::UploaderBuilder::build()
             auto err = encoded.err;
             std::string errmsg = Datadog::err_to_msg(&err, "Error serializing profile");
             ddog_Error_drop(&err);
-            // cached_exporter is intentionally kept; encoding failure is not the exporter's fault.
+            // exporter is intentionally kept; encoding failure is not the exporter's fault.
             return errmsg;
         }
     }

--- a/tests/profiling/tag_rotation_program.py
+++ b/tests/profiling/tag_rotation_program.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+"""Manual-profiling driver that rotates a per-upload tag.
+
+Runs three upload cycles, each tagged with a different ``phase`` value.
+With the exporter now reused across cycles and ``user_tags`` shipped via
+``optional_additional_tags``, every cycle should land at the agent carrying
+its own ``phase:<value>`` tag.
+
+Usage (standalone, against a real agent on a profiler host):
+
+    DD_TRACE_AGENT_URL=http://localhost:8126 \
+    DD_PROFILING_ENABLED=1 \
+    python tests/profiling/tag_rotation_program.py
+
+The script prints the cycle/phase it just uploaded so a wrapping test
+(see ``test_per_upload_tags.py``) can correlate captured HTTP bodies.
+"""
+import os
+import sys
+import time
+
+import ddtrace
+from ddtrace.internal.datadog.profiling import ddup
+from ddtrace.profiling import Profiler
+
+
+PHASES = ("setup", "warmup", "production")
+
+
+def busy_loop(seconds: float) -> None:
+    end = time.time() + seconds
+    while time.time() < end:
+        sum(range(10_000))
+
+
+def main() -> int:
+    tracer = ddtrace.tracer
+    profiler = Profiler(service="tag-rotation-test", env="test", version="0.1.0")
+    profiler.start(stop_on_exit=False)
+
+    try:
+        for cycle, phase in enumerate(PHASES):
+            ddup.config(tags={"phase": phase, "cycle": str(cycle)})
+            busy_loop(0.5)
+            ddup.upload(tracer)
+            print(f"uploaded cycle={cycle} phase={phase}", flush=True)
+    finally:
+        profiler.stop()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/profiling/tag_rotation_program.py
+++ b/tests/profiling/tag_rotation_program.py
@@ -36,7 +36,7 @@ def busy_loop(seconds: float) -> None:
 def main() -> int:
     tracer = ddtrace.tracer
     profiler = Profiler(service="tag-rotation-test", env="test", version="0.1.0")
-    profiler.start(stop_on_exit=False)
+    profiler.start()
 
     try:
         for cycle, phase in enumerate(PHASES):

--- a/tests/profiling/test_per_upload_tags.py
+++ b/tests/profiling/test_per_upload_tags.py
@@ -1,0 +1,109 @@
+"""Verify that user tags can change between uploads.
+
+The cached exporter does NOT bake user tags any more — they ride on every
+``Exporter_send_blocking`` call via ``optional_additional_tags``. This test
+runs ``tag_rotation_program.py`` against an in-process HTTP server, captures
+the multipart bodies, and asserts each cycle's expected ``phase`` tag is
+present in the corresponding upload's body.
+"""
+import http.server
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+
+PHASES = ("setup", "warmup", "production")
+
+
+class _CapturingHandler(http.server.BaseHTTPRequestHandler):
+    captured: list[bytes] = []
+    paths: list[str] = []
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length) if length else b""
+        _CapturingHandler.captured.append(body)
+        _CapturingHandler.paths.append(self.path)
+        # 202 Accepted matches what the trace agent returns for profile intake
+        self.send_response(202)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, *_args, **_kwargs) -> None:  # silence stderr noise
+        pass
+
+
+class _Server(http.server.ThreadingHTTPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="profiling extension only supported on linux/macos; uploads gated to linux for CI",
+)
+def test_user_tags_change_between_uploads() -> None:
+    _CapturingHandler.captured = []
+    _CapturingHandler.paths = []
+
+    server = _Server(("127.0.0.1", 0), _CapturingHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        env = os.environ.copy()
+        env["DD_TRACE_AGENT_URL"] = f"http://127.0.0.1:{port}"
+        env["DD_PROFILING_ENABLED"] = "1"
+        # Disable other intakes that might race the mock
+        env.pop("DD_PROFILING_OUTPUT_PPROF", None)
+
+        driver = Path(__file__).parent / "tag_rotation_program.py"
+        proc = subprocess.run(
+            [sys.executable, str(driver)],
+            env=env,
+            timeout=60,
+            capture_output=True,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    stdout = proc.stdout.decode(errors="replace")
+    stderr = proc.stderr.decode(errors="replace")
+    assert proc.returncode == 0, f"driver failed:\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+
+    profiling_uploads = [
+        body for path, body in zip(_CapturingHandler.paths, _CapturingHandler.captured) if "profiling" in path
+    ]
+    assert len(profiling_uploads) >= len(PHASES), (
+        f"expected at least {len(PHASES)} profiling uploads, got {len(profiling_uploads)}; "
+        f"paths captured: {_CapturingHandler.paths}"
+    )
+
+    # Tags are encoded somewhere in the multipart body (libdatadog wraps them
+    # in a form field). We just look for the verbatim "phase:<value>" string,
+    # which is the canonical Datadog tag encoding and robust to multipart
+    # framing changes.
+    for cycle, expected_phase in enumerate(PHASES):
+        body = profiling_uploads[cycle]
+        token = f"phase:{expected_phase}".encode()
+        assert token in body, (
+            f"cycle {cycle}: expected tag '{token.decode()}' not found in upload body "
+            f"(len={len(body)} bytes). First 200 bytes: {body[:200]!r}"
+        )
+
+    # Cross-check: an OLD phase tag must NOT appear in a LATER upload.
+    # This is what would happen if the exporter still baked the user tags.
+    for older_cycle, newer_cycle in [(0, 1), (0, 2), (1, 2)]:
+        older_tag = f"phase:{PHASES[older_cycle]}".encode()
+        newer_body = profiling_uploads[newer_cycle]
+        assert older_tag not in newer_body, (
+            f"stale tag from cycle {older_cycle} ('{older_tag.decode()}') leaked into upload "
+            f"for cycle {newer_cycle} — exporter is baking user tags instead of using per-send additional_tags"
+        )


### PR DESCRIPTION
## Description

Supersedes #17584 (auto-closed by the stale-PR bot after ~1 month of inactivity while awaiting staging validation). Same 5 commits, rebased on current `main`. No content changes since the last review.

The profiler was creating a fresh `ddog_prof_ProfileExporter` on every upload cycle (~60s) and dropping it immediately after. Each creation allocates a tokio runtime, TLS connector and HTTP client on the Rust side (~10-15 native allocations per cycle) and churns memory. This PR caches the exporter on `ProfilerState`, reuses it across cycles, and drops it in `prefork()` on the parent side (while tokio threads are still alive) and in `cleanup()`.

The exporter is a natural fit for reuse: endpoint (URL + timeout) and static identity tags (env, service, version, runtime, runtime_id, runtime_version, profiler_version, process_id, language) do not change during a process's lifetime. Per-upload **user tags** *can* change (manual `Profiler()` usage — e.g. Delancie Workers setting a per-task tag), so they are **not** baked into the exporter; they ride each send via `optional_additional_tags` instead.

## Changes

1. `perf(profiling): reuse profile exporter across upload cycles` — caches `ddog_prof_ProfileExporter` on `ProfilerState`; drops in `prefork()` (parent side, under `upload_lock`) and `cleanup()`. `Uploader` no longer owns the exporter; reaches it via `ProfilerState::get().exporter`.
2. `refactor(profiling): pass user tags per-send, drop "cached" qualifier` — addresses Thomas's user-tag-mutation concern; renames `cached_exporter` → `exporter` throughout.
3. `test(profiling): verify user tags differ per upload + restore family/language distinction` — adds `tag_rotation_program.py` driver and `test_per_upload_tags.py` mock-agent test (three cycles, three phases; asserts each cycle carries its own tag AND no stale phase leaks into later cycles). Also restores `g_family_name` alongside `g_language_name` as distinct constants (they coincide here but are distinct concepts — eBPF profiler can be family=native sampling python).
4. `test(profiling): drop nonexistent stop_on_exit kwarg in tag rotation driver` — `Profiler.start()` takes no args in current `main`.
5. `chore(profiling): flag UploaderBuilder->ProfilerState hidden dep for follow-up` — `AIDEV-NOTE` at `UploaderBuilder::build()` documenting that the singleton reach-in is a pre-existing pattern (all 13 `set_*` methods do it) and pointing at a follow-up refactor (decouple via explicit config struct).

## Testing

- **Mock-agent pytest**: `tests/profiling/test_per_upload_tags.py::test_user_tags_change_between_uploads` passed (Python 3.12). All three `phase:<value>` tags land in the right upload body; no cross-cycle leakage.
- **Real trace-agent**: manual run of the driver against a live trace-agent (linux workspace, staging build) exited cleanly with the three expected `uploaded cycle=N phase=…` lines and no upload errors.
- All profiling CI jobs green on prior (identical-content) PR #17584 tip. Rebase adds only one line from #18798 (`copy_fast_copy_metadata_from`) which co-exists cleanly.

## Risks

- Fork handling: exporter is now dropped in `prefork()` on the parent side under `upload_lock`. Both parent and child re-create it lazily on the next upload via `UploaderBuilder::build → ensure_exporter`. This is required because the tokio worker threads owned by the Rust runtime do not survive fork; dropping post-fork in the child could deadlock or touch dead-thread state.
- User tags: previously baked into the exporter at build time, now shipped per-send via `optional_additional_tags`. Manual `Profiler()` users mutating `ddup.config(tags=…)` between cycles will now see their new tags reflected on the next upload (was undefined/broken before). Verified by `test_per_upload_tags.py`.

## Follow-up

- `AIDEV-NOTE` at `uploader_builder.cpp::UploaderBuilder::build()` flags the pre-existing `ProfilerState::get()` reach-in pattern. Follow-up ticket (to be filed): thread an explicit config through the `UploaderBuilder` API to decouple it from the `ProfilerState` singleton.
