### PR TITLE
fix(profiling): cover alternate asyncio task creation

### DIFF
--- a/ddtrace/profiling/_asyncio.py
+++ b/ddtrace/profiling/_asyncio.py
@@ -192,6 +192,28 @@ def _(asyncio: ModuleType) -> None:
 
         base_event_loop_class = sys.modules["asyncio.base_events"].BaseEventLoop
 
+        @partial(wrap, base_event_loop_class.run_forever)
+        def _(
+            f: typing.Callable[..., None],
+            args: tuple[typing.Any, ...],
+            kwargs: dict[str, typing.Any],
+        ) -> None:
+            # Runner(loop_factory=...) and direct run_until_complete() can execute a loop that was never registered
+            # through an event-loop policy. Track it only while it is running so stopped loops are not retained.
+            loop = typing.cast("aio.AbstractEventLoop", args[0])
+            thread_id = typing.cast(int, ddtrace_threading.current_thread().ident)
+            try:
+                stack.track_asyncio_loop(thread_id, loop)
+            except Exception:  # nosec B110
+                pass
+            try:
+                return f(*args, **kwargs)
+            finally:
+                try:
+                    stack.track_asyncio_loop(thread_id, None)
+                except Exception:  # nosec B110
+                    pass
+
         @partial(wrap, base_event_loop_class.create_task)
         def _(
             f: typing.Callable[..., aio.Task[typing.Any]],
@@ -208,6 +230,33 @@ def _(asyncio: ModuleType) -> None:
                 had_custom_task_factory,
             )
             return task
+
+        def _publish_ensured_future(
+            f: typing.Callable[..., aio.Future[typing.Any]],
+            args: tuple[typing.Any, ...],
+            kwargs: dict[str, typing.Any],
+        ) -> aio.Future[typing.Any]:
+            awaitable = get_argument_value(args, kwargs, 0, "coro_or_future")
+            loop = typing.cast("typing.Optional[aio.AbstractEventLoop]", kwargs.get("loop"))
+            if loop is None:
+                loop = globals()["get_running_loop"]()
+            if loop is None and awaitable is not None:
+                try:
+                    loop = awaitable.get_loop()
+                except Exception:  # nosec B110
+                    pass
+            had_custom_task_factory = loop is None or _has_custom_task_factory(loop)
+            future = f(*args, **kwargs)
+            if future is not awaitable:
+                _publish_task_span(typing.cast("aio.Task[typing.Any]", future), None, had_custom_task_factory)
+            return future
+
+        wrap(sys.modules["asyncio"].tasks.ensure_future, _publish_ensured_future)
+        # Python 3.10 and 3.11 gather() call the private helper directly. Wrapping both also covers third-party event
+        # loops whose create_task implementation does not inherit BaseEventLoop.create_task.
+        private_ensure_future = getattr(sys.modules["asyncio"].tasks, "_ensure_future", None)
+        if private_ensure_future is not None:
+            wrap(private_ensure_future, _publish_ensured_future)
 
         @partial(wrap, sys.modules["asyncio"].tasks._GatheringFuture.__init__)
         def _(f: typing.Callable[..., None], args: tuple[typing.Any, ...], kwargs: dict[str, typing.Any]) -> None:
@@ -306,7 +355,15 @@ def _(asyncio: ModuleType) -> None:
                         args: tuple[typing.Any, ...],
                         kwargs: dict[str, typing.Any],
                     ) -> aio.Task[typing.Any]:
+                        task_group = args[0]
+                        loop = typing.cast("typing.Optional[aio.AbstractEventLoop]", getattr(task_group, "_loop", None))
+                        had_custom_task_factory = loop is None or _has_custom_task_factory(loop)
                         result: aio.Task[typing.Any] = f(*args, **kwargs)
+                        _publish_task_span(
+                            result,
+                            typing.cast("typing.Optional[contextvars.Context]", kwargs.get("context")),
+                            had_custom_task_factory,
+                        )
 
                         parent: typing.Optional[aio.Task[typing.Any]] = globals()["current_task"]()
                         if parent is not None and result is not None:
@@ -327,7 +384,14 @@ def _(asyncio: ModuleType) -> None:
             kwargs: dict[str, typing.Any],
         ) -> aio.Task[typing.Any]:
             # kwargs will typically contain context (Python 3.11+ only) and eager_start (Python 3.14+ only)
+            loop = globals()["get_running_loop"]()
+            had_custom_task_factory = loop is None or _has_custom_task_factory(loop)
             task: aio.Task[typing.Any] = f(*args, **kwargs)
+            _publish_task_span(
+                task,
+                typing.cast("typing.Optional[contextvars.Context]", kwargs.get("context")),
+                had_custom_task_factory,
+            )
             parent: typing.Optional[aio.Task[typing.Any]] = globals()["current_task"]()
 
             if parent is not None:

--- a/tests/profiling/collector/test_stack_asyncio_endpoint_labels.py
+++ b/tests/profiling/collector/test_stack_asyncio_endpoint_labels.py
@@ -2,6 +2,8 @@ import sys
 
 import pytest
 
+from tests.profiling.collector import test_utils
+
 
 @pytest.mark.subprocess(
     env={
@@ -203,6 +205,103 @@ def test_stack_respects_explicit_empty_child_task_context():
         assert all(pprof_utils.get_str_label(profile, sample, "trace endpoint") is None for sample in child_samples)
         assert all(pprof_utils.get_num_label(profile, sample, "span id") is None for sample in child_samples)
         assert all(pprof_utils.get_num_label(profile, sample, "local root span id") is None for sample in child_samples)
+
+
+@pytest.mark.skipif(not test_utils.uvloop_available(), reason="uvloop is not installed in this environment")
+@pytest.mark.subprocess(
+    env={
+        "DD_PROFILING_OUTPUT_PPROF": "/tmp/test_stack_uvloop_raw_gather_context",
+        "_DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED": "0",
+    },
+    err=None,
+)
+def test_stack_publishes_inherited_span_to_uvloop_raw_gather_task():
+    import asyncio
+    import os
+    import time
+
+    import uvloop
+
+    from ddtrace import ext
+    from ddtrace.profiling import profiler
+    from ddtrace.trace import tracer
+    from tests.profiling.collector import pprof_utils
+
+    endpoint = "uvloop-gather-endpoint"
+
+    def uvloop_raw_gather_work():
+        deadline = time.thread_time_ns() + 500_000_000
+        while time.thread_time_ns() < deadline:
+            pass
+
+    async def cpu_child():
+        uvloop_raw_gather_work()
+
+    async def sleeping_child():
+        await asyncio.sleep(0.6)
+
+    async def parent_task():
+        with tracer.trace("uvloop.parent.request", resource=endpoint, span_type=ext.SpanTypes.WEB):
+            await asyncio.gather(cpu_child(), sleeping_child())
+
+    tracer._endpoint_call_counter_span_processor.enable()
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+    uvloop.run(parent_task())
+    p.stop()
+
+    profile = pprof_utils.parse_newest_profile(os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid()))
+    wall_samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
+    child_samples = pprof_utils.get_samples_with_function(profile, wall_samples, "uvloop_raw_gather_work")
+
+    assert child_samples
+    assert all(pprof_utils.get_str_label(profile, sample, "trace endpoint") == endpoint for sample in child_samples)
+
+
+@pytest.mark.subprocess(
+    env={
+        "DD_PROFILING_OUTPUT_PPROF": "/tmp/test_stack_unregistered_asyncio_loop",
+        "_DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED": "0",
+    },
+    err=None,
+)
+def test_stack_tracks_asyncio_loop_without_set_event_loop():
+    import asyncio
+    import os
+    import time
+
+    from ddtrace import ext
+    from ddtrace.profiling import profiler
+    from ddtrace.trace import tracer
+    from tests.profiling.collector import pprof_utils
+
+    endpoint = "unregistered-loop-endpoint"
+
+    def unregistered_loop_task_work():
+        deadline = time.thread_time_ns() + 500_000_000
+        while time.thread_time_ns() < deadline:
+            pass
+
+    async def main():
+        with tracer.trace("unregistered.loop.request", resource=endpoint, span_type=ext.SpanTypes.WEB):
+            unregistered_loop_task_work()
+
+    tracer._endpoint_call_counter_span_processor.enable()
+    p = profiler.Profiler(tracer=tracer)
+    p.start()
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(main())
+    finally:
+        loop.close()
+    p.stop()
+
+    profile = pprof_utils.parse_newest_profile(os.environ["DD_PROFILING_OUTPUT_PPROF"] + "." + str(os.getpid()))
+    wall_samples = pprof_utils.get_samples_with_value_type(profile, "wall-time")
+    samples = pprof_utils.get_samples_with_function(profile, wall_samples, "unregistered_loop_task_work")
+
+    assert samples
+    assert all(pprof_utils.get_str_label(profile, sample, "trace endpoint") == endpoint for sample in samples)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="asyncio task context requires Python 3.11+")


### PR DESCRIPTION
## Description

Stacked on #19421, following the core asyncio task attribution in #19346.

Covers asyncio task and loop execution paths that can bypass `BaseEventLoop.create_task()` or event-loop policy registration.

The change:

- wraps public and private `ensure_future` paths, including the helper used by supported Python versions of `gather()`;
- publishes tasks returned by `TaskGroup.create_task()`;
- publishes tasks returned by the public `asyncio.create_task()` path;
- captures task-factory state before each creation path and reuses the inherited-Context validation from #19421;
- registers a `BaseEventLoop` for the duration of `run_forever()`, covering `run_until_complete()` and `Runner(loop_factory=...)` loops that were never installed through `set_event_loop()`;
- removes that runtime registration in `finally`, so stopped loops are not retained or later unwound from the wrong thread.

Duplicate publication through nested standard-library helpers is safe and idempotent. The task mapping is simply updated with the same copied metadata, and weak finalizer registration is deduplicated by task ID.

A task created entirely inside third-party native code can still be unobserved. Such a task remains unattributed and never falls back to the event-loop thread link.

## Testing

Added regressions for:

- inherited endpoint attribution for uvloop tasks created by raw coroutine arguments to `asyncio.gather()`;
- a loop executed with `new_event_loop().run_until_complete()` without calling `set_event_loop()`.

Python 3.13 uvloop environment:

```text
uvloop gather and explicit/custom empty Context: 2 passed, 403 deselected
unregistered run_until_complete loop: 1 passed, 404 deselected
```

Also passed `scripts/lint`, `git diff --check`, and targeted formatting. `scripts/run-benchmarks --list` found no benchmark suite matching `_asyncio.py`.

## Risks

- The additional wrappers run only when native stack profiling is enabled. Publication is best effort and cannot make task creation or loop execution fail.
- `run_forever()` adds two loop-registration calls per invocation, not per event-loop iteration.
- Unsupported native-only creation paths lose attribution instead of borrowing another task's or the thread's span.

## Additional Notes

No separate release note is needed because this extends the customer-facing asyncio fix documented in #19346. Add the `changelog/no-changelog` label.

- Foundation: #19420
- Shared lifecycle: #19341
- Core asyncio attribution: #19346
- Inherited Context validation: #19421
- Jira: [PROF-14213](https://datadoghq.atlassian.net/browse/PROF-14213)


[PROF-14213]: https://datadoghq.atlassian.net/browse/PROF-14213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ