### PR TITLE
fix(django): don't force ROOT_URLCONF import during django.setup()

### DIFF
--- a/ddtrace/contrib/internal/django/patch.py
+++ b/ddtrace/contrib/internal/django/patch.py
@@ -170,18 +170,8 @@ def traced_populate(django, pin, func, instance, args, kwargs):
         except Exception:
             log.debug("Error patching rest_framework", exc_info=True)
 
-    # Eager endpoint discovery: walk the ROOT_URLCONF resolver now that apps
-    # are ready, so the telemetry "app-endpoints" payload is populated at
-    # startup (not only when a request arrives). Dynamic per-tenant urlconfs
-    # set by middleware are still picked up by the per-request walk in
-    # traced_get_response / traced_get_response_async.
-    try:
-        from django.urls import get_resolver
-
-        _collect_routes_once(get_resolver(None))
-    except Exception:
-        log.debug("Error collecting Django routes for endpoint discovery", exc_info=True)
-
+    # Endpoint discovery must not run here: walking the root resolver imports ROOT_URLCONF and every view behind it,
+    # which a worker must not pay for. See traced_load_middleware.
     return ret
 
 
@@ -237,24 +227,36 @@ def traced_func(django, name, resource=None, ignored_excs=None):
 def traced_load_middleware(django, pin, func, instance, args, kwargs):
     """
     Patches django.core.handlers.base.BaseHandler.load_middleware to instrument all
-    middlewares.
+    middlewares and to trigger endpoint discovery.
     """
-    from ddtrace.contrib.internal.django.middleware import wrap_middleware
+    if config_django.instrument_middleware:
+        from ddtrace.contrib.internal.django.middleware import wrap_middleware
 
-    settings_middleware = []
-    # Gather all the middleware
-    if getattr(django.conf.settings, "MIDDLEWARE", None):
-        settings_middleware += django.conf.settings.MIDDLEWARE
-    if getattr(django.conf.settings, "MIDDLEWARE_CLASSES", None):
-        settings_middleware += django.conf.settings.MIDDLEWARE_CLASSES
+        settings_middleware = []
+        # Gather all the middleware
+        if getattr(django.conf.settings, "MIDDLEWARE", None):
+            settings_middleware += django.conf.settings.MIDDLEWARE
+        if getattr(django.conf.settings, "MIDDLEWARE_CLASSES", None):
+            settings_middleware += django.conf.settings.MIDDLEWARE_CLASSES
 
-    # Iterate over each middleware provided in settings.py
-    # Each middleware can either be a function or a class
-    for mw_path in settings_middleware:
-        mw = django.utils.module_loading.import_string(mw_path)
-        wrap_middleware(mw, mw_path)
+        # Iterate over each middleware provided in settings.py
+        # Each middleware can either be a function or a class
+        for mw_path in settings_middleware:
+            mw = django.utils.module_loading.import_string(mw_path)
+            wrap_middleware(mw, mw_path)
 
-    return func(*args, **kwargs)
+    ret = func(*args, **kwargs)
+
+    # Building a BaseHandler is the earliest reliable signal that this process serves HTTP, so the URLconf import
+    # forced here is one the first request would pay anyway. Dynamic per-tenant urlconfs still come from response.py.
+    try:
+        from django.urls import get_resolver
+
+        _collect_routes_once(get_resolver(None))
+    except Exception:
+        log.debug("Error collecting Django routes for endpoint discovery", exc_info=True)
+
+    return ret
 
 
 def instrument_view(django, view):
@@ -393,13 +395,12 @@ def _collect_django_routes(patterns: "Iterable[Union[URLPattern, URLResolver]]",
 def _collect_routes_once(resolver: "Optional[URLResolver]") -> None:
     """Populate endpoint_collection by walking resolver.url_patterns once per resolver.
 
-    Called from traced_get_response / traced_get_response_async on every
-    request. The WeakSet gate makes repeated calls O(1), and naturally handles
-    per-request request.urlconf swaps (each distinct urlconf gets its own
-    resolver from django.urls.get_resolver, walked on first use). When the
-    endpoint-collection flag is off, the walk is skipped entirely — telemetry
-    would discard the collected entries anyway, and if the flag is later
-    flipped on the WeakSet stays empty so the next request will walk.
+    Called once per BaseHandler from traced_load_middleware, and from traced_get_response /
+    traced_get_response_async on every request. The WeakSet gate makes repeated calls O(1), and naturally handles
+    per-request request.urlconf swaps (each distinct urlconf gets its own resolver from django.urls.get_resolver,
+    walked on first use). When the endpoint-collection flag is off, the walk is skipped entirely — telemetry would
+    discard the collected entries anyway, and if the flag is later flipped on the WeakSet stays empty so the next
+    request will walk.
     """
     if resolver is None or not appsec_telemetry_config.ENDPOINT_COLLECTION_ENABLED:
         return
@@ -560,10 +561,11 @@ def _patch(django):
 
     when_imported("django.apps.registry")(lambda m: trace_utils.wrap(m, "Apps.populate", traced_populate(django)))
 
-    if config_django.instrument_middleware:
-        when_imported("django.core.handlers.base")(
-            lambda m: trace_utils.wrap(m, "BaseHandler.load_middleware", traced_load_middleware(django))
-        )
+    # Always wrapped: endpoint discovery also hangs off load_middleware. traced_load_middleware checks
+    # instrument_middleware itself.
+    when_imported("django.core.handlers.base")(
+        lambda m: trace_utils.wrap(m, "BaseHandler.load_middleware", traced_load_middleware(django))
+    )
 
     when_imported("django.core.handlers.wsgi")(lambda m: trace_utils.wrap(m, "WSGIRequest.__init__", wrap_wsgi_environ))
     core.dispatch("django.patch", ())

--- a/ddtrace/contrib/internal/django/patch.py
+++ b/ddtrace/contrib/internal/django/patch.py
@@ -395,8 +395,9 @@ def _collect_django_routes(patterns: "Iterable[Union[URLPattern, URLResolver]]",
 def _collect_routes_once(resolver: "Optional[URLResolver]") -> None:
     """Populate endpoint_collection by walking resolver.url_patterns once per resolver.
 
-    Called once per BaseHandler from traced_load_middleware, and from traced_get_response /
-    traced_get_response_async on every request. The WeakSet gate makes repeated calls O(1), and naturally handles
+    Called from traced_load_middleware when a request handler is built, and from traced_get_response /
+    traced_get_response_async on every request; the walk itself happens once per distinct resolver rather than once
+    per call site. The WeakSet gate makes repeated calls O(1), and naturally handles
     per-request request.urlconf swaps (each distinct urlconf gets its own resolver from django.urls.get_resolver,
     walked on first use). When the endpoint-collection flag is off, the walk is skipped entirely — telemetry would
     discard the collected entries anyway, and if the flag is later flipped on the WeakSet stays empty so the next

--- a/releasenotes/notes/fix-django-eager-urlconf-import-aa3eff2dd008ec0f.yaml
+++ b/releasenotes/notes/fix-django-eager-urlconf-import-aa3eff2dd008ec0f.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    django: Fixes an issue where Django processes that never serve HTTP requests, such as Celery and dramatiq
-    workers, used substantially more memory and took longer to start. API endpoint discovery now runs when the
-    WSGI or ASGI application is built rather than during ``django.setup()``. (#19454)
+    django: Fixes an issue (#19454) where Django processes that never serve HTTP requests, such as Celery and
+    dramatiq workers, used substantially more memory and took longer to start. API endpoint discovery now runs
+    when the WSGI or ASGI application is built rather than during ``django.setup()``.

--- a/releasenotes/notes/fix-django-eager-urlconf-import-aa3eff2dd008ec0f.yaml
+++ b/releasenotes/notes/fix-django-eager-urlconf-import-aa3eff2dd008ec0f.yaml
@@ -1,7 +1,6 @@
 ---
 fixes:
   - |
-    django: Fixes an issue where ``django.setup()`` imported the root URLconf and every module
-    reachable from it, causing large resident memory increases and slower startup in processes
-    that never serve HTTP requests, such as Celery and dramatiq workers, management commands and
-    cron jobs. API endpoint discovery now runs when the WSGI or ASGI application is built.
+    django: Fixes an issue where Django processes that never serve HTTP requests, such as Celery and dramatiq
+    workers, used substantially more memory and took longer to start. API endpoint discovery now runs when the
+    WSGI or ASGI application is built rather than during ``django.setup()``. (#19454)

--- a/releasenotes/notes/fix-django-eager-urlconf-import-aa3eff2dd008ec0f.yaml
+++ b/releasenotes/notes/fix-django-eager-urlconf-import-aa3eff2dd008ec0f.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    django: Fixes an issue where ``django.setup()`` imported the root URLconf and every module
+    reachable from it, causing large resident memory increases and slower startup in processes
+    that never serve HTTP requests, such as Celery and dramatiq workers, management commands and
+    cron jobs. API endpoint discovery now runs when the WSGI or ASGI application is built.

--- a/tests/contrib/django/test_django_patch.py
+++ b/tests/contrib/django/test_django_patch.py
@@ -72,3 +72,81 @@ def test_tracing_minimal_patching():
     from ddtrace.internal.wrapping import is_wrapped
 
     assert is_wrapped(django.template.base.Template.render)
+
+
+@pytest.mark.subprocess(
+    ddtrace_run=True,
+    env={"DJANGO_SETTINGS_MODULE": "tests.contrib.django.django_app.settings"},
+)
+def test_setup_does_not_import_root_urlconf():
+    """django.setup() must not pull in ROOT_URLCONF.
+
+    Reading resolver.url_patterns imports the URLconf and the entire view import closure behind it. Processes that
+    never serve a request (Celery/dramatiq workers, management commands, cron jobs) would otherwise load all of it
+    for nothing, which cost one reporter 150MB of RSS per worker.
+    """
+    import sys
+
+    import django
+    from django.conf import settings
+
+    django.setup()
+
+    assert settings.ROOT_URLCONF not in sys.modules, (
+        f"django.setup() imported {settings.ROOT_URLCONF}; endpoint discovery must stay lazy"
+    )
+
+    from ddtrace.internal.endpoints import endpoint_collection
+
+    assert not endpoint_collection.endpoints
+
+
+@pytest.mark.subprocess(
+    ddtrace_run=True,
+    env={"DJANGO_SETTINGS_MODULE": "tests.contrib.django.django_app.settings"},
+)
+def test_wsgi_application_collects_endpoints():
+    """Building the WSGI application must collect endpoints without serving a request.
+
+    The counterpart of test_setup_does_not_import_root_urlconf: gunicorn and uwsgi import a module that calls
+    get_wsgi_application(), which constructs a BaseHandler. That is the point where a process commits to serving
+    HTTP, so paying for the URLconf import there is free -- the first request would have paid for it anyway.
+    """
+    import sys
+
+    from django.conf import settings
+    from django.core.wsgi import get_wsgi_application
+
+    get_wsgi_application()
+
+    assert settings.ROOT_URLCONF in sys.modules
+
+    from ddtrace.internal.endpoints import endpoint_collection
+
+    paths = {e.path for e in endpoint_collection.endpoints}
+    assert "path/" in paths, paths
+    # "test/" mounted under include("...extra_urls") at the "include/" prefix, pinning the sub-application prefix
+    # joining from #17695 at startup rather than only per-request.
+    assert "include/test/" in paths, paths
+
+
+@pytest.mark.subprocess(
+    ddtrace_run=True,
+    env={
+        "DJANGO_SETTINGS_MODULE": "tests.contrib.django.django_app.settings",
+        "DD_DJANGO_INSTRUMENT_MIDDLEWARE": "false",
+    },
+)
+def test_wsgi_application_collects_endpoints_without_middleware_instrumentation():
+    """Endpoint discovery must not be gated on DD_DJANGO_INSTRUMENT_MIDDLEWARE.
+
+    The walk hangs off BaseHandler.load_middleware, which used to be wrapped only when middleware instrumentation
+    was enabled.
+    """
+    from django.core.wsgi import get_wsgi_application
+
+    get_wsgi_application()
+
+    from ddtrace.internal.endpoints import endpoint_collection
+
+    assert endpoint_collection.endpoints

--- a/tests/contrib/django/test_django_patch.py
+++ b/tests/contrib/django/test_django_patch.py
@@ -81,9 +81,10 @@ def test_tracing_minimal_patching():
 def test_setup_does_not_import_root_urlconf():
     """django.setup() must not pull in ROOT_URLCONF.
 
-    Reading resolver.url_patterns imports the URLconf and the entire view import closure behind it. Processes that
-    never serve a request (Celery/dramatiq workers, management commands, cron jobs) would otherwise load all of it
-    for nothing, which cost one reporter 150MB of RSS per worker.
+    Reading resolver.url_patterns imports the URLconf and the entire view import closure behind it. A process that
+    never serves a request, such as a Celery or dramatiq worker, would otherwise load all of it for nothing, which
+    cost one reporter 154MB of RSS per worker. Management commands are not in scope: Django's own check_url_config
+    imports the URLconf whenever system checks run.
     """
     import sys
 
@@ -129,6 +130,13 @@ def test_wsgi_application_collects_endpoints():
     # joining from #17695 at startup rather than only per-request.
     assert "include/test/" in paths, paths
 
+    # Counterpart of test_wsgi_application_collects_endpoints_without_middleware_instrumentation: with the flag at
+    # its default, moving the middleware wrapping under a runtime check must not have stopped it happening.
+    from ddtrace.internal.wrapping import is_wrapped
+    from tests.contrib.django.middleware import ClsMiddleware
+
+    assert is_wrapped(ClsMiddleware.__call__)
+
 
 @pytest.mark.subprocess(
     ddtrace_run=True,
@@ -141,7 +149,8 @@ def test_wsgi_application_collects_endpoints_without_middleware_instrumentation(
     """Endpoint discovery must not be gated on DD_DJANGO_INSTRUMENT_MIDDLEWARE.
 
     The walk hangs off BaseHandler.load_middleware, which used to be wrapped only when middleware instrumentation
-    was enabled.
+    was enabled. The middleware assertion keeps the flag itself honest: without it this test would still pass if
+    wrapping had accidentally stayed on.
     """
     from django.core.wsgi import get_wsgi_application
 
@@ -150,3 +159,8 @@ def test_wsgi_application_collects_endpoints_without_middleware_instrumentation(
     from ddtrace.internal.endpoints import endpoint_collection
 
     assert endpoint_collection.endpoints
+
+    from ddtrace.internal.wrapping import is_wrapped
+    from tests.contrib.django.middleware import ClsMiddleware
+
+    assert not is_wrapped(ClsMiddleware.__call__)

--- a/tests/suitespec.yml
+++ b/tests/suitespec.yml
@@ -267,6 +267,9 @@ suites:
       - '@settings'
       - '@profiling'
       - '@vendor'
+      # tests/telemetry runs real django and flask apps; '@contrib' is only shared infrastructure.
+      - '@django'
+      - '@flask'
       - tests/telemetry/*
       - tests/snapshots/tests.telemetry.*
     snapshot: true

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -87,16 +87,7 @@ def test_update_dependencies_event(test_agent_session, ddtrace_run_python_code_i
     assert len(deps) == 1, deps
 
 
-def test_endpoint_discovery_event(test_agent_session, ddtrace_run_python_code_in_subprocess):
-    env = os.environ.copy()
-    # app-started events are sent 10 seconds after ddtrace imported, this configuration overrides this
-    # behavior to force the app-started event to be queued immediately
-    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
-
-    # Import httppretty after ddtrace is imported, this ensures that the module is sent in a dependencies event
-    # Imports httpretty twice and ensures only one dependency entry is sent
-
-    mini_django_app = """
+_MINI_DJANGO_APP = """
 from os import path as osp
 def rel_path(*p): return osp.normpath(osp.join(rel_path.path, *p))
 rel_path.path = osp.abspath(osp.dirname(__file__))
@@ -119,8 +110,7 @@ if __name__=='__main__':
     settings.configure(**SETTINGS)
 
 if __name__ == '__main__':
-    from django.core import management
-    management.execute_from_command_line()
+    %(bootstrap)s
 
 from django.urls import path
 from django.http import HttpResponse
@@ -132,6 +122,24 @@ def mini_app(request):
     return HttpResponse('response text')
 urlpatterns = [ path('mini_app/',mini_app), path('view_name/', view_name) ]
 """
+
+# What gunicorn/uwsgi do: build the WSGI application, which constructs a BaseHandler.
+_SERVING_BOOTSTRAP = """from django.core.wsgi import get_wsgi_application
+    get_wsgi_application()"""
+
+# A management command: calls django.setup() but never builds a handler.
+_NON_SERVING_BOOTSTRAP = """from django.core import management
+    management.execute_from_command_line()
+    assert this not in __import__('sys').modules, 'django.setup() imported the URLconf'"""
+
+
+def test_endpoint_discovery_event(test_agent_session, ddtrace_run_python_code_in_subprocess):
+    env = os.environ.copy()
+    # app-started events are sent 10 seconds after ddtrace imported, this configuration overrides this
+    # behavior to force the app-started event to be queued immediately
+    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+
+    mini_django_app = _MINI_DJANGO_APP % {"bootstrap": _SERVING_BOOTSTRAP}
 
     _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(mini_django_app, env=env)
     assert status == 0, stderr
@@ -154,6 +162,26 @@ urlpatterns = [ path('mini_app/',mini_app), path('view_name/', view_name) ]
         and e["operation_name"] == "django.request"
         for e in endpoints
     ), endpoints
+
+
+def test_endpoint_discovery_skipped_without_http_handler(test_agent_session, ddtrace_run_python_code_in_subprocess):
+    """A process that never builds a request handler must not import the URLconf.
+
+    Reading resolver.url_patterns imports ROOT_URLCONF and, through include(), every view module behind it. Celery
+    and dramatiq workers, management commands and cron jobs would otherwise load that whole import closure for
+    nothing, which cost one reporter 154MB of RSS per worker.
+    """
+    env = os.environ.copy()
+    env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
+
+    mini_django_app = _MINI_DJANGO_APP % {"bootstrap": _NON_SERVING_BOOTSTRAP}
+
+    _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(mini_django_app, env=env)
+    assert status == 0, stderr
+    deps = test_agent_session.get_dependencies("django")
+    assert len(deps) == 1, deps
+
+    assert test_agent_session.get_events("app-endpoints") == []
 
 
 def test_instrumentation_source_config(

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -127,9 +127,11 @@ urlpatterns = [ path('mini_app/',mini_app), path('view_name/', view_name) ]
 _SERVING_BOOTSTRAP = """from django.core.wsgi import get_wsgi_application
     get_wsgi_application()"""
 
-# A management command: calls django.setup() but never builds a handler.
-_NON_SERVING_BOOTSTRAP = """from django.core import management
-    management.execute_from_command_line()
+# What a Celery or dramatiq worker does: django.setup() and nothing else. Not a management
+# command -- Django's own check_url_config imports the URLconf whenever system checks run, so
+# most manage.py invocations import it with or without ddtrace.
+_WORKER_BOOTSTRAP = """import django
+    django.setup()
     assert this not in __import__('sys').modules, 'django.setup() imported the URLconf'"""
 
 
@@ -167,14 +169,14 @@ def test_endpoint_discovery_event(test_agent_session, ddtrace_run_python_code_in
 def test_endpoint_discovery_skipped_without_http_handler(test_agent_session, ddtrace_run_python_code_in_subprocess):
     """A process that never builds a request handler must not import the URLconf.
 
-    Reading resolver.url_patterns imports ROOT_URLCONF and, through include(), every view module behind it. Celery
-    and dramatiq workers, management commands and cron jobs would otherwise load that whole import closure for
-    nothing, which cost one reporter 154MB of RSS per worker.
+    Reading resolver.url_patterns imports ROOT_URLCONF and, through include(), every view module behind it. A Celery
+    or dramatiq worker would otherwise load that whole import closure for nothing, which cost one reporter 154MB of
+    RSS per worker.
     """
     env = os.environ.copy()
     env["_DD_INSTRUMENTATION_TELEMETRY_TESTS_FORCE_APP_STARTED"] = "true"
 
-    mini_django_app = _MINI_DJANGO_APP % {"bootstrap": _NON_SERVING_BOOTSTRAP}
+    mini_django_app = _MINI_DJANGO_APP % {"bootstrap": _WORKER_BOOTSTRAP}
 
     _, stderr, status, _ = ddtrace_run_python_code_in_subprocess(mini_django_app, env=env)
     assert status == 0, stderr


### PR DESCRIPTION
APPSEC-69515

## Description

Alternative to #19465 for the same regression (#19454). Endpoint discovery walked the root resolver at the end of
`traced_populate`, so `django.setup()` imported `ROOT_URLCONF` and every view module behind it — 154 MB of RSS per
dramatiq worker that serves no requests. The eager call arrived in #17695, so every release from 4.9.0rc1 is affected.

This moves the walk to `traced_load_middleware`: building a `BaseHandler` is the earliest reliable signal that a
process will serve HTTP, so workers pay nothing while gunicorn/uwsgi/daphne still report endpoints at startup.
`BaseHandler.load_middleware` is now wrapped unconditionally so discovery no longer depends on
`DD_DJANGO_INSTRUMENT_MIDDLEWARE`.

#19465 instead guards the walk on `ROOT_URLCONF` already being in `sys.modules`, but Django imports the URLconf
neither during `django.setup()` nor during `WSGIHandler.__init__` — only at the first `resolve()`. Measured with
`get_wsgi_application()`, which is what gunicorn imports:

| | urlconf imported | endpoints at startup |
|---|---|---|
| `main` | yes | 32 |
| #19465 | no | **0** |
| this PR | yes | 32 |

Also adds `'@django'` and `'@flask'` to the `telemetry` suite in suitespec, which runs real apps of both but was
gated only on shared contrib infrastructure — which is why #19465's CI is green while it deterministically fails
`test_endpoint_discovery_event`.

## Testing

`test_setup_does_not_import_root_urlconf` and `test_endpoint_discovery_skipped_without_http_handler` fail on `main`
and pass here. `test_endpoint_discovery_event` now builds the WSGI application and still passes (it fails on #19465).
`test_wsgi_application_collects_endpoints` pins #17695's `include/test/` prefix joining at startup, and a paired test
pins that discovery survives `DD_DJANGO_INSTRUMENT_MIDDLEWARE=false` while middleware wrapping does not.

On a bare `django.setup()` (py3.13 / django 5.1): `sys.modules` 1243 → 1220, live GC objects 109,218 → 106,123, max
RSS 82,884 → 81,496 KB. Small here only because the test app's view closure is small — the delta *is* that closure.

`contrib::django` passes except 5 `test_django_appsec_snapshots.py` failures that reproduce identically on `main`.

## Risks

Serving processes import the URLconf when the handler is built rather than on the first request — earlier than Django
would, but later and safer than the previous `Apps.populate` timing. Processes that build no handler no longer report
endpoints, which is the point. Management commands are unaffected either way: Django's own `check_url_config` imports
the URLconf whenever system checks run.

## Additional Notes

Pre-existing and out of scope: `_collect_routes_once` marks a resolver collected in its `finally` block even when the
walk raised; the `wsgi`, `appsec_integrations_django` and `ddtracerun` suites have the same suitespec gap. ASGI
collection is reasoned but untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Credit to @bellini666 for diagnosing the regression and for `test_setup_does_not_import_root_urlconf`, carried over
from #19465.
