### PR TITLE
test(appsec): clean up module hooks on unpatch

### DIFF
--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -81,8 +81,6 @@ def unpatch_common_modules():
     try_unwrap("urllib.request", "OpenerDirector.open")
     try_unwrap("http.client", "HTTPConnection.request")
     try_unwrap("http.client", "HTTPConnection.getresponse")
-    try_unwrap("_io", "BytesIO.read")
-    try_unwrap("_io", "StringIO.read")
 
     unpatch_stripe_for_appsec()
 

--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -32,19 +32,21 @@ _RASP_SYSTEM = "rasp_os.system"
 _RASP_POPEN = "rasp_Popen"
 
 
+def _patch_subprocess(module):
+    # ensure that the subprocess patch is applied even after one click activation
+    subprocess_patch.patch()
+    subprocess_patch.add_str_callback(_RASP_SYSTEM, wrapped_system_5542593D237084A7)
+    subprocess_patch.add_lst_callback(_RASP_POPEN, popen_FD233052260D8B4D)
+    log.debug("Patching common modules: subprocess_patch")
+
+
 def patch_common_modules():
     global _is_patched
 
-    @ModuleWatchdog.after_module_imported("subprocess")
-    def _(module):
-        # ensure that the subprocess patch is applied even after one click activation
-        subprocess_patch.patch()
-        subprocess_patch.add_str_callback(_RASP_SYSTEM, wrapped_system_5542593D237084A7)
-        subprocess_patch.add_lst_callback(_RASP_POPEN, popen_FD233052260D8B4D)
-        log.debug("Patching common modules: subprocess_patch")
-
     if _is_patched:
         return
+
+    ModuleWatchdog.register_module_hook("subprocess", _patch_subprocess)
 
     try_wrap_function_wrapper(
         "urllib3.connectionpool", "HTTPConnectionPool._make_request", wrapped_urllib3_make_request_6D4E8B2A1F095C73
@@ -71,6 +73,7 @@ def unpatch_common_modules():
         return
 
     try_unwrap("urllib3.connectionpool", "HTTPConnectionPool._make_request")
+    try_unwrap("urllib3.connectionpool", "HTTPConnectionPool.urlopen")
     try_unwrap("urllib3._request_methods", "RequestMethods.request")
     try_unwrap("urllib3.request", "RequestMethods.request")
     try_unwrap("builtins", "open")
@@ -86,6 +89,7 @@ def unpatch_common_modules():
     subprocess_patch.unpatch()
     subprocess_patch.del_str_callback(_RASP_SYSTEM)
     subprocess_patch.del_lst_callback(_RASP_POPEN)
+    ModuleWatchdog.unregister_module_hook("subprocess", _patch_subprocess)
 
     log.debug("Unpatching common modules subprocess, builtins and urllib.request")
     _is_patched = False

--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -81,6 +81,7 @@ def unpatch_common_modules():
     try_unwrap("urllib.request", "OpenerDirector.open")
     try_unwrap("http.client", "HTTPConnection.request")
     try_unwrap("http.client", "HTTPConnection.getresponse")
+    core.reset_listeners("asm.block.dbapi.execute", execute_4C9BAC8E228EB347)
 
     unpatch_stripe_for_appsec()
 

--- a/ddtrace/appsec/_patch_utils.py
+++ b/ddtrace/appsec/_patch_utils.py
@@ -77,9 +77,21 @@ def get_caller_frame_info() -> tuple:
 
 
 _DD_ORIGINAL_ATTRIBUTES: dict[Any, Any] = {}
+_MODULE_HOOKS: dict[tuple[str, str], list[Callable[[Any], None]]] = {}
+
+
+def _module_name(module: Any) -> str:
+    return module if isinstance(module, str) else module.__name__
+
+
+def _unregister_module_hooks(module: Any, name: str) -> None:
+    module_name = _module_name(module)
+    for hook in _MODULE_HOOKS.pop((module_name, name), ()):
+        ModuleWatchdog.unregister_module_hook(module_name, hook)
 
 
 def try_unwrap(module: Any, name: str) -> None:
+    _unregister_module_hooks(module, name)
     try:
         (parent, attribute, _) = resolve_path(module, name)
         if (parent, attribute) in _DD_ORIGINAL_ATTRIBUTES:
@@ -91,12 +103,14 @@ def try_unwrap(module: Any, name: str) -> None:
 
 
 def try_wrap_function_wrapper(module_name: str, name: str, wrapper: Callable[..., Any]) -> None:
-    @ModuleWatchdog.after_module_imported(module_name)
     def _(module: Any) -> None:
         try:
             wrap_object(module, name, FunctionWrapper, (wrapper,))
         except (ImportError, AttributeError):
             log.debug("Module %s.%s does not exist", module_name, name)
+
+    _MODULE_HOOKS.setdefault((module_name, name), []).append(_)
+    ModuleWatchdog.register_module_hook(module_name, _)
 
 
 def wrap_object(

--- a/tests/appsec/appsec/test_common_modules.py
+++ b/tests/appsec/appsec/test_common_modules.py
@@ -11,6 +11,7 @@ from ddtrace.appsec._common_module_patches import try_wrap_function_wrapper
 from ddtrace.appsec._common_module_patches import unpatch_common_modules
 from ddtrace.appsec._common_module_patches import wrapped_urllib3_urlopen
 from ddtrace.internal import core
+from ddtrace.internal.module import ModuleWatchdog
 
 
 def test_patch_read():
@@ -38,6 +39,26 @@ def test_patch_read_enabled():
         assert open.__wrapped__ is original_open
     finally:
         unpatch_common_modules()
+
+
+def test_patch_common_modules_unregisters_module_hooks():
+    unpatch_common_modules()
+    watchdog = ModuleWatchdog._instance
+    assert watchdog is not None
+    initial_hooks = {module: tuple(hooks) for module, hooks in watchdog._hook_map.items() if hooks}
+
+    try:
+        patch_common_modules()
+        patched_hooks = sum(len(hooks) for hooks in watchdog._hook_map.values())
+        assert patched_hooks > sum(len(hooks) for hooks in initial_hooks.values())
+
+        patch_common_modules()
+        assert sum(len(hooks) for hooks in watchdog._hook_map.values()) == patched_hooks
+    finally:
+        unpatch_common_modules()
+
+    remaining_hooks = {module: tuple(hooks) for module, hooks in watchdog._hook_map.items() if hooks}
+    assert remaining_hooks == initial_hooks
 
 
 @pytest.mark.parametrize(

--- a/tests/appsec/appsec/test_common_modules.py
+++ b/tests/appsec/appsec/test_common_modules.py
@@ -5,6 +5,7 @@ import types
 import pytest
 from wrapt import FunctionWrapper
 
+from ddtrace.appsec._common_module_patches import execute_4C9BAC8E228EB347
 from ddtrace.appsec._common_module_patches import patch_common_modules
 from ddtrace.appsec._common_module_patches import try_unwrap
 from ddtrace.appsec._common_module_patches import try_wrap_function_wrapper
@@ -59,6 +60,20 @@ def test_patch_common_modules_unregisters_module_hooks():
 
     remaining_hooks = {module: tuple(hooks) for module, hooks in watchdog._hook_map.items() if hooks}
     assert remaining_hooks == initial_hooks
+
+
+def test_patch_common_modules_unregisters_dbapi_listener():
+    event = "asm.block.dbapi.execute"
+    unpatch_common_modules()
+    core.reset_listeners(event, execute_4C9BAC8E228EB347)
+
+    try:
+        patch_common_modules()
+        assert core.has_listeners(event)
+    finally:
+        unpatch_common_modules()
+
+    assert not core.has_listeners(event)
 
 
 @pytest.mark.parametrize(

--- a/tests/appsec/appsec/test_exploit_prevention.py
+++ b/tests/appsec/appsec/test_exploit_prevention.py
@@ -6,6 +6,7 @@ import traceback
 import pytest
 
 import ddtrace.appsec._common_module_patches as cmp
+from ddtrace.internal.module import ModuleWatchdog
 
 
 def test_lfi_normal_exception():
@@ -82,6 +83,10 @@ def test_wrapping_twice():
     def wrapper2(original, instance, args, kargs):
         return original("C" + args[0])
 
+    watchdog = ModuleWatchdog._instance
+    assert watchdog is not None
+    initial_hooks = len(watchdog._hook_map.get(__name__, ()))
+
     assert get_result("1") == "A1"
     cmp.try_wrap_function_wrapper(__name__, "get_result", wrapper1)
     assert get_result("1") == "AB1"
@@ -93,6 +98,7 @@ def test_wrapping_twice():
     assert get_result("1") == "ABC1"
     cmp.try_unwrap(__name__, "get_result")
     assert get_result("1") == "A1"
+    assert len(watchdog._hook_map.get(__name__, ())) == initial_hooks
     cmp.try_wrap_function_wrapper(__name__, "get_result", wrapper1)
     assert get_result("1") == "AB1"
     # second wrap with same wrapper is ignored
@@ -100,3 +106,4 @@ def test_wrapping_twice():
     assert get_result("1") == "AB1"
     cmp.try_unwrap(__name__, "get_result")
     assert get_result("1") == "A1"
+    assert len(watchdog._hook_map.get(__name__, ())) == initial_hooks


### PR DESCRIPTION
## Description

Improves AppSec and IAST test isolation by releasing callbacks across patch/unpatch cycles.

The test teardown helpers restored wrapped functions but left their lazy module-import hooks and DBAPI event listener registered. Repeated IAST fixture cycles therefore accumulated callbacks and made serial randomized runs order-dependent.

This change:
- tracks lazy hooks alongside each wrapped target and unregisters them during test teardown;
- makes the subprocess import hook stable and removable;
- unregisters the `asm.block.dbapi.execute` listener during teardown;
- restores the missing `HTTPConnectionPool.urlopen` teardown;
- removes stale `BytesIO.read` and `StringIO.read` teardown left behind when their instrumentation moved to AST aspects;
- adds regression coverage verifying the hook map and DBAPI listener return to their initial state.

The production lifecycle does not call these unpatch helpers, so this is scoped as test infrastructure rather than a runtime fix.

The touched LFI test file already contained the generic `test_wrapping_twice` helper lifecycle test. Its LFI assertions are unchanged; the new assertions only verify that each `try_unwrap()` returns the watchdog hook count for that test module to its baseline.

## Testing

- Focused common-module and exploit-prevention lifecycle tests: 79 passed.
- `scripts/lint checks`: passed.

## Risks

Low. Changes are limited to internal teardown paths used by tests. Patch behavior remains unchanged.

## Additional Notes

No release note; this is test-only lifecycle cleanup.