### PR TITLE
fix(asm): fix concurrent access crash

### DIFF
--- a/ddtrace/appsec/_ddwaf/waf.py
+++ b/ddtrace/appsec/_ddwaf/waf.py
@@ -1,4 +1,5 @@
 import json
+import threading
 import time
 from typing import Any
 from typing import Optional
@@ -55,6 +56,7 @@ class DDWaf:
         ruleset_map_object = ddwaf_object.from_json_bytes(ruleset_json_str)
         if not ruleset_map_object:
             raise ValueError("Invalid ruleset provided to DDWaf constructor")
+        self._builder_lock: threading.Lock = threading.Lock()
         self._builder = py_ddwaf_builder_init()
         # libddwaf 2.0 has no ddwaf_config: obfuscator regexes are a builder config. Both keys are
         # optional (defaults apply when omitted), so only add it when a regex is set. The builder
@@ -128,44 +130,45 @@ class DDWaf:
         self, removals: Sequence[tuple[str, str]], updates: Sequence[tuple[str, str, PayloadType]]
     ) -> bool:
         """update the rules of the WAF instance. return False if an error occurs."""
-        ok = True
-        for product, path in removals:
-            py_remove_config(self._builder, path)
-            self._rc_products.get(product, set()).discard(path)
-            if product == "ASM_DD":
-                self._asm_dd_cache.discard(path)
-        for product, path, rules in updates:
-            if product not in self._rc_products:
-                self._rc_products[product] = set()
-            self._rc_products[product].add(path)
-            if product == "ASM_DD":
-                if ASM_DD_DEFAULT in self._asm_dd_cache:
-                    # we need to remove the default ruleset before adding the new one
-                    ok &= py_remove_config(self._builder, ASM_DD_DEFAULT)
-                    self._asm_dd_cache.discard(ASM_DD_DEFAULT)
-                self._asm_dd_cache.add(path)
-            diagnostics = ddwaf_object()
-            ruleset_object = ddwaf_object.create_without_limits(rules)
-            res = py_add_or_update_config(self._builder, path, ruleset_object, diagnostics)
-            self._set_info(diagnostics, "update")
-            ddwaf_object_free(ruleset_object)
-            ok &= res
-            if not res:
-                self._rc_products[product].discard(path)
+        with self._builder_lock:
+            ok = True
+            for product, path in removals:
+                py_remove_config(self._builder, path)
+                self._rc_products.get(product, set()).discard(path)
                 if product == "ASM_DD":
                     self._asm_dd_cache.discard(path)
-        if not self._asm_dd_cache:
-            # we need to add the default ruleset back
-            diagnostics = ddwaf_object()
-            ok &= py_add_or_update_config(self._builder, ASM_DD_DEFAULT, self._default_ruleset, diagnostics)
-            self._set_info(diagnostics, "update")
-            self._asm_dd_cache.add(ASM_DD_DEFAULT)
-        new_handle = py_ddwaf_builder_build_instance(self._builder)
-        self._rc_products_str = ",".join(f"{p}:{len(v)}" for p, v in sorted(self._rc_products.items()) if v)
-        if new_handle:
-            self._handle = new_handle
-            self._rc_updates += 1
-        return ok
+            for product, path, rules in updates:
+                if product not in self._rc_products:
+                    self._rc_products[product] = set()
+                self._rc_products[product].add(path)
+                if product == "ASM_DD":
+                    if ASM_DD_DEFAULT in self._asm_dd_cache:
+                        # we need to remove the default ruleset before adding the new one
+                        ok &= py_remove_config(self._builder, ASM_DD_DEFAULT)
+                        self._asm_dd_cache.discard(ASM_DD_DEFAULT)
+                    self._asm_dd_cache.add(path)
+                diagnostics = ddwaf_object()
+                ruleset_object = ddwaf_object.create_without_limits(rules)
+                res = py_add_or_update_config(self._builder, path, ruleset_object, diagnostics)
+                self._set_info(diagnostics, "update")
+                ddwaf_object_free(ruleset_object)
+                ok &= res
+                if not res:
+                    self._rc_products[product].discard(path)
+                    if product == "ASM_DD":
+                        self._asm_dd_cache.discard(path)
+            if not self._asm_dd_cache:
+                # we need to add the default ruleset back
+                diagnostics = ddwaf_object()
+                ok &= py_add_or_update_config(self._builder, ASM_DD_DEFAULT, self._default_ruleset, diagnostics)
+                self._set_info(diagnostics, "update")
+                self._asm_dd_cache.add(ASM_DD_DEFAULT)
+            new_handle = py_ddwaf_builder_build_instance(self._builder)
+            self._rc_products_str = ",".join(f"{p}:{len(v)}" for p, v in sorted(self._rc_products.items()) if v)
+            if new_handle:
+                self._handle = new_handle
+                self._rc_updates += 1
+            return ok
 
     def _at_request_start(self) -> Optional[ddwaf_context_capsule]:
         ctx = None

--- a/releasenotes/notes/appsec-serialize-waf-builder-updates-cdde063d7dcf457f.yaml
+++ b/releasenotes/notes/appsec-serialize-waf-builder-updates-cdde063d7dcf457f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ASM: A rare crash that could happen when rules were updated concurrently has been fixed.


### PR DESCRIPTION
## Description

This PR fixes a rare crash in ASM.

`libddwaf` is [explicit](https://github.com/DataDog/libddwaf/blob/master/docs/c-api/binding-integration-guide.md) about not being thread-safe:

> ddwaf_builder operations are not thread-safe. If you need to update configurations from multiple threads, use external synchronization (e.g., a mutex).

`DDWaf.update_rules` used to mutate `self._builder` without a lock, such that any concurrent access to `_builder` (e.g. a fork-time reset (`AppSecSpanProcessor._reset`), a re-entrant `disable()`/`enable()` racing an in-flight update, or `DDWaf.__del__` freeing `self._default_ruleset` while `update_rules` is still using it -- could corrupt `libddwaf`'s internal state.

---

**Example backtrace**

```
Error UnixSignal: Process terminated with SEGV_MAPERR (SIGSEGV)
#0   0x00007effca6b9d65  
#1   0x00007effca6b96fd  
#2   0x00007effca62fb7c ddwaf_builder_add_or_update_config 
#3   0x00007effd6c536ce ffi_call_unix64 (src/x86/unix64.S:107)
#4   0x00007effd6c5297e ffi_call_int.cold (src/x86/ffi64.c:678)
#5   0x00007effd6c531ab ffi_call (src/x86/ffi64.c:714)
#6   0x00007effd6c6fe32  
#7   0x00007effd6c6ddcc  
#8   0x00007effd8a97c6c _PyObject_MakeTpCall 
#9   0x00007effd8aa87da _PyEval_EvalFrameDefault 
#10  0x00007effd8a9a2d0  
#11  0x00007effd8b87aed  
#12  0x00007effd8a97c6c _PyObject_MakeTpCall 
#13  0x00007effd8aa87da _PyEval_EvalFrameDefault 
#14  0x00007effd8ae7f52  
#15  0x00007effd8b37775  
#16  0x0000000000000000 PeriodicThread__periodic (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/_threads.cpp:441)
#17  0x0000000000000000 operator() (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/_threads.cpp:570)
#18  0x0000000000000000 __invoke_impl<void, _PeriodicThread_do_start(PeriodicThread*, bool)::<lambda()> > (/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/invoke.h:60)
#19  0x0000000000000000 __invoke<_PeriodicThread_do_start(PeriodicThread*, bool)::<lambda()> > (/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/invoke.h:95)
#20  0x0000000000000000 _M_invoke<0> (/opt/rh/devtoolset-10/root/usr/include/c++/10/thread:264)
#21  0x0000000000000000 operator() (/opt/rh/devtoolset-10/root/usr/include/c++/10/thread:271)
#22  0x00007effd3f7c084 PeriodicThread__periodic (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/_threads.cpp:441)
#23  0x00007effd3f7c084 operator() (/go/src/github.com/DataDog/apm-reliability/dd-trace-py/ddtrace/internal/_threads.cpp:570)
#24  0x00007effd3f7c084 __invoke_impl<void, _PeriodicThread_do_start(PeriodicThread*, bool)::<lambda()> > (/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/invoke.h:60)
#25  0x00007effd3f7c084 __invoke<_PeriodicThread_do_start(PeriodicThread*, bool)::<lambda()> > (/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/invoke.h:95)
#26  0x00007effd3f7c084 _M_invoke<0> (/opt/rh/devtoolset-10/root/usr/include/c++/10/thread:264)
#27  0x00007effd3f7c084 operator() (/opt/rh/devtoolset-10/root/usr/include/c++/10/thread:271)
#28  0x00007effd3f7c084 std::thread::_State_impl<std::thread::_Invoker<std::tuple<_PeriodicThread_do_start(periodic_thread*, bool)::{lambda()#1}> > >::_M_run() [clone .cold] (/opt/rh/devtoolset-10/root/usr/include/c++/10/thread:215)
#29  0x00007effd3f7cd60 execute_native_thread_routine 
#30  0x00007effd87acb7b start_thread (nptl/nptl/pthread_create.c:448)
#31  0x00007effd882a7f8 __clone3 (sysdeps/unix/sysv/linux/x86_64/clone3.S:80)
```