### PR TITLE
refactor: move debug.py under _trace

### DIFF
--- a/benchmarks/suitespec.yml
+++ b/benchmarks/suitespec.yml
@@ -61,7 +61,6 @@ components:
     - ddtrace/internal/compat.py
     - ddtrace/internal/core/*
     - ddtrace/internal/datadog/__init__.py
-    - ddtrace/internal/debug.py
     - ddtrace/internal/dogstatsd.py
     - ddtrace/internal/forksafe.py
     - ddtrace/internal/gitmetadata.py

--- a/ddtrace/_trace/debug.py
+++ b/ddtrace/_trace/debug.py
@@ -6,17 +6,18 @@ from typing import TYPE_CHECKING  # noqa:F401
 from typing import Any  # noqa:F401
 from typing import Union  # noqa:F401
 
-import ddtrace
+from ddtrace import _monkey
+from ddtrace.internal import agent
+from ddtrace.internal.logger import get_logger
 from ddtrace.internal.packages import get_distributions
 from ddtrace.internal.settings import env
 from ddtrace.internal.settings._agent import config as agent_config
+from ddtrace.internal.settings._config import config
 from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.utils.cache import callonce
 from ddtrace.internal.writer import AgentWriterInterface
 from ddtrace.internal.writer import LogWriter
 from ddtrace.version import __version__
-
-from .logger import get_logger
 
 
 logger = get_logger(__name__)
@@ -41,24 +42,21 @@ def tags_to_str(tags: dict[str, Any]) -> str:
     return ",".join(["%s:%s" % (k, v) for k, v in tags.items()])
 
 
-def collect() -> dict[str, Any]:
+def collect(tracer) -> dict[str, Any]:
     """Collect system and library information into a serializable dict."""
 
     # Inline expensive imports to avoid unnecessary overhead on startup.
     from ddtrace.internal import gitmetadata
     from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker
     from ddtrace.internal.settings.crashtracker import config as crashtracker_config
-    from ddtrace.trace import tracer
 
     if isinstance(tracer._span_aggregator.writer, LogWriter):
         agent_url = "AGENTLESS"
         agent_error = None
     elif isinstance(tracer._span_aggregator.writer, AgentWriterInterface):
-        writer = tracer._span_aggregator.writer
-        agent_url = writer.intake_url
+        agent_url = tracer._span_aggregator.writer.intake_url
         try:
-            writer.write([])
-            writer.flush_queue(raise_exc=True)
+            agent.info(agent_url)
         except Exception as e:
             agent_error = "Agent not reachable at %s. Exception raised: %s" % (agent_url, str(e))
         else:
@@ -73,11 +71,11 @@ def collect() -> dict[str, Any]:
 
     packages_available = {name: version for (name, version) in get_distributions().items()}
     integration_configs: dict[str, Union[dict[str, Any], str]] = {}
-    for module, enabled in ddtrace._monkey.PATCH_MODULES.items():
+    for module, enabled in _monkey.PATCH_MODULES.items():
         # TODO: this check doesn't work in all cases... we need a mapping
         #       between the module and the library name.
         module_available = module in packages_available
-        module_instrumented = module in ddtrace._monkey._PATCHED_MODULES
+        module_instrumented = module in _monkey._PATCHED_MODULES
         module_imported = module in sys.modules
 
         if enabled:
@@ -87,9 +85,9 @@ def collect() -> dict[str, Any]:
             # This also doesn't load work in all cases since we don't always
             # name the configuration entry the same as the integration module
             # name :/
-            config = ddtrace.config._config.get(module, "N/A")
+            module_config = config._config.get(module, "N/A")
         else:
-            config = None
+            module_config = None
 
         if module_available:
             integration_configs[module] = dict(
@@ -97,7 +95,7 @@ def collect() -> dict[str, Any]:
                 instrumented=module_instrumented,
                 module_version=packages_available[module],
                 module_imported=module_imported,
-                config=config,
+                config=module_config,
             )
 
     pip_version = packages_available.get("pip", "N/A")
@@ -121,17 +119,17 @@ def collect() -> dict[str, Any]:
         agent_url=agent_url,
         agent_error=agent_error,
         statsd_url=agent_config.dogstatsd_url,
-        env=ddtrace.config.env or "",
-        ddtrace_enabled=ddtrace.config._tracing_enabled,
+        env=config.env or "",
+        ddtrace_enabled=config._tracing_enabled,
         sampling_rules=sampling_rules,
-        service=ddtrace.config.service or "",
+        service=config.service or "",
         debug=logger.isEnabledFor(logging.DEBUG),
         enabled_cli="ddtrace" in env.get("PYTHONPATH", ""),
-        log_injection_enabled=ddtrace.config._logs_injection,
-        health_metrics_enabled=ddtrace.config._health_metrics_enabled,
+        log_injection_enabled=config._logs_injection,
+        health_metrics_enabled=config._health_metrics_enabled,
         runtime_metrics_enabled=RuntimeWorker.enabled,
-        dd_version=ddtrace.config.version or "",
-        global_tags=tags_to_str(ddtrace.config.tags),
+        dd_version=config.version or "",
+        global_tags=tags_to_str(config.tags),
         tracer_tags=tags_to_str(tracer._tags),
         integrations=integration_configs,
         partial_flush_enabled=tracer._span_aggregator.partial_flush_enabled,
@@ -139,8 +137,8 @@ def collect() -> dict[str, Any]:
         asm_enabled=asm_config._asm_enabled,
         iast_enabled=asm_config._iast_enabled,
         waf_timeout=asm_config._waf_timeout,
-        remote_config_enabled=ddtrace.config._remote_config_enabled,
-        config_endpoint=ddtrace.config._from_endpoint,
+        remote_config_enabled=config._remote_config_enabled,
+        config_endpoint=config._from_endpoint,
         crashtracking_enabled=crashtracker_config.enabled,
         gitmetadata_enabled=gitmetadata.config.enabled,
         git_repository_url=git_repository_url,
@@ -150,7 +148,7 @@ def collect() -> dict[str, Any]:
     )
 
 
-def pretty_collect(color=True):
+def pretty_collect(tracer, color=True):
     class bcolors:
         HEADER = "\033[95m"
         OKBLUE = "\033[94m"
@@ -171,7 +169,7 @@ def pretty_collect(color=True):
         bcolors.ENDC = ""
         bcolors.BOLD = ""
 
-    info = collect()
+    info = collect(tracer)
 
     info_pretty = """{blue}{bold}Tracer Configurations:{end}
     Tracer enabled: {tracer_enabled}

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -16,6 +16,7 @@ from typing import TypeVar
 from typing import Union
 from typing import cast
 
+from ddtrace._trace import debug
 from ddtrace._trace.context import Context
 from ddtrace._trace.processor import SpanAggregator
 from ddtrace._trace.processor import SpanProcessor
@@ -31,7 +32,6 @@ from ddtrace.constants import PID
 from ddtrace.constants import VERSION_KEY
 from ddtrace.internal import atexit
 from ddtrace.internal import core
-from ddtrace.internal import debug
 from ddtrace.internal import forksafe
 from ddtrace.internal import hostname
 from ddtrace.internal.constants import _SERVICE_SOURCE
@@ -389,7 +389,7 @@ class Tracer(object):
     def _generate_diagnostic_logs(self):
         if config._debug_mode or config._startup_logs_enabled:
             try:
-                info = debug.collect()
+                info = debug.collect(self)
             except Exception as e:
                 msg = "Failed to collect start-up logs: %s" % e
                 self._log_compat(logging.WARNING, "- DATADOG TRACER DIAGNOSTIC - %s" % msg)

--- a/ddtrace/bootstrap/preload.py
+++ b/ddtrace/bootstrap/preload.py
@@ -62,7 +62,7 @@ if profiling_config.enabled:
         log.error("failed to enable profiling", exc_info=True)
 
 if config._runtime_metrics_enabled:
-    RuntimeWorker.enable()
+    RuntimeWorker.enable(tracer=tracer)
 
 
 @ModuleWatchdog.after_module_imported("opentelemetry")

--- a/ddtrace/commands/ddtrace_run.py
+++ b/ddtrace/commands/ddtrace_run.py
@@ -88,9 +88,10 @@ def _prepare_env(parser: argparse.ArgumentParser):
 
     if args.info:
         # Inline imports for performance.
-        from ddtrace.internal.debug import pretty_collect
+        from ddtrace._trace.debug import pretty_collect
+        from ddtrace.trace import tracer
 
-        print(pretty_collect(color=not args.colorless))
+        print(pretty_collect(tracer, color=not args.colorless))
         sys.exit(0)
 
     root_dir = os.path.dirname(ddtrace.__file__)

--- a/ddtrace/internal/agent.py
+++ b/ddtrace/internal/agent.py
@@ -27,7 +27,7 @@ def process_info_headers(resp):
         log.debug("Could not compute base hash: %s", e)
 
 
-def info(url=None):
+def info(url: t.Optional[str] = None) -> t.Optional[dict]:
     agent_url = config.trace_agent_url if url is None else url
     timeout = config.trace_agent_timeout_seconds
     _conn = get_connection(agent_url, timeout=timeout)
@@ -47,7 +47,7 @@ def info(url=None):
         log.warning("Unexpected error: HTTP error status %s, reason %s", resp.status, resp.reason)
         return None
 
-    return json.loads(data)
+    return t.cast(dict, json.loads(data))
 
 
 class AgentCheckPeriodicService(ForksafeAwakeablePeriodicService, metaclass=abc.ABCMeta):

--- a/ddtrace/internal/runtime/runtime_metrics.py
+++ b/ddtrace/internal/runtime/runtime_metrics.py
@@ -2,9 +2,10 @@ import itertools
 from typing import ClassVar  # noqa:F401
 from typing import Optional  # noqa:F401
 
-import ddtrace
 from ddtrace.internal import atexit
 from ddtrace.internal.constants import EXPERIMENTAL_FEATURES
+from ddtrace.internal.settings._agent import config as agent_config
+from ddtrace.internal.settings._config import config
 from ddtrace.internal.threads import Lock
 from ddtrace.vendor.dogstatsd import DogStatsd
 
@@ -83,18 +84,16 @@ class RuntimeWorker(periodic.PeriodicService):
     def __init__(self, interval=DEFAULT_RUNTIME_METRICS_INTERVAL, tracer=None, dogstatsd_url=None) -> None:
         super().__init__(interval=interval)
         self.dogstatsd_url: Optional[str] = dogstatsd_url
-        self._dogstatsd_client: DogStatsd = get_dogstatsd_client(
-            self.dogstatsd_url or ddtrace.internal.settings._agent.config.dogstatsd_url
-        )
-        self.tracer: ddtrace.trace.Tracer = tracer or ddtrace.tracer
+        self._dogstatsd_client: DogStatsd = get_dogstatsd_client(self.dogstatsd_url or agent_config.dogstatsd_url)
+        self.tracer = tracer
         self._runtime_metrics: RuntimeMetrics = RuntimeMetrics()
-        if EXPERIMENTAL_FEATURES.RUNTIME_METRICS in ddtrace.config._experimental_features_enabled:
+        if EXPERIMENTAL_FEATURES.RUNTIME_METRICS in config._experimental_features_enabled:
             # Enables sending runtime metrics as gauges (instead of distributions with a new metric name)
             self.send_metric = self._dogstatsd_client.gauge
         else:
             self.send_metric = self._dogstatsd_client.distribution
 
-        if ddtrace.config._runtime_metrics_runtime_id_enabled:
+        if config._runtime_metrics_runtime_id_enabled:
             # Enables tagging runtime metrics with runtime-id (as well as all the v1 tags)
             self._platform_tags = self._format_tags(PlatformTagsV2())
         else:
@@ -124,7 +123,7 @@ class RuntimeWorker(periodic.PeriodicService):
     @classmethod
     def enable(
         cls,
-        tracer: Optional[ddtrace.trace.Tracer] = None,
+        tracer=None,
         dogstatsd_url: Optional[str] = None,
     ) -> None:
         with cls._lock:

--- a/ddtrace/runtime/__init__.py
+++ b/ddtrace/runtime/__init__.py
@@ -42,7 +42,9 @@ class RuntimeMetrics(metaclass=_RuntimeMetricsStatus):
         :param tracer: The tracer instance to correlate with.
         """
         telemetry_writer.add_configuration(TELEMETRY_RUNTIMEMETRICS_ENABLED, True, origin="code")
-        ddtrace.internal.runtime.runtime_metrics.RuntimeWorker.enable(tracer=tracer, dogstatsd_url=dogstatsd_url)
+        ddtrace.internal.runtime.runtime_metrics.RuntimeWorker.enable(
+            tracer=tracer or ddtrace.trace.tracer, dogstatsd_url=dogstatsd_url
+        )
 
     @staticmethod
     def disable() -> None:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1289,7 +1289,7 @@ disallow_untyped_calls = false
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
 
-[mypy-ddtrace.internal.debug]
+[mypy-ddtrace._trace.debug]
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
 

--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -8,7 +8,7 @@ import mock
 import pytest
 
 import ddtrace
-from ddtrace.internal import debug
+from ddtrace._trace import debug
 from tests.integration.utils import AGENT_VERSION
 from tests.subprocesstest import SubprocessTestCase
 from tests.subprocesstest import run_in_subprocess
@@ -31,9 +31,10 @@ def re_matcher(pattern):
 def test_standard_tags():
     from datetime import datetime
 
-    from ddtrace.internal import debug
+    from ddtrace._trace import debug
+    from ddtrace.trace import tracer
 
-    f = debug.collect()
+    f = debug.collect(tracer)
 
     date = f.get("date")
     assert isinstance(date, str)
@@ -96,9 +97,10 @@ def test_standard_tags():
 def test_debug_post_configure_uds():
     import re
 
-    from ddtrace.internal import debug
+    from ddtrace._trace import debug
+    from ddtrace.trace import tracer
 
-    f = debug.collect()
+    f = debug.collect(tracer)
 
     agent_url = f.get("agent_url")
     assert agent_url == "unix:///file.sock"
@@ -121,7 +123,7 @@ class TestGlobalConfig(SubprocessTestCase):
         )
     )
     def test_env_config(self):
-        f = debug.collect()
+        f = debug.collect(ddtrace.trace.tracer)
         assert f.get("agent_url") == "http://0.0.0.0:4321"
         assert f.get("health_metrics_enabled") is True
         assert f.get("log_injection_enabled") is True
@@ -141,7 +143,7 @@ class TestGlobalConfig(SubprocessTestCase):
         )
     )
     def test_trace_agent_url(self):
-        f = debug.collect()
+        f = debug.collect(ddtrace.trace.tracer)
         assert f.get("agent_url") == "http://0.0.0.0:1234"
 
     @run_in_subprocess(
@@ -210,18 +212,19 @@ class TestGlobalConfig(SubprocessTestCase):
 
 @pytest.mark.subprocess(ddtrace_run=True, err=None)
 def test_runtime_metrics_enabled_via_manual_start():
-    from ddtrace.internal import debug
+    from ddtrace._trace import debug
     from ddtrace.runtime import RuntimeMetrics
+    from ddtrace.trace import tracer
 
-    f = debug.collect()
+    f = debug.collect(tracer)
     assert f.get("runtime_metrics_enabled") is False
 
     RuntimeMetrics.enable()
-    f = debug.collect()
+    f = debug.collect(tracer)
     assert f.get("runtime_metrics_enabled") is True
 
     RuntimeMetrics.disable()
-    f = debug.collect()
+    f = debug.collect(tracer)
     assert f.get("runtime_metrics_enabled") is False
 
 
@@ -229,10 +232,11 @@ def test_runtime_metrics_enabled_via_manual_start():
 def test_runtime_metrics_enabled_via_env_var_start():
     import os
 
-    from ddtrace.internal import debug
+    from ddtrace._trace import debug
     from ddtrace.internal.utils.formats import asbool
+    from ddtrace.trace import tracer
 
-    f = debug.collect()
+    f = debug.collect(tracer)
     assert f.get("runtime_metrics_enabled") is asbool(os.getenv("DD_RUNTIME_METRICS_ENABLED")), (
         f.get("runtime_metrics_enabled"),
         asbool(os.getenv("DD_RUNTIME_METRICS_ENABLED")),
@@ -240,15 +244,16 @@ def test_runtime_metrics_enabled_via_env_var_start():
 
 
 def test_to_json():
-    info = debug.collect()
+    info = debug.collect(ddtrace.trace.tracer)
     json.dumps(info)
 
 
 @pytest.mark.subprocess(env={"AWS_LAMBDA_FUNCTION_NAME": "something"})
 def test_agentless(monkeypatch):
-    from ddtrace.internal import debug
+    from ddtrace._trace import debug
+    from ddtrace.trace import tracer
 
-    info = debug.collect()
+    info = debug.collect(tracer)
     assert info.get("agent_url") == "AGENTLESS"
 
 
@@ -256,7 +261,7 @@ def test_agentless(monkeypatch):
 def test_custom_writer():
     from typing import Optional
 
-    from ddtrace.internal import debug
+    from ddtrace._trace import debug
     from ddtrace.internal.writer import TraceWriter
     from ddtrace.trace import Span
     from ddtrace.trace import tracer
@@ -275,16 +280,17 @@ def test_custom_writer():
             pass
 
     tracer._span_aggregator.writer = CustomWriter()
-    info = debug.collect()
+    info = debug.collect(tracer)
 
     assert info.get("agent_url") == "CUSTOM"
 
 
 @pytest.mark.subprocess(env={"DD_TRACE_SAMPLING_RULES": '[{"sample_rate":1.0}]'})
 def test_startup_logs_sampling_rules():
-    from ddtrace.internal import debug
+    from ddtrace._trace import debug
+    from ddtrace.trace import tracer
 
-    f = debug.collect()
+    f = debug.collect(tracer)
 
     assert f.get("sampling_rules") == [
         "SamplingRule(sample_rate=1.0, service=None, name=None, resource=None, tags={}, provenance=default)"
@@ -293,18 +299,20 @@ def test_startup_logs_sampling_rules():
 
 @pytest.mark.subprocess()
 def test_startup_logs_log_level_override_default():
-    from ddtrace.internal import debug
+    from ddtrace._trace import debug
+    from ddtrace.trace import tracer
 
-    f = debug.collect()
+    f = debug.collect(tracer)
 
     assert f.get("log_level_override") is None
 
 
 @pytest.mark.subprocess(env={"DD_TRACE_LOG_LEVEL": "WARNING"})
 def test_startup_logs_log_level_override_set():
-    from ddtrace.internal import debug
+    from ddtrace._trace import debug
+    from ddtrace.trace import tracer
 
-    f = debug.collect()
+    f = debug.collect(tracer)
 
     assert f.get("log_level_override") == "WARNING"
 
@@ -378,9 +386,10 @@ def test_debug_span_log():
     )
 )
 def test_partial_flush_log():
-    from ddtrace.internal import debug
+    from ddtrace._trace import debug
+    from ddtrace.trace import tracer
 
-    f = debug.collect()
+    f = debug.collect(tracer)
 
     partial_flush_enabled = f.get("partial_flush_enabled")
     partial_flush_min_spans = f.get("partial_flush_min_spans")

--- a/tests/suitespec.yml
+++ b/tests/suitespec.yml
@@ -50,7 +50,6 @@ components:
     - ddtrace/internal/compat.py
     - ddtrace/internal/core/*
     - ddtrace/internal/datadog/__init__.py
-    - ddtrace/internal/debug.py
     - ddtrace/internal/dogstatsd.py
     - ddtrace/internal/forksafe.py
     - ddtrace/internal/gitmetadata.py


### PR DESCRIPTION
## Description

The debug.py internal utility is effectively designed around the tracer so it logically belongs to that product more than the internal core. We make the move which also allows to fix the remaining circular imports.