### PR TITLE
chore: revert bump version to 4.9.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.9.8"
+version = "4.9.7"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#19403. The 4.9.7 version was not released, there's no need to bump the version.