### PR TITLE
chore: assign aiguard settings module to asm-python in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -152,6 +152,7 @@ ddtrace/internal/_exceptions.py     @DataDog/asm-python
 ddtrace/internal/appsec/            @DataDog/asm-python
 ddtrace/internal/iast/              @DataDog/asm-python
 ddtrace/internal/sca/               @DataDog/asm-python
+ddtrace/internal/settings/aiguard.py         @DataDog/asm-python
 ddtrace/internal/settings/appsec_telemetry.py    @DataDog/asm-python
 ddtrace/internal/settings/asm.py             @DataDog/asm-python
 # tests files


### PR DESCRIPTION
## Description

`ddtrace/internal/settings/aiguard.py` had no entry in CODEOWNERS, so changes to the AI Guard configuration module did not request a review from the owning team. Every other piece of AI Guard code already routes to `@DataDog/asm-python` (`ddtrace/aiguard/`, `tests/aiguard/`, `.cursor/rules/ai-guard.mdc`), as do the sibling settings modules `appsec_telemetry.py` and `asm.py`.

Adds the missing line in the existing ASM block:

```
ddtrace/internal/settings/aiguard.py         @DataDog/asm-python
```

No later pattern in the file matches `ddtrace/internal/settings/aiguard.py`, so nothing is shadowed and no other team's ownership changes.

## Testing

No code change; CODEOWNERS only. Verified there is no competing pattern for that path elsewhere in the file (last match wins).

## Risks

None.

## Additional Notes

Chore, no Jira ticket. No release note needed (`changelog/no-changelog`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)