### PR TITLE
docs: clarify fork PR CI cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Follow **`docs/contributing.rst`** ("Pull Request Requirements" and "Branches an
 - **PR titles must follow Conventional Commits** (`commitlint.config.js`): `type(scope): description`. Common types: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `perf`, `ci`. Scope is optional. Example: `fix(tracing): resolve span link propagation issue`.
 - Link relevant issues or JIRA tickets; include a testing plan.
 - When reviewing/generating PRs, check for: missing sections, missing changelog, missing tests, backward-compatibility risks.
-- **Fork PRs** (external contributors) never get `dd-gitlab/default-pipeline` or `system-tests finished` — GitLab/`dd-octo-sts` only vend credentials to pipelines tied to a PR owned by this repo. A maintainer must push the fork's exact commit to a repo-owned branch (e.g. `<you>/mirror-<PR#>`) and open a real PR from that branch into `main` to trigger CI with full credentials. Once the mirror PR's checks go green (same commit SHA), `/merge` the original fork PR, then close the mirror PR without merging it.
+- **Fork PR CI** — Push the fork's exact head SHA to a repo-owned branch and open a mirror PR into `main`; a bare branch push does not trigger the required System Tests workflow. Use a Conventional Commit title, add `Closes #<mirror-PR>` to the original PR description, and `/merge` the original once checks pass. Its merge closes the mirror; then delete the mirror branch.
 - **Release notes**: use the `releasenote` skill before opening a PR — it decides whether one is needed and, if so, writes it to dd-trace-py's customer-facing conventions (`docs/releasenotes.rst`). If not needed, add the `changelog/no-changelog` label instead.
 
 ## Troubleshooting

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -81,21 +81,24 @@ At this time, do not use the merge queue option.
 Merging Pull Requests from Forks
 ---------------------------------
 
-Pull requests opened from a fork (i.e. by an external contributor) cannot run our internal
-CI pipeline directly: our GitLab pipeline and system tests only issue credentials to pipelines
-tied to a pull request owned by this repository, and GitLab never mirrors branches from
-external forks.
+Pull requests opened from a fork (i.e. by an external contributor) cannot run all required
+CI directly. GitLab does not mirror branches from external forks, and the System Tests
+workflow does not run when an arbitrary branch is merely pushed to this repository.
 
 If you're a maintainer merging a fork PR, you'll need to mirror it into the repository first:
 
 #. Push the fork PR's exact head commit to a new branch in this repository, e.g.
    ``git push origin <fork-pr-head-sha>:refs/heads/<you>/mirror-<PR#>``.
-#. Open a pull request from that branch into ``main``. This gives the commit a
-   repository-owned PR context, which is required for CI to authenticate correctly.
+#. Open a mirror pull request from that branch into ``main``. Its branch name does not need
+   to match the contributor's branch. Use a `Conventional Commit
+   <https://www.conventionalcommits.org/en/v1.0.0/>`_ title and state in the description that
+   this PR exists only to run CI and must not be merged.
+#. Add ``Closes #<mirror-PR>`` to the *original* PR's description. When the original merges,
+   GitHub will close the mirror PR automatically.
 #. Wait for the mirror PR's checks to pass. Since it's the same commit SHA, the original
    fork PR's checks will reflect the same results.
 #. Comment ``/merge`` on the *original* fork PR once its checks are green.
-#. Close the mirror PR without merging it, and delete its branch.
+#. After the original merges, verify that the mirror closed and delete its branch.
 
 Backporting
 -----------


### PR DESCRIPTION
## Description

Clarifies the fork-PR CI guidance added in #19127:

- A bare repo-owned branch can start GitLab, but it does not trigger the required System Tests workflow.
- Mirror branch names do not need to match the contributor's branch.
- Mirror PR titles must follow Conventional Commits.
- The original PR description should include `Closes #<mirror-PR>` so merging the original automatically closes the temporary mirror PR.

## Testing

- `scripts/lint spelling -- docs/contributing.rst AGENTS.md`
- `scripts/lint checks`

## Risks

None; documentation-only change.

## Additional Notes

No closing keyword applies to this follow-up because #19127 is already merged and there is no open tracking issue.