### PR TITLE
ci: fix baseline detect uv output

### DIFF
--- a/scripts/_uv-bootstrap.sh
+++ b/scripts/_uv-bootstrap.sh
@@ -23,13 +23,13 @@ ensure_uv() {
     fi
   done
 
-  echo "[uv] uv not found, installing..."
+  echo "[uv] uv not found, installing..." >&2
   if [[ "$OSTYPE" == "darwin"* ]] || command -v brew >/dev/null 2>&1; then
-    echo "[uv] Installing via Homebrew..."
-    brew install uv
+    echo "[uv] Installing via Homebrew..." >&2
+    brew install uv >&2
   else
-    echo "[uv] Installing via installer script..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    echo "[uv] Installing via installer script..." >&2
+    curl -LsSf https://astral.sh/uv/install.sh | sh >&2
   fi
 
   for path in "${CANDIDATE_PATHS[@]}"; do
@@ -39,6 +39,6 @@ ensure_uv() {
     fi
   done
 
-  echo "[uv] ERROR: uv installation failed or not found in PATH."
+  echo "[uv] ERROR: uv installation failed or not found in PATH." >&2
   return 1
 }


### PR DESCRIPTION
## Description

The original fix PR #19339 never tested the behavior when running on the `main` branch directly. It causes `uv` to output some unnecessary logs to stdout causing the dotenv creation/uploading to fail.

This PR fixes the `uv` logging issue.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
