### PR TITLE
chore: bump version to 4.11.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.11.3"
+version = "4.11.4"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }


### PR DESCRIPTION
Bump version in `pyproject.toml` for the next patch release on the 4.11 branch.