### PR TITLE
fix(google_adk): bound run_live event buffer to prevent memory exhaustion

### DIFF
--- a/ddtrace/contrib/internal/google_adk/patch.py
+++ b/ddtrace/contrib/internal/google_adk/patch.py
@@ -11,6 +11,7 @@ from ddtrace.contrib.trace_utils import wrap
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.llmobs._integrations import GoogleAdkIntegration
+from ddtrace.llmobs._integrations.google_utils import extract_messages_from_adk_events
 from ddtrace.llmobs._integrations.google_utils import extract_provider_and_model_name
 
 
@@ -18,12 +19,16 @@ logger = get_logger(__name__)
 
 config._add("google_adk", {})
 
-# Cap on the number of agent response events retained for LLMObs tagging. `run_live` streams
-# events for the lifetime of a (potentially unbounded) live agent session, so without a bound an
-# attacker able to keep a session open or drive many events could force the traced process to
-# retain every event object and exhaust memory (APMSP-3136). Buffering is additionally skipped
-# entirely when LLMObs is disabled, since the events are only ever consumed by llmobs_set_tags.
-_MAX_BUFFERED_AGENT_EVENTS = 10000
+# Bounds on what the agent-run wrapper retains for LLMObs tagging. `run_live` streams events for
+# the lifetime of a (potentially unbounded) live agent session, so an attacker able to keep a
+# session open or drive many/large events could force the traced process to retain everything and
+# exhaust memory (APMSP-3136). We therefore (1) only retain data when LLMObs is enabled — the
+# retained data is consumed solely by llmobs_set_tags — and (2) retain the compact extracted
+# message representation (which drops raw inline_data/blob bytes) rather than the raw event
+# objects, bounded by both a message count and a total character budget so that neither many
+# small events nor a few very large ones can grow the buffer without limit.
+_MAX_BUFFERED_AGENT_MESSAGES = 10000
+_MAX_BUFFERED_AGENT_CHARS = 10 * 1024 * 1024  # 10 MiB of extracted text
 
 
 def _supported_versions() -> dict[str, str]:
@@ -69,39 +74,52 @@ def _traced_agent_run_async(wrapped, instance, args, kwargs):
         raise
 
     async def _generator():
-        # Only retain response events when LLMObs is enabled — they are consumed solely by
-        # llmobs_set_tags, which no-ops when LLMObs is disabled. Even when enabled, cap how many
-        # are retained so a long-lived run_live stream cannot grow the buffer without bound
-        # (APMSP-3136).
-        buffer_events = integration.llmobs_enabled
-        response_events: list = []
-        truncated = False
+        # Extract each event into its compact message representation as it streams and retain only
+        # that, so raw event objects (which may carry large inline_data/blob payloads) aren't held
+        # for the lifetime of a live session. Retention is bounded by both a message count and a
+        # character budget, and only happens while LLMObs is enabled — re-checked every iteration
+        # so that disabling LLMObs mid-stream (e.g. LLMObs.disable() or remote config) immediately
+        # releases the buffer instead of retaining until the session ends (APMSP-3136).
+        response_messages: list = []
+        retained_chars = 0
+        capped = False
         try:
             async for event in agen:
-                if buffer_events:
-                    if len(response_events) < _MAX_BUFFERED_AGENT_EVENTS:
-                        response_events.append(event)
-                    elif not truncated:
-                        truncated = True
-                        logger.warning(
-                            "google_adk: response event buffer for %s reached the cap of %d "
-                            "events; further events will not be captured for LLMObs.",
-                            wrapped.__name__,
-                            _MAX_BUFFERED_AGENT_EVENTS,
-                        )
+                if not integration.llmobs_enabled:
+                    if response_messages:
+                        # LLMObs was disabled mid-stream: release what we were holding for it.
+                        response_messages = []
+                        retained_chars = 0
+                elif not capped:
+                    for message in extract_messages_from_adk_events(event):
+                        if (
+                            len(response_messages) >= _MAX_BUFFERED_AGENT_MESSAGES
+                            or retained_chars >= _MAX_BUFFERED_AGENT_CHARS
+                        ):
+                            capped = True
+                            logger.warning(
+                                "google_adk: response buffer for %s reached its retention cap; "
+                                "further messages will not be captured for LLMObs.",
+                                wrapped.__name__,
+                            )
+                            break
+                        response_messages.append(message)
+                        retained_chars += len(str(message))
                 yield event
         except Exception:
             span.set_exc_info(*sys.exc_info())
             raise
         finally:
             # Pass a copy with the resolved agent/session metadata so the original call kwargs are
-            # left untouched.
+            # left untouched. `response` holds the already-extracted messages (see above).
             tag_kwargs = dict(kwargs)
             tag_kwargs["instance"] = instance.agent
             tag_kwargs["session_id"] = session_id
             tag_kwargs["user_id"] = user_id
             tag_kwargs["app_name"] = app_name
-            integration.llmobs_set_tags(span, args=args, kwargs=tag_kwargs, response=response_events, operation="agent")
+            integration.llmobs_set_tags(
+                span, args=args, kwargs=tag_kwargs, response=response_messages, operation="agent"
+            )
             span.finish()
 
     return _generator()

--- a/ddtrace/contrib/internal/google_adk/patch.py
+++ b/ddtrace/contrib/internal/google_adk/patch.py
@@ -18,6 +18,13 @@ logger = get_logger(__name__)
 
 config._add("google_adk", {})
 
+# Cap on the number of agent response events retained for LLMObs tagging. `run_live` streams
+# events for the lifetime of a (potentially unbounded) live agent session, so without a bound an
+# attacker able to keep a session open or drive many events could force the traced process to
+# retain every event object and exhaust memory (APMSP-3136). Buffering is additionally skipped
+# entirely when LLMObs is disabled, since the events are only ever consumed by llmobs_set_tags.
+_MAX_BUFFERED_AGENT_EVENTS = 10000
+
 
 def _supported_versions() -> dict[str, str]:
     return {"google.adk": ">=1.0.0"}
@@ -62,10 +69,26 @@ def _traced_agent_run_async(wrapped, instance, args, kwargs):
         raise
 
     async def _generator():
-        response_events = []
+        # Only retain response events when LLMObs is enabled — they are consumed solely by
+        # llmobs_set_tags, which no-ops when LLMObs is disabled. Even when enabled, cap how many
+        # are retained so a long-lived run_live stream cannot grow the buffer without bound
+        # (APMSP-3136).
+        buffer_events = integration.llmobs_enabled
+        response_events: list = []
+        truncated = False
         try:
             async for event in agen:
-                response_events.append(event)
+                if buffer_events:
+                    if len(response_events) < _MAX_BUFFERED_AGENT_EVENTS:
+                        response_events.append(event)
+                    elif not truncated:
+                        truncated = True
+                        logger.warning(
+                            "google_adk: response event buffer for %s reached the cap of %d "
+                            "events; further events will not be captured for LLMObs.",
+                            wrapped.__name__,
+                            _MAX_BUFFERED_AGENT_EVENTS,
+                        )
                 yield event
         except Exception:
             span.set_exc_info(*sys.exc_info())

--- a/ddtrace/llmobs/_integrations/google_adk.py
+++ b/ddtrace/llmobs/_integrations/google_adk.py
@@ -8,7 +8,6 @@ from ddtrace.internal.utils import get_argument_value
 from ddtrace.llmobs._constants import DISPATCH_ON_TOOL_CALL
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._integrations.google_utils import extract_message_from_part_google_genai
-from ddtrace.llmobs._integrations.google_utils import extract_messages_from_adk_events
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _get_attr
 from ddtrace.llmobs._utils import safe_json
@@ -79,7 +78,9 @@ class GoogleAdkIntegration(BaseLLMIntegration):
         message = ""
         for part in new_message_parts:
             message += extract_message_from_part_google_genai(part, new_message_role).get("content", "")
-        result = extract_messages_from_adk_events(response)
+        # ``response`` is the compact message representation the patch wrapper already extracted
+        # from the streamed ADK events (bounded to avoid retaining raw event payloads).
+        result = response or []
 
         # Surface the ADK session metadata (user id, app name) as searchable span tags.
         session_tags = {}

--- a/releasenotes/notes/fix-google-adk-run-live-unbounded-buffer-6f2a1b4c9d3e7a08.yaml
+++ b/releasenotes/notes/fix-google-adk-run-live-unbounded-buffer-6f2a1b4c9d3e7a08.yaml
@@ -2,8 +2,9 @@
 fixes:
   - |
     google-adk: Fixes unbounded memory growth when tracing ``Runner.run_live`` (and
-    ``Runner.run_async``). Response events yielded by the agent were buffered for the entire
-    lifetime of the generator regardless of whether LLM Observability was enabled. For long-lived
-    ``run_live`` streaming sessions this could retain every event object and exhaust process
-    memory. Events are now buffered only when LLM Observability is enabled, and the number
-    retained is bounded.
+    ``Runner.run_async``). Response events yielded by the agent were buffered in full for the
+    entire lifetime of the generator regardless of whether LLM Observability was enabled, so a
+    long-lived ``run_live`` streaming session could retain every event object (including large
+    ``inline_data`` payloads) and exhaust process memory. The integration now retains only the
+    compact extracted message representation, only while LLM Observability is enabled (re-checked
+    as the stream is consumed), and bounded by both a message count and a total size budget.

--- a/releasenotes/notes/fix-google-adk-run-live-unbounded-buffer-6f2a1b4c9d3e7a08.yaml
+++ b/releasenotes/notes/fix-google-adk-run-live-unbounded-buffer-6f2a1b4c9d3e7a08.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    google-adk: Fixes unbounded memory growth when tracing ``Runner.run_live`` (and
+    ``Runner.run_async``). Response events yielded by the agent were buffered for the entire
+    lifetime of the generator regardless of whether LLM Observability was enabled. For long-lived
+    ``run_live`` streaming sessions this could retain every event object and exhaust process
+    memory. Events are now buffered only when LLM Observability is enabled, and the number
+    retained is bounded.

--- a/tests/contrib/google_adk/test_google_adk_llmobs.py
+++ b/tests/contrib/google_adk/test_google_adk_llmobs.py
@@ -286,3 +286,89 @@ class TestLLMObsGoogleADK:
                 "app_name": "TestADKApp",
             },
         )
+
+    @pytest.mark.asyncio
+    async def test_run_live_does_not_buffer_events_when_llmobs_disabled(self, adk, test_spans):
+        """APMSP-3136: the agent wrapper must not retain response events when LLMObs is disabled.
+
+        Events were previously buffered unconditionally for the generator's lifetime, so a
+        long-lived run_live stream could exhaust memory even though the buffer is only ever
+        consumed by llmobs_set_tags (a no-op when LLMObs is disabled).
+        """
+        from ddtrace.contrib.internal.google_adk.patch import _traced_agent_run_async
+
+        integration = adk._datadog_integration
+        assert not integration.llmobs_enabled
+
+        instance = _fake_agent_instance()
+
+        async def run_live(*args, **kwargs):
+            for _ in range(50):
+                yield object()
+
+        run_live.__name__ = "run_live"
+
+        captured = {}
+
+        def _spy(span, args, kwargs, response=None, operation=""):
+            captured["response"] = response
+
+        with mock.patch.object(integration, "llmobs_set_tags", _spy):
+            gen = _traced_agent_run_async(run_live, instance, (), {"session_id": "s", "user_id": "u"})
+            consumed = [event async for event in gen]
+
+        # All 50 events still flow through to the caller...
+        assert len(consumed) == 50
+        # ...but none are retained when LLMObs is disabled.
+        assert captured["response"] == []
+
+    @pytest.mark.asyncio
+    async def test_run_live_caps_buffered_events_when_llmobs_enabled(
+        self, adk, test_spans, google_adk_llmobs, monkeypatch
+    ):
+        """APMSP-3136: even with LLMObs enabled, the retained event buffer is bounded."""
+        from ddtrace.contrib.internal.google_adk import patch as adk_patch_mod
+        from ddtrace.contrib.internal.google_adk.patch import _traced_agent_run_async
+
+        monkeypatch.setattr(adk_patch_mod, "_MAX_BUFFERED_AGENT_EVENTS", 5)
+
+        integration = adk._datadog_integration
+        assert integration.llmobs_enabled
+
+        instance = _fake_agent_instance()
+
+        async def run_live(*args, **kwargs):
+            for _ in range(20):
+                yield object()
+
+        run_live.__name__ = "run_live"
+
+        captured = {}
+
+        def _spy(span, args, kwargs, response=None, operation=""):
+            captured["response"] = response
+
+        with mock.patch.object(integration, "llmobs_set_tags", _spy):
+            gen = _traced_agent_run_async(run_live, instance, (), {"session_id": "s", "user_id": "u"})
+            consumed = [event async for event in gen]
+
+        # All events still reach the caller, but only the cap is retained for tagging.
+        assert len(consumed) == 20
+        assert len(captured["response"]) == 5
+
+
+def _fake_agent_instance():
+    """Minimal stand-in for an ADK ``Runner`` for exercising the agent-run wrapper directly."""
+
+    class _Model:
+        pass
+
+    class _Agent:
+        name = "test_agent"
+        model = _Model()
+
+    class _Runner:
+        agent = _Agent()
+        app_name = "TestADKApp"
+
+    return _Runner()

--- a/tests/contrib/google_adk/test_google_adk_llmobs.py
+++ b/tests/contrib/google_adk/test_google_adk_llmobs.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -288,8 +290,8 @@ class TestLLMObsGoogleADK:
         )
 
     @pytest.mark.asyncio
-    async def test_run_live_does_not_buffer_events_when_llmobs_disabled(self, adk, test_spans):
-        """APMSP-3136: the agent wrapper must not retain response events when LLMObs is disabled.
+    async def test_run_live_does_not_buffer_when_llmobs_disabled(self, adk, test_spans):
+        """APMSP-3136: the agent wrapper must not retain anything when LLMObs is disabled.
 
         Events were previously buffered unconditionally for the generator's lifetime, so a
         long-lived run_live stream could exhaust memory even though the buffer is only ever
@@ -300,61 +302,122 @@ class TestLLMObsGoogleADK:
         integration = adk._datadog_integration
         assert not integration.llmobs_enabled
 
-        instance = _fake_agent_instance()
-
         async def run_live(*args, **kwargs):
-            for _ in range(50):
-                yield object()
+            for i in range(50):
+                yield _fake_event("event-%d" % i)
 
         run_live.__name__ = "run_live"
 
-        captured = {}
-
-        def _spy(span, args, kwargs, response=None, operation=""):
-            captured["response"] = response
-
-        with mock.patch.object(integration, "llmobs_set_tags", _spy):
-            gen = _traced_agent_run_async(run_live, instance, (), {"session_id": "s", "user_id": "u"})
+        with _capture_tagged_response(integration) as captured:
+            gen = _traced_agent_run_async(run_live, _fake_agent_instance(), (), {"session_id": "s", "user_id": "u"})
             consumed = [event async for event in gen]
 
         # All 50 events still flow through to the caller...
         assert len(consumed) == 50
-        # ...but none are retained when LLMObs is disabled.
+        # ...but nothing is retained when LLMObs is disabled.
         assert captured["response"] == []
 
     @pytest.mark.asyncio
-    async def test_run_live_caps_buffered_events_when_llmobs_enabled(
-        self, adk, test_spans, google_adk_llmobs, monkeypatch
-    ):
-        """APMSP-3136: even with LLMObs enabled, the retained event buffer is bounded."""
+    async def test_run_live_bounds_retained_messages_by_count(self, adk, test_spans, google_adk_llmobs, monkeypatch):
+        """APMSP-3136: retention is bounded by message count, and compact messages (not raw
+        events) are retained.
+        """
         from ddtrace.contrib.internal.google_adk import patch as adk_patch_mod
         from ddtrace.contrib.internal.google_adk.patch import _traced_agent_run_async
 
-        monkeypatch.setattr(adk_patch_mod, "_MAX_BUFFERED_AGENT_EVENTS", 5)
+        monkeypatch.setattr(adk_patch_mod, "_MAX_BUFFERED_AGENT_MESSAGES", 5)
 
         integration = adk._datadog_integration
         assert integration.llmobs_enabled
 
-        instance = _fake_agent_instance()
-
         async def run_live(*args, **kwargs):
-            for _ in range(20):
-                yield object()
+            for i in range(20):
+                yield _fake_event("event-%d" % i)
 
         run_live.__name__ = "run_live"
 
-        captured = {}
-
-        def _spy(span, args, kwargs, response=None, operation=""):
-            captured["response"] = response
-
-        with mock.patch.object(integration, "llmobs_set_tags", _spy):
-            gen = _traced_agent_run_async(run_live, instance, (), {"session_id": "s", "user_id": "u"})
+        with _capture_tagged_response(integration) as captured:
+            gen = _traced_agent_run_async(run_live, _fake_agent_instance(), (), {"session_id": "s", "user_id": "u"})
             consumed = [event async for event in gen]
 
-        # All events still reach the caller, but only the cap is retained for tagging.
+        # All events still reach the caller, but only the cap is retained for tagging...
         assert len(consumed) == 20
         assert len(captured["response"]) == 5
+        # ...as the extracted compact representation, not the raw event objects.
+        assert all(isinstance(m, dict) for m in captured["response"])
+
+    @pytest.mark.asyncio
+    async def test_run_live_bounds_retained_messages_by_size(self, adk, test_spans, google_adk_llmobs, monkeypatch):
+        """APMSP-3136: a few very large events cannot grow the buffer without bound; retention is
+        also capped by a total character budget.
+        """
+        from ddtrace.contrib.internal.google_adk import patch as adk_patch_mod
+        from ddtrace.contrib.internal.google_adk.patch import _traced_agent_run_async
+
+        monkeypatch.setattr(adk_patch_mod, "_MAX_BUFFERED_AGENT_MESSAGES", 10000)
+        monkeypatch.setattr(adk_patch_mod, "_MAX_BUFFERED_AGENT_CHARS", 500)
+
+        integration = adk._datadog_integration
+
+        async def run_live(*args, **kwargs):
+            for _ in range(10):
+                yield _fake_event("x" * 1000)
+
+        run_live.__name__ = "run_live"
+
+        with _capture_tagged_response(integration) as captured:
+            gen = _traced_agent_run_async(run_live, _fake_agent_instance(), (), {"session_id": "s", "user_id": "u"})
+            consumed = [event async for event in gen]
+
+        # Well under the message-count cap, but the size budget stops retention early.
+        assert len(consumed) == 10
+        assert 0 < len(captured["response"]) < 10
+
+    @pytest.mark.asyncio
+    async def test_run_live_releases_buffer_when_llmobs_disabled_midstream(self, adk, test_spans, google_adk_llmobs):
+        """APMSP-3136: disabling LLMObs mid-stream releases the retained buffer instead of holding
+        it until the (potentially unbounded) live session ends.
+        """
+        from ddtrace.contrib.internal.google_adk.patch import _traced_agent_run_async
+        from ddtrace.llmobs import LLMObs
+
+        integration = adk._datadog_integration
+        assert integration.llmobs_enabled
+
+        async def run_live(*args, **kwargs):
+            for i in range(10):
+                yield _fake_event("event-%d" % i)
+
+        run_live.__name__ = "run_live"
+
+        with _capture_tagged_response(integration) as captured:
+            gen = _traced_agent_run_async(run_live, _fake_agent_instance(), (), {"session_id": "s", "user_id": "u"})
+            consumed = 0
+            async for _ in gen:
+                consumed += 1
+                if consumed == 3:
+                    LLMObs.disable()
+
+        assert consumed == 10
+        # Buffer was released once LLMObs turned off.
+        assert captured["response"] == []
+
+
+@contextmanager
+def _capture_tagged_response(integration):
+    """Replace ``llmobs_set_tags`` to capture the ``response`` handed to it by the wrapper."""
+    captured = {}
+
+    def _spy(span, args, kwargs, response=None, operation=""):
+        captured["response"] = response
+
+    with mock.patch.object(integration, "llmobs_set_tags", _spy):
+        yield captured
+
+
+def _fake_event(text):
+    """A minimal stand-in for an ADK ``Event`` carrying a single text part."""
+    return SimpleNamespace(content=create_test_message(text))
 
 
 def _fake_agent_instance():


### PR DESCRIPTION
## Description

The `google_adk` agent-run wrapper (`_traced_agent_run_async`) buffered **every** event yielded by `Runner.run_async` / `Runner.run_live` into a list for the entire lifetime of the generator, **unconditionally** — regardless of whether LLM Observability was enabled. The buffer is only ever consumed by `integration.llmobs_set_tags(...)`, which no-ops for LLMObs when disabled, and `google_adk` does not override `_set_apm_shadow_tags`.

Because `run_live` drives live/streaming agent sessions, an attacker able to interact with an exposed ADK agent endpoint could keep a session open or drive many events, forcing the traced process to retain every event object → memory exhaustion (DoS). Reported by a Codex security scan (APMSP-3136 / MLOB-7926).

This change:
1. **Buffers events only when LLMObs is enabled** — nothing is retained when LLMObs is off (the common APM-only case).
2. **Caps retention even when enabled** via a private `_MAX_BUFFERED_AGENT_EVENTS` constant (10000), logging once on truncation, so a long-lived `run_live` stream cannot grow the buffer without bound.

All events still flow through to the caller unchanged — only what is retained for span tagging is bounded. No public/env-var setting is introduced.

## Testing

Added two wrapper-level regression tests in `tests/contrib/google_adk/test_google_adk_llmobs.py`:
- LLMObs disabled → wrapper retains 0 events while all events still reach the caller.
- LLMObs enabled with the cap monkeypatched low → retained buffer is bounded to the cap while all events still reach the caller.

`scripts/lint style` passes. Note: the `google_adk` suite was not executed locally (Docker/riot venv unavailable in the dev environment); relying on CI.

## Risks

Low. When LLMObs is enabled and an agent run legitimately exceeds the 10000-event cap, the agent span's `output_value` is truncated to the first 10000 events (a one-time warning is logged). Tracing behavior is otherwise unchanged; event delivery to the application is never affected.

## Additional Notes

Follow-up (out of scope): consider aggregating output incrementally for the live/streaming path rather than buffering full history at all.

Jira: https://datadoghq.atlassian.net/browse/MLOB-7926

Claude session: \`7833308a-a604-48d4-9f23-108b34da4edb\`
Resume: \`claude --resume 7833308a-a604-48d4-9f23-108b34da4edb\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)