### PR TITLE
fix(django): don't force ROOT_URLCONF import during django.setup()

### DIFF
--- a/ddtrace/contrib/internal/django/patch.py
+++ b/ddtrace/contrib/internal/django/patch.py
@@ -11,6 +11,7 @@ import asyncio
 from inspect import getmro
 from inspect import iscoroutinefunction
 from inspect import unwrap
+import sys
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
@@ -170,15 +171,18 @@ def traced_populate(django, pin, func, instance, args, kwargs):
         except Exception:
             log.debug("Error patching rest_framework", exc_info=True)
 
-    # Eager endpoint discovery: walk the ROOT_URLCONF resolver now that apps
-    # are ready, so the telemetry "app-endpoints" payload is populated at
-    # startup (not only when a request arrives). Dynamic per-tenant urlconfs
-    # set by middleware are still picked up by the per-request walk in
-    # traced_get_response / traced_get_response_async.
+    # Eager endpoint discovery, but only for a URLconf that is already imported.
+    # Reading resolver.url_patterns imports ROOT_URLCONF and, through include(),
+    # every view module behind it. A process that never serves a request (worker,
+    # management command, cron) would otherwise load that whole graph for nothing.
+    # When the walk is skipped, the per-request walk in traced_get_response /
+    # traced_get_response_async still collects the endpoints.
     try:
         from django.urls import get_resolver
 
-        _collect_routes_once(get_resolver(None))
+        root_urlconf = getattr(settings, "ROOT_URLCONF", None)
+        if root_urlconf is not None and root_urlconf in sys.modules:
+            _collect_routes_once(get_resolver(None))
     except Exception:
         log.debug("Error collecting Django routes for endpoint discovery", exc_info=True)
 

--- a/releasenotes/notes/fix-django-eager-urlconf-import-5b0e79e33ea3e7e8.yaml
+++ b/releasenotes/notes/fix-django-eager-urlconf-import-5b0e79e33ea3e7e8.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    django: Fixes an issue where ``django.setup()`` imported ``ROOT_URLCONF`` and every module
+    reachable from it, causing large resident memory increases and slower startup in processes that
+    never serve HTTP requests, such as Celery and dramatiq workers, management commands, and cron
+    jobs. API endpoint discovery now walks the URLconf at startup only when it is already imported,
+    and otherwise collects the same routes on the first request.

--- a/tests/contrib/django/test_django_patch.py
+++ b/tests/contrib/django/test_django_patch.py
@@ -72,3 +72,27 @@ def test_tracing_minimal_patching():
     from ddtrace.internal.wrapping import is_wrapped
 
     assert is_wrapped(django.template.base.Template.render)
+
+
+@pytest.mark.subprocess(
+    ddtrace_run=True,
+    env={"DJANGO_SETTINGS_MODULE": "tests.contrib.django.django_app.settings"},
+)
+def test_setup_does_not_import_root_urlconf():
+    """django.setup() must not pull in ROOT_URLCONF.
+
+    Reading resolver.url_patterns imports the URLconf and the entire view import
+    closure behind it. Processes that never serve a request (Celery/dramatiq
+    workers, management commands, cron jobs) would otherwise load all of it for
+    nothing, which cost one reporter 150MB of RSS per worker.
+    """
+    import sys
+
+    import django
+    from django.conf import settings
+
+    django.setup()
+
+    assert settings.ROOT_URLCONF not in sys.modules, (
+        f"django.setup() imported {settings.ROOT_URLCONF}; endpoint discovery must stay lazy"
+    )


### PR DESCRIPTION
## Description

Fixes #19454.

`traced_populate` ends by calling `_collect_routes_once(get_resolver(None))`, so endpoint discovery
walks the root resolver during `django.setup()`. Reading `resolver.url_patterns` imports
`ROOT_URLCONF`, which through `include()` imports every view module and everything those views pull
in behind them.

Processes that never serve a request pay for that whole graph. The reporter's dramatiq worker loaded
977 extra modules and 308k extra live GC objects at boot, worth 154 MB of RSS per worker, none of
which the worker had any use for. On 4.8.13 the URLconf was never imported in that process at all.
The cost tracks the import closure behind the routes rather than the route count.

This guards the walk on `ROOT_URLCONF` already being present in `sys.modules`. `include("app.urls")`
imports its submodule eagerly at root-import time, so the root module being loaded implies the rest
of the tree is too, and the walk then forces nothing. A process that has not loaded its URLconf skips
the walk and the existing per-request walk in `traced_get_response` /`traced_get_response_async`
collects the same endpoints; `_report_endpoints` runs on every telemetry heartbeat rather than only
in the app-started payload, so they still get published.

Keeping the walk rather than removing it preserves what #17695 was after: an app that has its URLconf
loaded at startup still publishes endpoints at startup.

The eager call arrived in #17695, so the regression is in every release from 4.9.0rc1 onward.

## Testing

`test_setup_does_not_import_root_urlconf` asserts `settings.ROOT_URLCONF` is absent from
`sys.modules` after `django.setup()` under `ddtrace-run`.

Measured against a generated Django project whose view modules are reachable only through the
URLconf, on Debian 13 / glibc 2.41 / aarch64 / Python 3.13:

| ddtrace | guard | URLconf already imported | RSS | urlconf imported | endpoints collected |
|---|---|---|---|---|---|
| 4.8.13 | – | no | 72.0 MB | no | 0 |
| 4.9.7 | no | no | 182.3 MB | yes | 240 |
| 4.9.7 | yes | no | 72.5 MB | no | 0 |
| 4.9.7 | yes | yes | 181.4 MB | yes | 240 |

The last row is the point of the guard over a plain removal: when the URLconf is already loaded,
startup collection still yields the full endpoint set.

On the reporter's production app, measured at the end of `django.setup()` in a dramatiq worker:
`sys.modules` goes from 6468 to 7443 and live GC objects from 893,789 to 1,184,595 between 4.8.13
and 4.9.0rc1, worth 580.2 MB against 733.5 MB of RSS. `malloc_trim(0)` reclaims 31.3 MB on 4.8.13
and 0.5 MB on 4.9.0rc1, and `malloc_info` reports zero free-but-retained bytes on both, so the
memory is live rather than fragmented.

The `contrib::django` suite passes. There is no unit test for the already-imported branch: the test
app's `urls.py` imports `django.contrib.auth.models.User` at module level, so it cannot be imported
before `django.setup()` to set that state up. The existing endpoint-collection tests in
`tests/appsec/contrib_appsec/test_django.py` cover the per-request walk.

## Risks

For a process whose URLconf is not yet imported at `django.setup()`, endpoint telemetry is now
published on the first request that uses it rather than at startup. For a service under traffic that
is a delay of one request; the payload is unchanged. Anything depending on `app-endpoints` arriving
in the app-started payload specifically would see it on a later heartbeat.

## Additional Notes

`DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED=false` skips the walk on affected versions and works as
a stopgap before upgrading, verified against the generated project above.

---

Note: This was created with the help of Claude 🤖 