### PR TITLE
fix(aap): serialize WAF builder updates

### DIFF
--- a/ddtrace/appsec/_ddwaf/waf.py
+++ b/ddtrace/appsec/_ddwaf/waf.py
@@ -34,6 +34,7 @@ from ddtrace.appsec._metrics import report_error
 from ddtrace.appsec._utils import DDWaf_info
 from ddtrace.appsec._utils import DDWaf_result
 from ddtrace.appsec._utils import _observator
+from ddtrace.internal import forksafe
 from ddtrace.internal._unpatched import threading_Lock
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.remoteconfig import PayloadType
@@ -176,6 +177,7 @@ class DDWaf:
         if not ruleset_map_object:
             raise ValueError("Invalid ruleset provided to DDWaf constructor")
         self._builder = py_ddwaf_builder_init()
+        self._builder_lock: threading_Lock = forksafe.Lock()
         # libddwaf 2.0 has no ddwaf_config: obfuscator regexes are a builder config. Both keys are
         # optional (defaults apply when omitted), so only add it when a regex is set. The builder
         # copies the config, so the source can be freed right after.
@@ -248,44 +250,47 @@ class DDWaf:
         self, removals: Sequence[tuple[str, str]], updates: Sequence[tuple[str, str, PayloadType]]
     ) -> bool:
         """update the rules of the WAF instance. return False if an error occurs."""
-        ok = True
-        for product, path in removals:
-            py_remove_config(self._builder, path)
-            self._rc_products.get(product, set()).discard(path)
-            if product == "ASM_DD":
-                self._asm_dd_cache.discard(path)
-        for product, path, rules in updates:
-            if product not in self._rc_products:
-                self._rc_products[product] = set()
-            self._rc_products[product].add(path)
-            if product == "ASM_DD":
-                if ASM_DD_DEFAULT in self._asm_dd_cache:
-                    # we need to remove the default ruleset before adding the new one
-                    ok &= py_remove_config(self._builder, ASM_DD_DEFAULT)
-                    self._asm_dd_cache.discard(ASM_DD_DEFAULT)
-                self._asm_dd_cache.add(path)
-            diagnostics = ddwaf_object()
-            ruleset_object = ddwaf_object.create_without_limits(rules)
-            res = py_add_or_update_config(self._builder, path, ruleset_object, diagnostics)
-            self._set_info(diagnostics, "update")
-            ddwaf_object_free(ruleset_object)
-            ok &= res
-            if not res:
-                self._rc_products[product].discard(path)
+        # ctypes releases the GIL, and libddwaf requires external synchronization for builder access.
+        # Keep native operations and their Python-side bookkeeping in the same critical section.
+        with self._builder_lock:
+            ok = True
+            for product, path in removals:
+                py_remove_config(self._builder, path)
+                self._rc_products.get(product, set()).discard(path)
                 if product == "ASM_DD":
                     self._asm_dd_cache.discard(path)
-        if not self._asm_dd_cache:
-            # we need to add the default ruleset back
-            diagnostics = ddwaf_object()
-            ok &= py_add_or_update_config(self._builder, ASM_DD_DEFAULT, self._default_ruleset, diagnostics)
-            self._set_info(diagnostics, "update")
-            self._asm_dd_cache.add(ASM_DD_DEFAULT)
-        new_handle = py_ddwaf_builder_build_instance(self._builder)
-        self._rc_products_str = ",".join(f"{p}:{len(v)}" for p, v in sorted(self._rc_products.items()) if v)
-        if new_handle:
-            self._handle = new_handle
-            self._rc_updates += 1
-        return ok
+            for product, path, rules in updates:
+                if product not in self._rc_products:
+                    self._rc_products[product] = set()
+                self._rc_products[product].add(path)
+                if product == "ASM_DD":
+                    if ASM_DD_DEFAULT in self._asm_dd_cache:
+                        # we need to remove the default ruleset before adding the new one
+                        ok &= py_remove_config(self._builder, ASM_DD_DEFAULT)
+                        self._asm_dd_cache.discard(ASM_DD_DEFAULT)
+                    self._asm_dd_cache.add(path)
+                diagnostics = ddwaf_object()
+                ruleset_object = ddwaf_object.create_without_limits(rules)
+                res = py_add_or_update_config(self._builder, path, ruleset_object, diagnostics)
+                self._set_info(diagnostics, "update")
+                ddwaf_object_free(ruleset_object)
+                ok &= res
+                if not res:
+                    self._rc_products[product].discard(path)
+                    if product == "ASM_DD":
+                        self._asm_dd_cache.discard(path)
+            if not self._asm_dd_cache:
+                # we need to add the default ruleset back
+                diagnostics = ddwaf_object()
+                ok &= py_add_or_update_config(self._builder, ASM_DD_DEFAULT, self._default_ruleset, diagnostics)
+                self._set_info(diagnostics, "update")
+                self._asm_dd_cache.add(ASM_DD_DEFAULT)
+            new_handle = py_ddwaf_builder_build_instance(self._builder)
+            self._rc_products_str = ",".join(f"{p}:{len(v)}" for p, v in sorted(self._rc_products.items()) if v)
+            if new_handle:
+                self._handle = new_handle
+                self._rc_updates += 1
+            return ok
 
     def _at_request_start(self) -> Optional[DDWafContext]:
         ctx = None

--- a/releasenotes/notes/appsec-serialize-waf-builder-updates-cdde063d7dcf457f.yaml
+++ b/releasenotes/notes/appsec-serialize-waf-builder-updates-cdde063d7dcf457f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    AAP: Fixes a rare crash that can occur when rules are updated concurrently.


### PR DESCRIPTION
## Description

Serializes the complete libddwaf builder update transaction under a fork-safe lock. This covers configuration removals and additions, Python-side remote-configuration bookkeeping, rebuilding the WAF instance, and publishing the new handle.

`ctypes` releases the GIL around these native calls, while libddwaf requires callers to synchronize shared builder access. Concurrent remote-configuration callbacks could therefore mutate the same builder simultaneously and corrupt its configuration state, resulting in a rare process crash.

## Testing

– I don't see how to make a test an accurate test without excessive patching to synchronize two threads at specific moments. This would make for an unmaintainable and not very valuable test => Intentionally no testing... But if you have a suggestions I am all hears.

## Risks

Low.

## Additional Notes

The release note describes the customer-visible AAP crash fix.