### PR TITLE
chore(tracing): refactor SpanData meta/metrics

### DIFF
--- a/src/native/span/attributes.rs
+++ b/src/native/span/attributes.rs
@@ -1,122 +1,239 @@
-use pyo3::{ffi, types::PyString, Bound, IntoPyObject as _, Py, PyAny, Python};
-use rustc_hash::FxHashMap;
-use std::borrow::Borrow;
-use std::hash::{Hash, Hasher};
+use crate::py_string::PyBackedString;
+use libdd_trace_utils::span::v04::VecMap;
+use pyo3::types::PyString;
+use pyo3::{Bound, IntoPyObject as _, Py, PyAny, Python};
+use std::cell::RefCell;
+use std::ops::{Deref, DerefMut};
+use std::thread::LocalKey;
 
-/// 8-byte map key for span attributes — owns a reference to a Python str object.
-/// `Hash`, `Eq`, and `Borrow<str>` dispatch to the string's UTF-8 content via
-/// `PyUnicode_AsUTF8AndSize`, which CPython caches on the string object after
-/// the first call; per-op cost is O(1).
-///
-/// # Safety contract
-///
-/// `Hash`, `Eq`, and `Borrow<str>` call `PyUnicode_AsUTF8AndSize` using the raw
-/// `PyObject` pointer. This is safe because the GIL is held by every caller — all
-/// `AttributeMap` operations occur inside `#[pymethods]` entry points.
-/// `pub(crate)` visibility enforces this: callers outside the crate cannot
-/// construct an `AttrKey` and trigger `Hash`/`Eq` without the GIL.
-pub(crate) struct AttrKey(Py<PyString>);
-
-impl AttrKey {
-    pub(crate) fn new(s: Py<PyString>) -> Self {
-        Self(s)
-    }
-
-    pub(crate) fn as_bound<'py>(&self, py: Python<'py>) -> Bound<'py, PyString> {
-        self.0.bind(py).clone()
-    }
-
-    pub(crate) fn traverse(&self, visit: &pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
-        visit.call(&self.0)
-    }
-
-    fn as_str(&self) -> &str {
-        // SAFETY: GIL is held by every caller (see type-level contract above).
-        // `PyUnicode_AsUTF8AndSize` caches the UTF-8 encoding on the PyUnicode object;
-        // subsequent calls return the same pointer without re-encoding.
-        let bytes = unsafe {
-            let mut size: ffi::Py_ssize_t = 0;
-            let ptr = ffi::PyUnicode_AsUTF8AndSize(self.0.as_ptr(), &mut size);
-            // NULL is returned for lone surrogates or allocation failure; an exception
-            // is set on the interpreter. Clear it so the #[pymethods] caller doesn't
-            // see a spurious UnicodeEncodeError on its next return to Python.
-            let Some(ptr) = std::ptr::NonNull::new(
-                // cast_mut: NonNull::new requires *mut T; no writes occur through this pointer.
-                ptr.cast_mut().cast::<u8>(),
-            ) else {
-                ffi::PyErr_Clear();
-                return "";
-            };
-            let Ok(len) = usize::try_from(size) else {
-                return "";
-            };
-            std::slice::from_raw_parts(ptr.as_ptr(), len)
-        };
-        // CPython guarantees valid UTF-8 from a non-NULL return; this is a
-        // belt-and-suspenders check in case that invariant is ever violated.
-        std::str::from_utf8(bytes).unwrap_or("")
-    }
-}
-
-impl Hash for AttrKey {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.as_str().hash(state);
-    }
-}
-
-impl PartialEq for AttrKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.as_str() == other.as_str()
-    }
-}
-
-impl Eq for AttrKey {}
-
-impl Borrow<str> for AttrKey {
-    fn borrow(&self) -> &str {
-        self.as_str()
-    }
-}
-
-/// Typed storage for a single span attribute value.
-///
-/// Each variant is one machine word (8 bytes); the enum is 16 bytes total
-/// (8-byte payload + discriminant + alignment). Keeping all variants at one
-/// word avoids the slot-size bloat that a `PyBackedString` value would impose
-/// on numeric-only attributes.
+/// Typed storage for a single numeric span attribute (a `metrics` entry).
 ///
 /// Bool is intentionally absent — `extract::<i64>()` succeeds for Python bool
 /// (True → 1, False → 0), so bool collapses into `Int` at write time.
-pub(crate) enum AttributeValue {
-    /// A Python str, stored as a reference to the live Python object.
-    Str(Py<PyString>),
+#[derive(Clone, Copy)]
+pub(crate) enum MetricValue {
     Int(i64),
     Float(f64),
 }
 
-impl AttributeValue {
-    pub(crate) fn traverse(&self, visit: &pyo3::PyVisit<'_>) -> Result<(), pyo3::PyTraverseError> {
-        if let AttributeValue::Str(s) = self {
-            visit.call(s)?;
-        }
-        Ok(())
-    }
-
-    /// Return the natural Python object for this value (no v0.4 projection).
-    /// Str → str, Int → int, Float → float.
+impl MetricValue {
+    /// Int → Python int, Float → Python float.
     pub(crate) fn as_py<'py>(&self, py: Python<'py>) -> Bound<'py, PyAny> {
         match self {
-            AttributeValue::Str(s) => s.bind(py).clone().into_any(),
-            AttributeValue::Int(i) => i.into_pyobject(py).expect("i64 into_pyobject").into_any(),
-            AttributeValue::Float(f) => f.into_pyobject(py).expect("f64 into_pyobject").into_any(),
+            MetricValue::Int(i) => i.into_pyobject(py).expect("i64 into_pyobject").into_any(),
+            MetricValue::Float(f) => f.into_pyobject(py).expect("f64 into_pyobject").into_any(),
+        }
+    }
+
+    /// Value projected into the v0.4 wire `metrics` type (always `f64`).
+    #[allow(dead_code)]
+    pub(crate) fn as_f64(&self) -> f64 {
+        match self {
+            MetricValue::Int(i) => *i as f64,
+            MetricValue::Float(f) => *f,
         }
     }
 }
 
-/// Span attribute map.
-///
-/// `FxHashMap` over `std::collections::HashMap` — keys are short, trusted tag
-/// names from instrumented Python code, so SipHash DoS resistance is unnecessary.
-/// FxHash is faster on short keys and `FxBuildHasher` is a ZST (saves the
-/// 16-byte `RandomState` per map instance).
-pub(crate) type AttributeMap = FxHashMap<AttrKey, AttributeValue>;
+/// Span `meta` map: string-valued tags.
+pub(crate) type MetaMap = Pooled<MetaPool>;
+
+/// Span `metrics` map: numeric-valued tags. Mutually exclusive with [`MetaMap`] — a key lives in
+/// exactly one of the two; `SpanData`'s attribute methods enforce this.
+pub(crate) type MetricsMap = Pooled<MetricsPool>;
+
+// --- Thread-local backing-buffer recycle pool ----------------------------------------------------
+// Allocating a `meta`/`metrics` backing `Vec` per span is millions of short-lived allocations under
+// load (the top per-span native allocator under memray). Instead, a dropped map's buffer is cleared
+// and returned to a per-thread pool, and the next span's first insert pops it instead of
+// allocating. Acquire and recycle run on the same thread, so no locking is needed; pooled buffers
+// are always empty, so they hold no Python references and are safe across requests and forks.
+//
+// The caps bound retained memory (~0.5 MB per thread, both pools) and only bind under bursty or
+// outlier load: ATTR_POOL_MAX caps buffers per map per thread — a trace frees its spans in a burst
+// at finish, so 128 covers several concurrent traces — and ATTR_POOL_BUF_CAP keeps an outlier span
+// with hundreds of tags from parking an oversized Vec for the thread's life.
+const ATTR_POOL_MAX: usize = 128;
+const ATTR_POOL_BUF_CAP: usize = 64;
+
+/// One recycled backing buffer: a `VecMap`'s row `Vec`, kept empty (capacity only) for reuse.
+type PoolBuf<K, V> = Vec<(K, V)>;
+/// A map's thread-local stack of recycled buffers.
+type PoolCell<K, V> = RefCell<Vec<PoolBuf<K, V>>>;
+type PoolRef<K, V> = &'static LocalKey<PoolCell<K, V>>;
+
+thread_local! {
+    static META_POOL: PoolCell<PyBackedString, Py<PyString>> = const { RefCell::new(Vec::new()) };
+    static METRICS_POOL: PoolCell<PyBackedString, MetricValue> = const { RefCell::new(Vec::new()) };
+}
+
+/// Take a recycled backing buffer from `pool`, or allocate one presized to `floor` on a miss.
+fn pool_acquire<K, V>(pool: PoolRef<K, V>, floor: usize) -> VecMap<K, V> {
+    match pool.with(|p| p.borrow_mut().pop()) {
+        Some(backing) => VecMap::from(backing),
+        None => VecMap::with_capacity(floor),
+    }
+}
+
+/// Clear `map`'s backing buffer and return it to `pool` for reuse. Drops it instead if the map
+/// never allocated or the pool is already at `ATTR_POOL_MAX`.
+fn pool_recycle<K, V>(pool: PoolRef<K, V>, map: VecMap<K, V>) {
+    let mut backing: Vec<(K, V)> = map.into();
+    // Nothing to reclaim from a map that never allocated (the common no-metrics span); let an
+    // outlier oversized buffer free rather than hoard it.
+    let cap = backing.capacity();
+    if cap == 0 || cap > ATTR_POOL_BUF_CAP {
+        return;
+    }
+    backing.clear();
+    pool.with(|p| {
+        let mut p = p.borrow_mut();
+        if p.len() < ATTR_POOL_MAX {
+            p.push(backing);
+        }
+    });
+}
+
+/// Associates a map's value type with its thread-local pool and presize floor, so [`Pooled`]
+/// routes acquire/recycle generically (one wrapper, not per-type).
+pub(crate) trait Pool {
+    /// `'static` because the pool is a `thread_local!` (`&'static LocalKey`).
+    type V: 'static;
+    /// Capacity a fresh backing buffer is presized to on a pool miss.
+    const PRESIZE: usize;
+    fn local() -> PoolRef<PyBackedString, Self::V>;
+}
+
+/// `meta` pool marker — meta carries most of a span's tags.
+pub(crate) struct MetaPool;
+impl Pool for MetaPool {
+    type V = Py<PyString>;
+    const PRESIZE: usize = 8;
+    fn local() -> PoolRef<PyBackedString, Self::V> {
+        &META_POOL
+    }
+}
+
+/// `metrics` pool marker — metrics is usually a handful of numeric tags.
+pub(crate) struct MetricsPool;
+impl Pool for MetricsPool {
+    type V = MetricValue;
+    const PRESIZE: usize = 4;
+    fn local() -> PoolRef<PyBackedString, Self::V> {
+        &METRICS_POOL
+    }
+}
+
+/// A libdatadog [`VecMap`] whose backing buffer is drawn from and returned to a thread-local
+/// recycle pool. Reads reach the inner `VecMap` through `Deref`/`DerefMut`; note its duplicate
+/// semantics — `insert` is a plain append, `get` scans from the back so the last write wins, and
+/// `remove_slow` clears every occurrence of a key.
+pub(crate) struct Pooled<P: Pool> {
+    map: VecMap<PyBackedString, P::V>,
+    /// Set on the first pool acquisition; distinguishes "never touched" (skip recycling on drop)
+    /// from "emptied via removes" (still holds a backing buffer worth recycling).
+    acquired: bool,
+}
+
+impl<P: Pool> Default for Pooled<P> {
+    fn default() -> Self {
+        Self {
+            map: VecMap::default(),
+            acquired: false,
+        }
+    }
+}
+
+impl<P: Pool> Deref for Pooled<P> {
+    type Target = VecMap<PyBackedString, P::V>;
+    fn deref(&self) -> &Self::Target {
+        &self.map
+    }
+}
+
+impl<P: Pool> DerefMut for Pooled<P> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.map
+    }
+}
+
+impl<P: Pool> Drop for Pooled<P> {
+    /// Return the backing buffer to the pool. Runs during `SpanData` dealloc / `__clear__` reset
+    /// (GIL held), so clearing it -- which drops the `Py` keys/values -- is safe.
+    fn drop(&mut self) {
+        if self.acquired {
+            pool_recycle(P::local(), std::mem::take(&mut self.map));
+        }
+    }
+}
+
+impl<P: Pool> Pooled<P> {
+    /// Acquire a buffer from the pool on the first insert, so a map never inserted into never
+    /// allocates. Shadows the inner `VecMap::insert` (reachable only via `Deref`), so a plain
+    /// `.insert(..)` on a span's `meta`/`metrics` always goes through the pool.
+    pub(crate) fn insert(&mut self, key: PyBackedString, value: P::V) {
+        if !self.acquired {
+            self.map = pool_acquire(P::local(), P::PRESIZE);
+            self.acquired = true;
+        }
+        self.map.insert(key, value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use libdd_trace_utils::span::v04::VecMap;
+
+    thread_local! {
+        static TEST_POOL: std::cell::RefCell<Vec<Vec<(String, i32)>>> =
+            const { std::cell::RefCell::new(Vec::new()) };
+    }
+
+    #[test]
+    fn pool_acquire_miss_presizes_recycle_then_hit_reuses() {
+        TEST_POOL.with(|p| p.borrow_mut().clear());
+        // miss -> allocate at the floor
+        let mut m = super::pool_acquire(&TEST_POOL, 8);
+        m.insert("a".to_string(), 1);
+        m.insert("b".to_string(), 2);
+        let backing: Vec<(String, i32)> = m.into();
+        let cap = backing.capacity();
+        assert!(cap >= 8);
+        let m: VecMap<String, i32> = backing.into();
+        // recycle -> buffer returns to the pool
+        super::pool_recycle(&TEST_POOL, m);
+        assert_eq!(TEST_POOL.with(|p| p.borrow().len()), 1);
+        // hit -> reuse the same cleared buffer, no realloc
+        let m2 = super::pool_acquire(&TEST_POOL, 8);
+        let backing2: Vec<(String, i32)> = m2.into();
+        assert_eq!(backing2.capacity(), cap);
+        assert!(backing2.is_empty());
+        assert_eq!(TEST_POOL.with(|p| p.borrow().len()), 0);
+    }
+
+    #[test]
+    fn pool_recycle_respects_max_and_skips_unallocated() {
+        TEST_POOL.with(|p| p.borrow_mut().clear());
+        // a never-allocated map is not pooled
+        let empty: VecMap<String, i32> = VecMap::default();
+        super::pool_recycle(&TEST_POOL, empty);
+        assert_eq!(TEST_POOL.with(|p| p.borrow().len()), 0);
+        // recycling past the cap leaves the pool at exactly ATTR_POOL_MAX
+        for _ in 0..(super::ATTR_POOL_MAX + 10) {
+            let mut backing: Vec<(String, i32)> = Vec::with_capacity(4);
+            backing.push(("x".to_string(), 1));
+            let m: VecMap<String, i32> = backing.into();
+            super::pool_recycle(&TEST_POOL, m);
+        }
+        assert_eq!(TEST_POOL.with(|p| p.borrow().len()), super::ATTR_POOL_MAX);
+    }
+
+    #[test]
+    fn pool_recycle_drops_oversized_buffer() {
+        TEST_POOL.with(|p| p.borrow_mut().clear());
+        let backing: Vec<(String, i32)> = Vec::with_capacity(super::ATTR_POOL_BUF_CAP + 1);
+        let m: VecMap<String, i32> = backing.into();
+        super::pool_recycle(&TEST_POOL, m);
+        assert_eq!(TEST_POOL.with(|p| p.borrow().len()), 0);
+    }
+}

--- a/src/native/span/span_data.rs
+++ b/src/native/span/span_data.rs
@@ -7,7 +7,7 @@ use pyo3::{
     Bound, IntoPyObject as _, Py, PyAny, PyResult, Python,
 };
 
-use super::attributes::{AttrKey, AttributeMap, AttributeValue};
+use super::attributes::{MetaMap, MetricValue, MetricsMap};
 use crate::ddtrace_utils::flatten_key_value_vec as flatten_key_value_vec_fn;
 use crate::py_string::{PyBackedString, PyTraceData};
 use libdd_trace_utils::span::{
@@ -42,11 +42,11 @@ pub struct SpanData {
     pub span_links: Vec<NativeSpanLink<PyTraceData>>,
     pub span_events: Vec<NativeSpanEvent<PyTraceData>>,
     pub span_api: PyBackedString,
-    /// Unified attribute storage — source of truth for all tag/metric attributes.
-    /// `meta` and `metrics` are left empty in the native span; they are materialized
-    /// from this map at encode time (currently by the Python encoder via the bulk read
-    /// accessors `_get_str_attributes` / `_get_numeric_attributes`).
-    pub(crate) attributes: AttributeMap,
+    /// String-valued tags. Mutually exclusive with `metrics`: a key lives in exactly one of the
+    /// two; `insert_meta`/`insert_metric`/`remove_attribute` enforce this invariant.
+    pub(crate) meta: MetaMap,
+    /// Numeric-valued tags. Mutually exclusive with `meta` (see above).
+    pub(crate) metrics: MetricsMap,
     /// Lazy Python int cache for the `trace_id` getter.
     /// Populated on first read; invalidated on every write to `trace_id`.
     /// `trace_id` is always the source of truth.
@@ -74,6 +74,23 @@ impl SpanData {
         if !self.has_attribute(k) {
             let _ = self.set_attribute(k, v);
         }
+    }
+
+    /// Insert into `meta`, evicting any `metrics` entry for the same key to keep the two maps
+    /// mutually exclusive. The emptiness check skips the eviction scan on a meta-only span.
+    fn insert_meta(&mut self, key: PyBackedString, value: Py<PyString>) {
+        if !self.metrics.is_empty() {
+            self.metrics.remove_slow(&key);
+        }
+        self.meta.insert(key, value);
+    }
+
+    /// Insert into `metrics`, evicting any `meta` entry for the same key (see [`Self::insert_meta`]).
+    fn insert_metric(&mut self, key: PyBackedString, value: MetricValue) {
+        if !self.meta.is_empty() {
+            self.meta.remove_slow(&key);
+        }
+        self.metrics.insert(key, value);
     }
 }
 
@@ -435,8 +452,8 @@ impl SpanData {
 
     // ── Attribute API (meta / metrics) ──────────────────────────────────────
 
-    /// Set a tag/metric on the span. Stores the value in the unified `attributes` map,
-    /// preserving the original Python type (str → Str, int/bool → Int, float → Float).
+    /// Set a tag/metric on the span, routing the value into `meta` or `metrics` based on
+    /// its Python type (str → meta, int/bool/float → metrics).
     ///
     /// Special case: `http.status_code` is always coerced to a string so the trace agent
     /// can compute HTTP metrics from the meta tag.
@@ -452,7 +469,11 @@ impl SpanData {
         let Ok(key_str) = key.cast::<PyString>() else {
             return Ok(());
         };
-        let attr_key = AttrKey::new(key_str.clone().unbind());
+        // Keys with no valid UTF-8 representation (lone surrogates) can't back a
+        // `PyBackedString`; drop the tag rather than store it under a collapsed "" key.
+        let Ok(key_backed) = PyBackedString::try_from(key_str.clone()) else {
+            return Ok(());
+        };
 
         // http.status_code must always be a string in meta.
         // Fast path: typed contract is `str`, so most callers already pass a PyString.
@@ -466,19 +487,17 @@ impl SpanData {
                 };
                 s
             };
-            self.attributes
-                .insert(attr_key, AttributeValue::Str(s.unbind()));
+            self.insert_meta(key_backed, s.unbind());
             return Ok(());
         }
 
-        // str → Str
+        // str → meta
         if let Ok(s) = value.cast::<PyString>() {
-            self.attributes
-                .insert(attr_key, AttributeValue::Str(s.clone().unbind()));
+            self.insert_meta(key_backed, s.clone().unbind());
             return Ok(());
         }
 
-        // float → Float (drop NaN/Inf)
+        // float → metrics (drop NaN/Inf)
         // Check before int because some types (e.g. numpy.float64) implement __float__
         // but not __index__, so PyFloat succeeds and PyInt would fail.
         if let Ok(f) = value.cast::<PyFloat>() {
@@ -486,25 +505,24 @@ impl SpanData {
             if n.is_nan() || n.is_infinite() {
                 return Ok(());
             }
-            self.attributes.insert(attr_key, AttributeValue::Float(n));
+            self.insert_metric(key_backed, MetricValue::Float(n));
             return Ok(());
         }
 
-        // int (catches bool and numpy.int* via __index__) → Int.
+        // int (catches bool and numpy.int* via __index__) → metrics.
         // extract::<i64>() succeeds for bool (True → 1, False → 0) and for any
         // type implementing __index__. Python ints that overflow i64 fall through
         // to the str() fallback below.
         if let Ok(n) = value.extract::<i64>() {
-            self.attributes.insert(attr_key, AttributeValue::Int(n));
+            self.insert_metric(key_backed, MetricValue::Int(n));
             return Ok(());
         }
 
-        // bytes → UTF-8 decoded Str (with U+FFFD replacements for invalid sequences)
+        // bytes → UTF-8 decoded meta (with U+FFFD replacements for invalid sequences)
         if let Ok(b) = value.cast::<PyBytes>() {
             let decoded = String::from_utf8_lossy(b.as_bytes());
             let py_str = PyString::new(key.py(), &decoded);
-            self.attributes
-                .insert(attr_key, AttributeValue::Str(py_str.unbind()));
+            self.insert_meta(key_backed, py_str.unbind());
             return Ok(());
         }
 
@@ -512,8 +530,7 @@ impl SpanData {
         let Ok(s) = value.str() else {
             return Ok(());
         };
-        self.attributes
-            .insert(attr_key, AttributeValue::Str(s.unbind()));
+        self.insert_meta(key_backed, s.unbind());
         Ok(())
     }
 
@@ -549,7 +566,7 @@ impl SpanData {
         Ok(())
     }
 
-    /// Return True if the span has an attribute with the given key.
+    /// Return True if the span has an attribute with the given key (in either meta or metrics).
     #[pyo3(name = "_has_attribute")]
     fn has_attribute(&self, key: &Bound<'_, PyAny>) -> bool {
         let Ok(k) = key.cast::<PyString>() else {
@@ -558,10 +575,10 @@ impl SpanData {
         let Ok(k_str) = k.to_str() else {
             return false;
         };
-        self.attributes.contains_key(k_str)
+        self.meta.contains_key(k_str) || self.metrics.contains_key(k_str)
     }
 
-    /// Remove an attribute by key.
+    /// Remove an attribute by key from whichever map holds it.
     #[pyo3(name = "_remove_attribute")]
     fn remove_attribute(&mut self, key: &Bound<'_, PyAny>) {
         let Ok(k) = key.cast::<PyString>() else {
@@ -570,11 +587,17 @@ impl SpanData {
         let Ok(k_str) = k.to_str() else {
             return;
         };
-        self.attributes.remove(k_str);
+        // The maps are mutually exclusive, so removing from meta first and only scanning metrics
+        // when nothing was removed beats probing with `contains_key` (which rescans meta on a hit).
+        let meta_len = self.meta.len();
+        self.meta.remove_slow(k_str);
+        if self.meta.len() == meta_len {
+            self.metrics.remove_slow(k_str);
+        }
     }
 
     /// Return the raw stored value for the given key, or None if not found.
-    /// Returns the natural Python type: str for Str, int for Int, float for Float.
+    /// Returns the natural Python type: str for meta, int/float for metrics.
     #[pyo3(name = "_get_attribute")]
     fn get_attribute<'py>(
         &self,
@@ -583,10 +606,13 @@ impl SpanData {
     ) -> Option<Bound<'py, PyAny>> {
         let k = key.cast::<PyString>().ok()?;
         let k_str = k.to_str().ok()?;
-        Some(self.attributes.get(k_str)?.as_py(py))
+        match self.meta.get(k_str) {
+            Some(s) => Some(s.bind(py).clone().into_any()),
+            None => Some(self.metrics.get(k_str)?.as_py(py)),
+        }
     }
 
-    /// Return the string attribute for the given key, or None if not a Str variant.
+    /// Return the string attribute for the given key, or None if not present in `meta`.
     #[pyo3(name = "_get_str_attribute")]
     fn get_str_attribute<'py>(
         &self,
@@ -595,13 +621,10 @@ impl SpanData {
     ) -> Option<Bound<'py, PyAny>> {
         let k = key.cast::<PyString>().ok()?;
         let k_str = k.to_str().ok()?;
-        match self.attributes.get(k_str)? {
-            AttributeValue::Str(s) => Some(s.bind(py).clone().into_any()),
-            _ => None,
-        }
+        Some(self.meta.get(k_str)?.bind(py).clone().into_any())
     }
 
-    /// Return the numeric attribute for the given key, or None if not a numeric variant.
+    /// Return the numeric attribute for the given key, or None if not present in `metrics`.
     /// Returns int for Int values and float for Float values, preserving the original type.
     #[pyo3(name = "_get_numeric_attribute")]
     fn get_numeric_attribute<'py>(
@@ -611,15 +634,7 @@ impl SpanData {
     ) -> Option<Bound<'py, PyAny>> {
         let k = key.cast::<PyString>().ok()?;
         let k_str = k.to_str().ok()?;
-        match self.attributes.get(k_str)? {
-            AttributeValue::Int(i) => {
-                Some(i.into_pyobject(py).expect("i64 into_pyobject").into_any())
-            }
-            AttributeValue::Float(f) => {
-                Some(f.into_pyobject(py).expect("f64 into_pyobject").into_any())
-            }
-            AttributeValue::Str(_) => None,
-        }
+        Some(self.metrics.get(k_str)?.as_py(py))
     }
 
     /// Return all attributes merged into a single dict.
@@ -628,45 +643,34 @@ impl SpanData {
     #[pyo3(name = "_get_attributes")]
     fn get_attributes<'py>(&self, py: Python<'py>) -> pyo3::PyResult<Bound<'py, PyDict>> {
         let d = PyDict::new(py);
-        for (k, v) in &self.attributes {
-            d.set_item(k.as_bound(py), v.as_py(py))?;
+        for (k, v) in self.meta.iter() {
+            d.set_item(k.as_py(py), v.bind(py))?;
+        }
+        for (k, v) in self.metrics.iter() {
+            d.set_item(k.as_py(py), v.as_py(py))?;
         }
         Ok(d)
     }
 
-    /// Return all Str-variant attributes as a Python dict snapshot.
+    /// Return the `meta` map as a Python dict snapshot.
     /// Used by the Python encoder to build the v0.4 `meta` dict.
-    /// Note: Int values with abs > 2^53 are NOT folded in here; the encoder
-    /// is responsible for moving them from metrics to meta at encode time.
     #[pyo3(name = "_get_str_attributes")]
     fn get_str_attributes<'py>(&self, py: Python<'py>) -> pyo3::PyResult<Bound<'py, PyDict>> {
         let d = PyDict::new(py);
-        for (k, v) in &self.attributes {
-            if let AttributeValue::Str(s) = v {
-                d.set_item(k.as_bound(py), s.bind(py))?;
-            }
+        for (k, v) in self.meta.iter() {
+            d.set_item(k.as_py(py), v.bind(py))?;
         }
         Ok(d)
     }
 
-    /// Return all numeric (Int and Float) attributes as a Python dict snapshot.
+    /// Return the `metrics` map as a Python dict snapshot.
     /// Int values are returned as Python int; Float values as Python float.
     /// Used by the Python encoder to build the v0.4 `metrics` dict.
-    /// Note: the encoder is responsible for moving Int values with abs > 2^53
-    /// out of metrics and into meta as strings before serialization.
     #[pyo3(name = "_get_numeric_attributes")]
     fn get_numeric_attributes<'py>(&self, py: Python<'py>) -> pyo3::PyResult<Bound<'py, PyDict>> {
         let d = PyDict::new(py);
-        for (k, v) in &self.attributes {
-            match v {
-                AttributeValue::Int(i) => {
-                    d.set_item(k.as_bound(py), *i)?;
-                }
-                AttributeValue::Float(f) => {
-                    d.set_item(k.as_bound(py), *f)?;
-                }
-                AttributeValue::Str(_) => {}
-            }
+        for (k, v) in self.metrics.iter() {
+            d.set_item(k.as_py(py), v.as_py(py))?;
         }
         Ok(d)
     }
@@ -898,12 +902,13 @@ impl SpanData {
         self.name.traverse(&visit)?;
         self.resource.traverse(&visit)?;
         self.span_type.traverse(&visit)?;
-        // `self.attributes` is the unified tag/metric store.
-        // Keys hold `Py<PyString>`; Str values hold `Py<PyString>`. Int/Float
-        // variants are primitive Rust types with no Python references.
-        for (k, v) in self.attributes.iter() {
+        for (k, v) in self.meta.iter() {
             k.traverse(&visit)?;
-            v.traverse(&visit)?;
+            visit.call(v)?;
+        }
+        // `metrics` values are primitive Rust types with no Python references; keys only.
+        for (k, _) in self.metrics.iter() {
+            k.traverse(&visit)?;
         }
         for link in self.span_links.iter() {
             link.tracestate.traverse(&visit)?;

--- a/tests/tracer/test_span_tags.py
+++ b/tests/tracer/test_span_tags.py
@@ -93,6 +93,31 @@ def test_set_tag_metric():
     assert s.get_metrics() == dict(test=1)
 
 
+def test_tag_metric_mutual_exclusion():
+    # A key lives in exactly one of meta/metrics; re-setting it with the other type moves it.
+    # test_set_tag_metric covers the meta -> metrics direction, this covers the reverse.
+    s = Span(name="test.span")
+
+    s.set_metric("n", 3.5)  # ast-grep-ignore: span-set-metric
+    assert s.get_metric("n") == 3.5
+    assert s.get_tag("n") is None
+    s.set_tag("n", "now-a-string")
+    assert s.get_tag("n") == "now-a-string"
+    assert s.get_metric("n") is None
+    assert s.get_tags() == {"n": "now-a-string"}
+    assert s.get_metrics() == {}
+
+
+def test_set_tag_lone_surrogate_key_is_dropped():
+    # A key with no valid UTF-8 representation (e.g. a lone surrogate out of os.fsdecode()) is
+    # silently dropped rather than raising or landing under a collapsed key.
+    s = Span(name="test.span")
+
+    s.set_tag("\udcff", "value")
+    assert s.get_tags() == {}
+    assert s.get_metrics() == {}
+
+
 def test_set_valid_metrics():
     s = Span(name="test.span")
     s.set_metric("a", 0)  # ast-grep-ignore: span-set-metric


### PR DESCRIPTION
## Description

Split storage: helps later when we add SpanData -> v0.4 conversion, we can avoid dynamically sized VecMaps when building v0.4 meta and metrics

Meta/Metrics VecMap pool: one high place of memory pressure is creating/resizing/freeing meta/metrics/attributes maps. we also add here a VecMap pool where when a SpanData is GC'd we can clear and return the already allocated meta/metrics VecMaps back into a pool to be reused on new spans.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

No changes to internal or external APIs, this is an internal only storage refactoring.
