### PR TITLE
fix(iast): retain request data from stale async contexts [backport 4.12]

### DIFF
--- a/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/taint_range.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/taint_tracking/taint_range.cpp
@@ -4,6 +4,17 @@
 
 namespace py = pybind11;
 
+static PyObject*
+new_reference(PyObject* object)
+{
+#if PY_VERSION_HEX >= 0x030A0000
+    return Py_NewRef(object);
+#else
+    Py_INCREF(object);
+    return object;
+#endif
+}
+
 void
 TaintRange::reset()
 {
@@ -142,7 +153,7 @@ api_taint_pyobject(PyObject* self, PyObject* const* args, const Py_ssize_t nargs
     if (!taint_engine_context) {
         // Return the original object unchanged if context is not initialized
         if (nargs >= 1) {
-            return args[0];
+            return new_reference(args[0]);
         }
         PyErr_SetString(PyExc_RuntimeError, "IAST not initialized");
         return nullptr;
@@ -158,7 +169,7 @@ api_taint_pyobject(PyObject* self, PyObject* const* args, const Py_ssize_t nargs
         size_t context_id = PyLong_AsSize_t(ctx_obj);
         const auto tx_map = safe_get_tainted_object_map_by_ctx_id(context_id);
         if (not tx_map) {
-            return tainted_object;
+            return new_reference(tainted_object);
         }
 
         pyobject_n = new_pyobject_id(tainted_object);

--- a/releasenotes/notes/iast-stale-context-owned-reference-a4c2493d7e8b61f0.yaml
+++ b/releasenotes/notes/iast-stale-context-owned-reference-a4c2493d7e8b61f0.yaml
@@ -1,4 +1,4 @@
 fixes:
   - |
-    ASM: Fixes an issue where applications using Interactive Application Security Testing (IAST)
-    can crash when asynchronous tasks access request data after the originating request has completed.
+    IAST: Fixes an issue where applications can crash when asynchronous tasks access request data
+    after the originating request has completed.

--- a/releasenotes/notes/iast-stale-context-owned-reference-a4c2493d7e8b61f0.yaml
+++ b/releasenotes/notes/iast-stale-context-owned-reference-a4c2493d7e8b61f0.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    ASM: Fixes an issue where applications using Interactive Application Security Testing (IAST)
+    can crash when asynchronous tasks access request data after the originating request has completed.

--- a/riotfile.py
+++ b/riotfile.py
@@ -4297,7 +4297,10 @@ venv = Venv(
         ),
         Venv(
             name="appsec_threats_fastapi_iast",
-            command="pytest tests/appsec/contrib_appsec/test_fastapi.py::Test_FastAPI {cmdargs}",
+            command=(
+                "pytest tests/appsec/contrib_appsec/test_fastapi.py::Test_FastAPI"
+                " tests/appsec/contrib_appsec/test_fastapi.py::Test_FastAPI_IAST_Context {cmdargs}"
+            ),
             pkgs={
                 "pytest": latest,
                 "pytest-cov": latest,

--- a/tests/appsec/contrib_appsec/test_fastapi.py
+++ b/tests/appsec/contrib_appsec/test_fastapi.py
@@ -147,5 +147,49 @@ class Test_FastAPI(_Test_FastAPI_Base, utils.Contrib_TestClass_For_Threats):
         return path
 
 
+class Test_FastAPI_IAST_Context:
+    @pytest.mark.xfail(
+        strict=True,
+        reason="IAST returns a borrowed header value after a detached request context is released",
+    )
+    @pytest.mark.subprocess(
+        ddtrace_run=True,
+        env={"DD_IAST_ENABLED": "true", "DD_IAST_REQUEST_SAMPLING": "100"},
+        err=None,
+    )
+    def test_detached_task_reads_header_after_request(self):
+        import asyncio
+        import threading
+
+        from fastapi import FastAPI
+        from fastapi import Request
+        from fastapi.testclient import TestClient
+
+        release_background = threading.Event()
+        background_finished = threading.Event()
+        observed = []
+        app = FastAPI()
+
+        @app.get("/")
+        async def endpoint(request: Request):
+            async def background():
+                await asyncio.to_thread(release_background.wait)
+                observed.append(request.headers.get("x-customer-id"))
+                background_finished.set()
+
+            asyncio.create_task(background())
+            return {"accepted": True}
+
+        with TestClient(app) as client:
+            response = client.get("/", headers={"x-customer-id": "customer-123"})
+            assert response.status_code == 200
+
+            # AIDEV-NOTE: The response must finish before this task reads the
+            # header so its copied ContextVar points to a released native slot.
+            release_background.set()
+            assert background_finished.wait(timeout=5)
+            assert observed == ["customer-123"]
+
+
 class Test_FastAPI_RC(_Test_FastAPI_Base, utils.Contrib_TestClass_For_Threats_RC):
     pass

--- a/tests/appsec/contrib_appsec/test_fastapi.py
+++ b/tests/appsec/contrib_appsec/test_fastapi.py
@@ -148,16 +148,12 @@ class Test_FastAPI(_Test_FastAPI_Base, utils.Contrib_TestClass_For_Threats):
 
 
 class Test_FastAPI_IAST_Context:
-    @pytest.mark.xfail(
-        strict=True,
-        reason="IAST returns a borrowed header value after a detached request context is released",
-    )
     @pytest.mark.subprocess(
         ddtrace_run=True,
         env={"DD_IAST_ENABLED": "true", "DD_IAST_REQUEST_SAMPLING": "100"},
         err=None,
     )
-    def test_detached_task_reads_header_after_request(self):
+    def test_detached_task_reads_request_data_after_request(self):
         import asyncio
         import threading
 
@@ -174,7 +170,7 @@ class Test_FastAPI_IAST_Context:
         async def endpoint(request: Request):
             async def background():
                 await asyncio.to_thread(release_background.wait)
-                observed.append(request.headers.get("x-customer-id"))
+                observed.append((request.headers.get("x-customer-id"), request.url.path))
                 background_finished.set()
 
             asyncio.create_task(background())
@@ -185,10 +181,10 @@ class Test_FastAPI_IAST_Context:
             assert response.status_code == 200
 
             # AIDEV-NOTE: The response must finish before this task reads the
-            # header so its copied ContextVar points to a released native slot.
+            # request data so its copied ContextVar points to a released native slot.
             release_background.set()
             assert background_finished.wait(timeout=5)
-            assert observed == ["customer-123"]
+            assert observed == [("customer-123", "/")]
 
 
 class Test_FastAPI_RC(_Test_FastAPI_Base, utils.Contrib_TestClass_For_Threats_RC):

--- a/tests/appsec/iast/test_taint_pyobject_refcount.py
+++ b/tests/appsec/iast/test_taint_pyobject_refcount.py
@@ -1,0 +1,44 @@
+import pytest
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="api_taint_pyobject returns a borrowed input when its request slot is gone",
+)
+@pytest.mark.subprocess(err=None)
+def test_taint_pyobject_in_copied_context_returns_owned_reference():
+    import contextvars
+    import os
+    import sys
+
+    from ddtrace.appsec._iast._iast_request_context_base import IAST_CONTEXT
+    from ddtrace.appsec._iast._taint_tracking import OriginType
+    from ddtrace.appsec._iast._taint_tracking import initialize_native_state
+    from ddtrace.appsec._iast._taint_tracking._context import finish_request_context
+    from ddtrace.appsec._iast._taint_tracking._context import start_request_context
+    from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+
+    initialize_native_state()
+    context_id = start_request_context()
+    assert context_id is not None
+    IAST_CONTEXT.set(context_id)
+    copied_context = contextvars.copy_context()
+
+    finish_request_context(context_id)
+    IAST_CONTEXT.set(None)
+
+    value = bytearray(b"customer input")
+    refcount_before = sys.getrefcount(value)
+    returned = copied_context.run(
+        taint_pyobject,
+        value,
+        "parameter",
+        "customer input",
+        OriginType.PARAMETER,
+    )
+    refcount_after = sys.getrefcount(value)
+
+    if returned is not value or refcount_after != refcount_before + 1:
+        # AIDEV-NOTE: Avoid normal cleanup: both names appear to own the same
+        # reference, which can turn this deterministic check into a UAF crash.
+        os._exit(1)

--- a/tests/appsec/iast/test_taint_pyobject_refcount.py
+++ b/tests/appsec/iast/test_taint_pyobject_refcount.py
@@ -1,10 +1,6 @@
 import pytest
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="api_taint_pyobject returns a borrowed input when its request slot is gone",
-)
 @pytest.mark.subprocess(err=None)
 def test_taint_pyobject_in_copied_context_returns_owned_reference():
     import contextvars


### PR DESCRIPTION
## Description

Backport of #19290 to the supported `4.12` release line. The production allocator crash was observed on ddtrace 4.12.2, and this branch contains the same ownership repair, deterministic native regression, public FastAPI/Starlette regression, and IAST release note as the main PR.

`api_taint_pyobject` now returns an owned reference from both early fallback paths instead of exposing a borrowed input as a new Python result.

## Testing

- `rt run 112cf54 --force-reinstall -- -q -k test_taint_pyobject_in_copied_context_returns_owned_reference --no-cov` (Python 3.9): passed
- `rt run 1477633 --force-reinstall -- -q -k test_detached_task_reads_request_data_after_request --no-cov` (FastAPI 0.86): passed
- `rt run 1391c58 --force-reinstall -- -q -k test_detached_task_reads_request_data_after_request --no-cov` (FastAPI 0.94): passed
- `rt run 151f23f --force-reinstall -- -q -k test_detached_task_reads_request_data_after_request --no-cov` (FastAPI 0.114): passed
- `scripts/lint cformat`: passed
- `scripts/lint fmt -- tests/appsec/iast/test_taint_pyobject_refcount.py tests/appsec/contrib_appsec/test_fastapi.py riotfile.py`: passed

`scripts/lint checks` passed formatting, C++ formatting, typing, security, and suite-spec validation, then stopped on a branch-infrastructure issue: the `4.12` lint configuration invokes `scripts/check_profiling_native_coverage.py`, but that file does not exist on `4.12`.

## Risks

Low. This is a clean semantic backport of the main fix. The normal tainting path is unchanged; the two fallback returns only gain the reference required by the Python C API contract.

## Additional Notes

- All three backport commits are signed.
- The production attribution remains a strong hypothesis, not proven; see #19290 for the allocator evidence and limitation.
