### PR TITLE
fix(llmobs): correct Claude Agent SDK token counts for cache-served turns

### DIFF
--- a/ddtrace/llmobs/_integrations/claude_agent_sdk.py
+++ b/ddtrace/llmobs/_integrations/claude_agent_sdk.py
@@ -125,12 +125,9 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
         input_messages = self._extract_input_messages(prompt, span)
 
         output_messages: list[Message] = [Message(content="")]
-        metrics: dict[str, int] = {}
         init_system_message: dict[str, Any] = {}
         if not span.error and response is not None:
-            output_messages, metrics, init_system_message, stop_reason, assistant_error = self._extract_output_data(
-                response
-            )
+            output_messages, init_system_message, stop_reason, assistant_error = self._extract_output_data(response)
             if stop_reason:
                 metadata["stop_reason"] = stop_reason
             error_type, error_message = assistant_error
@@ -148,7 +145,6 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
             input_value=input_messages,
             metadata=metadata,
             output_value=output_messages,
-            metrics=metrics,
             agent_manifest=agent_manifest,
         )
 
@@ -239,20 +235,17 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
 
         return messages
 
-    def _extract_output_data(
-        self, response: Any
-    ) -> tuple[list[Message], dict[str, int], dict[str, Any], str, tuple[str, str]]:
-        """Extract output data from response, including output messages, usage metrics, init system message,
+    def _extract_output_data(self, response: Any) -> tuple[list[Message], dict[str, Any], str, tuple[str, str]]:
+        """Extract output data from response, including output messages, init system message,
         stop reason, and assistant error as a (error_type, error_message) tuple.
         """
         output_messages: list[Message] = []
-        metrics: dict[str, int] = {}
         init_system_message: dict[str, Any] = {}
         stop_reason: str = ""
         assistant_error: tuple[str, str] = ("", "")
 
         if not response or not isinstance(response, list):
-            return [Message(content="")], metrics, init_system_message, stop_reason, assistant_error
+            return [Message(content="")], init_system_message, stop_reason, assistant_error
 
         for msg in response:
             msg_type = type(msg).__name__
@@ -273,8 +266,6 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
             elif msg_type == "ResultMessage":
                 if not stop_reason:
                     stop_reason = _get_attr(msg, "stop_reason", "") or ""
-                if not metrics:
-                    metrics = self._extract_usage(msg)
                 result = _get_attr(msg, "result", "") or ""
                 if result:
                     output_messages.append(Message(content=str(result), role="assistant"))
@@ -284,7 +275,7 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
                         Message(content=safe_json(structured_output) or str(structured_output), role="assistant")
                     )
 
-        return output_messages or [Message(content="")], metrics, init_system_message, stop_reason, assistant_error
+        return output_messages or [Message(content="")], init_system_message, stop_reason, assistant_error
 
     def _extract_assistant_error(self, msg: Any) -> tuple[str, str]:
         """Return (error_type, error_message) for an AssistantMessage carrying an error.
@@ -320,12 +311,14 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
             cache_creation = usage.get("cache_creation_input_tokens") or 0
             cache_read = usage.get("cache_read_input_tokens") or 0
 
-            if input_tokens:
-                metrics[INPUT_TOKENS_METRIC_KEY] = input_tokens + cache_creation + cache_read
+            # input includes cache tokens; guard on the folded total so cache-only turns aren't dropped
+            total_input = input_tokens + cache_creation + cache_read
+            if total_input:
+                metrics[INPUT_TOKENS_METRIC_KEY] = total_input
             if output_tokens:
                 metrics[OUTPUT_TOKENS_METRIC_KEY] = output_tokens
-            if input_tokens and output_tokens:
-                metrics[TOTAL_TOKENS_METRIC_KEY] = metrics[INPUT_TOKENS_METRIC_KEY] + metrics[OUTPUT_TOKENS_METRIC_KEY]
+            if total_input and output_tokens:
+                metrics[TOTAL_TOKENS_METRIC_KEY] = total_input + output_tokens
             if cache_creation:
                 metrics[CACHE_WRITE_INPUT_TOKENS_METRIC_KEY] = cache_creation
             if cache_read:

--- a/releasenotes/notes/fix-claude-agent-sdk-token-counts-95cb0fc2db6ddc27.yaml
+++ b/releasenotes/notes/fix-claude-agent-sdk-token-counts-95cb0fc2db6ddc27.yaml
@@ -3,4 +3,5 @@ fixes:
   - |
     LLM Observability: Fixes an issue where Claude Agent SDK LLM spans reported no input
     token count for fully cache-served turns, causing trace-level input token and cost
-    totals to be undercounted.
+    totals to be undercounted. This applies to ``claude-agent-sdk`` 0.1.49 and later, which
+    is the first version to report per-turn token usage.

--- a/releasenotes/notes/fix-claude-agent-sdk-token-counts-95cb0fc2db6ddc27.yaml
+++ b/releasenotes/notes/fix-claude-agent-sdk-token-counts-95cb0fc2db6ddc27.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixes an issue where Claude Agent SDK LLM spans reported no input
+    token count for fully cache-served turns, causing trace-level input token and cost
+    totals to be undercounted.

--- a/tests/contrib/claude_agent_sdk/conftest.py
+++ b/tests/contrib/claude_agent_sdk/conftest.py
@@ -19,6 +19,7 @@ from tests.contrib.claude_agent_sdk.utils import MOCK_DOUBLE_ASSISTANT_NO_TOOLS_
 from tests.contrib.claude_agent_sdk.utils import MOCK_GREP_TOOL_RESPONSE_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_PARALLEL_TOOL_USE_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_QUERY_RESPONSE_SEQUENCE
+from tests.contrib.claude_agent_sdk.utils import MOCK_QUERY_RESPONSE_SEQUENCE_CACHE_ONLY
 from tests.contrib.claude_agent_sdk.utils import MOCK_QUERY_RESPONSE_SEQUENCE_WITH_USAGE
 from tests.contrib.claude_agent_sdk.utils import MOCK_STRUCTURED_OUTPUT_RESPONSE_SEQUENCE
 from tests.contrib.claude_agent_sdk.utils import MOCK_TOOL_ERROR_RESPONSE_SEQUENCE
@@ -144,6 +145,12 @@ def mock_internal_client_tool_error(claude_agent_sdk):
 @pytest.fixture
 def mock_internal_client_with_usage(claude_agent_sdk):
     with _create_mock_internal_client(MOCK_QUERY_RESPONSE_SEQUENCE_WITH_USAGE):
+        yield
+
+
+@pytest.fixture
+def mock_internal_client_cache_only(claude_agent_sdk):
+    with _create_mock_internal_client(MOCK_QUERY_RESPONSE_SEQUENCE_CACHE_ONLY):
         yield
 
 

--- a/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
+++ b/tests/contrib/claude_agent_sdk/test_claude_agent_sdk_llmobs.py
@@ -8,7 +8,7 @@ from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import get_llmobs_span_links
 from ddtrace.llmobs._utils import safe_json
 from tests.contrib.claude_agent_sdk.utils import EXPECTED_ASSISTANT_USAGE
-from tests.contrib.claude_agent_sdk.utils import EXPECTED_QUERY_USAGE
+from tests.contrib.claude_agent_sdk.utils import EXPECTED_CACHE_ONLY_USAGE
 from tests.contrib.claude_agent_sdk.utils import EXPECTED_SYSTEM_MESSAGE_DATA
 from tests.contrib.claude_agent_sdk.utils import MOCK_ASSISTANT_MESSAGE_ERROR
 from tests.contrib.claude_agent_sdk.utils import MOCK_ASSISTANT_MESSAGE_ERROR_TEXT
@@ -77,7 +77,7 @@ class TestLLMObsClaudeAgentSdk:
                 ]
             ),
             metadata={"stop_reason": "end_turn", "_dd": {"agent_manifest": expected_agent_manifest()}},
-            metrics=EXPECTED_QUERY_USAGE,
+            metrics={},
             tags=COMMON_TAGS,
         )
         # The LLM Observability UI filters out span links from parent to direct
@@ -138,7 +138,7 @@ class TestLLMObsClaudeAgentSdk:
                 "stop_reason": "end_turn",
                 "_dd": {"agent_manifest": expected_agent_manifest(max_iterations=3)},
             },
-            metrics=EXPECTED_QUERY_USAGE,
+            metrics={},
             tags=COMMON_TAGS,
         )
 
@@ -186,7 +186,7 @@ class TestLLMObsClaudeAgentSdk:
                 ]
             ),
             metadata={"stop_reason": "end_turn", "_dd": {"agent_manifest": expected_agent_manifest()}},
-            metrics=EXPECTED_QUERY_USAGE,
+            metrics={},
             tags=COMMON_TAGS,
         )
 
@@ -281,7 +281,7 @@ class TestLLMObsClaudeAgentSdk:
                 ]
             ),
             metadata={"stop_reason": "end_turn", "_dd": {"agent_manifest": expected_agent_manifest()}},
-            metrics=EXPECTED_QUERY_USAGE,
+            metrics={},
             error={"type": MOCK_ASSISTANT_MESSAGE_ERROR, "message": MOCK_ASSISTANT_MESSAGE_ERROR, "stack": ANY},
             tags=COMMON_TAGS,
         )
@@ -341,7 +341,7 @@ class TestLLMObsClaudeAgentSdk:
                 ]
             ),
             metadata={"stop_reason": "end_turn", "_dd": {"agent_manifest": expected_agent_manifest()}},
-            metrics=EXPECTED_QUERY_USAGE,
+            metrics={},
             error=expected_error,
             tags=COMMON_TAGS,
         )
@@ -392,13 +392,7 @@ class TestLLMObsClaudeAgentSdk:
                 **({"stop_reason": "end_turn"} if CLAUDE_AGENT_SDK_VERSION >= (0, 1, 49) else {}),
                 "_dd": {"agent_manifest": expected_agent_manifest()},
             },
-            metrics={
-                "input_tokens": 14599,
-                "output_tokens": 5,
-                "total_tokens": 14604,
-                "cache_write_input_tokens": 12742,
-                "cache_read_input_tokens": 1854,
-            },
+            metrics={},
             tags=COMMON_TAGS,
         )
 
@@ -479,7 +473,7 @@ class TestLLMObsClaudeAgentSdk:
                 ]
             ),
             metadata={"stop_reason": "end_turn", "_dd": {"agent_manifest": expected_agent_manifest()}},
-            metrics=EXPECTED_QUERY_USAGE,
+            metrics={},
             tags=COMMON_TAGS,
         )
         _assert_span_link(llm_span, tool_span, "output", "input")
@@ -561,7 +555,7 @@ class TestLLMObsClaudeAgentSdk:
                 ]
             ),
             metadata={"stop_reason": "end_turn", "_dd": {"agent_manifest": expected_agent_manifest()}},
-            metrics=EXPECTED_QUERY_USAGE,
+            metrics={},
             tags=COMMON_TAGS,
         )
         _assert_span_link(llm_span, tool_span, "output", "input")
@@ -643,7 +637,7 @@ class TestLLMObsClaudeAgentSdk:
                 ]
             ),
             metadata={"stop_reason": "end_turn", "_dd": {"agent_manifest": expected_agent_manifest()}},
-            metrics=EXPECTED_QUERY_USAGE,
+            metrics={},
             tags=COMMON_TAGS,
         )
         _assert_span_link(llm_span, tool_span, "output", "input")
@@ -695,7 +689,7 @@ class TestLLMObsClaudeAgentSdk:
                 ]
             ),
             metadata={"stop_reason": "end_turn", "_dd": {"agent_manifest": expected_agent_manifest()}},
-            metrics=EXPECTED_QUERY_USAGE,
+            metrics={},
             tags=COMMON_TAGS,
         )
 
@@ -749,13 +743,7 @@ class TestLLMObsClaudeAgentSdk:
                 **({"stop_reason": "end_turn"} if CLAUDE_AGENT_SDK_VERSION >= (0, 1, 49) else {}),
                 "_dd": {"agent_manifest": expected_agent_manifest()},
             },
-            metrics={
-                "input_tokens": 14599,
-                "output_tokens": 5,
-                "total_tokens": 14604,
-                "cache_write_input_tokens": 12742,
-                "cache_read_input_tokens": 1854,
-            },
+            metrics={},
             tags=COMMON_TAGS,
         )
 
@@ -918,6 +906,30 @@ class TestLLMObsClaudeAgentSdk:
             input_value=safe_json(input_msgs),
             output_value=safe_json(output_msgs),
             metrics=EXPECTED_ASSISTANT_USAGE,
+            tags=COMMON_TAGS,
+        )
+
+    async def test_llmobs_llm_span_folds_cache_only_input_tokens(
+        self, claude_agent_sdk, mock_internal_client_cache_only, claude_agent_sdk_llmobs, test_spans
+    ):
+        """A fully cache-served turn (uncached input_tokens == 0, cache_read > 0) must still report
+        the folded cache input on the llm span rather than dropping it.
+        """
+        prompt = "What is 2+2?"
+        async for _ in claude_agent_sdk.query(prompt=prompt):
+            pass
+
+        spans = [s for trace in test_spans.pop_traces() for s in trace]
+        llm_span = next(s for s in spans if s.name == "claude_agent_sdk.llm")
+
+        assert_llmobs_span_data(
+            _get_llmobs_data_metastruct(llm_span),
+            span_kind="llm",
+            model_name=MOCK_MODEL,
+            model_provider="anthropic",
+            input_messages=[{"content": prompt, "role": "user"}],
+            output_messages=[{"content": "4", "role": "assistant"}],
+            metrics=EXPECTED_CACHE_ONLY_USAGE,
             tags=COMMON_TAGS,
         )
 

--- a/tests/contrib/claude_agent_sdk/utils.py
+++ b/tests/contrib/claude_agent_sdk/utils.py
@@ -252,6 +252,26 @@ MOCK_QUERY_RESPONSE_SEQUENCE_WITH_USAGE = [
 ]
 
 
+MOCK_CACHE_ONLY_USAGE = {
+    "input_tokens": 0,
+    "output_tokens": 15,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 5000,
+}
+EXPECTED_CACHE_ONLY_USAGE = {
+    "input_tokens": 5000,
+    "output_tokens": 15,
+    "total_tokens": 5015,
+    "cache_read_input_tokens": 5000,
+}
+MOCK_ASSISTANT_RESPONSE_CACHE_ONLY = create_mock_assistant_message("4", usage=MOCK_CACHE_ONLY_USAGE)
+MOCK_QUERY_RESPONSE_SEQUENCE_CACHE_ONLY = [
+    MOCK_SYSTEM_MESSAGE,
+    MOCK_ASSISTANT_RESPONSE_CACHE_ONLY,
+    MOCK_RESULT_MESSAGE,
+]
+
+
 MOCK_READ_TOOL_ID = "toolu_01C4Thx957VoSn21zERxbeQX"
 MOCK_TOOL_USE_ASSISTANT = create_mock_assistant_message_with_tool_use(
     [("Read", {"file_path": "/etc/hostname"}, MOCK_READ_TOOL_ID)],
@@ -378,20 +398,6 @@ MOCK_STRUCTURED_OUTPUT_RESPONSE_SEQUENCE = [
     MOCK_ASSISTANT_RESPONSE,
     MOCK_STRUCTURED_RESULT_MESSAGE,
 ]
-
-EXPECTED_CACHE_WRITE_INPUT_TOKENS = 12742
-EXPECTED_CACHE_READ_INPUT_TOKENS = 1854
-EXPECTED_INPUT_TOKENS = 3 + EXPECTED_CACHE_WRITE_INPUT_TOKENS + EXPECTED_CACHE_READ_INPUT_TOKENS
-EXPECTED_OUTPUT_TOKENS = 5
-EXPECTED_TOTAL_TOKENS = EXPECTED_INPUT_TOKENS + EXPECTED_OUTPUT_TOKENS
-EXPECTED_QUERY_USAGE = {
-    "input_tokens": EXPECTED_INPUT_TOKENS,
-    "output_tokens": EXPECTED_OUTPUT_TOKENS,
-    "total_tokens": EXPECTED_TOTAL_TOKENS,
-    "cache_write_input_tokens": EXPECTED_CACHE_WRITE_INPUT_TOKENS,
-    "cache_read_input_tokens": EXPECTED_CACHE_READ_INPUT_TOKENS,
-}
-
 
 # mocked client messages are in a raw format compared to normal query responses
 MOCK_CLIENT_RAW_MESSAGES = [


### PR DESCRIPTION
## Description

The Claude Agent SDK integration reads token usage off the SDK message stream (ddtrace never sees the underlying HTTP call). Two problems affected the token counts trace-level cost is aggregated from:

1. **Dropped input on cache-served turns.** `_extract_usage` folds cache-read/cache-write into `input_tokens`, but guarded that fold on the *uncached* `input_tokens` being truthy. A fully cache-served turn has `input_tokens == 0` with a large `cache_read_input_tokens`, so the folded input (e.g. `5000`) was dropped entirely and the `llm` span reported no input tokens — undercounting Σ(llm) input and cost. The guard now keys off the folded total.

2. **Redundant usage on the root span.** The root/agent span was additionally tagged with `ResultMessage.usage`. That block is the accurate *cumulative* total for the whole query — its `output_tokens` equals the sum of every turn's output. The problem is not the value's accuracy but that it is unnecessary: trace-level token/cost totals are aggregated from the per-turn `llm` spans, and the root/agent span's own metrics are not consumed for those totals. Tagging the cumulative total on the root therefore had no effect on accounting and only surfaced a number on the root that could look inconsistent alongside the per-turn `llm` spans. The root no longer reports token usage; the per-turn `llm` spans are the single source.

Each model turn already maps to exactly one `llm` span (same-`message_id` chunks are merged), so Σ(`llm` span tokens) equals the true per-turn billed total once the cache-served input is no longer dropped.

## SDK version behavior

Per-turn `llm`-span token metrics come from `AssistantMessage.usage`, which the SDK only added in **claude-agent-sdk 0.1.49**. On the older supported versions (`0.0.23`, `0.1.29`) `AssistantMessage` carries no `usage`, so per-turn `llm`-span token metrics are unavailable on those versions — a pre-existing limitation that this PR neither introduces nor changes. Dropping the root-span usage does not regress token/cost accounting on those versions: the root/agent span's metrics were not consumed for trace-level totals (which come from `llm` spans) regardless of SDK version.

## Testing

- Added `test_llmobs_llm_span_folds_cache_only_input_tokens`: a fully cache-served turn (`input_tokens=0, cache_read=5000`) now reports `input_tokens=5000`, `total_tokens=5015` on the `llm` span.
- Updated existing agent-span assertions to expect no token metrics.

## Risk

Low. Token-count-only change to one LLMObs integration; no public API change. Non-cache turns are unaffected (folded total is identical when the uncached base is non-zero).

Claude session: `faac1da4-8dd7-4bb2-ae27-224c12d628ff`
Resume: `claude --resume faac1da4-8dd7-4bb2-ae27-224c12d628ff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)