### PR TITLE
ci: use custom eventhubs emulator image

### DIFF
--- a/.gitlab/services.yml
+++ b/.gitlab/services.yml
@@ -134,7 +134,7 @@
       BLOB_SERVER: azurite
       METADATA_SERVER: azurite
   azureeventhubsemulator:
-    name: registry.ddbuild.io/images/mirror/azure-messaging/eventhubs-emulator:2.1.0
+    name: registry.ddbuild.io/dd-trace-py:v128241639-e35a704-eventhubs-emulator@sha256:a7d3093298401a7392a735a09f553d841212024e80823bb2046dcd10694872e3
     alias: azureeventhubsemulator
     variables:
       ACCEPT_EULA: "Y"


### PR DESCRIPTION
## Description

Today there can be a race condition between `azurite` and `eventhubs-emulator` starting.

This PR moves to using a custom build `eventhubs-emulator` image which polls for `azurite` to be up and healthy before trying to start the `eventhubs-emulator`.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
