### PR TITLE
test(appsec): isolate remote configuration state

### DIFF
--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -32,19 +32,21 @@ _RASP_SYSTEM = "rasp_os.system"
 _RASP_POPEN = "rasp_Popen"
 
 
+def _patch_subprocess(module):
+    # ensure that the subprocess patch is applied even after one click activation
+    subprocess_patch.patch()
+    subprocess_patch.add_str_callback(_RASP_SYSTEM, wrapped_system_5542593D237084A7)
+    subprocess_patch.add_lst_callback(_RASP_POPEN, popen_FD233052260D8B4D)
+    log.debug("Patching common modules: subprocess_patch")
+
+
 def patch_common_modules():
     global _is_patched
 
-    @ModuleWatchdog.after_module_imported("subprocess")
-    def _(module):
-        # ensure that the subprocess patch is applied even after one click activation
-        subprocess_patch.patch()
-        subprocess_patch.add_str_callback(_RASP_SYSTEM, wrapped_system_5542593D237084A7)
-        subprocess_patch.add_lst_callback(_RASP_POPEN, popen_FD233052260D8B4D)
-        log.debug("Patching common modules: subprocess_patch")
-
     if _is_patched:
         return
+
+    ModuleWatchdog.register_module_hook("subprocess", _patch_subprocess)
 
     try_wrap_function_wrapper(
         "urllib3.connectionpool", "HTTPConnectionPool._make_request", wrapped_urllib3_make_request_6D4E8B2A1F095C73
@@ -71,6 +73,7 @@ def unpatch_common_modules():
         return
 
     try_unwrap("urllib3.connectionpool", "HTTPConnectionPool._make_request")
+    try_unwrap("urllib3.connectionpool", "HTTPConnectionPool.urlopen")
     try_unwrap("urllib3._request_methods", "RequestMethods.request")
     try_unwrap("urllib3.request", "RequestMethods.request")
     try_unwrap("builtins", "open")
@@ -86,6 +89,7 @@ def unpatch_common_modules():
     subprocess_patch.unpatch()
     subprocess_patch.del_str_callback(_RASP_SYSTEM)
     subprocess_patch.del_lst_callback(_RASP_POPEN)
+    ModuleWatchdog.unregister_module_hook("subprocess", _patch_subprocess)
 
     log.debug("Unpatching common modules subprocess, builtins and urllib.request")
     _is_patched = False

--- a/ddtrace/appsec/_patch_utils.py
+++ b/ddtrace/appsec/_patch_utils.py
@@ -77,9 +77,21 @@ def get_caller_frame_info() -> tuple:
 
 
 _DD_ORIGINAL_ATTRIBUTES: dict[Any, Any] = {}
+_MODULE_HOOKS: dict[tuple[str, str], list[Callable[[Any], None]]] = {}
+
+
+def _module_name(module: Any) -> str:
+    return module if isinstance(module, str) else module.__name__
+
+
+def _unregister_module_hooks(module: Any, name: str) -> None:
+    module_name = _module_name(module)
+    for hook in _MODULE_HOOKS.pop((module_name, name), ()):
+        ModuleWatchdog.unregister_module_hook(module_name, hook)
 
 
 def try_unwrap(module: Any, name: str) -> None:
+    _unregister_module_hooks(module, name)
     try:
         (parent, attribute, _) = resolve_path(module, name)
         if (parent, attribute) in _DD_ORIGINAL_ATTRIBUTES:
@@ -91,12 +103,14 @@ def try_unwrap(module: Any, name: str) -> None:
 
 
 def try_wrap_function_wrapper(module_name: str, name: str, wrapper: Callable[..., Any]) -> None:
-    @ModuleWatchdog.after_module_imported(module_name)
     def _(module: Any) -> None:
         try:
             wrap_object(module, name, FunctionWrapper, (wrapper,))
         except (ImportError, AttributeError):
             log.debug("Module %s.%s does not exist", module_name, name)
+
+    _MODULE_HOOKS.setdefault((module_name, name), []).append(_)
+    ModuleWatchdog.register_module_hook(module_name, _)
 
 
 def wrap_object(

--- a/tests/appsec/appsec/test_common_modules.py
+++ b/tests/appsec/appsec/test_common_modules.py
@@ -11,6 +11,7 @@ from ddtrace.appsec._common_module_patches import try_wrap_function_wrapper
 from ddtrace.appsec._common_module_patches import unpatch_common_modules
 from ddtrace.appsec._common_module_patches import wrapped_urllib3_urlopen
 from ddtrace.internal import core
+from ddtrace.internal.module import ModuleWatchdog
 
 
 def test_patch_read():
@@ -38,6 +39,26 @@ def test_patch_read_enabled():
         assert open.__wrapped__ is original_open
     finally:
         unpatch_common_modules()
+
+
+def test_patch_common_modules_unregisters_module_hooks():
+    unpatch_common_modules()
+    watchdog = ModuleWatchdog._instance
+    assert watchdog is not None
+    initial_hooks = {module: tuple(hooks) for module, hooks in watchdog._hook_map.items() if hooks}
+
+    try:
+        patch_common_modules()
+        patched_hooks = sum(len(hooks) for hooks in watchdog._hook_map.values())
+        assert patched_hooks > sum(len(hooks) for hooks in initial_hooks.values())
+
+        patch_common_modules()
+        assert sum(len(hooks) for hooks in watchdog._hook_map.values()) == patched_hooks
+    finally:
+        unpatch_common_modules()
+
+    remaining_hooks = {module: tuple(hooks) for module, hooks in watchdog._hook_map.items() if hooks}
+    assert remaining_hooks == initial_hooks
 
 
 @pytest.mark.parametrize(

--- a/tests/appsec/appsec/test_exploit_prevention.py
+++ b/tests/appsec/appsec/test_exploit_prevention.py
@@ -6,6 +6,7 @@ import traceback
 import pytest
 
 import ddtrace.appsec._common_module_patches as cmp
+from ddtrace.internal.module import ModuleWatchdog
 
 
 def test_lfi_normal_exception():
@@ -82,6 +83,10 @@ def test_wrapping_twice():
     def wrapper2(original, instance, args, kargs):
         return original("C" + args[0])
 
+    watchdog = ModuleWatchdog._instance
+    assert watchdog is not None
+    initial_hooks = len(watchdog._hook_map.get(__name__, ()))
+
     assert get_result("1") == "A1"
     cmp.try_wrap_function_wrapper(__name__, "get_result", wrapper1)
     assert get_result("1") == "AB1"
@@ -93,6 +98,7 @@ def test_wrapping_twice():
     assert get_result("1") == "ABC1"
     cmp.try_unwrap(__name__, "get_result")
     assert get_result("1") == "A1"
+    assert len(watchdog._hook_map.get(__name__, ())) == initial_hooks
     cmp.try_wrap_function_wrapper(__name__, "get_result", wrapper1)
     assert get_result("1") == "AB1"
     # second wrap with same wrapper is ignored
@@ -100,3 +106,4 @@ def test_wrapping_twice():
     assert get_result("1") == "AB1"
     cmp.try_unwrap(__name__, "get_result")
     assert get_result("1") == "A1"
+    assert len(watchdog._hook_map.get(__name__, ())) == initial_hooks

--- a/tests/appsec/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/appsec/test_remoteconfiguration.py
@@ -4,9 +4,12 @@ import time
 import mock
 import pytest
 
+from ddtrace._trace.processor import SpanProcessor
 from ddtrace.appsec._capabilities import _appsec_rc_capabilities
+import ddtrace.appsec._common_module_patches as common_module_patches
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import DEFAULT
+from ddtrace.appsec._listeners import disable_appsec
 from ddtrace.appsec._processor import AppSecSpanProcessor
 from ddtrace.appsec._remoteconfiguration import _appsec_callback
 from ddtrace.appsec._remoteconfiguration import disable_appsec_rc
@@ -26,11 +29,35 @@ from tests.utils import override_env
 from tests.utils import override_global_config
 
 
+def _appsec_remote_config_state():
+    return {
+        "api_security_active": asm_config._api_security_active,
+        "rc_client_id": asm_config._rc_client_id,
+        "appsec_processor": AppSecSpanProcessor._instance,
+        "span_processors": tuple(SpanProcessor.__processors__),
+        "common_modules_patched": common_module_patches._is_patched,
+        "appsec_callback_cache": dict(_appsec_callback._cache),
+    }
+
+
 @pytest.fixture(autouse=True)
-def patch_remoteconfig_poller_for_appsec(rc_poller):
-    """Patch the global remoteconfig_poller with the test fixture for appsec tests."""
-    with mock.patch("ddtrace.appsec._remoteconfiguration.remoteconfig_poller", rc_poller):
-        yield
+def isolate_appsec_remote_config(rc_poller):
+    """Isolate every AppSec remote-config test from process-global security state."""
+    initial_state = _appsec_remote_config_state()
+    with (
+        mock.patch("ddtrace.appsec._remoteconfiguration.remoteconfig_poller", rc_poller),
+        mock.patch.object(asm_config, "_rc_client_id", None),
+        mock.patch.object(_appsec_callback, "_cache", {}),
+        override_global_config({}),
+    ):
+        try:
+            yield
+        finally:
+            disable_appsec_rc()
+            disable_appsec()
+            common_module_patches.unpatch_common_modules()
+
+    assert _appsec_remote_config_state() == initial_state
 
 
 def _set_and_get_appsec_tags(tracer, check_client_id=False):
@@ -206,8 +233,6 @@ def test_rc_capabilities_updated_after_one_click_activation(tracer, rc_poller):
         assert advertised().isdisjoint(_ALL_ASM_BLOCKING)
         assert advertised() == set(_rc_capabilities())
 
-    disable_appsec_rc()
-
 
 def test_rc_activation_validate_products(tracer, rc_poller):
     with override_global_config(dict(_asm_enabled=False, _remote_config_enabled=True, api_version="v0.4")):
@@ -216,7 +241,6 @@ def test_rc_activation_validate_products(tracer, rc_poller):
         enable_appsec_rc()
 
         assert rc_poller._client._product_callbacks[RemoteConfigProduct.AsmFeatures]
-    disable_appsec_rc()
 
 
 def test_rc_activation_validate_client_id(tracer, rc_poller):
@@ -224,7 +248,6 @@ def test_rc_activation_validate_client_id(tracer, rc_poller):
         tracer.configure(appsec_enabled=True)
         enable_appsec_rc()
         _set_and_get_appsec_tags(tracer, True)
-    disable_appsec_rc()
 
 
 @pytest.mark.parametrize(
@@ -292,8 +315,6 @@ def test_rc_activation_check_asm_features_product_disables_rest_of_products(
         assert bool(rc_poller._client._product_callbacks.get(RemoteConfigProduct.Asm)) is expected
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmFeatures)
 
-    disable_appsec_rc()
-
 
 @pytest.mark.parametrize("auto_user", [True, False])
 def test_rc_activation_with_auto_user_appsec_fixed(tracer, rc_poller, auto_user):
@@ -314,8 +335,6 @@ def test_rc_activation_with_auto_user_appsec_fixed(tracer, rc_poller, auto_user)
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmData)
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.Asm)
         assert bool(rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmFeatures)) == auto_user
-
-    disable_appsec_rc()
 
 
 def test_rc_activation_ip_blocking_data(tracer, rc_poller):
@@ -413,8 +432,6 @@ def test_rc_activation_does_not_report_appsec_product_when_only_rc_enabled(trace
             # Telemetry should NOT report AppSec as activated
             mock_tw.product_activated.assert_not_called()
 
-    disable_appsec_rc()
-
 
 def test_rc_activation_reports_appsec_product_when_enabled(tracer, rc_poller):
     """When AppSec is explicitly enabled, enable_appsec_rc should report the product as activated."""
@@ -424,8 +441,6 @@ def test_rc_activation_reports_appsec_product_when_enabled(tracer, rc_poller):
             enable_appsec_rc()
 
             mock_tw.product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, True)
-
-    disable_appsec_rc()
 
 
 def test_rc_enable_then_disable_asm_reports_telemetry(tracer, rc_poller):
@@ -448,5 +463,3 @@ def test_rc_enable_then_disable_asm_reports_telemetry(tracer, rc_poller):
             disable_config = [build_payload("ASM_FEATURES", {"asm": {}}, "config")]
             _appsec_callback(disable_config)
             mock_tw.product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, False)
-
-    disable_appsec_rc()


### PR DESCRIPTION
## Description

Makes every AppSec remote-configuration unit test run inside the same complete lifecycle boundary.

The existing autouse fixture replaced only the remote-config poller. Tests still shared the AppSec processor, API Security manager, common-module patch state, RC client identity, and callback cache. Individual tests attempted partial cleanup with scattered `disable_appsec_rc()` calls, which left process-global state behind and made serial randomized runs order-dependent.

The enriched autouse fixture uniformly:
- snapshots the relevant process-global security state before each test and asserts exact restoration after teardown;
- provides an isolated poller, RC client identity, and callback cache;
- snapshots and restores the full AppSec configuration through the existing config override helper;
- tears down remote configuration, AppSec services, and common-module patches through their lifecycle APIs;
- applies to every test in the module, including failures during setup, calls, or teardown.

This directly covers the state reported by the disposable detector: API Security activation, RC client identity, the AppSec processor singleton and global processor registry, common-module patch state, and the AppSec callback cache.

This is a testing-only problem. Production initializes this state once during product startup and does not exercise the repeated test patch/unpatch lifecycle.

## Testing

- Focused remote-config module: 32 passed, 1 expected xfail; the fixture post-teardown invariant passed for every test.
- Disposable detector on the equivalent lifecycle behavior: 0 mutations.
- Full serial AppSec suite: 674 passed, 2 expected xfails.
- `scripts/lint checks`: passed.
- Targeted test-file typing reaches two existing exclusions: missing `mock` stubs and the non-exported `tests.appsec.utils.build_payload` helper. The repository configured full typing check passes.

## Risks

Low. The change is confined to AppSec remote-configuration test fixtures. A test that intentionally depends on process-global persistence will now fail its fixture teardown, which makes that dependency explicit.

## Additional Notes

This is stacked on #19460 because safe common-module teardown requires its watchdog-hook unregistration. Retarget to `main` after #19460 lands.

No release note; test-only lifecycle cleanup.
