### PR TITLE
test(profiling): detect uWSGI worker crashes

### DIFF
--- a/tests/profiling/test_uwsgi.py
+++ b/tests/profiling/test_uwsgi.py
@@ -378,6 +378,10 @@ def test_uwsgi_threads_processes_no_primary_lazy_apps(
     res_pid, res_status = os.waitpid(parent_pid, 0)
     print("")
     print(f"INFO: Master process {parent_pid} exited with status {res_status} and pid {res_pid}")
+    assert res_pid == parent_pid
+    assert not os.WIFSIGNALED(res_status), (
+        f"uWSGI worker {parent_pid} crashed with signal {os.WTERMSIG(res_status)} and raw wait status {res_status}"
+    )
 
     # Attempt to kill worker proc once
     worker_pid: int = worker_pids[1]

--- a/tests/profiling/test_uwsgi.py
+++ b/tests/profiling/test_uwsgi.py
@@ -378,10 +378,6 @@ def test_uwsgi_threads_processes_no_primary_lazy_apps(
     res_pid, res_status = os.waitpid(parent_pid, 0)
     print("")
     print(f"INFO: Master process {parent_pid} exited with status {res_status} and pid {res_pid}")
-    assert res_pid == parent_pid
-    assert not os.WIFSIGNALED(res_status), (
-        f"uWSGI worker {parent_pid} crashed with signal {os.WTERMSIG(res_status)} and raw wait status {res_status}"
-    )
 
     # Attempt to kill worker proc once
     worker_pid: int = worker_pids[1]
@@ -394,6 +390,11 @@ def test_uwsgi_threads_processes_no_primary_lazy_apps(
         print(f"WARNING: Worker {worker_pid} could not be killed with SIGKILL (will be cleaned up by init).")
     except OSError:
         print(f"INFO: Worker {worker_pid} was successfully killed.")
+
+    assert res_pid == parent_pid
+    assert not os.WIFSIGNALED(res_status), (
+        f"uWSGI worker {parent_pid} crashed with signal {os.WTERMSIG(res_status)} and raw wait status {res_status}"
+    )
 
     for pid in worker_pids:
         _wait_for_profile_samples(filename, pid, "wall-time")


### PR DESCRIPTION
## Description

Strengthens the existing uWSGI `--lazy-apps` test without `--master` by checking the PID returned from `waitpid()` and rejecting signal-based termination.

This closes a test blind spot where the process could crash during shutdown while the test continued to validate generated profile samples. The sibling worker is cleaned up before the captured exit status is asserted, including on the failure path. The change is extracted from #18724 because it is independent of the CPU timer profiler.

## Testing

- `scripts/run-tests --venv 1ef9287 -- -s -- -k test_uwsgi_threads_processes_no_primary_lazy_apps`
  - `1 passed, 12 deselected` on Python 3.13.13 with `uwsgi<2.0.30`
- `scripts/lint fmt -- tests/profiling/test_uwsgi.py`
- `scripts/lint checks`
- `git diff --check`

## Risks

None. This only makes an existing test detect process crashes that it previously overlooked.

## Additional Notes

No release note is needed because this is a test-only change.

