### PR TITLE
ci(iast): isolate request tainted telemetry test

### DIFF
--- a/tests/appsec/iast/test_telemetry.py
+++ b/tests/appsec/iast/test_telemetry.py
@@ -12,6 +12,7 @@ from ddtrace.appsec._iast._metrics import metric_verbosity
 from ddtrace.appsec._iast._overhead_control_engine import oce
 from ddtrace.appsec._iast._patch_modules import _testing_unpatch_iast
 from ddtrace.appsec._iast._taint_tracking import OriginType
+from ddtrace.appsec._iast._taint_tracking import initialize_native_state
 from ddtrace.appsec._iast._taint_tracking import origin_to_str
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast.constants import VULN_CODE_INJECTION
@@ -167,10 +168,12 @@ def test_metric_request_tainted(no_request_sampling, telemetry_writer, tracer):
     ):
         oce.reconfigure()
         tracer.configure(iast_enabled=True)
-        # tracer.configure() sets _iast_enabled but does not register AppSecIastSpanProcessor
-        # in SpanProcessor.__processors__. Without this, on_span_start is never called and
-        # no IAST context is created, causing the test to fail non-deterministically depending
-        # on whether a previous test had already enabled the processor.
+        # Reset leaked request and processor state before starting a fresh request.
+        # Otherwise taint_pyobject can emit executed.source against a freed native slot,
+        # while request.tainted is missing when the span finishes.
+        _iast_finish_request()
+        initialize_native_state()
+        AppSecIastSpanProcessor.disable()
         AppSecIastSpanProcessor.enable()
         try:
             with tracer.trace("test", span_type=SpanTypes.WEB) as span:


### PR DESCRIPTION
<!-- dd-meta {"pullId":"80ee33a1-cca4-4c47-8f13-ba82a5463d6d","source":"chat","resourceId":"5b4129d1-5d45-459a-a80b-9224606bd72d","workflowId":"b08a26f0-0d64-4060-976f-39c7c913f6df","codeChangeId":"b08a26f0-0d64-4060-976f-39c7c913f6df","sourceType":"test-optimization"} -->
## Description

Fix the order-dependent `test_metric_request_tainted` flake across Python versions.

The observed failure emits `executed.source` but omits `request.tainted`. Under xdist scheduling, the test can run without another IAST test having initialized native taint state, or with leaked request/processor state. In either case, `taint_pyobject()` can emit the source metric without recording a native tainted object for span-finish telemetry.

Make the test self-contained by:

- finishing any stale IAST request context;
- explicitly initializing native taint state;
- resetting and registering the IAST span processor for the test;
- retaining processor cleanup in `finally`.

## Testing

- regression tests

## Risks

Low. The change is test-only and resets state already intended to be scoped to each test request.

## Additional Notes

No release note is required for this test-only change.

Fix flaky tests DD_YCO70Q DD_5MTS37 DD_J9SXOO DD_OOWJ7B DD_T6XU3F DD_NFN6HX

PR originally generated by Bits: [view session in Datadog](https://app.datadoghq.com/code/5b4129d1-5d45-459a-a80b-9224606bd72d).
