### PR TITLE
ci(appsec): clean up Tornado test client lifecycle

### DIFF
--- a/tests/appsec/contrib_appsec/test_tornado.py
+++ b/tests/appsec/contrib_appsec/test_tornado.py
@@ -63,18 +63,21 @@ class _Test_Tornado_Base:
     @pytest.fixture
     def interface(self, printer):
         ttc = TornadoTestClient()
-        interface = utils.Interface("tornado", None, ttc.get_http_client())
-        interface.version = TORNADO_VERSION
-
-        interface.client.get = wrap_fetch(interface.client.fetch, ttc, interface)
-        interface.client.post = wrap_fetch(interface.client.fetch, ttc, interface, method="POST")
-        interface.client.options = wrap_fetch(interface.client.fetch, ttc, interface, method="OPTIONS")
-
         with scoped_tracer() as tracer:
             ttc.setUp()
-            interface.tracer = tracer
-            interface.printer = printer
-            yield interface
+            try:
+                interface = utils.Interface("tornado", None, ttc.http_client)
+                interface.version = TORNADO_VERSION
+
+                interface.client.get = wrap_fetch(interface.client.fetch, ttc, interface)
+                interface.client.post = wrap_fetch(interface.client.fetch, ttc, interface, method="POST")
+                interface.client.options = wrap_fetch(interface.client.fetch, ttc, interface, method="OPTIONS")
+
+                interface.tracer = tracer
+                interface.printer = printer
+                yield interface
+            finally:
+                ttc.tearDown()
 
     def status(self, response):
         return response.code


### PR DESCRIPTION
## Description

Fix flaky test DD_9QF0FU

The Tornado AppSec fixture created its `AsyncHTTPClient` before `AsyncHTTPTestCase.setUp()`. Tornado binds clients to the current I/O loop, while setup creates a fresh per-test loop, so requests could use a client owned by a different loop. The fixture also skipped `AsyncHTTPTestCase.tearDown()`, leaking the test HTTP server, client, connections, and I/O loop across the 1,045-case suite.

Set up the Tornado test case before constructing the interface, use the client created by setup, and always tear the test case down after the fixture yields.

The observed flake failed after 20.03 seconds with `tornado.simple_httpclient.HTTPTimeoutError: Timeout while connecting`; its automatic retry passed in the same job.

## Testing

## Risks

Low. This only changes test fixture lifecycle. Teardown may surface genuinely leaked asynchronous work instead of carrying it into later tests.

## Additional Notes

No release note: test-only change.