### PR TITLE
fix(appsec): manage listener activation lifecycle

### DIFF
--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -786,6 +786,11 @@ def asm_listen() -> None:
     core.on("asm.get_blocked", get_blocked, "block_config")
 
 
+def asm_unlisten() -> None:
+    core.reset_listeners("asm.set_blocked", set_blocked_dict)
+    core.reset_listeners("asm.get_blocked", get_blocked)
+
+
 def iast_disabled_taint_sources() -> "contextlib.AbstractContextManager[None]":
     if asm_config._iast_enabled:
         from ddtrace.appsec._iast._iast_request_context_base import iast_suppress_context

--- a/ddtrace/appsec/_contrib/aws_lambda/__init__.py
+++ b/ddtrace/appsec/_contrib/aws_lambda/__init__.py
@@ -93,3 +93,9 @@ def listen() -> None:
     core.on("aws_lambda.start_request", _on_lambda_start_request)
     core.on("aws_lambda.start_response", _on_lambda_start_response)
     core.on("aws_lambda.parse_body", _on_lambda_parse_body)
+
+
+def unlisten() -> None:
+    core.reset_listeners("aws_lambda.start_request", _on_lambda_start_request)
+    core.reset_listeners("aws_lambda.start_response", _on_lambda_start_response)
+    core.reset_listeners("aws_lambda.parse_body", _on_lambda_parse_body)

--- a/ddtrace/appsec/_contrib/django/__init__.py
+++ b/ddtrace/appsec/_contrib/django/__init__.py
@@ -283,3 +283,19 @@ def listen() -> None:
 
     core.on("context.ended.django.traced_get_response", _on_context_ended)
     core.on("django.traced_get_response.pre", _on_traced_get_response_pre)
+
+
+def unlisten() -> None:
+    core.reset_listeners("django.login", _on_django_login)
+    core.reset_listeners("django.auth", _on_django_auth)
+    core.reset_listeners("django.process_request", _on_django_process)
+    core.reset_listeners("django.create_user", _on_django_signup_user)
+
+    core.reset_listeners("django.start_response.post", _call_waf_first)
+    core.reset_listeners("django.finalize_response", _call_waf)
+    core.reset_listeners("django.after_request_headers", _get_headers_if_appsec)
+    core.reset_listeners("django.extract_body", _get_headers_if_appsec)
+    core.reset_listeners("django.after_request_headers.finalize", _set_headers_and_response)
+
+    core.reset_listeners("context.ended.django.traced_get_response", _on_context_ended)
+    core.reset_listeners("django.traced_get_response.pre", _on_traced_get_response_pre)

--- a/ddtrace/appsec/_contrib/fastapi/__init__.py
+++ b/ddtrace/appsec/_contrib/fastapi/__init__.py
@@ -126,3 +126,14 @@ def listen() -> None:
     core.on("asgi.finalize_response", _set_headers_and_response)
 
     core.on("context.ended.asgi.__call__", _on_context_ended)
+
+
+def unlisten() -> None:
+    core.reset_listeners("asgi.request.parse.body", _on_asgi_request_parse_body)
+    core.reset_listeners("asgi.block.started", _asgi_make_block_content)
+
+    core.reset_listeners("asgi.start_request", _call_waf_first)
+    core.reset_listeners("asgi.start_response", _call_waf)
+    core.reset_listeners("asgi.finalize_response", _set_headers_and_response)
+
+    core.reset_listeners("context.ended.asgi.__call__", _on_context_ended)

--- a/ddtrace/appsec/_contrib/flask/__init__.py
+++ b/ddtrace/appsec/_contrib/flask/__init__.py
@@ -274,3 +274,19 @@ def listen() -> None:
     core.on("flask.start_response", _call_waf_first)
 
     core.on("context.ended.wsgi.__call__", _on_context_ended)
+
+
+def unlisten() -> None:
+    core.reset_listeners("flask.request_call_modifier", _on_request_span_modifier)
+    core.reset_listeners("flask.blocked_request_callable", _on_flask_blocked_request)
+    core.reset_listeners("flask.start_response.blocked", _on_start_response_blocked)
+    core.reset_listeners("wsgi.block.started", _wsgi_make_block_content)
+
+    core.reset_listeners("flask.finalize_request.post", _set_headers_and_response)
+    core.reset_listeners("flask.wrapped_view", _on_wrapped_view)
+    core.reset_listeners("flask._patched_request", _on_pre_tracedrequest)
+    core.reset_listeners("wsgi.block_decided", _on_block_decided)
+    core.reset_listeners("flask.start_response", _call_waf_first)
+
+    core.reset_listeners("context.ended.wsgi.__call__", _on_context_ended)
+    core.reset_listeners("flask.block.request.content")

--- a/ddtrace/appsec/_contrib/httpx/__init__.py
+++ b/ddtrace/appsec/_contrib/httpx/__init__.py
@@ -1,0 +1,12 @@
+from ddtrace.appsec._contrib.httpx.subscribers import AppSecHttpxRequestContextSubscriber
+from ddtrace.appsec._contrib.httpx.subscribers import AppSecHttpxSingleRequestContextSubscriber
+
+
+def listen() -> None:
+    AppSecHttpxRequestContextSubscriber.register()
+    AppSecHttpxSingleRequestContextSubscriber.register()
+
+
+def unlisten() -> None:
+    AppSecHttpxRequestContextSubscriber.unregister()
+    AppSecHttpxSingleRequestContextSubscriber.unregister()

--- a/ddtrace/appsec/_contrib/httpx/subscribers.py
+++ b/ddtrace/appsec/_contrib/httpx/subscribers.py
@@ -23,6 +23,7 @@ APPSEC_SSRF_ANALYZE_BODY_KEY = "appsec.ssrf_analyze_body"
 
 
 class AppSecHttpxRequestContextSubscriber(ContextSubscriber[HttpClientRequestEvent]):
+    auto_register = False
     event_names = (HttpClientEvents.HTTPX_REQUEST.value,)
 
     @classmethod
@@ -74,6 +75,7 @@ class AppSecHttpxRequestContextSubscriber(ContextSubscriber[HttpClientRequestEve
 
 
 class AppSecHttpxSingleRequestContextSubscriber(ContextSubscriber[HttpClientSendEvent]):
+    auto_register = False
     event_names = (HttpClientEvents.HTTPX_SEND_REQUEST.value,)
 
     @classmethod

--- a/ddtrace/appsec/_contrib/openai/handlers.py
+++ b/ddtrace/appsec/_contrib/openai/handlers.py
@@ -24,3 +24,9 @@ def listen() -> None:
     core.on("openai.chat.completions.create.before", _on_openai_llm_call)
     core.on("openai.responses.create.before", _on_openai_llm_call)
     core.on("openai.completions.create.before", _on_openai_llm_call)
+
+
+def unlisten() -> None:
+    core.reset_listeners("openai.chat.completions.create.before", _on_openai_llm_call)
+    core.reset_listeners("openai.responses.create.before", _on_openai_llm_call)
+    core.reset_listeners("openai.completions.create.before", _on_openai_llm_call)

--- a/ddtrace/appsec/_contrib/stripe/handlers.py
+++ b/ddtrace/appsec/_contrib/stripe/handlers.py
@@ -139,3 +139,11 @@ def listen() -> None:
     core.on("appsec.stripe.webhook.construct_event", _on_payment_intent_event)
     core.on("appsec.stripe.stripe_client.construct_event", _on_payment_intent_event)
     core.on("appsec.stripe.stripe_client.parse_event_notification", _on_payment_intent_event)
+
+
+def unlisten() -> None:
+    core.reset_listeners("appsec.stripe.checkout.session.create", _on_checkout_session_create)
+    core.reset_listeners("appsec.stripe.payment_intent.create", _on_payment_intent_create)
+    core.reset_listeners("appsec.stripe.webhook.construct_event", _on_payment_intent_event)
+    core.reset_listeners("appsec.stripe.stripe_client.construct_event", _on_payment_intent_event)
+    core.reset_listeners("appsec.stripe.stripe_client.parse_event_notification", _on_payment_intent_event)

--- a/ddtrace/appsec/_contrib/tornado/__init__.py
+++ b/ddtrace/appsec/_contrib/tornado/__init__.py
@@ -119,3 +119,10 @@ def listen() -> None:
     core.on("tornado.block_request", tornado_block, "tornado_future")
     core.on("tornado.send_response", tornado_call_waf_response)
     core.on("context.ended.request.tornado", _on_context_ended)
+
+
+def unlisten() -> None:
+    core.reset_listeners("tornado.start_request", tornado_call_waf_first)
+    core.reset_listeners("tornado.block_request", tornado_block)
+    core.reset_listeners("tornado.send_response", tornado_call_waf_response)
+    core.reset_listeners("context.ended.request.tornado", _on_context_ended)

--- a/ddtrace/appsec/_handlers.py
+++ b/ddtrace/appsec/_handlers.py
@@ -136,7 +136,15 @@ def _on_telemetry_periodic() -> None:
 
 
 def listen() -> None:
-    core.on("telemetry.periodic", _on_telemetry_periodic)
-
     core.on("set_http_meta_for_asm", _on_set_http_meta)
     core.on("set_http_meta_for_asm", _on_set_http_meta_for_normalized_route)
+
+
+def unlisten() -> None:
+    core.reset_listeners("set_http_meta_for_asm", _on_set_http_meta)
+    core.reset_listeners("set_http_meta_for_asm", _on_set_http_meta_for_normalized_route)
+
+
+def listen_telemetry() -> None:
+    # This listener must observe both enabled and disabled AppSec states.
+    core.on("telemetry.periodic", _on_telemetry_periodic)

--- a/ddtrace/appsec/_listeners.py
+++ b/ddtrace/appsec/_listeners.py
@@ -1,12 +1,9 @@
-import sys
-
 from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.trace import tracer
 
 
-_APPSEC_TO_BE_LOADED = True
 log = get_logger(__name__)
 
 
@@ -42,11 +39,37 @@ def _abort_appsec(failure_msg: str) -> None:
 def disable_appsec(reconfigure_tracer: bool = False) -> None:
     try:
         from ddtrace.appsec._processor import AppSecSpanProcessor
+        from ddtrace.appsec._processor import unlisten as processor_unlisten
     except Exception as e:
         _abort_appsec(str(e))
         return
 
     AppSecSpanProcessor.disable()
+    processor_unlisten()
+
+    from ddtrace.appsec._asm_request_context import asm_unlisten
+    from ddtrace.appsec._contrib.aws_lambda import unlisten as aws_lambda_unlisten
+    from ddtrace.appsec._contrib.django import unlisten as django_unlisten
+    from ddtrace.appsec._contrib.fastapi import unlisten as fastapi_unlisten
+    from ddtrace.appsec._contrib.flask import unlisten as flask_unlisten
+    from ddtrace.appsec._contrib.httpx import unlisten as httpx_unlisten
+    from ddtrace.appsec._contrib.openai.handlers import unlisten as openai_unlisten
+    from ddtrace.appsec._contrib.stripe.handlers import unlisten as stripe_unlisten
+    from ddtrace.appsec._contrib.tornado import unlisten as tornado_unlisten
+    from ddtrace.appsec._handlers import unlisten
+    from ddtrace.appsec._trace_utils import unlisten as trace_utils_unlisten
+
+    unlisten()
+    asm_unlisten()
+    aws_lambda_unlisten()
+    flask_unlisten()
+    django_unlisten()
+    fastapi_unlisten()
+    httpx_unlisten()
+    openai_unlisten()
+    stripe_unlisten()
+    tornado_unlisten()
+    trace_utils_unlisten()
 
     if asm_config._api_security_active:
         from ddtrace.appsec._api_security.api_manager import APIManager
@@ -65,6 +88,7 @@ def load_appsec(reconfigure_tracer: bool = False, origin: str = "") -> bool:
     """Lazily load the appsec module listeners."""
     try:
         from ddtrace.appsec._processor import AppSecSpanProcessor
+        from ddtrace.appsec._processor import listen as processor_listen
     except Exception as e:
         _abort_appsec(str(e))
         return False
@@ -74,31 +98,31 @@ def load_appsec(reconfigure_tracer: bool = False, origin: str = "") -> bool:
     from ddtrace.appsec._contrib.django import listen as django_listen
     from ddtrace.appsec._contrib.fastapi import listen as fastapi_listen
     from ddtrace.appsec._contrib.flask import listen as flask_listen
+    from ddtrace.appsec._contrib.httpx import listen as httpx_listen
     from ddtrace.appsec._contrib.openai.handlers import listen as openai_listen
     from ddtrace.appsec._contrib.stripe.handlers import listen as stripe_listen
     from ddtrace.appsec._contrib.tornado import listen as tornado_listen
     from ddtrace.appsec._handlers import listen
+    from ddtrace.appsec._handlers import listen_telemetry
+    from ddtrace.appsec._trace_utils import listen as trace_utils_listen
     # from ddtrace.appsec._contrib.grpc import listen as grpc_listen
 
-    global _APPSEC_TO_BE_LOADED
-    if _APPSEC_TO_BE_LOADED:
-        listen()
-        asm_listen()
-        aws_lambda_listen()
-        flask_listen()
-        django_listen()
-        fastapi_listen()
-        import ddtrace.appsec._contrib.httpx.subscribers  # noqa: F401
+    listen()
+    listen_telemetry()
+    asm_listen()
+    aws_lambda_listen()
+    flask_listen()
+    django_listen()
+    fastapi_listen()
+    httpx_listen()
+    openai_listen()
+    stripe_listen()
+    tornado_listen()
+    trace_utils_listen()
+    processor_listen()
 
-        openai_listen()
-        stripe_listen()
-        tornado_listen()
-
-        # GRPC integration was disabled in commit 5fe1c163738c9e6d13127067f8eceee2302bcb67, deemed too unreliable
-        # grpc_listen()
-
-        core.on("asm.switch_state", _asm_switch_state)
-        _APPSEC_TO_BE_LOADED = False
+    # GRPC integration was disabled in commit 5fe1c163738c9e6d13127067f8eceee2302bcb67, deemed too unreliable
+    # grpc_listen()
 
     from ddtrace.appsec._processor import AppSecSpanProcessor
 
@@ -126,13 +150,5 @@ def load_common_appsec_modules() -> None:
         patch_common_modules()
 
 
-# Test only helpers
-# for tests that needs to load the appsec module later
+# Test-only helper for tests that need to load AppSec modules later.
 core.on("test.config.override", load_common_appsec_modules)
-
-
-def _asm_switch_state() -> None:
-    if asm_config._asm_enabled:
-        load_appsec()
-    elif "ddtrace.appsec._processor" in sys.modules:
-        disable_appsec()

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -450,5 +450,12 @@ def waf_update(
         AppSecSpanProcessor._instance._update_rules(removals, updates)
 
 
+def listen() -> None:
+    core.on("waf.update", waf_update)
+
+
+def unlisten() -> None:
+    core.reset_listeners("waf.update", waf_update)
+
+
 core.on("test.config.override", AppSecSpanProcessor._reset)
-core.on("waf.update", waf_update)

--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -389,5 +389,9 @@ def block_request_if_user_blocked(userid: str, mode: str = "sdk", session_id: Op
         _asm_request_context.block_request()
 
 
-# Registered here (always imported on AppSec startup) so set_user enforces user blocking.
-core.on("set_user_for_asm", block_request_if_user_blocked, "block_user")
+def listen() -> None:
+    core.on("set_user_for_asm", block_request_if_user_blocked, "block_user")
+
+
+def unlisten() -> None:
+    core.reset_listeners("set_user_for_asm", block_request_if_user_blocked)

--- a/ddtrace/internal/core/subscriber.py
+++ b/ddtrace/internal/core/subscriber.py
@@ -58,6 +58,7 @@ class Subscriber:
     """
 
     event_names: Sequence[str]
+    auto_register: ClassVar[bool] = True
     _event_handlers: tuple = ()
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
@@ -79,12 +80,20 @@ class Subscriber:
             log.debug("Subscriber class %s does not define 'event_names' and will not be registered. ", cls.__name__)
             return
 
+        if cls.auto_register:
+            cls.register()
+
+    @classmethod
+    def register(cls) -> None:
+        """Register this subscriber for its declared events."""
         for event_name in cls.event_names:
-            core.on(
-                event_name,
-                cls._on_event,
-                name=f"{cls.__name__}",
-            )
+            core.on(event_name, cls._on_event, name=cls.__name__)
+
+    @classmethod
+    def unregister(cls) -> None:
+        """Unregister this subscriber from its declared events."""
+        for event_name in cls.event_names:
+            core.reset_listeners(event_name, cls._on_event)
 
     @classmethod
     def on_event(cls, event_instance):
@@ -134,6 +143,7 @@ class ContextSubscriber(Generic[EventType]):
     """
 
     event_names: ClassVar[Sequence[str]]
+    auto_register: ClassVar[bool] = True
     _started_handlers: tuple = ()
     _ended_handlers: tuple = ()
 
@@ -166,6 +176,12 @@ class ContextSubscriber(Generic[EventType]):
             log.debug("Subscriber class %s does not define 'event_names' and will not be registered. ", cls.__name__)
             return
 
+        if cls.auto_register:
+            cls.register()
+
+    @classmethod
+    def register(cls) -> None:
+        """Register this subscriber for its declared context events."""
         for event_name in cls.event_names:
             core.on(
                 f"context.started.{event_name}",
@@ -177,6 +193,13 @@ class ContextSubscriber(Generic[EventType]):
                 cls._on_context_ended,
                 name=f"{cls.__name__}.ended",
             )
+
+    @classmethod
+    def unregister(cls) -> None:
+        """Unregister this subscriber from its declared context events."""
+        for event_name in cls.event_names:
+            core.reset_listeners(f"context.started.{event_name}", cls._on_context_started)
+            core.reset_listeners(f"context.ended.{event_name}", cls._on_context_ended)
 
     @classmethod
     def on_started(cls, ctx: core.ExecutionContext[EventType]):

--- a/releasenotes/notes/appsec-listener-lifecycle-5b37baf46d536420.yaml
+++ b/releasenotes/notes/appsec-listener-lifecycle-5b37baf46d536420.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    ASM: Fixes an issue where AppSec integration event handlers remain active after
+    AppSec is disabled through one-click activation.

--- a/tests/appsec/appsec/test_listeners.py
+++ b/tests/appsec/appsec/test_listeners.py
@@ -1,0 +1,64 @@
+import pytest
+
+
+@pytest.mark.subprocess(
+    env={
+        "DD_APPSEC_ENABLED": "false",
+        "DD_REMOTE_CONFIGURATION_ENABLED": "false",
+    }
+)
+def test_appsec_listeners_follow_activation_lifecycle():
+    from unittest import mock
+
+    from ddtrace.appsec._contrib.openai import handlers as openai_handlers
+    from ddtrace.appsec._listeners import disable_appsec
+    from ddtrace.appsec._listeners import load_appsec
+    from ddtrace.contrib._events.http_client import HttpClientEvents
+    from ddtrace.internal import core
+
+    appsec_events = (
+        "set_http_meta_for_asm",
+        "asm.set_blocked",
+        "asm.get_blocked",
+        "aws_lambda.start_request",
+        "django.login",
+        "asgi.start_request",
+        f"context.started.{HttpClientEvents.HTTPX_SEND_REQUEST.value}",
+        "openai.chat.completions.create.before",
+        "appsec.stripe.checkout.session.create",
+        "tornado.start_request",
+        "set_user_for_asm",
+        "waf.update",
+    )
+
+    # Disabling before the first explicit load must also be safe and complete.
+    disable_appsec()
+    active_events = [event for event in appsec_events if core.has_listeners(event)]
+    if active_events:
+        raise AssertionError(active_events)
+
+    with mock.patch.object(openai_handlers, "in_asm_context", return_value=False) as in_asm_context:
+        assert load_appsec()
+        assert load_appsec()
+        assert all(core.has_listeners(event) for event in appsec_events)
+
+        core.dispatch("openai.chat.completions.create.before", ({},))
+        in_asm_context.assert_called_once_with()
+
+        core.dispatch("wsgi.block_decided", (lambda: None,))
+        assert core.has_listeners("flask.block.request.content")
+
+        disable_appsec()
+        disable_appsec()
+        assert not any(core.has_listeners(event) for event in appsec_events)
+        assert not core.has_listeners("flask.block.request.content")
+
+        core.dispatch("wsgi.block_decided", (lambda: None,))
+        assert not core.has_listeners("flask.block.request.content")
+        core.dispatch("openai.chat.completions.create.before", ({},))
+        in_asm_context.assert_called_once_with()
+
+        assert load_appsec()
+        assert all(core.has_listeners(event) for event in appsec_events)
+        core.dispatch("openai.chat.completions.create.before", ({},))
+        assert in_asm_context.call_count == 2

--- a/tests/internal/test_subscribers.py
+++ b/tests/internal/test_subscribers.py
@@ -51,6 +51,15 @@ def test_base_subscriber():
         called,
     )
 
+    DirectSubscriber.unregister()
+    core.dispatch_event(SubscriberEvent())
+    assert called == [SubscriberEvent.event_name]
+
+    DirectSubscriber.register()
+    DirectSubscriber.register()
+    core.dispatch_event(SubscriberEvent())
+    assert called == [SubscriberEvent.event_name, SubscriberEvent.event_name]
+
 
 def test_base_subscriber_inheritance():
     """Test that parent and child BaseSubscriber handlers run in order."""
@@ -70,6 +79,23 @@ def test_base_subscriber_inheritance():
     core.dispatch_event(SubscriberEvent())
 
     assert called == ["parent", "child"], "parent and child subscribers should run in order; got %r" % (called,)
+
+
+def test_base_subscriber_can_disable_automatic_registration():
+    class ExplicitSubscriber(Subscriber):
+        auto_register = False
+        event_names = (SubscriberEvent.event_name,)
+
+        @classmethod
+        def on_event(cls, event_instance):
+            called.append(event_instance.event_name)
+
+    core.dispatch_event(SubscriberEvent())
+    assert called == []
+
+    ExplicitSubscriber.register()
+    core.dispatch_event(SubscriberEvent())
+    assert called == [SubscriberEvent.event_name]
 
 
 def test_base_subscriber_multiple_event_names():
@@ -128,6 +154,18 @@ def test_base_context_subscriber():
     with core.context_with_event(TestContextEventWithAttributes(in_context="foo", not_in_context="bar")):
         pass
 
+    assert called == ["started", "foo", "ended"]
+
+    called.clear()
+    DirectSubscriber.unregister()
+    with core.context_with_event(TestContextEventWithAttributes(in_context="foo", not_in_context="bar")):
+        pass
+    assert called == []
+
+    DirectSubscriber.register()
+    DirectSubscriber.register()
+    with core.context_with_event(TestContextEventWithAttributes(in_context="foo", not_in_context="bar")):
+        pass
     assert called == ["started", "foo", "ended"]
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -249,7 +249,6 @@ def override_global_config(values: dict[str, Any]):
         AppSecIastSpanProcessor.disable()
     try:
         core.dispatch("test.config.override")
-        core.dispatch("asm.switch_state")
         yield
     finally:
         # Reset all to their original values


### PR DESCRIPTION
## Description

Replace the process-global `_APPSEC_TO_BE_LOADED` sentinel with explicit, symmetric listener registration and deregistration.

AppSec activation now registers every activation-sensitive listener it owns, including the typed HTTPX subscribers and listeners that were previously installed as import side effects. Deactivation unregisters those listeners and clears the request-scoped Flask blocking callback. Registration remains idempotent, so load/load and disable/disable sequences are safe.

The AppSec telemetry listener intentionally remains registered after deactivation so it can report the disabled state.

## Testing

- `rt run 248da41@12d4546 -- --no-cov tests/appsec/appsec/test_listeners.py tests/appsec/appsec/test_remoteconfiguration.py tests/appsec/appsec/test_processor.py` (131 passed, 1 xfailed)
- `rt run 248da41@12d4546 -- --no-cov tests/appsec/appsec/test_telemetry.py::test_appsec_enabled_metric tests/appsec/appsec/test_listeners.py` (13 passed)
- `rt run 1cdebe0@1625618 -- --no-cov tests/internal/test_subscribers.py` (14 passed)
- `scripts/lint checks`
- Import-cycle analysis (no new cycles)

## Risks

Listener ownership is spread across several AppSec integration modules. The lifecycle test covers each registration group, repeated activation/deactivation, HTTPX typed subscribers, and the dynamically registered Flask block callback. The telemetry test covers reporting both enabled and disabled AppSec states.

## Additional Notes

This PR is intentionally limited to AppSec listener activation lifecycle. The common-module/subprocess signal redesign remains separate.
