### PR TITLE
feat(tracing): add Span remove_tag and remove_metric

### DIFF
--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -296,6 +296,10 @@ class Span(SpanData):
             for k, v in iter(tags.items()):
                 self.set_tag(k, v)
 
+    def remove_tag(self, key: str) -> None:
+        """Remove a tag from the span. No-op if the key is not set."""
+        self._remove_attribute(key)
+
     def set_metric(self, key: str, value: NumericType) -> None:
         """This method sets a numeric tag value for the given key."""
         # Enforce a specific constant for `_dd.measured`
@@ -331,6 +335,10 @@ class Span(SpanData):
     def get_metrics(self) -> dict[str, NumericType]:
         """Return all metrics."""
         return dict(self._get_numeric_attributes())
+
+    def remove_metric(self, key: str) -> None:
+        """Remove a metric from the span. No-op if the key is not set."""
+        self._remove_attribute(key)
 
     def _add_on_finish_exception_callback(self, callback: Callable[["Span"], None]):
         """Add an errortracking related callback to the on_finish_callback array"""

--- a/releasenotes/notes/add-span-remove-tag-metric-e1bc64ef74ac735a.yaml
+++ b/releasenotes/notes/add-span-remove-tag-metric-e1bc64ef74ac735a.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    tracing: Adds ``Span.remove_tag(key)`` and ``Span.remove_metric(key)`` for removing
+    a previously set tag or metric from a span. Both are no-ops if the key is not set.

--- a/tests/tracer/test_span_tags.py
+++ b/tests/tracer/test_span_tags.py
@@ -93,6 +93,25 @@ def test_set_tag_metric():
     assert s.get_metrics() == dict(test=1)
 
 
+def test_remove_tag():
+    s = Span(name="test.span")
+    s.set_tag("a", "a")
+    s.set_tag("b", "b")
+
+    s.remove_tag("a")
+
+    assert s.get_tags() == dict(b="b")
+    assert s.get_tag("a") is None
+
+
+def test_remove_tag_missing_key():
+    s = Span(name="test.span")
+
+    s.remove_tag("does-not-exist")
+
+    assert s.get_tags() == dict()
+
+
 def test_set_valid_metrics():
     s = Span(name="test.span")
     s.set_metric("a", 0)  # ast-grep-ignore: span-set-metric
@@ -119,6 +138,25 @@ def test_set_invalid_metric():
         k = str(i)
         s.set_metric(k, m)  # ast-grep-ignore: span-set-metric
         assert s.get_metric(k) is None
+
+
+def test_remove_metric():
+    s = Span(name="test.span")
+    s.set_metric("a", 1)  # ast-grep-ignore: span-set-metric
+    s.set_metric("b", 2)  # ast-grep-ignore: span-set-metric
+
+    s.remove_metric("a")
+
+    assert s.get_metrics() == dict(b=2)
+    assert s.get_metric("a") is None
+
+
+def test_remove_metric_missing_key():
+    s = Span(name="test.span")
+
+    s.remove_metric("does-not-exist")
+
+    assert s.get_metrics() == dict()
 
 
 def test_set_numpy_metric():


### PR DESCRIPTION
## Description

Fixes #19152

Original request is asking for a way to remove tags. The main use case is a trace processor to allow list predefined tags only to prevent possible PII leak (if tag is not in predefined list, remove and log. then they can audit the new tag and approve or continue to block/remove).

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
