### PR TITLE
fix(ci_visibility): avoid itr coverage tracking on site/dist packages directories

### DIFF
--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -39,6 +39,12 @@ _PY_GE_312 = sys.version_info >= (3, 12)
 _PY_GE_313 = sys.version_info >= (3, 13)
 _PY_GE_314 = sys.version_info >= (3, 14)
 _FILE_LEVEL_COVERED_PATHS_CACHE_MAX_SIZE = 4096
+_SITE_PACKAGES_DIRNAMES = frozenset(("site-packages", "dist-packages"))
+
+
+def _is_site_packages_path(path: Path) -> bool:
+    return not _SITE_PACKAGES_DIRNAMES.isdisjoint(path.parts)
+
 
 ctx_covered: ContextVar[list[defaultdict[str, CoverageLines]]] = ContextVar("ctx_covered", default=[])
 ctx_covered_files: ContextVar[list[set[str]]] = ContextVar("ctx_covered_files", default=[])
@@ -517,6 +523,10 @@ class ModuleCodeCollector(ModuleWatchdog):
             return code
 
         code_path = resolved_code_origin(code)
+
+        if _is_site_packages_path(code_path):
+            # Do not instrument dependencies vendored or installed under the workspace.
+            return code
 
         if not any(code_path.is_relative_to(include_path) for include_path in self._include_paths):
             # Not a code object we want to instrument

--- a/releasenotes/notes/fix-ci-visibility-coverage-ignore-installed-packages-71bb2cdf9a837757.yaml
+++ b/releasenotes/notes/fix-ci-visibility-coverage-ignore-installed-packages-71bb2cdf9a837757.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    CI Visibility: Fixes an issue where code coverage collected for Intelligent Test Runner (ITR) included files from ``site-packages`` or ``dist-packages`` directories.

--- a/tests/coverage/test_import_dependency_tracking.py
+++ b/tests/coverage/test_import_dependency_tracking.py
@@ -24,6 +24,60 @@ import sys
 import pytest
 
 
+@pytest.mark.subprocess(
+    parametrize={"_DD_COVERAGE_FILE_LEVEL": ["true", "false"], "PACKAGES_DIRNAME": ["site-packages", "dist-packages"]}
+)
+def test_site_or_dist_packages_paths_are_not_instrumented():
+    import importlib
+    import os
+    from pathlib import Path
+    import sys
+    import tempfile
+    import uuid
+
+    from ddtrace.internal.coverage.code import ModuleCodeCollector
+    from ddtrace.internal.coverage.installer import install
+
+    module_suffix = uuid.uuid4().hex
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace_path = Path(tmpdir)
+        packages_dirname = os.environ["PACKAGES_DIRNAME"]
+        app_module_name = f"app_module_{module_suffix}"
+        vendor_module_name = f"vendor_module_{module_suffix}"
+        app_module_path = workspace_path / f"{app_module_name}.py"
+        packages_path = workspace_path / "nested" / packages_dirname
+        vendor_module_path = packages_path / f"{vendor_module_name}.py"
+
+        app_module_path.write_text("value = 1\n")
+        packages_path.mkdir(parents=True)
+        vendor_module_path.write_text("value = 1\n")
+
+        sys.path.insert(0, str(packages_path))
+        sys.path.insert(0, str(workspace_path))
+        try:
+            install(include_paths=[workspace_path], collect_import_time_coverage=True)
+
+            ModuleCodeCollector.start_coverage()
+            importlib.import_module(app_module_name)
+            importlib.import_module(vendor_module_name)
+            ModuleCodeCollector.stop_coverage()
+        finally:
+            sys.path.remove(str(workspace_path))
+            sys.path.remove(str(packages_path))
+
+        app_module_path_str = os.fspath(app_module_path)
+        vendor_module_path_str = os.fspath(vendor_module_path)
+        collector = ModuleCodeCollector._instance
+        assert collector is not None
+
+        assert app_module_path_str in collector.lines
+        assert app_module_path_str in collector._get_covered_lines(include_imported=True)
+        assert vendor_module_path_str not in collector.lines
+        assert vendor_module_path_str not in collector._get_covered_lines(include_imported=True)
+        assert vendor_module_path_str not in collector._import_time_name_to_path.values()
+
+
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="Test specific to Python 3.12+ monitoring API")
 @pytest.mark.subprocess(parametrize={"_DD_COVERAGE_FILE_LEVEL": ["true", "false"]})
 def test_direct_import_dependency():


### PR DESCRIPTION
## Description

This change prevents CI Visibility's built-in coverage collector from instrumenting Python files inside `site-packages` or `dist-packages` directories.

This avoids reporting installed dependencies as covered files for Intelligent Test Runner (ITR) coverage. It also avoids setting up file-level coverage events for those files in the first place.

A release note was added because this fixes user-visible coverage data.

## Testing

New unit test

## Risks

Low. The change only skips coverage instrumentation for files whose path contains `site-packages` or `dist-packages`.