### PR TITLE
fix(mcp): cap supported mcp version below 2.0

### DIFF
--- a/ddtrace/contrib/internal/mcp/patch.py
+++ b/ddtrace/contrib/internal/mcp/patch.py
@@ -45,7 +45,7 @@ def get_version() -> str:
 
 
 def _supported_versions() -> dict[str, str]:
-    return {"mcp": ">=1.10.0"}
+    return {"mcp": ">=1.10.0,<2"}
 
 
 def _set_distributed_headers_into_mcp_request(request: "ClientRequest") -> "ClientRequest":

--- a/releasenotes/notes/fix-mcp-2x-bf6c19b795b749fc.yaml
+++ b/releasenotes/notes/fix-mcp-2x-bf6c19b795b749fc.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    MCP: Fixes a ``ModuleNotFoundError`` raised when patching mcp 2.0 or later,
+    which no longer provides ``mcp.shared.session``. The integration is now
+    skipped on those versions.


### PR DESCRIPTION
## Description

mcp 2.0.0 removed `mcp.shared.session`. `_supported_versions()` had no upper bound so
`patch()` ran against 2.x and raised `ModuleNotFoundError`. Caps the spec at `<2`.

Upstream recommends the same bound for anyone not yet migrated:
https://github.com/modelcontextprotocol/python-sdk/releases/tag/v2.0.0

Fixes #19439

## Testing

`pip install mcp==2.0.0`, then import `ddtrace.auto` followed by `mcp`.
before: `ModuleNotFoundError` traceback out of `patch()`.
after: integration skipped, no traceback.

## Risks

None. Only changes behaviour on mcp 2.x, where the integration cannot work.

## Additional Notes

v1.x is maintenance-only now, so 2.x support will need doing eventually. `FastMCP`
became `MCPServer` and `ClientSession` folded into `Client`, so it is not a small patch.
This just stops it trying.
