### PR TITLE
fix(tracing): report OTLP endpoint on export failure

### DIFF
--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -949,6 +949,8 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
             )
 
     def _intake_endpoint(self, client=None):
+        if self._otlp_endpoint is not None:
+            return self._otlp_endpoint
         return "{}/{}".format(self.intake_url, client.ENDPOINT if client else self._endpoint)
 
     @property

--- a/releasenotes/notes/fix-otlp-export-error-endpoint-6e7b7c8f756ef3a7.yaml
+++ b/releasenotes/notes/fix-otlp-export-error-endpoint-6e7b7c8f756ef3a7.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    tracing: Fixes an issue where OTLP trace export failures report the Datadog Agent intake URL
+    instead of the configured OTLP endpoint.

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -1450,3 +1450,8 @@ def test_native_writer_stores_otlp_endpoint():
     """NativeWriter stores the otlp_endpoint when provided."""
     writer = NativeWriter("http://localhost:8126", otlp_endpoint="http://localhost:4318/v1/traces")
     assert writer._otlp_endpoint == "http://localhost:4318/v1/traces"
+
+
+def test_native_writer_reports_otlp_intake_endpoint():
+    writer = NativeWriter("http://localhost:8126", otlp_endpoint="http://localhost:4318/v1/traces")
+    assert writer._intake_endpoint() == "http://localhost:4318/v1/traces"


### PR DESCRIPTION
## Description

When native OTLP trace export fails, `NativeWriter` currently reports its configured Datadog Agent intake URL even though libdatadog attempted the OTLP endpoint. This makes an OTLP protocol or connectivity error look like an Agent fallback.

Use the configured OTLP trace endpoint in failure diagnostics whenever OTLP trace export is active. Agent export diagnostics keep their existing behavior.

The original investigation also exposed a separate protocol mismatch: released versions send OTLP traces over HTTP/JSON, while the repro targeted the collector's gRPC port. HTTP/protobuf and gRPC support are already tracked by DataDog/dd-trace-py#18609, DataDog/libdatadog#2171, and DataDog/libdatadog#2273; this PR does not duplicate those transport changes.

## Testing

- `scripts/run-tests --venv 1ef5a52 -- -- tests/tracer/test_writer.py -k 'native_writer_reports_otlp_intake_endpoint or native_writer_stores_otlp_endpoint'` (Python 3.13; 2 passed)
- `scripts/lint checks`
- `scripts/lint style -- ddtrace/internal/writer/writer.py tests/tracer/test_writer.py`
- `scripts/lint spelling -- releasenotes/notes/fix-otlp-export-error-endpoint-6e7b7c8f756ef3a7.yaml`
- `riot run reno lint`

## Risks

Low. The change only affects the endpoint displayed in trace-export failure diagnostics when an OTLP endpoint is configured. It does not change routing, serialization, or retry behavior.

## Additional Notes

The OTLP/DDOT reference and the original handoff document were corrected separately to record that the old port-4317 reproduction was testing an HTTP exporter against a gRPC receiver.
