### PR TITLE
ci(benchmarks): restore telemetry dependency baseline

### DIFF
--- a/benchmarks/telemetry_dependencies/scenario.py
+++ b/benchmarks/telemetry_dependencies/scenario.py
@@ -12,25 +12,6 @@ from unittest.mock import patch
 
 from bm import Scenario
 
-from ddtrace.internal.settings._telemetry import config as telemetry_config
-
-
-try:
-    from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
-except ModuleNotFoundError as error:
-    if error.name != "ddtrace.internal.settings.appsec_telemetry":
-        raise
-
-    from ddtrace.internal.settings._config import config as tracer_config
-
-    def _enable_sca():
-        tracer_config._sca_enabled = True
-
-else:
-
-    def _enable_sca():
-        appsec_telemetry_config.SCA_ENABLED = True
-
 
 # --- Backward-compatible imports ---
 # New API (this branch): DependencyTracker with collect_report()
@@ -43,6 +24,26 @@ try:
     HAS_DEPENDENCY_TRACKER = True
 except ImportError:
     HAS_DEPENDENCY_TRACKER = False
+
+if HAS_DEPENDENCY_TRACKER:
+    from ddtrace.internal.settings._telemetry import config as telemetry_config
+
+    try:
+        from ddtrace.internal.settings.appsec_telemetry import config as appsec_telemetry_config
+    except ModuleNotFoundError as error:
+        if error.name != "ddtrace.internal.settings.appsec_telemetry":
+            raise
+
+        from ddtrace.internal.settings._config import config as tracer_config
+
+        def _enable_sca():
+            tracer_config._sca_enabled = True
+
+    else:
+
+        def _enable_sca():
+            appsec_telemetry_config.SCA_ENABLED = True
+
 
 # Old API (main): update_imported_dependencies from data.py
 try:


### PR DESCRIPTION
## Description

Restore compatibility between the `telemetry_dependencies` microbenchmark and its historical baseline wheel.

The benchmark scenario imported `ddtrace.internal.settings._telemetry` unconditionally after the telemetry configuration refactor. The baseline wheel predates `ddtrace.internal.settings`, so the scenario failed at import time before its existing old dependency API fallback could run. This change loads the candidate-only telemetry and AppSec configuration modules only when `DependencyTracker` is available.

This only changes benchmark harness compatibility; runtime tracer behavior and public APIs are unchanged.

## Testing

- Historical baseline import-path smoke check
- Current candidate import-path smoke check in the built Python 3.13 environment
- `rt run 7dec5d4 -- tests/telemetry/test_dependency.py` (16 passed)
- `scripts/lint checks`
- `git diff --check`

## Risks

Low. The candidate benchmark path retains the same imports and behavior, while the old API path no longer imports modules it does not use.

## Additional Notes

No customer-facing changelog entry is needed for this CI-only benchmark repair.