### PR TITLE
fix(tracing): avoid blocking exporter shutdown after fork

### DIFF
--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -582,3 +582,12 @@ class SpanAggregator(SpanProcessor):
                 "spans_created": defaultdict(int),
                 "spans_finished": defaultdict(int),
             }
+
+    def reset_after_fork(self) -> None:
+        """Reset child-process state without stopping inherited background workers."""
+        self.writer = self.writer.reset_after_fork()
+        self._traces = defaultdict(lambda: _Trace())
+        self._span_metrics = {
+            "spans_created": defaultdict(int),
+            "spans_finished": defaultdict(int),
+        }

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -406,13 +406,20 @@ class Tracer(object):
 
     def _child_after_fork(self):
         self._pid = getpid()
-        self._recreate(reset_buffer=True)
+        self._reset_after_fork()
         self._new_process = True
         self._store_metadata()
         # Re-dispatch activation post-fork: native code clears profiler span links; inherited context is unchanged.
         active = self.context_provider.active()
         if active is not None:
             core.dispatch("ddtrace.context_provider.activate", (self.context_provider, active))
+
+    def _reset_after_fork(self) -> None:
+        """Reinitialize processors and writer state without blocking in the child fork hook."""
+        self._span_aggregator.reset_after_fork()
+        self._span_processors = _default_span_processors_factory(
+            self._endpoint_call_counter_span_processor,
+        )
 
     def _recreate(
         self,

--- a/ddtrace/internal/native/_native.pyi
+++ b/ddtrace/internal/native/_native.pyi
@@ -450,6 +450,9 @@ class TraceExporterBuilder:
         :param timeout_ms: Timeout in milliseconds.
         """
         ...
+    def set_restart_after_fork(self, restart: bool) -> TraceExporterBuilder:
+        """Configure whether exporter workers are restarted in a forked child."""
+        ...
     def build(self, shared_runtime: SharedRuntime) -> TraceExporter:
         """
         Build and return a TraceExporter instance with the configured settings.

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -125,6 +125,10 @@ class TraceWriter(metaclass=abc.ABCMeta):
     def stop(self, timeout: Optional[float] = None) -> None:
         pass
 
+    def reset_after_fork(self) -> "TraceWriter":
+        """Reset fork-unsafe writer state in a child process."""
+        return self.recreate()
+
     @abc.abstractmethod
     def write(self, spans: Optional[list["Span"]] = None) -> None:
         pass
@@ -157,6 +161,9 @@ class LogWriter(TraceWriter):
 
     def stop(self, timeout: Optional[float] = None) -> None:
         return
+
+    def reset_after_fork(self) -> "LogWriter":
+        return self
 
     def write(self, spans: Optional[list["Span"]] = None) -> None:
         if not spans:
@@ -508,6 +515,18 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
         super(HTTPWriter, self)._stop_service()
         self.join(timeout=timeout)
 
+    def reset_after_fork(self) -> "HTTPWriter":
+        self._reset_connection()
+        self._clients = [
+            client.__class__(self._buffer_size, self._max_payload_size)  # type: ignore[call-arg,arg-type]
+            for client in self._clients
+        ]
+        self._metrics = defaultdict(int)
+        self._drop_sma = SimpleMovingAverage(DEFAULT_SMA_WINDOW)
+        self._worker = None
+        self.status = service.ServiceStatus.STOPPED
+        return self
+
     def on_shutdown(self):
         try:
             self.periodic()
@@ -699,6 +718,7 @@ def _build_base_exporter_builder(
         .set_tracer_version(__version__)
         .set_git_commit_sha(commit_sha)
         .set_client_computed_top_level()
+        .set_restart_after_fork(False)
     )
     # Only report the hostname when DD_TRACE_REPORT_HOSTNAME is enabled. Otherwise it must be omitted
     # from both the trace payload and the OTLP resource attributes (host.name).
@@ -1118,6 +1138,22 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
         # FIXME: don't join() on stop(), let the caller handle this
         super(NativeWriter, self)._stop_service()
         self.join(timeout=timeout)
+
+    def reset_after_fork(self) -> "NativeWriter":
+        # AIDEV-NOTE: Exporter workers are deliberately not restarted by the shared runtime in a child.
+        # Discarding this inherited exporter is therefore safe and avoids running its
+        # blocking, non-cancel-safe worker shutdown from an at-fork callback.
+        self._exporter.drop()
+        self._exporter = self._create_exporter()
+        self._clients = [
+            client.__class__(self._buffer_size, self._max_payload_size)  # type: ignore[call-arg,arg-type]
+            for client in self._clients
+        ]
+        self._metrics = defaultdict(int)
+        self._drop_sma = SimpleMovingAverage(DEFAULT_SMA_WINDOW)
+        self._worker = None
+        self.status = service.ServiceStatus.STOPPED
+        return self
 
     def on_shutdown(self):
         try:

--- a/releasenotes/notes/fix-native-writer-fork-shutdown-deadlock-9b48c2b1d762fd31.yaml
+++ b/releasenotes/notes/fix-native-writer-fork-shutdown-deadlock-9b48c2b1d762fd31.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    tracing: Fixes an issue that could cause forked child processes to hang
+    while shutting down the tracer.

--- a/src/native/data_pipeline/mod.rs
+++ b/src/native/data_pipeline/mod.rs
@@ -212,6 +212,11 @@ impl TraceExporterBuilderPy {
         Ok(slf.into())
     }
 
+    fn set_restart_after_fork(mut slf: PyRefMut<'_, Self>, restart: bool) -> PyResult<Py<Self>> {
+        slf.try_as_mut()?.set_restart_after_fork(restart);
+        Ok(slf.into())
+    }
+
     /// Consumes the wrapped builder, requires a shared runtime to be passed to spawn async tasks.
     ///
     /// The builder shouldn't be reused.

--- a/tests/appsec/integrations/django_tests/django_app/urls.py
+++ b/tests/appsec/integrations/django_tests/django_app/urls.py
@@ -15,8 +15,7 @@ else:
 
 def shutdown(request):
     # Endpoint used to flush traces to the agent when doing snapshots.
-    # Keep this below the test client's timeout so a delayed flush cannot fail fixture teardown.
-    tracer.shutdown(timeout=5)
+    tracer.shutdown()
     return HttpResponse(status=200)
 
 

--- a/tests/appsec/integrations/django_tests/django_app/urls.py
+++ b/tests/appsec/integrations/django_tests/django_app/urls.py
@@ -15,7 +15,8 @@ else:
 
 def shutdown(request):
     # Endpoint used to flush traces to the agent when doing snapshots.
-    tracer.shutdown()
+    # Keep this below the test client's timeout so a delayed flush cannot fail fixture teardown.
+    tracer.shutdown(timeout=5)
     return HttpResponse(status=200)
 
 

--- a/tests/tracer/test_processors.py
+++ b/tests/tracer/test_processors.py
@@ -209,6 +209,31 @@ def test_aggregator_reset_with_args():
     assert len(aggr._span_metrics["spans_created"]) == 1
 
 
+def test_aggregator_reset_after_fork_does_not_recreate_writer():
+    aggr = SpanAggregator(
+        partial_flush_enabled=False,
+        partial_flush_min_spans=1,
+        dd_processors=[DummyProcessor()],
+    )
+    writer = NativeWriter("http://localhost:8126")
+    aggr.writer = writer
+    span = Span("span", on_finish=[aggr.on_span_finish])
+    aggr.on_span_start(span)
+
+    with (
+        mock.patch.object(writer, "recreate") as mock_recreate,
+        mock.patch.object(writer, "reset_after_fork") as mock_reset_after_fork,
+    ):
+        mock_reset_after_fork.return_value = writer
+        aggr.reset_after_fork()
+
+    mock_recreate.assert_not_called()
+    mock_reset_after_fork.assert_called_once_with()
+    assert aggr.writer is writer
+    assert not aggr._traces
+    assert not aggr._span_metrics["spans_created"]
+
+
 def test_aggregator_bad_processor():
     class Proc(TraceProcessor):
         def process_trace(self, trace):

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -1890,6 +1890,55 @@ def test_fork_manual_span_same_context():
     assert exit_code == 12
 
 
+def test_child_after_fork_resets_writer_without_recreating_it(tracer):
+    with (
+        mock.patch.object(tracer._span_aggregator, "reset_after_fork") as mock_reset_after_fork,
+        mock.patch.object(tracer._span_aggregator, "reset") as mock_reset,
+    ):
+        tracer._child_after_fork()
+
+    mock_reset_after_fork.assert_called_once_with()
+    mock_reset.assert_not_called()
+
+
+@pytest.mark.subprocess(timeout=10, err=None, env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
+def test_child_after_fork_does_not_shutdown_inherited_native_exporter():
+    import os
+    import threading
+    import time
+
+    from ddtrace.trace import tracer
+
+    class BlockingExporter:
+        def shutdown(self, timeout):
+            threading.Event().wait()
+
+        def drop(self):
+            return None
+
+    writer = tracer._span_aggregator.writer
+    original_exporter = writer._exporter
+    writer._exporter = BlockingExporter()
+    pid = os.fork()
+
+    if pid == 0:
+        os._exit(0)
+
+    writer._exporter = original_exporter
+    deadline = time.monotonic() + 3
+    while time.monotonic() < deadline:
+        child_pid, status = os.waitpid(pid, os.WNOHANG)
+        if child_pid == pid:
+            assert os.WIFEXITED(status)
+            assert os.WEXITSTATUS(status) == 0
+            break
+        time.sleep(0.01)
+    else:
+        os.kill(pid, 9)
+        os.waitpid(pid, 0)
+        raise AssertionError("child blocked while resetting the inherited native exporter")
+
+
 @pytest.mark.subprocess(err=None, env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
 def test_fork_manual_span_different_contexts():
     import ddtrace.auto  # noqa

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -21,6 +21,7 @@ from ddtrace.internal.encoding import MSGPACK_ENCODERS
 from ddtrace.internal.native._native import IoError
 from ddtrace.internal.native._native import NetworkError
 from ddtrace.internal.runtime import get_runtime_id
+from ddtrace.internal.service import ServiceStatus
 from ddtrace.internal.settings._opentelemetry import ExporterConfig
 from ddtrace.internal.settings._opentelemetry import _is_otlp_traces_exporter_enabled
 from ddtrace.internal.uds import UDSHTTPConnection
@@ -993,6 +994,40 @@ def test_writer_recreate_keeps_response_callback():
     assert writer._response_cb is response_callback
 
 
+def test_native_writer_reset_after_fork_discards_exporter_without_shutdown():
+    writer = NativeWriter("http://dne:1234")
+    old_exporter = mock.Mock(spec=writer._exporter)
+    writer._exporter = old_exporter
+    old_clients = list(writer._clients)
+
+    writer.reset_after_fork()
+
+    old_exporter.drop.assert_called_once_with()
+    old_exporter.shutdown.assert_not_called()
+    assert writer._exporter is not old_exporter
+    assert writer._clients != old_clients
+    assert writer._worker is None
+    assert writer.status == ServiceStatus.STOPPED
+
+
+def test_http_writer_reset_after_fork_drops_connection_and_buffer():
+    writer = AgentlessTraceWriter("http://dne:1234", "api-key")
+    writer._encoder.put([Span("span")])
+    connection = mock.Mock()
+    writer._conn = connection
+    old_clients = list(writer._clients)
+
+    reset_writer = writer.reset_after_fork()
+
+    connection.close.assert_called_once_with()
+    assert reset_writer is writer
+    assert writer._conn is None
+    assert writer._clients != old_clients
+    assert len(writer._encoder) == 0
+    assert writer._worker is None
+    assert writer.status == ServiceStatus.STOPPED
+
+
 @pytest.mark.parametrize(
     "sys_platform, api_version, ddtrace_api_version, raises_error, expected",
     [
@@ -1154,6 +1189,7 @@ def test_writer_telemetry_enabled_on_linux(
         "set_tracer_version",
         "set_git_commit_sha",
         "set_client_computed_top_level",
+        "set_restart_after_fork",
         "set_input_format",
         "set_output_format",
         "enable_telemetry",
@@ -1163,6 +1199,8 @@ def test_writer_telemetry_enabled_on_linux(
     with mock_sys_platform(platform):
         with override_global_config(dict(_telemetry_enabled=config_value)):
             _writer = NativeWriter("http://localhost:8126/v0.5/traces", sync_mode=True)
+
+            mock_builder.set_restart_after_fork.assert_called_once_with(False)
 
             if expected_enabled:
                 mock_builder.enable_telemetry.assert_called_once_with(60000, get_runtime_id(), config._debug_mode)


### PR DESCRIPTION
## Description

Fix the fork-child exporter lifecycle that caused the flaky Python 3.13 Gunicorn shutdown hang in `test_iast_vulnerable_request_downstream_django[gunicorn_django_server-config5]`.

The Gunicorn master creates the native trace exporter before forking. The shared native runtime then restarted exporter workers in the child, while the tracer's child fork hook recreated the writer by shutting down that inherited exporter with a timeout. The native worker-stop operation is not cancellation-safe, so timing out that shutdown can leave the child's exporter runtime partially stopped. The later `/shutdown` request then waits indefinitely in the real `tracer.shutdown()` call.

This change makes the fork boundary ownership explicit:

- native exporter workers are not restarted automatically in a child;
- the child fork hook discards inherited exporter state without blocking and builds child-owned state;
- inherited trace buffers, connections, metrics, and processor state are cleared;
- the Django test application keeps its normal unbounded `tracer.shutdown()` call.

The regression test installs an inherited exporter whose `shutdown()` blocks forever, forks, and verifies that the child reset completes without calling it. This tests the deadlock boundary directly instead of hiding it behind a shorter timeout.

## Testing

- `./scripts/lint checks`
- `cargo fmt --manifest-path src/native/Cargo.toml -- --check`
- `cargo check --manifest-path src/native/Cargo.toml`
- Python 3.13 focused tracer fork/reset tests: 11 passed
- Python 3.13 latest-Django exact Gunicorn config5 test: passed twice with unbounded tracer shutdown
- Before the causal change, the exact test also passed more than 20 consecutive times naturally; the deterministic blocking-exporter regression is therefore the primary proof of the fixed lifecycle boundary

## Risks

Limited to post-fork writer initialization. Parent-process behavior is unchanged. Forked children now discard inherited buffers and connections and create their own exporter, rather than trying to stop inherited native workers. Custom trace writers retain the existing recreate behavior through the default `reset_after_fork()` implementation.

## Additional Notes

- Includes a customer-facing fix release note.
- Related to #18929, but also accounts for libdatadog v38's exporter-worker restart-after-fork behavior.
