### PR TITLE
fix(internal): fix leak from code origins [backport 4.11]

### DIFF
--- a/ddtrace/internal/wrapping/context.py
+++ b/ddtrace/internal/wrapping/context.py
@@ -81,6 +81,9 @@ T = t.TypeVar("T")
 
 StorageVar = ContextVar[t.Optional[dict[str, t.Any]]]
 
+_STORAGE_PREV = "__dd_wrapping_context_prev__"
+_STORAGE_OWNER = "__dd_wrapping_context_owner__"
+
 # Free lists of storage context variables, keyed by variable name.
 #
 # Once a ContextVar has been set, the running Context holds a strong reference
@@ -88,9 +91,19 @@ StorageVar = ContextVar[t.Optional[dict[str, t.Any]]]
 # again (ContextVar.reset is not usable here, see the note on _pop_storage).
 # Since wrapping contexts are created per function object, code that decorates
 # ephemeral functions on every call would otherwise pin one variable per
-# invocation. Recycling the variables of collected wrapping contexts bounds the
-# number of live ones by the peak number of concurrently live wrapping
-# contexts.
+# invocation. Recycling the variables of collected wrapping contexts caps the
+# number of live ones at the peak number of concurrently live wrapping
+# contexts. The pool is deliberately never trimmed: dropping a variable from it
+# would not release the Context entries it already holds, and would only force
+# the allocation of a new variable, adding entries instead of reusing them. That
+# peak is therefore retained for the lifetime of the process, but it no longer
+# grows with the number of functions that get wrapped.
+#
+# A recycled variable may still be set in some Context when it is handed out: a
+# context that is collected without exiting leaves its storage behind, and the
+# finalizer cannot reset it because it runs in an unrelated Context. Storage
+# dicts are tagged with an owner token so that the new owner can tell a leftover
+# value apart from one of its own; see __enter__.
 _storage_var_pools: dict[str, list[StorageVar]] = {}
 
 # Reentrant because the release happens from a finalizer, which can run at
@@ -389,7 +402,14 @@ class BaseWrappingContext(ABC):
         # strong refs drop, without relying on the cyclic GC at all.
         self._wrapped_ref: weakref.ref[FunctionType] = weakref.ref(f)
 
-        name = f"{type(self).__name__}__storage"
+        # Identifies the storage dicts written by this context. A dedicated token
+        # is used rather than self so that the storage dict cannot keep the
+        # context, and therefore the wrapped function, alive.
+        self._storage_owner = object()
+
+        # Qualified so that same-named context types (e.g. the two
+        # LazyWrappingContext classes in this package) do not share a pool.
+        name = f"{type(self).__module__}.{type(self).__qualname__}__storage"
         self._storage: StorageVar = _acquire_storage_var(name)
         weakref.finalize(self, _release_storage_var, name, self._storage).atexit = False
 
@@ -406,13 +426,21 @@ class BaseWrappingContext(ABC):
 
     def __enter__(self) -> "BaseWrappingContext":
         prev = self._storage.get()
-        self._storage.set({"__dd_wrapping_context_prev__": prev})
+        if prev is not None and prev.get(_STORAGE_OWNER) is not self._storage_owner:
+            # Storage left behind by a previous owner of this recycled variable.
+            # Chaining it into our own prev would restore it on every exit from
+            # now on, pinning it (and the frame it holds, for a universal
+            # wrapping context) for the lifetime of the thread. Dropping it here
+            # instead frees it as soon as we overwrite the variable below.
+            prev = None
+        self._storage.set({_STORAGE_PREV: prev, _STORAGE_OWNER: self._storage_owner})
 
         return self
 
     def _pop_storage(self) -> dict[str, t.Any]:
         storage = t.cast(dict[str, t.Any], self._storage.get())
-        self._storage.set(storage.pop("__dd_wrapping_context_prev__"))
+        self._storage.set(storage.pop(_STORAGE_PREV))
+        del storage[_STORAGE_OWNER]
         return storage
 
     def __return__(self, value: T) -> T:

--- a/ddtrace/internal/wrapping/context.py
+++ b/ddtrace/internal/wrapping/context.py
@@ -79,6 +79,44 @@ log = get_logger(__name__)
 
 T = t.TypeVar("T")
 
+StorageVar = ContextVar[t.Optional[dict[str, t.Any]]]
+
+# Free lists of storage context variables, keyed by variable name.
+#
+# Once a ContextVar has been set, the running Context holds a strong reference
+# to it for the lifetime of the thread, and there is no way to drop that entry
+# again (ContextVar.reset is not usable here, see the note on _pop_storage).
+# Since wrapping contexts are created per function object, code that decorates
+# ephemeral functions on every call would otherwise pin one variable per
+# invocation. Recycling the variables of collected wrapping contexts bounds the
+# number of live ones by the peak number of concurrently live wrapping
+# contexts.
+_storage_var_pools: dict[str, list[StorageVar]] = {}
+
+# Reentrant because the release happens from a finalizer, which can run at
+# any point, including in the middle of an acquisition on the same thread.
+_storage_var_pools_lock = RLock()
+
+
+def _acquire_storage_var(name: str) -> StorageVar:
+    with _storage_var_pools_lock:
+        pool = _storage_var_pools.get(name)
+        if pool:
+            var = pool.pop()
+            if not pool:
+                # Drop exhausted pools so that the names of wrapping contexts
+                # that are no longer in use don't accumulate either.
+                del _storage_var_pools[name]
+            return var
+
+    return ContextVar(name, default=None)
+
+
+def _release_storage_var(name: str, var: StorageVar) -> None:
+    with _storage_var_pools_lock:
+        _storage_var_pools.setdefault(name, []).append(var)
+
+
 # This module implements utilities for wrapping a function with a context
 # manager. The rough idea is to re-write the function's bytecode to look like
 # this:
@@ -350,9 +388,10 @@ class BaseWrappingContext(ABC):
         # reference count to reach zero (and be freed) as soon as all external
         # strong refs drop, without relying on the cyclic GC at all.
         self._wrapped_ref: weakref.ref[FunctionType] = weakref.ref(f)
-        self._storage: ContextVar[t.Optional[dict[str, t.Any]]] = ContextVar(
-            f"{type(self).__name__}__storage", default=None
-        )
+
+        name = f"{type(self).__name__}__storage"
+        self._storage: StorageVar = _acquire_storage_var(name)
+        weakref.finalize(self, _release_storage_var, name, self._storage).atexit = False
 
     @property
     def __wrapped__(self) -> FunctionType:

--- a/releasenotes/notes/fix-wrapping-contextvar-leak-5c1f0a2d94b7e831.yaml
+++ b/releasenotes/notes/fix-wrapping-contextvar-leak-5c1f0a2d94b7e831.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    internal: A memory leak triggered when using ``@tracer.wrap`` on
+    functions created at run time has been fixed.

--- a/releasenotes/notes/fix-wrapping-contextvar-leak-5c1f0a2d94b7e831.yaml
+++ b/releasenotes/notes/fix-wrapping-contextvar-leak-5c1f0a2d94b7e831.yaml
@@ -1,7 +1,5 @@
 ---
 fixes:
   - |
-    code origin: fixed unbounded memory growth when instrumenting functions that
-    are created at run time, such as when applying ``@tracer.wrap`` to a function
-    defined inside another function. Memory usage is now bounded by the peak
-    number of such functions instrumented at the same time.
+    internal: A memory leak triggered when using ``@tracer.wrap`` on
+    functions created at run time has been fixed.

--- a/releasenotes/notes/fix-wrapping-contextvar-leak-5c1f0a2d94b7e831.yaml
+++ b/releasenotes/notes/fix-wrapping-contextvar-leak-5c1f0a2d94b7e831.yaml
@@ -1,5 +1,7 @@
 ---
 fixes:
   - |
-    internal: A memory leak triggered when using ``@tracer.wrap`` on
-    functions created at run time has been fixed.
+    code origin: fixed unbounded memory growth when instrumenting functions that
+    are created at run time, such as when applying ``@tracer.wrap`` to a function
+    defined inside another function. Memory usage is now bounded by the peak
+    number of such functions instrumented at the same time.

--- a/tests/internal/test_wrapping.py
+++ b/tests/internal/test_wrapping.py
@@ -1342,7 +1342,107 @@ def test_wrapping_context_storage_vars_are_recycled():
         make_wrap_and_call()
 
     growth = len(contextvars.copy_context()) - baseline
-    assert growth <= 4, f"{growth} context variables pinned by {n} ephemeral wrapped functions"
+    assert growth == 0, f"{growth} context variables pinned by {n} ephemeral wrapped functions"
+
+
+@pytest.mark.subprocess(err=None)
+def test_wrapping_context_recycled_storage_var_drops_stale_value():
+    """A context that is collected without exiting leaves its storage set, and the
+    finalizer cannot reset it because it runs in an unrelated Context. The next
+    owner of the recycled variable must drop the leftover value rather than chain
+    it into its own prev, which would restore it on every exit from then on.
+    """
+    import gc
+    import weakref as wr
+
+    from tests.internal.test_wrapping import DummyLazyWrappingContext
+
+    class Payload:
+        pass
+
+    def abandoned_function():
+        pass
+
+    def heir_function():
+        pass
+
+    abandoned = DummyLazyWrappingContext(abandoned_function)
+    abandoned.__enter__()
+    abandoned.set("payload", payload := Payload())
+    var = abandoned._storage
+
+    del abandoned
+    gc.collect()
+
+    # The variable went back to the pool with the stale storage still in it.
+    assert var.get() is not None, "expected the abandoned context to leave its storage set"
+
+    heir = DummyLazyWrappingContext(heir_function)
+    assert heir._storage is var, "expected the recycled variable to be handed back out"
+
+    heir.__enter__()
+    assert heir._storage.get()["__dd_wrapping_context_prev__"] is None, "stale storage chained into the new context"
+
+    heir._pop_storage()
+    assert heir._storage.get() is None, "storage variable not restored to its default"
+
+    # Overwriting the variable released the stale storage, so nothing keeps the
+    # payload it held alive.
+    payload_ref = wr.ref(payload)
+    del payload
+    gc.collect()
+    assert payload_ref() is None, "stale storage is still reachable"
+
+
+@pytest.mark.subprocess(err=None)
+def test_wrapping_context_storage_var_pool_is_thread_safe():
+    """Storage variables are released from a finalizer, which can run on any thread,
+    including while another thread is acquiring one. No variable may be handed out
+    to two live contexts.
+    """
+    import threading
+
+    from tests.internal.test_wrapping import DummyLazyWrappingContext
+
+    def f():
+        pass
+
+    live = set()
+    live_lock = threading.Lock()
+    errors = []
+
+    def churn():
+        try:
+            for _ in range(200):
+                contexts = [DummyLazyWrappingContext(f) for _ in range(8)]
+                acquired = {c._storage for c in contexts}
+                assert len(acquired) == len(contexts), "storage variable handed out twice on one thread"
+
+                with live_lock:
+                    assert not live & acquired, "storage variable handed out to two live contexts"
+                    live.update(acquired)
+
+                for context in contexts:
+                    context.__enter__()
+                for context in reversed(contexts):
+                    context._pop_storage()
+
+                # Stop advertising the variables before dropping the contexts, so
+                # that they are never reported as live once the finalizers have
+                # handed them back to the pool.
+                with live_lock:
+                    live.difference_update(acquired)
+                del contexts, acquired
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=churn) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors, errors
 
 
 @pytest.mark.asyncio

--- a/tests/internal/test_wrapping.py
+++ b/tests/internal/test_wrapping.py
@@ -1303,6 +1303,48 @@ def test_wrapping_context_lazy_no_memory_leak_invoked():
     assert alive_contexts == 0, f"{alive_contexts} lazily-wrapped, invoked context(s) leaked"
 
 
+@pytest.mark.subprocess(err=None)
+def test_wrapping_context_storage_vars_are_recycled():
+    """A ContextVar that has been set is retained by the running Context for the
+    lifetime of the thread. Wrapping ephemeral functions must therefore recycle
+    the storage variables of collected contexts, or the thread's context grows
+    without bound (two entries per wrapped function).
+    """
+    import contextvars
+    import gc
+
+    from tests.internal.test_wrapping import DummyLazyWrappingContext
+
+    def make_wrap_and_call() -> contextvars.ContextVar:
+        def ephemeral() -> int:
+            return 42
+
+        wc = DummyLazyWrappingContext(ephemeral)
+        wc.wrap()
+        assert ephemeral() == 42
+
+        # Collect eagerly so that the number of storage variables in flight does
+        # not depend on when the garbage collector happens to run.
+        var = wc._storage
+        del wc, ephemeral
+        gc.collect()
+
+        return var
+
+    # The storage variable of a collected context is handed straight back out.
+    assert make_wrap_and_call() is make_wrap_and_call()
+
+    for _ in range(20):
+        make_wrap_and_call()
+    baseline = len(contextvars.copy_context())
+
+    for _ in range(n := 200):
+        make_wrap_and_call()
+
+    growth = len(contextvars.copy_context()) - baseline
+    assert growth <= 4, f"{growth} context variables pinned by {n} ephemeral wrapped functions"
+
+
 @pytest.mark.asyncio
 async def test_async_wrapper_frames_have_valid_linenos():
     """Regression test: async wrapping must not inject instructions with lineno=None.


### PR DESCRIPTION
## Description

Backports #19442 to the 4.11 release branch.

This fixes unbounded memory growth when `@tracer.wrap` is applied to functions created at runtime. It recycles wrapping-context storage variables, prevents stale values from being inherited by a new owner, and isolates pools for same-named context classes.

## Testing

- `scripts/run-tests --venv c16a7c1 -- -- tests/internal/test_wrapping.py` (Python 3.9: 49 passed)
- `scripts/run-tests --venv 7c819c6 -- -- tests/internal/test_wrapping.py` (Python 3.13: 49 passed)
- Targeted style, typing, spelling, and security checks

## Risks

Low. The change is limited to internal wrapping-context storage management and includes regression and concurrency coverage.

## Additional Notes

Cherry-picked the three commits from #19442 without conflicts.
