### PR TITLE
chore(appsec): update default waf rules to 1.18.2

### DIFF
--- a/ddtrace/appsec/rules.json
+++ b/ddtrace/appsec/rules.json
@@ -1,7 +1,7 @@
 {
   "version": "2.2",
   "metadata": {
-    "rules_version": "1.18.0"
+    "rules_version": "1.18.2"
   },
   "rules": [
     {
@@ -5682,88 +5682,14 @@
       "transformers": []
     },
     {
-      "id": "dog-920-100",
-      "name": "File upload with double extension",
-      "tags": {
-        "type": "http_protocol_violation",
-        "category": "attack_attempt",
-        "cwe": "434",
-        "capec": "1000/255/153/267/71",
-        "confidence": "0",
-        "module": "waf"
-      },
-      "conditions": [
-        {
-          "parameters": {
-            "inputs": [
-              {
-                "address": "server.request.body.filenames"
-              },
-              {
-                "address": "server.request.headers.no_cookies",
-                "key_path": [
-                  "x-filename"
-                ]
-              },
-              {
-                "address": "server.request.headers.no_cookies",
-                "key_path": [
-                  "x_filename"
-                ]
-              },
-              {
-                "address": "server.request.headers.no_cookies",
-                "key_path": [
-                  "x.filename"
-                ]
-              },
-              {
-                "address": "server.request.headers.no_cookies",
-                "key_path": [
-                  "x-file-name"
-                ]
-              },
-              {
-                "address": "server.request.headers.no_cookies",
-                "key_path": [
-                  "content-disposition"
-                ]
-              },
-              {
-                "address": "server.request.headers.no_cookies",
-                "key_path": [
-                  "upload-filename"
-                ]
-              },
-              {
-                "address": "server.request.headers.no_cookies",
-                "key_path": [
-                  "filename"
-                ]
-              }
-            ],
-            "regex": "\\w\\.[a-zA-Z0-9]{2,6}\\.[a-zA-Z0-9]+\\.?$",
-            "options": {
-              "case_sensitive": true,
-              "min_length": 6
-            }
-          },
-          "operator": "match_regex"
-        }
-      ],
-      "transformers": [
-        "removeNulls"
-      ]
-    },
-    {
       "id": "dog-920-110",
       "name": "Zipslip Attack - Unsafe Zip extraction",
       "tags": {
-        "type": "http_protocol_violation",
+        "type": "zipslip",
         "category": "attack_attempt",
         "cwe": "23",
         "capec": "1000/152/586",
-        "confidence": "0",
+        "confidence": "1",
         "module": "waf"
       },
       "conditions": [
@@ -5834,6 +5760,153 @@
             "regex": "(?:^|[/\\\\])\\.\\.[/\\\\]",
             "options": {
               "case_sensitive": true,
+              "min_length": 4
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "dog-920-111",
+      "name": "Zipslip Attack - Extraction of code files",
+      "tags": {
+        "type": "zipslip",
+        "category": "attack_attempt",
+        "cwe": "23",
+        "capec": "1000/152/586",
+        "confidence": "1",
+        "module": "waf"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.body.filenames"
+              },
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "x-filename"
+                ]
+              },
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "x_filename"
+                ]
+              },
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "x.filename"
+                ]
+              },
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "x-file-name"
+                ]
+              },
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "content-disposition"
+                ]
+              },
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "upload-filename"
+                ]
+              },
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "filename"
+                ]
+              }
+            ],
+            "regex": "\\.(?:zip|(?:(?:tar\\.)?gz|bz2|7z|xz)|rar|tar)$",
+            "options": {
+              "case_sensitive": false,
+              "min_length": 5
+            }
+          },
+          "operator": "match_regex"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.io.fs.file_write"
+              }
+            ],
+            "regex": ".\\.(?:jsp|php|py|rb|sh|pl|cgi|action|tagx?|tld|js[fv]|js)$",
+            "options": {
+              "case_sensitive": false,
+              "min_length": 4
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "dog-920-121",
+      "name": "Zipslip Attack - Write to relative path",
+      "tags": {
+        "type": "zipslip",
+        "category": "attack_attempt",
+        "cwe": "23",
+        "capec": "1000/152/586",
+        "confidence": "0",
+        "module": "waf"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.io.fs.file_write"
+              }
+            ],
+            "regex": "(?:^|[/\\\\])\\.\\.[/\\\\]",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 4
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "dog-920-122",
+      "name": "Zipslip Attack - Write code files",
+      "tags": {
+        "type": "zipslip",
+        "category": "attack_attempt",
+        "cwe": "23",
+        "capec": "1000/152/586",
+        "confidence": "0",
+        "module": "waf"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.io.fs.file_write"
+              }
+            ],
+            "regex": ".\\.(?:jsp|php|py|rb|sh|pl|cgi|action|tagx?|tld|js[fv]|js)$",
+            "options": {
+              "case_sensitive": false,
               "min_length": 4
             }
           },
@@ -6000,6 +6073,9 @@
                 "address": "server.request.body"
               },
               {
+                "address": "server.request.body.files_content"
+              },
+              {
                 "address": "grpc.server.request.message"
               },
               {
@@ -6009,7 +6085,7 @@
                 "address": "graphql.server.resolver"
               }
             ],
-            "regex": "<!DOCTYPE\\b.*<!ENTITY[^>]+SYSTEM\\s+[^>]+>",
+            "regex": "(?s)<!DOCTYPE\\b.*<!ENTITY[^>]+SYSTEM\\s+[^>]+>",
             "options": {
               "case_sensitive": false,
               "min_length": 24
@@ -6080,7 +6156,7 @@
       ]
     },
     {
-      "id": "dog-942-001",
+      "id": "dog-941-002",
       "name": "Blind XSS callback domains",
       "tags": {
         "type": "xss",
@@ -6117,6 +6193,53 @@
               }
             ],
             "regex": "https?:\\/\\/(?:.*\\.)?(?:bxss\\.(?:in|me)|xss\\.ht|js\\.rip)",
+            "options": {
+              "case_sensitive": false
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "dog-942-100",
+      "name": "Postgres exploit through SQL Injection (CVE-2026-2005)",
+      "tags": {
+        "type": "sql_injection",
+        "category": "attack_attempt",
+        "cwe": "83",
+        "capec": "1000/152/248/66",
+        "confidence": "1",
+        "module": "waf"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
+              }
+            ],
+            "regex": "\\bpgp_pub_decrypt_bytea\\(",
             "options": {
               "case_sensitive": false
             }
@@ -9106,6 +9229,36 @@
       "transformers": []
     },
     {
+      "id": "ua0-600-69x",
+      "name": "RedTail",
+      "tags": {
+        "type": "attack_tool",
+        "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
+        "tool_name": "redtail",
+        "confidence": "0",
+        "module": "waf"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "\\blibredtail-http\\b"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
       "id": "ua0-600-6xx",
       "name": "Stealthy scanner",
       "tags": {
@@ -9271,6 +9424,54 @@
       ],
       "transformers": [
         "lowercase"
+      ]
+    },
+    {
+      "id": "strc-920-100",
+      "name": "File upload with double extension",
+      "enabled": false,
+      "tags": {
+        "type": "http_protocol_violation",
+        "category": "attack_attempt",
+        "cwe": "434",
+        "capec": "1000/255/153/267/71",
+        "confidence": "0",
+        "module": "waf"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.body.filenames"
+              }
+            ],
+            "regex": "\\w\\.[a-zA-Z0-9]{2,6}\\.[a-zA-Z0-9]+\\.?$",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 6
+            }
+          },
+          "operator": "match_regex"
+        },
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.body.filenames"
+              }
+            ],
+            "regex": "\\.(?:jpe?g|png|gif|bmp|tiff|ico|webp|svg|hei[cf]|pdf\\.pdf)\\.?$",
+            "options": {
+              "case_sensitive": false,
+              "min_length": 6
+            }
+          },
+          "operator": "!match_regex"
+        }
+      ],
+      "transformers": [
+        "removeNulls"
       ]
     },
     {
@@ -11694,6 +11895,46 @@
       }
     },
     {
+      "id": "dog-920-120",
+      "name": "Zipslip Attack - Read local archive file",
+      "tags": {
+        "type": "zipslip_trace_tagging",
+        "category": "attack_attempt",
+        "cwe": "23",
+        "capec": "1000/152/586",
+        "confidence": "0",
+        "module": "waf"
+      },
+      "min_version": "1.25.0",
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.io.fs.file"
+              }
+            ],
+            "regex": "\\.(?:zip|(?:(?:tar\\.)?gz|bz2|7z|xz)|rar|tar)$",
+            "options": {
+              "case_sensitive": false,
+              "min_length": 5
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [],
+      "output": {
+        "event": false,
+        "keep": false,
+        "attributes": {
+          "appsec.events.zipslip.local_file_read": {
+            "value": true
+          }
+        }
+      }
+    },
+    {
       "id": "llm-001-000",
       "name": "LLM call",
       "tags": {
@@ -11870,6 +12111,61 @@
         ]
       },
       "evaluate": true,
+      "output": true
+    },
+    {
+      "id": "extract-auth",
+      "generator": "extract_schema",
+      "conditions": [
+        {
+          "operator": "equals",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.processor",
+                "key_path": [
+                  "extract-schema"
+                ]
+              }
+            ],
+            "type": "boolean",
+            "value": true
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "inputs": [
+              {
+                "address": "server.request.jwt"
+              }
+            ],
+            "output": "_dd.appsec.s.req.jwt"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              }
+            ],
+            "output": "_dd.appsec.s.req.cookies"
+          }
+        ],
+        "scanners": [
+          {
+            "tags": {
+              "category": "credentials"
+            }
+          },
+          {
+            "tags": {
+              "category": "pii"
+            }
+          }
+        ]
+      },
+      "evaluate": false,
       "output": true
     },
     {

--- a/ddtrace/appsec/rules.json
+++ b/ddtrace/appsec/rules.json
@@ -12155,6 +12155,11 @@
         "scanners": [
           {
             "tags": {
+              "category": "payment"
+            }
+          },
+          {
+            "tags": {
               "category": "credentials"
             }
           },

--- a/tests/appsec/appsec/api_security/test_schema_fuzz.py
+++ b/tests/appsec/appsec/api_security/test_schema_fuzz.py
@@ -116,6 +116,10 @@ def test_limits(obj, res):
 @pytest.mark.parametrize(
     "obj, res",
     [
+        (
+            {"mastercard": "5123456789123456"},
+            [{"mastercard": [8, {"card_type": "mastercard", "category": "payment", "type": "card"}]}],
+        ),
         ({"US PASSPORT": "C03005988"}, [{"US PASSPORT": [8, {"category": "pii", "type": "passport_number"}]}]),
         ({"ViN": "1HGBH41JXMN109186"}, [{"ViN": [8, {"category": "pii", "type": "vin"}]}]),
     ],

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
@@ -27,7 +27,7 @@
     "metrics": {
       "_dd.appsec.enabled": 1.0,
       "_dd.appsec.event_rules.error_count": 0.0,
-      "_dd.appsec.event_rules.loaded": 199.0,
+      "_dd.appsec.event_rules.loaded": 204.0,
       "_dd.appsec.waf.duration": 284.75,
       "_dd.appsec.waf.duration_ext": 375.8749990083743,
       "_dd.top_level": 1.0,

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_body_no_collection_snapshot.json
@@ -9,7 +9,7 @@
     "type": "web",
     "error": 0,
     "meta": {
-      "_dd.appsec.event_rules.version": "1.18.0",
+      "_dd.appsec.event_rules.version": "1.18.2",
       "_dd.appsec.fp.http.header": "hdr-0000000000--0-",
       "_dd.appsec.fp.http.network": "net-0-0000000000",
       "_dd.appsec.rc_products": "[] u:0 r:1",

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
@@ -28,7 +28,7 @@
     "metrics": {
       "_dd.appsec.enabled": 1.0,
       "_dd.appsec.event_rules.error_count": 0.0,
-      "_dd.appsec.event_rules.loaded": 199.0,
+      "_dd.appsec.event_rules.loaded": 204.0,
       "_dd.appsec.waf.duration": 91.0,
       "_dd.appsec.waf.duration_ext": 162.74999870802276,
       "_dd.top_level": 1.0,

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_cookies_no_collection_snapshot.json
@@ -9,7 +9,7 @@
     "type": "web",
     "error": 0,
     "meta": {
-      "_dd.appsec.event_rules.version": "1.18.0",
+      "_dd.appsec.event_rules.version": "1.18.2",
       "_dd.appsec.fp.http.header": "hdr-0000000000--0-",
       "_dd.appsec.fp.http.network": "net-0-0000000000",
       "_dd.appsec.fp.session": "ssn--3fd6b904-1f57cef4-",

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot.json
@@ -9,7 +9,7 @@
     "type": "web",
     "error": 0,
     "meta": {
-      "_dd.appsec.event_rules.version": "1.18.0",
+      "_dd.appsec.event_rules.version": "1.18.2",
       "_dd.appsec.fp.http.header": "hdr-0000000000--0-",
       "_dd.appsec.fp.http.network": "net-0-0000000000",
       "_dd.appsec.rc_products": "[] u:0 r:1",

--- a/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot.json
+++ b/tests/snapshots/tests.appsec.appsec.test_processor.test_appsec_span_tags_snapshot.json
@@ -29,7 +29,7 @@
     "metrics": {
       "_dd.appsec.enabled": 1.0,
       "_dd.appsec.event_rules.error_count": 0.0,
-      "_dd.appsec.event_rules.loaded": 199.0,
+      "_dd.appsec.event_rules.loaded": 204.0,
       "_dd.appsec.waf.duration": 90.666,
       "_dd.appsec.waf.duration_ext": 154.29199993377551,
       "_dd.top_level": 1.0,

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled.json
@@ -49,7 +49,7 @@
     "metrics": {
       "_dd.appsec.enabled": 1.0,
       "_dd.appsec.event_rules.error_count": 0.0,
-      "_dd.appsec.event_rules.loaded": 199.0,
+      "_dd.appsec.event_rules.loaded": 204.0,
       "_dd.appsec.waf.duration": 97.0,
       "_dd.appsec.waf.duration_ext": 177.41699775797315,
       "_dd.measured": 1.0,

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled.json
@@ -8,7 +8,7 @@
     "parent_id": 0,
     "type": "web",
     "meta": {
-      "_dd.appsec.event_rules.version": "1.18.0",
+      "_dd.appsec.event_rules.version": "1.18.2",
       "_dd.appsec.fp.http.endpoint": "http-get-8a5edab2--",
       "_dd.appsec.fp.http.header": "hdr-0110000010-bcea973b-1-4740ae63",
       "_dd.appsec.fp.http.network": "net-0-0000000000",

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled_attack.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled_attack.json
@@ -50,7 +50,7 @@
     "metrics": {
       "_dd.appsec.enabled": 1.0,
       "_dd.appsec.event_rules.error_count": 0.0,
-      "_dd.appsec.event_rules.loaded": 199.0,
+      "_dd.appsec.event_rules.loaded": 204.0,
       "_dd.appsec.rasp.duration": 67.166,
       "_dd.appsec.rasp.duration_ext": 146.45799819845706,
       "_dd.appsec.rasp.rule.eval": 3.0,

--- a/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled_attack.json
+++ b/tests/snapshots/tests.contrib.django.test_django_appsec_snapshots.test_appsec_enabled_attack.json
@@ -8,7 +8,7 @@
     "parent_id": 0,
     "type": "web",
     "meta": {
-      "_dd.appsec.event_rules.version": "1.18.0",
+      "_dd.appsec.event_rules.version": "1.18.2",
       "_dd.appsec.fp.http.endpoint": "http-get-b8b6a5d3--",
       "_dd.appsec.fp.http.header": "hdr-0110000010-bcea973b-1-4740ae63",
       "_dd.appsec.fp.http.network": "net-0-0000000000",


### PR DESCRIPTION
## Description

Vendors ASM rules 1.18.2 and preserves payment schema scanning alongside the new auth extractor.

## Testing

- CI

## Risks

None.
