### PR TITLE
docs: add docstring and comment guidelines to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,36 @@ Single source of truth for all AI coding assistants. Tool-specific entry points
 11. **Update docs** — Add/update documentation when changing internal or public APIs.
 12. **No stray prints** — Check for and remove unexpected `print()` calls.
 13. **Keep integration skills current** — When modifying integration code in `ddtrace/contrib/internal/` or `ddtrace/llmobs/_integrations/`, review `.claude/skills/apm-integrations/` and `.claude/skills/llmobs-integrations/` and update any reference files that describe the changed patterns.
+14. **Docstrings and comments** — Public API docstrings use reStructuredText; internal ones are plain prose. See "Docstrings and Comments" below.
+
+## Docstrings and Comments
+
+Guild-agreed convention. It splits on whether the code is part of the **public interface of
+`ddtrace`** — i.e. reachable through a non-underscored import path and rendered by Sphinx from
+`docs/`.
+
+**Public interface** — write the docstring in reStructuredText, because it *is* rendered:
+
+```python
+def enable(self, flush_interval: float = 1.0) -> None:
+    """Start the writer thread.
+
+    :param flush_interval: Seconds between flushes.
+    :raises RuntimeError: If the writer is already running.
+    """
+```
+
+**Everything else** (private modules, `_`-prefixed helpers, tests, inline comments) — plain text
+prose optimized for reading in an editor. Nothing renders it, so rST inline markup is noise:
+
+- No rST emphasis around parameter names — write the name as-is. For example, a parameter named
+  `path` should appear as `path`, not as `*path*` (rST's emphasis syntax, which renders as italics
+  in Sphinx but is just stray asterisks everywhere else).
+- No double backticks for inline literals (see the code style rules); plain text reads better.
+- Field lists (`:param:`, `:returns:`) are optional here; a one-line summary is usually enough.
+
+Either way, aim for **good documentation**: say why the code exists or what invariant it upholds,
+not what the next line already says. Keep it short — a one-line summary covers most helpers.
 
 ## Key Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Guild-agreed convention. It splits on whether the code is part of the **public i
 
 ```python
 def enable(self, flush_interval: float = 1.0) -> None:
-    """Start the writer thread.
+    """Start the writer thread, flushing every ``flush_interval`` seconds.
 
     :param flush_interval: Seconds between flushes.
     :raises RuntimeError: If the writer is already running.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,15 +17,18 @@ Single source of truth for all AI coding assistants. Tool-specific entry points
 11. **Update docs** — Add/update documentation when changing internal or public APIs.
 12. **No stray prints** — Check for and remove unexpected `print()` calls.
 13. **Keep integration skills current** — When modifying integration code in `ddtrace/contrib/internal/` or `ddtrace/llmobs/_integrations/`, review `.claude/skills/apm-integrations/` and `.claude/skills/llmobs-integrations/` and update any reference files that describe the changed patterns.
-14. **Docstrings and comments** — Public API docstrings use reStructuredText; internal ones are plain prose. See "Docstrings and Comments" below.
+14. **Docstrings and comments** — Docstrings Sphinx renders use reStructuredText; everything else is plain prose. See "Docstrings and Comments" below.
 
 ## Docstrings and Comments
 
-Guild-agreed convention. It splits on whether the code is part of the **public interface of
-`ddtrace`** — i.e. reachable through a non-underscored import path and rendered by Sphinx from
-`docs/`.
+Guild-agreed convention. It splits on **whether Sphinx renders the docstring**, not on whether the
+module is private. Rendered means: the public interface of `ddtrace` (reachable through a
+non-underscored import path), plus anything an `automodule` directive under `docs/` points at — which
+includes the `ddtrace/contrib/internal/<integration>/__init__.py` integration docstrings listed in
+`docs/integrations.rst` (required by `docs/contributing-integrations.rst`). When in doubt, grep
+`docs/` for the module.
 
-**Public interface** — write the docstring in reStructuredText, because it *is* rendered:
+**Rendered docstrings** — write them in reStructuredText, because they reach customers:
 
 ```python
 def enable(self, flush_interval: float = 1.0) -> None:
@@ -36,8 +39,9 @@ def enable(self, flush_interval: float = 1.0) -> None:
     """
 ```
 
-**Everything else** (private modules, `_`-prefixed helpers, tests, inline comments) — plain text
-prose optimized for reading in an editor. Nothing renders it, so rST inline markup is noise:
+**Everything else** (`_`-prefixed helpers, private modules nothing under `docs/` points at, tests,
+inline comments) — plain text prose optimized for reading in an editor. Nothing renders it, so rST
+inline markup is noise:
 
 - No rST emphasis around parameter names — write the name as-is. For example, a parameter named
   `path` should appear as `path`, not as `*path*` (rST's emphasis syntax, which renders as italics

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ prose optimized for reading in an editor. Nothing renders it, so rST inline mark
 
 Either way, aim for **good documentation**: say why the code exists or what invariant it upholds,
 not what the next line already says. Keep it short — a one-line summary covers most helpers.
+Do not add a comment if the comment simply states what the code does, and not why.
 
 ## Key Architecture
 


### PR DESCRIPTION
## Description

Codifies the docstring/comment convention agreed in the guild meeting so AI assistants (and humans reading `AGENTS.md`) apply it consistently. The rule splits on whether the code is part of the public interface of `ddtrace`:

- **Public interface** (non-underscored import path, rendered by Sphinx from `docs/`) — docstrings in reStructuredText, since they actually get rendered.
- **Everything else** (private modules, `_`-prefixed helpers, tests, inline comments) — plain prose optimized for reading in an editor. Nothing renders it, so rST inline markup is just noise: no emphasis around parameter names, no double-backtick inline literals, field lists optional.
- Either way: aim for good documentation — say why the code exists or what invariant it upholds, and keep it short.

Added as `AGENTS.md` Project Rule 14 plus a "Docstrings and Comments" section. `AGENTS.md` is the single source of truth imported by `.claude/CLAUDE.md` and `.cursor/rules/dd-trace-py.mdc`, so no other entry point needs updating.

## Checklist

- [x] PR author has added unit tests — N/A, documentation-only change (no code touched).
- [x] Change is not user-facing, `changelog/no-changelog` label applied instead of a release note.
- [x] Title follows Conventional Commits.

## Reviewer Checklist

- [ ] The guideline text matches what was agreed in the guild meeting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)