### PR TITLE
refactor(internal): allow an injectable sleep in the retry utility

### DIFF
--- a/ddtrace/internal/utils/retry.py
+++ b/ddtrace/internal/utils/retry.py
@@ -13,11 +13,20 @@ def retry(
     after: t.Union[int, float, t.Iterable[t.Union[int, float]]],
     until: t.Callable[[t.Any], bool] = lambda result: result is None,
     initial_wait: float = 0,
+    sleep_func: t.Callable[[float], t.Any] = sleep,
 ) -> t.Callable:
+    """Retry ``f`` until ``until`` accepts its result, waiting ``after`` between attempts.
+
+    ``sleep_func`` overrides how the waits are performed. It defaults to
+    ``time.sleep``; callers running on a background thread can pass an
+    interruptible wait (e.g. ``threading.Event.wait``) so a pending shutdown does
+    not have to sit through the remaining backoff.
+    """
+
     def retry_decorator(f):
         @wraps(f)
         def retry_wrapped(*args, **kwargs):
-            sleep(initial_wait)
+            sleep_func(initial_wait)
             after_iter = repeat(after) if isinstance(after, (int, float)) else after
             exception = None
 
@@ -31,7 +40,7 @@ def retry(
                 if until(result):
                     return result
 
-                sleep(s)
+                sleep_func(s)
 
             # Last chance to succeed
             try:

--- a/ddtrace/internal/utils/retry.py
+++ b/ddtrace/internal/utils/retry.py
@@ -13,20 +13,22 @@ def retry(
     after: t.Union[int, float, t.Iterable[t.Union[int, float]]],
     until: t.Callable[[t.Any], bool] = lambda result: result is None,
     initial_wait: float = 0,
-    sleep_func: t.Callable[[float], t.Any] = sleep,
+    sleep_func: t.Optional[t.Callable[[float], t.Any]] = None,
 ) -> t.Callable:
     """Retry ``f`` until ``until`` accepts its result, waiting ``after`` between attempts.
 
-    ``sleep_func`` overrides how the waits are performed. It defaults to
-    ``time.sleep``; callers running on a background thread can pass an
-    interruptible wait (e.g. ``threading.Event.wait``) so a pending shutdown does
-    not have to sit through the remaining backoff.
+    ``sleep_func`` overrides how the waits are performed, and is resolved on every
+    call so that the module-level ``sleep`` remains patchable. It defaults to
+    ``time.sleep``; a caller running on a background thread can pass an
+    interruptible wait instead, so that a pending shutdown does not have to sit
+    through the remaining backoff.
     """
 
     def retry_decorator(f):
         @wraps(f)
         def retry_wrapped(*args, **kwargs):
-            sleep_func(initial_wait)
+            _sleep = sleep if sleep_func is None else sleep_func
+            _sleep(initial_wait)
             after_iter = repeat(after) if isinstance(after, (int, float)) else after
             exception = None
 
@@ -40,7 +42,7 @@ def retry(
                 if until(result):
                     return result
 
-                sleep_func(s)
+                _sleep(s)
 
             # Last chance to succeed
             try:

--- a/tests/internal/test_utils_retry.py
+++ b/tests/internal/test_utils_retry.py
@@ -2,6 +2,7 @@ from itertools import count
 
 import pytest
 
+import ddtrace.internal.utils.retry as retry_module
 from ddtrace.internal.utils.retry import RetryError
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 from ddtrace.internal.utils.retry import retry
@@ -94,37 +95,34 @@ def test_retry_sleep_func_not_called_after_success():
     assert waits == [0]
 
 
-def test_retry_sleep_func_defaults_to_time_sleep():
-    """Callers that do not pass sleep_func keep the blocking time.sleep behavior."""
-    import ddtrace.internal.utils.retry as retry_module
+def test_retry_without_sleep_func_uses_module_sleep(monkeypatch):
+    """Callers that omit sleep_func wait through the module-level sleep."""
+    waits = []
+    monkeypatch.setattr(retry_module, "sleep", waits.append)
+    n = count()
 
-    calls = []
-    original = retry_module.sleep
-    retry_module.sleep = calls.append
-    try:
-        # The default is bound at definition time, so rebinding the module
-        # attribute must not change an already-imported default.
-        assert retry_module.retry.__defaults__[-1] is original
-    finally:
-        retry_module.sleep = original
+    @retry(after=[1, 2], initial_wait=0.5)
+    def f():
+        return next(n)
 
-    assert calls == []
+    with pytest.raises(RetryError):
+        f()
+
+    assert waits == [0.5, 1, 2]
+    assert next(n) == 3
 
 
-def test_retry_interruptible_sleep_func_can_stop_retrying():
-    """An event-style wait lets a caller abandon the remaining attempts."""
-    import threading
-
-    shutdown = threading.Event()
+def test_retry_sleep_func_can_stop_retrying():
+    """A flag flipped during the wait lets a caller abandon the remaining attempts."""
+    state = {"stop": False}
     attempts = count()
 
     def wait(delay):
-        # Only a real backoff signals shutdown; the zero initial wait must not.
+        # Only a real backoff requests the stop; the zero initial wait must not.
         if delay:
-            shutdown.set()
-        return shutdown.wait(0)
+            state["stop"] = True
 
-    @retry(after=[1, 2], until=lambda r: shutdown.is_set(), sleep_func=wait)
+    @retry(after=[1, 2], until=lambda r: state["stop"], sleep_func=wait)
     def f():
         return next(attempts)
 

--- a/tests/internal/test_utils_retry.py
+++ b/tests/internal/test_utils_retry.py
@@ -66,6 +66,74 @@ def test_retry_after_iter_exc():
     assert next(n) == 6
 
 
+def test_retry_sleep_func_receives_delays():
+    """A custom sleep_func is used for the initial wait and every backoff."""
+    waits = []
+    n = count()
+
+    @retry(after=[1, 2], initial_wait=0.5, sleep_func=waits.append)
+    def f():
+        return next(n)
+
+    with pytest.raises(RetryError):
+        f()
+
+    assert waits == [0.5, 1, 2]
+    assert next(n) == 3
+
+
+def test_retry_sleep_func_not_called_after_success():
+    """Only the initial wait happens when the first attempt is accepted."""
+    waits = []
+
+    @retry(after=[1, 2], until=lambda r: True, sleep_func=waits.append)
+    def f():
+        return "ok"
+
+    assert f() == "ok"
+    assert waits == [0]
+
+
+def test_retry_sleep_func_defaults_to_time_sleep():
+    """Callers that do not pass sleep_func keep the blocking time.sleep behavior."""
+    import ddtrace.internal.utils.retry as retry_module
+
+    calls = []
+    original = retry_module.sleep
+    retry_module.sleep = calls.append
+    try:
+        # The default is bound at definition time, so rebinding the module
+        # attribute must not change an already-imported default.
+        assert retry_module.retry.__defaults__[-1] is original
+    finally:
+        retry_module.sleep = original
+
+    assert calls == []
+
+
+def test_retry_interruptible_sleep_func_can_stop_retrying():
+    """An event-style wait lets a caller abandon the remaining attempts."""
+    import threading
+
+    shutdown = threading.Event()
+    attempts = count()
+
+    def wait(delay):
+        # Only a real backoff signals shutdown; the zero initial wait must not.
+        if delay:
+            shutdown.set()
+        return shutdown.wait(0)
+
+    @retry(after=[1, 2], until=lambda r: shutdown.is_set(), sleep_func=wait)
+    def f():
+        return next(attempts)
+
+    # Attempt 1 runs, its backoff sets the event, and `until` accepts attempt 2,
+    # so the third attempt never happens.
+    assert f() == 1
+    assert next(attempts) == 2
+
+
 def test_retry_fibonacci_backoff_with_jitter():
     n = count()
 


### PR DESCRIPTION
## Description

Adds an optional `sleep_func` parameter to `ddtrace/internal/utils/retry.py`, used for the initial wait and for each backoff between attempts. It defaults to `time.sleep`, so every existing caller behaves identically — the change is purely additive.

The motivation is background-thread callers: `time.sleep` cannot be interrupted, so a service shutting down mid-backoff has to wait out the remaining delay. Passing an interruptible wait such as `threading.Event.wait` lets the caller abandon the backoff immediately.

Split out of #19331 at review request. The Feature Flagging agentless poller is the first consumer and uses it to make shutdown prompt instead of waiting out up to ~30s of backoff.

## Testing

Four tests added to `tests/internal/test_utils_retry.py`:

- `sleep_func` receives the initial wait and every backoff delay, in order.
- No backoff wait happens when the first attempt is accepted.
- The default remains bound to `time.sleep` for callers that do not pass it.
- An event-style wait can stop the remaining attempts (the interruptible-shutdown case).

`tests/internal/test_utils_retry.py` passes in full (9 tests).

## Risks

None expected. The parameter is optional and defaults to the previous behavior, and no existing caller passes it.

## Additional Notes

No release note: this is an internal utility with no customer-visible behavior change, so `changelog/no-changelog` is applied.
