### PR TITLE
chore: bump version to 4.11.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.11.4"
+version = "4.11.5"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }


### PR DESCRIPTION
## Motivation

The 4.11 branch now contains the OpenFeature compatibility backport from #19446 and needs to advertise the next patch version before creating the GitHub release.

## Changes

This updates `project.version` in `pyproject.toml` from 4.11.4 to 4.11.5 so the branch is prepared for the next 4.11 patch release.

## Decisions

The change is intentionally limited to release version metadata. The OpenFeature fix and its release note landed separately in #19446, so this PR does not duplicate that code or changelog entry.

## Testing

- `scripts/lint format_check pyproject.toml`
- `python3 scripts/verify-package-version`
- `scripts/lint checks` (all available checks passed; the 4.11 branch references a missing `scripts/check_profiling_native_coverage.py`, so the remaining checks were run individually and passed)