### PR TITLE
feat(tracing): recognize new synthetics sampling mechanism value

### DIFF
--- a/ddtrace/internal/constants.py
+++ b/ddtrace/internal/constants.py
@@ -174,6 +174,7 @@ class SamplingMechanism(object):
     REMOTE_USER_TRACE_SAMPLING_RULE = 11
     REMOTE_DYNAMIC_TRACE_SAMPLING_RULE = 12
     AI_GUARD = 13
+    SYNTHETICS_BILLING_EXCLUSION = 15
 
 
 class TraceSource(object):

--- a/releasenotes/notes/support-synthetics-sampling-mechanism-dad8f805c890ac3e.yaml
+++ b/releasenotes/notes/support-synthetics-sampling-mechanism-dad8f805c890ac3e.yaml
@@ -1,6 +1,4 @@
 ---
 other:
   - |
-    tracing: Adds recognition of an additional Datadog-internal sampling mechanism used by
-    Datadog Synthetics, so traces using it no longer log a decoding warning or stop
-    propagating trace-level tags to downstream services.
+    tracing: Adds recognition of a new sampling mechanism used by Datadog Synthetics.

--- a/releasenotes/notes/support-synthetics-sampling-mechanism-dad8f805c890ac3e.yaml
+++ b/releasenotes/notes/support-synthetics-sampling-mechanism-dad8f805c890ac3e.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  - |
+    tracing: Adds recognition of an additional Datadog-internal sampling mechanism used by
+    Datadog Synthetics, so traces using it no longer log a decoding warning or stop
+    propagating trace-level tags to downstream services.

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -26,6 +26,7 @@ from ddtrace.internal.constants import PROPAGATION_STYLE_B3_MULTI
 from ddtrace.internal.constants import PROPAGATION_STYLE_B3_SINGLE
 from ddtrace.internal.constants import PROPAGATION_STYLE_DATADOG
 from ddtrace.internal.constants import W3C_TRACESTATE_KEY
+from ddtrace.internal.constants import SamplingMechanism
 from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
 from ddtrace.propagation._utils import get_wsgi_header
 from ddtrace.propagation.http import _HTTP_BAGGAGE_PREFIX
@@ -943,6 +944,10 @@ def test_extract_unicode(tracer):  # noqa: F811
             "_dd.p.dm=-22",
             {"_dd.propagation_error": "decoding_error"},
         ),  # This test validates a value that does not exist in the SamplingMechanism enum
+        (
+            "_dd.p.dm=-{}".format(SamplingMechanism.SYNTHETICS_BILLING_EXCLUSION),
+            {"_dd.p.dm": "-{}".format(SamplingMechanism.SYNTHETICS_BILLING_EXCLUSION)},
+        ),
     ],
 )
 def test_extract_dm(x_datadog_tags, expected_trace_tags):
@@ -960,6 +965,30 @@ def test_extract_dm(x_datadog_tags, expected_trace_tags):
     expected.update(expected_trace_tags)
 
     assert context._meta == expected
+
+
+def test_extract_and_reinject_known_dm_preserves_other_tags():
+    """A recognized _dd.p.dm value must not be stripped, and other _dd.p.* tags must
+    still be sent on the next outbound hop (regression test for APMS-20191, where an
+    unrecognized _dd.p.dm value caused the entire x-datadog-tags header to be dropped
+    on injection).
+    """
+    headers = {
+        "x-datadog-trace-id": "1234",
+        "x-datadog-parent-id": "5678",
+        "x-datadog-sampling-priority": "1",
+        "x-datadog-tags": "_dd.p.dm=-{},_dd.p.usr.id=baz64".format(SamplingMechanism.SYNTHETICS_BILLING_EXCLUSION),
+    }
+
+    context = HTTPPropagator.extract(headers)
+    assert "_dd.propagation_error" not in context._meta
+
+    new_headers = {}
+    HTTPPropagator.inject(context, new_headers)
+
+    injected_tags = new_headers["x-datadog-tags"]
+    assert "_dd.p.dm=-{}".format(SamplingMechanism.SYNTHETICS_BILLING_EXCLUSION) in injected_tags
+    assert "_dd.p.usr.id=baz64" in injected_tags
 
 
 def test_WSGI_extract(tracer):  # noqa: F811


### PR DESCRIPTION
## Summary
- Datadog Synthetics started injecting `_dd.p.dm=-15` on traffic to flag it for billing exclusion (per SYNTH-28240).
- `15` wasn't a registered `SamplingMechanism` value in the Python tracer, so the value was treated as unrecognized: the tracer stripped the tag and set `_dd.propagation_error=decoding_error`.
- That error state has a separate side effect: `_DatadogMultiHeader._inject` skips encoding the entire `x-datadog-tags` header when `_dd.propagation_error` is present, so *all* `_dd.p.*` tags stopped propagating downstream for affected traces (not just `_dd.p.dm`).
- This PR registers the new value (`SYNTHETICS_BILLING_EXCLUSION = 15`) so it's recognized and no longer triggers the strip/error path.