### PR TITLE
chore: separate run-tests prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,11 @@ CLAUDE.local.md
 .riot/.build.lock
 .riot/requirements/*.in
 
+# Riot venvs built inside the testrunner container (see docker-compose.yml
+# RIOT_ENV_BASE_PATH) — kept separate from .riot/venv* to avoid mixing Linux
+# container binaries with host-native (e.g. macOS) venvs on the shared mount.
+.riot/docker/
+
 # Benchmarks
 artifacts/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,6 +221,12 @@ services:
           DD_USE_SCCACHE: "1"
           SCCACHE_DIR: "/home/bits/.cache/sccache"
           DD_PROFILING_MEMALLOC_ASSERT_ON_REENTRY: "1"
+          # Store riot venvs in a subdir separate from the host's .riot/venv* dirs
+          # (shared via the project bind mount below). Without this, venvs built
+          # inside the Linux container and venvs built natively on the host (e.g.
+          # macOS) collide in the same path, and riot picks up incompatible
+          # prebuilt binaries.
+          RIOT_ENV_BASE_PATH: ".riot/docker"
         network_mode: host
         userns_mode: host
         working_dir: /home/bits/project/


### PR DESCRIPTION
## Description

We use a separate riot prefix for tests that are run via the run-tests scripts to avoid conflicts with local test runs on bare metal.