### PR TITLE
chore(appsec): remove type checking exceptions

### DIFF
--- a/ddtrace/_trace/processor/resource_renaming.py
+++ b/ddtrace/_trace/processor/resource_renaming.py
@@ -14,7 +14,7 @@ log = get_logger(__name__)
 
 
 class SimplifiedEndpointComputer:
-    def __init__(self):
+    def __init__(self) -> None:
         self._INT_RE = re.compile(r"^[1-9][0-9]+$")
         self._INT_ID_RE = re.compile(r"^(?=.*[0-9].*)[0-9._-]{3,}$")
         self._HEX_RE = re.compile(r"^(?=.*[0-9].*)[A-Fa-f0-9]{6,}$")

--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -132,7 +132,7 @@ class ASM_Environment:
 
 
 def _get_asm_context() -> Optional[ASM_Environment]:
-    return core.find_item(_ASM_CONTEXT)
+    return core.find_item(_ASM_CONTEXT)  # type: ignore[no-any-return]
 
 
 def get_active_asm_context() -> Optional[ASM_Environment]:
@@ -464,18 +464,11 @@ def set_waf_address(address: str, value: Any) -> None:
         core.set_item(address, value)
 
 
-def get_value(category: str, address: str, default: Any = None) -> Any:
+def get_waf_address(address: str, default: Any = None) -> Any:
     env = get_active_asm_context()
     if env is None:
         return default
-    asm_context_attr = getattr(env, category, None)
-    if asm_context_attr is not None:
-        return asm_context_attr.get(address, default)
-    return default
-
-
-def get_waf_address(address: str, default: Any = None) -> Any:
-    return get_value(_WAF_ADDRESSES, address, default=default)
+    return env.waf_addresses.get(address, default)
 
 
 def set_waf_info(info: Callable[[], "DDWaf_info"]) -> None:
@@ -523,7 +516,7 @@ def set_ip(ip: Optional[str]) -> None:
 
 
 def get_ip() -> Optional[str]:
-    return get_value(_WAF_ADDRESSES, SPAN_DATA_NAMES.REQUEST_HTTP_IP)
+    return get_waf_address(SPAN_DATA_NAMES.REQUEST_HTTP_IP)  # type: ignore[no-any-return]
 
 
 # Note: get/set headers use Any since we just carry the headers here without changing or using them
@@ -537,7 +530,7 @@ def set_headers(headers: Mapping) -> None:
 
 
 def get_headers() -> Optional[Mapping]:
-    return get_value(_WAF_ADDRESSES, SPAN_DATA_NAMES.REQUEST_HEADERS_NO_COOKIES, {})
+    return get_waf_address(SPAN_DATA_NAMES.REQUEST_HEADERS_NO_COOKIES, {})  # type: ignore[no-any-return]
 
 
 def set_headers_case_sensitive(case_sensitive: bool) -> None:
@@ -545,7 +538,7 @@ def set_headers_case_sensitive(case_sensitive: bool) -> None:
 
 
 def get_headers_case_sensitive() -> bool:
-    return get_value(_WAF_ADDRESSES, SPAN_DATA_NAMES.REQUEST_HEADERS_NO_COOKIES_CASE, False)  # type : ignore
+    return get_waf_address(SPAN_DATA_NAMES.REQUEST_HEADERS_NO_COOKIES_CASE, False)  # type: ignore[no-any-return]
 
 
 def set_block_request_callable(block_callable: Optional[Callable[[], None]]) -> None:
@@ -739,7 +732,7 @@ def _get_headers_if_appsec() -> Optional[Any]:
     return None
 
 
-## headers tags
+# headers tags
 
 _COLLECTED_REQUEST_HEADERS_ASM_ENABLED = {
     "accept",

--- a/ddtrace/appsec/_contrib/django/__init__.py
+++ b/ddtrace/appsec/_contrib/django/__init__.py
@@ -21,6 +21,7 @@ from ddtrace.appsec._trace_utils import _asm_manual_keep
 from ddtrace.appsec._trace_utils import track_user_login_failure_event
 from ddtrace.appsec._trace_utils import track_user_login_success_event
 from ddtrace.appsec._utils import _hash_user_id
+from ddtrace.appsec._utils import _UserExtraInfo
 from ddtrace.contrib.internal.django.user import _DjangoUserInfoRetriever
 from ddtrace.contrib.internal.trace_utils_base import set_user
 from ddtrace.ext import SpanTypes
@@ -99,12 +100,11 @@ def _on_django_auth(
 
     userid_list = info_retriever.possible_user_id_fields + info_retriever.possible_login_fields
 
+    user_id: Optional[object] = None
     for possible_key in userid_list:
         if possible_key in kwargs:
             user_id = kwargs[possible_key]
             break
-    else:
-        user_id = None
 
     if not result_user:
         with tracer.trace("django.contrib.auth.login", span_type=SpanTypes.AUTH):
@@ -115,7 +115,7 @@ def _on_django_auth(
                 name=django_config.include_user_realname,
             )
             if user_extra.get("login") is None:
-                user_extra["login"] = user_id
+                user_extra["login"] = str(user_id) if user_id is not None else None
             user_id = user_id_found or user_id
             user_login = user_extra.get("login")
 
@@ -135,17 +135,16 @@ def get_user_info(
     info_retriever: _DjangoUserInfoRetriever,
     django_config: IntegrationConfig,
     kwargs: Optional[dict[str, Any]] = None,
-) -> tuple[Any, dict[str, Any]]:
+) -> tuple[Optional[object], _UserExtraInfo]:
     if kwargs is None:
         kwargs = {}
     userid_list = info_retriever.possible_user_id_fields + info_retriever.possible_login_fields
 
+    user_id: Optional[object] = None
     for possible_key in userid_list:
         if possible_key in kwargs:
             user_id = kwargs[possible_key]
             break
-    else:
-        user_id = None
 
     user_id_found, user_extra = info_retriever.get_user_info(
         login=True,
@@ -153,7 +152,7 @@ def get_user_info(
         name=django_config.include_user_realname,
     )
     if user_extra.get("login") is None and user_id:
-        user_extra["login"] = user_id
+        user_extra["login"] = str(user_id)
     return user_id_found or user_id, user_extra
 
 
@@ -248,8 +247,7 @@ def _on_django_signup_user(
         _asm_manual_keep(span)
         span._set_attribute(APPSEC.USER_SIGNUP_EVENT_MODE, str(asm_config._user_event_mode))
         span._set_attribute(APPSEC.USER_SIGNUP_EVENT, "true")
-        if "login" in user_extra:
-            login = user_extra["login"]
+        if (login := user_extra.get("login")) is not None:
             if asm_config._user_event_mode == LOGIN_EVENTS_MODE.ANON:
                 login = _hash_user_id(login)
             span._set_attribute(APPSEC.USER_SIGNUP_EVENT_USERNAME, login)

--- a/ddtrace/appsec/_contrib/fastapi/__init__.py
+++ b/ddtrace/appsec/_contrib/fastapi/__init__.py
@@ -88,7 +88,6 @@ def _asgi_make_block_content(ctx: ExecutionContext, url: str) -> tuple[int, list
     if req_span is None:
         raise ValueError("request span not found")
     block_config = get_blocked() or Block_config()
-    ctype = None
     if block_config.type == "none":
         content = b""
         resp_headers = [
@@ -97,13 +96,10 @@ def _asgi_make_block_content(ctx: ExecutionContext, url: str) -> tuple[int, list
         ]
     else:
         content = http_utils._get_blocked_template(block_config.content_type, block_config.block_id).encode("UTF-8")
-        # ctype = f"{ctype}; charset=utf-8" can be considered at some point
         resp_headers = [(b"content-type", block_config.content_type.encode())]
     status = block_config.status_code
     try:
         req_span._set_attribute(RESPONSE_HEADERS + ".content-length", str(len(content)))
-        if ctype is not None:
-            req_span._set_attribute(RESPONSE_HEADERS + ".content-type", ctype)
         req_span._set_attribute(http.STATUS_CODE, str(status))
         query_string = environ.get("QUERY_STRING")
         _set_url_tag(middleware.integration_config, req_span, url, query_string)

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -309,7 +309,7 @@ class AppSecSpanProcessor(SpanProcessor):
                     if custom_data is not None and custom_data.get(key) is not None:
                         value = custom_data.get(key)
                     elif key in SPAN_DATA_NAMES:
-                        value = _asm_request_context.get_value("waf_addresses", SPAN_DATA_NAMES[key])
+                        value = _asm_request_context.get_waf_address(SPAN_DATA_NAMES[key])
                     # if value is a callable, it's a lazy value for api security that should not be sent now
                     if value is not None and not hasattr(value, "__call__"):
                         data[waf_name] = _serialize_address_values(waf_name, value)

--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -56,9 +56,9 @@ def _asm_manual_keep(span: Span) -> None:
     add_trace_source(span, TraceSource.ASM)
 
 
-def _handle_metadata(entry_span: Span, prefix: str, metadata: dict) -> None:
+def _handle_metadata(entry_span: Span, prefix: str, metadata: dict[Any, Any]) -> None:
     MAX_DEPTH = 6
-    stack = [(prefix, metadata, 1)]
+    stack: list[tuple[str, Any, int]] = [(prefix, metadata, 1)]
     while stack:
         current_prefix, data, level = stack.pop()
         if isinstance(data, list):

--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -1,5 +1,7 @@
 from typing import Any
 from typing import Optional
+from typing import TypeVar
+from typing import Union
 
 from ddtrace._trace.span import Span
 from ddtrace.appsec import _asm_request_context
@@ -30,13 +32,14 @@ _NO_ROOT_SPAN_WARNING = (
 )
 
 _BLOCKING_ACTIONS = frozenset({WAF_ACTIONS.BLOCK_ACTION, WAF_ACTIONS.REDIRECT_ACTION})
+_T = TypeVar("_T")
 
 
 def _is_blocking(res: Optional[DDWaf_result]) -> bool:
     return res is not None and not _BLOCKING_ACTIONS.isdisjoint(res.actions)
 
 
-def _maybe_hash(value: Optional[str], mode: str) -> Optional[str]:
+def _maybe_hash(value: Optional[_T], mode: str) -> Optional[Union[_T, str]]:
     if value is not None and mode == LOGIN_EVENTS_MODE.ANON and isinstance(value, str):
         return _hash_user_id(value)
     return value
@@ -133,7 +136,7 @@ def _track_user_login_common(
 
 def track_user_login_success_event(
     tracer: Any,
-    user_id: Optional[str],
+    user_id: Optional[object],
     metadata: Optional[dict] = None,
     login: Optional[str] = None,
     name: Optional[str] = None,
@@ -175,7 +178,18 @@ def track_user_login_success_event(
             span._set_attribute(APPSEC.USER_LOGIN_USERID, str(user_id))
         else:
             span._set_attribute(f"{APPSEC.USER_LOGIN_EVENT_PREFIX_PUBLIC}.success.usr.id", str(user_id))
-    set_user(None, user_id or "", name, email, scope, role, session_id, propagate, span, may_block=False)
+    set_user(
+        None,
+        str(user_id) if user_id else "",
+        name,
+        email,
+        scope,
+        role,
+        session_id,
+        propagate,
+        span,
+        may_block=False,
+    )
     if in_asm_context():
         custom_data = {
             "REQUEST_USER_ID": str(initial_user_id) if initial_user_id else None,
@@ -194,7 +208,7 @@ def track_user_login_success_event(
 
 def track_user_login_failure_event(
     tracer: Any,
-    user_id: Optional[str],
+    user_id: Optional[object],
     exists: Optional[bool] = None,
     metadata: Optional[dict] = None,
     login_events_mode: str = LOGIN_EVENTS_MODE.SDK,

--- a/ddtrace/appsec/_utils.py
+++ b/ddtrace/appsec/_utils.py
@@ -299,8 +299,14 @@ def _safe_userid(user_id: Any) -> Optional[Any]:
     return None
 
 
+class _UserExtraInfo(TypedDict, total=False):
+    login: Optional[str]
+    email: Optional[str]
+    name: Optional[str]
+
+
 class _UserInfoRetriever:
-    def __init__(self, user: Any) -> None:
+    def __init__(self, user: object) -> None:
         self.user = user
         self.possible_user_id_fields = ["pk", "id", "uid", "userid", "user_id", "PK", "ID", "UID", "USERID"]
         self.possible_login_fields = ["username", "user", "login", "USERNAME", "USER", "LOGIN"]
@@ -316,56 +322,63 @@ class _UserInfoRetriever:
             "FIRST_NAME",
         ]
 
-    def find_in_user_model(self, possible_fields: typing.Sequence[str]) -> typing.Optional[Any]:
+    def find_in_user_model(self, possible_fields: typing.Sequence[str]) -> typing.Optional[object]:
         for field in possible_fields:
-            value = getattr(self.user, field, None)
+            value: object = getattr(self.user, field, None)
             if value is not None:
                 return value
 
         return None  # explicit to make clear it has a meaning
 
-    def get_userid(self) -> Any:
-        user_login = getattr(self.user, asm_config._user_model_login_field, None)
+    def get_userid(self) -> Optional[object]:
+        user_login: object = getattr(self.user, asm_config._user_model_login_field, None)
         if user_login is not None:
             return user_login
 
         user_login = self.find_in_user_model(self.possible_user_id_fields)
         return user_login
 
-    def get_username(self) -> Any:
+    def get_username(self) -> Optional[str]:
         username = getattr(self.user, asm_config._user_model_name_field, None)
         if username is not None:
-            return username
+            return str(username)
 
         if hasattr(self.user, "get_username"):
             try:
-                return self.user.get_username()
+                username = self.user.get_username()
+                if username is not None:
+                    return str(username)
             except Exception:
                 log.debug("User model get_username member produced an exception: ", exc_info=True)
 
-        return self.find_in_user_model(self.possible_login_fields)
+        username = self.find_in_user_model(self.possible_login_fields)
+        return str(username) if username is not None else None
 
-    def get_user_email(self) -> Any:
+    def get_user_email(self) -> Optional[str]:
         email = getattr(self.user, asm_config._user_model_email_field, None)
         if email is not None:
-            return email
+            return str(email)
 
-        return self.find_in_user_model(self.possible_email_fields)
+        email = self.find_in_user_model(self.possible_email_fields)
+        return str(email) if email is not None else None
 
-    def get_name(self) -> Any:
+    def get_name(self) -> Optional[str]:
         name = getattr(self.user, asm_config._user_model_name_field, None)
         if name is not None:
-            return name
+            return str(name)
 
-        return self.find_in_user_model(self.possible_name_fields)
+        name = self.find_in_user_model(self.possible_name_fields)
+        return str(name) if name is not None else None
 
-    def get_user_info(self, login: bool = False, email: bool = False, name: bool = False) -> tuple[Any, dict[str, Any]]:
+    def get_user_info(
+        self, login: bool = False, email: bool = False, name: bool = False
+    ) -> tuple[Optional[object], _UserExtraInfo]:
         """
         In safe mode, try to get the user id from the user object.
         In extended mode, try to also get the username (which will be the returned user_id),
         email and name.
         """
-        user_extra_info = {}
+        user_extra_info: _UserExtraInfo = {}
 
         user_id = self.get_userid()
         if user_id is None:

--- a/ddtrace/appsec/_utils.py
+++ b/ddtrace/appsec/_utils.py
@@ -183,7 +183,7 @@ class Block_config:
         self.location = location.replace(APPSEC.SECURITY_RESPONSE_ID, security_response_id)
         self.content_type: str = "application/json"
 
-    def get(self, key: str, default: Any = None) -> Union[str, int]:
+    def get(self, key: str, default: Optional[Union[str, int]] = None) -> Optional[Union[str, int]]:
         """
         Dictionary-like get method for backward compatibility with Lambda integration.
 
@@ -192,7 +192,7 @@ class Block_config:
         """
         if key == "content-type":
             key = "content_type"
-        return getattr(self, key, default)  # type: ignore[no-any-return]
+        return getattr(self, key, default)
 
     def __getitem__(self, key: str) -> Optional[Union[str, int]]:
         if key == "content-type":

--- a/ddtrace/appsec/_utils.py
+++ b/ddtrace/appsec/_utils.py
@@ -192,7 +192,7 @@ class Block_config:
         """
         if key == "content-type":
             key = "content_type"
-        return getattr(self, key, default)
+        return getattr(self, key, default)  # type: ignore[no-any-return]
 
     def __getitem__(self, key: str) -> Optional[Union[str, int]]:
         if key == "content-type":
@@ -316,7 +316,7 @@ class _UserInfoRetriever:
             "FIRST_NAME",
         ]
 
-    def find_in_user_model(self, possible_fields: typing.Sequence[str]) -> typing.Optional[str]:
+    def find_in_user_model(self, possible_fields: typing.Sequence[str]) -> typing.Optional[Any]:
         for field in possible_fields:
             value = getattr(self.user, field, None)
             if value is not None:

--- a/ddtrace/appsec/sca/_cve_loader.py
+++ b/ddtrace/appsec/sca/_cve_loader.py
@@ -21,7 +21,7 @@ log = get_logger(__name__)
 _CVE_DATA_PATH = os.path.join(os.path.dirname(__file__), "_cve_data.json")
 
 
-def _parse_version_constraint(constraint: str) -> Optional[tuple]:
+def _parse_version_constraint(constraint: str) -> Optional[tuple[str, Version]]:
     """Parse a version constraint string into (operator, version).
 
     Supports: "<1.2.3", "<=1.2.3", ">1.2.3", ">=1.2.3", "==1.2.3"

--- a/ddtrace/appsec/sca/_instrumenter.py
+++ b/ddtrace/appsec/sca/_instrumenter.py
@@ -6,6 +6,7 @@ bytecode injection via dd-trace-py's bytecode_injection infrastructure.
 
 from __future__ import annotations
 
+import sys
 from threading import Lock
 import types
 from types import FunctionType
@@ -42,29 +43,35 @@ _lazy_module_targets: dict[str, set[str]] = {}
 _lazy_hooks_lock = Lock()
 
 
-def _first_instr_line(code: types.CodeType) -> int:
-    """Return the line number of the first real bytecode instruction.
+if sys.version_info < (3, 11):
 
-    On Python <3.11, co_firstlineno is the ``def`` line, which has no
-    bytecode instructions.  inject_hook needs the first *instruction*
-    line, which is the first line of the function body.
+    def _first_instr_line(code: types.CodeType) -> int:
+        """Return the first body-instruction line on Python 3.9 and 3.10."""
+        import dis
 
-    In CPython, ``dis.Instruction.starts_line`` is typically the absolute
-    line number (or ``None``).  We also defensively handle instruction
-    objects that expose a ``line_number`` attribute and prefer it when
-    present before falling back to ``starts_line``.
-    """
-    import dis
+        for instr in dis.get_instructions(code):
+            if instr.starts_line is not None:
+                return instr.starts_line
+        return code.co_firstlineno
 
-    for instr in dis.get_instructions(code):
-        # Prefer explicit line_number when provided by the instruction object.
-        line = getattr(instr, "line_number", None)
-        if line is not None:
-            return line
-        # Otherwise use starts_line when it carries the absolute line number.
-        if instr.starts_line is not None and isinstance(instr.starts_line, int):
-            return instr.starts_line
-    return code.co_firstlineno
+
+elif sys.version_info < (3, 14):
+
+    def _first_instr_line(code: types.CodeType) -> int:
+        """Return the RESUME instruction's line on Python 3.11 through 3.13."""
+        return code.co_firstlineno
+
+
+else:
+
+    def _first_instr_line(code: types.CodeType) -> int:
+        """Return the first instruction line on Python 3.14 and later."""
+        import dis
+
+        for instr in dis.get_instructions(code):
+            if instr.line_number is not None:
+                return instr.line_number
+        return code.co_firstlineno
 
 
 def _get_caller_info() -> tuple[str, int, str]:

--- a/ddtrace/appsec/sca/_resolver.py
+++ b/ddtrace/appsec/sca/_resolver.py
@@ -56,7 +56,7 @@ class SymbolResolver:
             # new bound-method wrapper each time, so inject_hook would patch a
             # throwaway copy instead of the real function in the class dict.
             parts = symbol_path.split(".")
-            target = module
+            target: object = module
             for i, part in enumerate(parts):
                 is_last = i == len(parts) - 1
                 if is_last and isinstance(target, type) and part in target.__dict__:

--- a/ddtrace/appsec/track_user_sdk.py
+++ b/ddtrace/appsec/track_user_sdk.py
@@ -15,6 +15,7 @@ from ddtrace.appsec import _trace_utils
 from ddtrace.appsec._asm_request_context import get_blocked as _get_blocked
 from ddtrace.appsec._constants import WAF_ACTIONS as _WAF_ACTIONS
 import ddtrace.appsec.trace_utils  # noqa: F401
+from ddtrace.contrib.internal.trace_utils_base import set_user
 from ddtrace.internal._exceptions import BlockingException
 
 
@@ -96,7 +97,7 @@ def track_user(
     usr_email = meta.pop("email", None) or meta.pop("usr.email", None)
     usr_scope = meta.pop("scope", None) or meta.pop("usr.scope", None)
     usr_role = meta.pop("role", None) or meta.pop("usr.role", None)
-    _trace_utils.set_user(
+    set_user(
         None,
         user_id,
         name=usr_name if isinstance(usr_name, str) else None,
@@ -148,7 +149,7 @@ def track_user_id(
     usr_email = meta.pop("email", None) or meta.pop("usr.email", None)
     usr_scope = meta.pop("scope", None) or meta.pop("usr.scope", None)
     usr_role = meta.pop("role", None) or meta.pop("usr.role", None)
-    _trace_utils.set_user(
+    set_user(
         None,
         user_id,
         name=usr_name if isinstance(usr_name, str) else None,

--- a/ddtrace/contrib/internal/django/compat.py
+++ b/ddtrace/contrib/internal/django/compat.py
@@ -1,20 +1,22 @@
+from typing import Any
+
 import django
 
 
 if django.VERSION >= (1, 10, 1):
     from django.urls import get_resolver
 
-    def user_is_authenticated(user):
+    def user_is_authenticated(user: Any) -> bool:
         # Explicit comparison due to the following bug
         # https://code.djangoproject.com/ticket/26988
-        return user.is_authenticated == True  # noqa E712
+        return user.is_authenticated == True  # type: ignore[no-any-return] # noqa E712
 
 else:
     from django.conf import settings
     from django.core import urlresolvers
 
-    def user_is_authenticated(user):
-        return user.is_authenticated()
+    def user_is_authenticated(user: Any) -> bool:
+        return user.is_authenticated()  # type: ignore[no-any-return]
 
     if django.VERSION >= (1, 9, 0):
 

--- a/ddtrace/contrib/internal/django/user.py
+++ b/ddtrace/contrib/internal/django/user.py
@@ -51,7 +51,7 @@ class _DjangoUserInfoRetriever(_UserInfoRetriever):
         except self.user_model.DoesNotExist:
             log.debug("try_load_user_model: could not load user model", exc_info=True)
 
-    def user_exists(self):
+    def user_exists(self) -> bool:
         return self.user is not None
 
     def get_username(self):

--- a/ddtrace/contrib/internal/django/user.py
+++ b/ddtrace/contrib/internal/django/user.py
@@ -1,3 +1,6 @@
+from typing import Any
+from typing import Optional
+
 from ddtrace.appsec._utils import _UserInfoRetriever
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings.asm import config as asm_config
@@ -7,7 +10,7 @@ log = get_logger(__name__)
 
 
 class _DjangoUserInfoRetriever(_UserInfoRetriever):
-    def __init__(self, user, credentials=None):
+    def __init__(self, user: object, credentials: Optional[dict[str, Any]] = None) -> None:
         super(_DjangoUserInfoRetriever, self).__init__(user)
 
         self.credentials = credentials if credentials else {}
@@ -54,29 +57,36 @@ class _DjangoUserInfoRetriever(_UserInfoRetriever):
     def user_exists(self) -> bool:
         return self.user is not None
 
-    def get_username(self):
-        if hasattr(self.user, "USERNAME_FIELD") and not asm_config._user_model_name_field:
-            user_type = type(self.user)
-            return getattr(self.user, user_type.USERNAME_FIELD, None)
+    def get_username(self) -> Optional[str]:
+        username_field = getattr(type(self.user), "USERNAME_FIELD", None)
+        if username_field is not None and not asm_config._user_model_name_field:
+            username = getattr(self.user, username_field, None)
+            return str(username) if username is not None else None
 
         return super(_DjangoUserInfoRetriever, self).get_username()
 
-    def get_name(self):
+    def get_name(self) -> Optional[str]:
         if not asm_config._user_model_name_field:
-            if hasattr(self.user, "get_full_name"):
+            get_full_name = getattr(self.user, "get_full_name", None)
+            if callable(get_full_name):
                 try:
-                    return self.user.get_full_name()
+                    full_name = get_full_name()
+                    if full_name is not None:
+                        return str(full_name)
                 except Exception:
                     log.debug("User model get_full_name member produced an exception: ", exc_info=True)
 
-            if hasattr(self.user, "first_name") and hasattr(self.user, "last_name"):
-                return "%s %s" % (self.user.first_name, self.user.last_name)
+            first_name = getattr(self.user, "first_name", None)
+            last_name = getattr(self.user, "last_name", None)
+            if first_name is not None and last_name is not None:
+                return "%s %s" % (first_name, last_name)
 
         return super(_DjangoUserInfoRetriever, self).get_name()
 
-    def get_user_email(self):
-        if hasattr(self.user, "EMAIL_FIELD") and not asm_config._user_model_name_field:
-            user_type = type(self.user)
-            return getattr(self.user, user_type.EMAIL_FIELD, None)
+    def get_user_email(self) -> Optional[str]:
+        email_field = getattr(type(self.user), "EMAIL_FIELD", None)
+        if email_field is not None and not asm_config._user_model_name_field:
+            email = getattr(self.user, email_field, None)
+            return str(email) if email is not None else None
 
         return super(_DjangoUserInfoRetriever, self).get_user_email()

--- a/ddtrace/internal/core/subscriber.py
+++ b/ddtrace/internal/core/subscriber.py
@@ -16,6 +16,7 @@ the same subscriber.
 
 import logging
 from types import TracebackType
+from typing import Any
 from typing import ClassVar
 from typing import Generic
 from typing import Optional
@@ -59,7 +60,7 @@ class Subscriber:
     event_names: Sequence[str]
     _event_handlers: tuple = ()
 
-    def __init_subclass__(cls, **kwargs):
+    def __init_subclass__(cls, **kwargs: Any) -> None:
         """Automatically register listeners at subclass definition.
         Handlers are registered from Base class to Children classes to allow
         behavior composition (a child class benefit from the parent class hook)
@@ -136,7 +137,7 @@ class ContextSubscriber(Generic[EventType]):
     _started_handlers: tuple = ()
     _ended_handlers: tuple = ()
 
-    def __init_subclass__(cls, **kwargs):
+    def __init_subclass__(cls, **kwargs: Any) -> None:
         """Automatically register listeners at subclass definition.
         Handlers are registered from Base class to Children classes to allow
         behavior composition (a child class benefit from the parent class hook)

--- a/ddtrace/vendor/packaging/_structures.py
+++ b/ddtrace/vendor/packaging/_structures.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import, division, print_function
 
 
-class Infinity(object):
+class InfinityClass(object):
 
     def __repr__(self):
         return "Infinity"
@@ -34,10 +34,10 @@ class Infinity(object):
         return NegativeInfinity
 
 
-Infinity = Infinity()
+Infinity = InfinityClass()
 
 
-class NegativeInfinity(object):
+class NegativeInfinityClass(object):
 
     def __repr__(self):
         return "-Infinity"
@@ -67,4 +67,4 @@ class NegativeInfinity(object):
         return Infinity
 
 
-NegativeInfinity = NegativeInfinity()
+NegativeInfinity = NegativeInfinityClass()

--- a/ddtrace/vendor/packaging/version.py
+++ b/ddtrace/vendor/packaging/version.py
@@ -40,26 +40,25 @@ class InvalidVersion(ValueError):
 
 
 class _BaseVersion(object):
-
     def __hash__(self):
         return hash(self._key)
 
-    def __lt__(self, other):
+    def __lt__(self, other) -> bool:
         return self._compare(other, lambda s, o: s < o)
 
-    def __le__(self, other):
+    def __le__(self, other) -> bool:
         return self._compare(other, lambda s, o: s <= o)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         return self._compare(other, lambda s, o: s == o)
 
-    def __ge__(self, other):
+    def __ge__(self, other) -> bool:
         return self._compare(other, lambda s, o: s >= o)
 
-    def __gt__(self, other):
+    def __gt__(self, other) -> bool:
         return self._compare(other, lambda s, o: s > o)
 
-    def __ne__(self, other):
+    def __ne__(self, other) -> bool:
         return self._compare(other, lambda s, o: s != o)
 
     def _compare(self, other, method):
@@ -220,7 +219,7 @@ class Version(_BaseVersion):
         re.VERBOSE | re.IGNORECASE,
     )
 
-    def __init__(self, version):
+    def __init__(self, version: str) -> None:
         # Validate the version and parse it into pieces
         match = self._regex.search(version)
         if not match:

--- a/mypy.ini
+++ b/mypy.ini
@@ -221,11 +221,9 @@ check_untyped_defs = false
 
 [mypy-ddtrace.appsec._api_security.api_manager]
 disallow_any_generics = false
-disallow_untyped_calls = false
 
 [mypy-ddtrace.appsec._asm_request_context]
 disallow_any_generics = false
-warn_return_any = false
 
 [mypy-ddtrace.appsec._common_module_patches]
 disallow_untyped_calls = false
@@ -239,17 +237,12 @@ disallow_any_generics = false
 
 [mypy-ddtrace.appsec._contrib.django]
 disallow_any_generics = false
-disallow_untyped_calls = false
 
 [mypy-ddtrace.appsec._contrib.fastapi]
 disallow_any_generics = false
-warn_unreachable = false
 
 [mypy-ddtrace.appsec._contrib.flask]
 disallow_any_generics = false
-
-[mypy-ddtrace.appsec._contrib.httpx.subscribers]
-disallow_untyped_calls = false
 
 [mypy-ddtrace.appsec._deduplications]
 warn_return_any = false
@@ -557,30 +550,15 @@ disallow_any_generics = false
 
 [mypy-ddtrace.appsec._processor]
 disallow_any_generics = false
-warn_unreachable = false
-
-[mypy-ddtrace.appsec._remoteconfiguration]
-disallow_untyped_calls = false
 
 [mypy-ddtrace.appsec._trace_utils]
 disallow_any_generics = false
-no_implicit_reexport = false
-warn_unreachable = false
-
-[mypy-ddtrace.appsec._utils]
-warn_return_any = false
 
 [mypy-ddtrace.appsec.sca._cve_loader]
 disallow_any_generics = false
-disallow_untyped_calls = false
-warn_return_any = false
 
 [mypy-ddtrace.appsec.sca._instrumenter]
 disallow_any_generics = false
-warn_return_any = false
-
-[mypy-ddtrace.appsec.sca._resolver]
-warn_unreachable = false
 
 
 # ── ddtrace.bootstrap ───────────────────────────────────────────────────

--- a/tests/appsec/appsec/test_appsec_utils.py
+++ b/tests/appsec/appsec/test_appsec_utils.py
@@ -1,4 +1,5 @@
 import os
+from types import SimpleNamespace
 
 import pytest
 
@@ -195,3 +196,14 @@ def test_block_config_get_preserves_attribute_access():
     # Both access methods should return identical values
     assert config.status_code == config.get("status_code")
     assert config.type == config.get("type")
+
+
+def test_user_info_retriever_preserves_id_and_stringifies_extra_values():
+    from ddtrace.appsec._utils import _UserInfoRetriever
+
+    retriever = _UserInfoRetriever(SimpleNamespace(pk=1, username=2, email=3, name=4))
+
+    assert retriever.get_user_info(login=True, email=True, name=True) == (
+        1,
+        {"login": "2", "email": "3", "name": "4"},
+    )


### PR DESCRIPTION
## Description

Tighten typing across a collection of small, independent internal helpers and remove the corresponding stale `mypy.ini` relaxations.

This includes:
- explicit return and container types in AppSec, Django, subscriber, tracer, and vendored packaging helpers;
- version-specific SCA instruction-line handling for Python <3.11, 3.11-3.13, and 3.14+;
- removal of dead FastAPI code and a generic ASM context lookup in favor of the typed WAF-address helper;
- direct use of the typed user-tagging helper.

## Testing

- `./scripts/lint typing`
- `./scripts/lint checks`
- regression tests

## Risks

Low. These are internal typing and dead-code cleanups. The SCA bytecode helper is runtime-version-sensitive, so its three interpreter branches were exercised separately.

## Additional Notes

No public API changes and no customer-facing behavior changes are intended.