### PR TITLE
ci(appsec): add temporary job to reproduce the IAST django shutdown hang [DO NOT MERGE]

### DIFF
--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -86,4 +86,76 @@ include:
     - export DD_TRACE_AGENT_URL="http://testagent:9126"
     - ln -s "${CI_PROJECT_DIR}" "/home/bits/project"
 
+# AIDEV-NOTE: TEMPORARY investigation job — delete together with this branch. It hunts the
+# ~0.1%-per-run hang in test_iast_vulnerable_request_downstream_django (config3/4/5, the
+# `-w 1 -k gevent` cells), where tracer.shutdown() in the /shutdown view never returns.
+# It reuses the base venvs built once by build_base_venvs; nothing here rebuilds the project.
+core/repro_iast_django_shutdown:
+  extends: .test_base_riot_snapshot
+  stage: core
+  timeout: 75m
+  parallel: 21
+  allow_failure: true
+  needs:
+    - job: build_base_venvs
+      artifacts: true
+  variables:
+    # Preference order: py3.13 and py3.11 carry the most observed failures in CI Visibility.
+    # Whichever base venv build_base_venvs actually produced wins.
+    REPRO_PYTHONS: "3.13 3.11 3.12 3.10"
+    REPRO_ITERATIONS: "120"
+    # Every third node runs under CPU contention: the failing CI runs were on a machine roughly
+    # 2x slower than normal (~11.6s before gunicorn even started, against 5-6s when healthy).
+    REPRO_STRESS: "4"
+    _DD_TEST_ABORT_HUNG_SERVER: "1"
+  script:
+    - |
+      set -u -o pipefail
+      python_version=""
+      for candidate in ${REPRO_PYTHONS}; do
+        if compgen -G ".riot/venv_py${candidate//./}*" > /dev/null; then
+          python_version="${candidate}"
+          break
+        fi
+      done
+      if [[ -z "${python_version}" ]]; then
+        echo "None of '${REPRO_PYTHONS}' has a base venv; build_base_venvs produced:"
+        ls -d .riot/venv_py3* || true
+        exit 1
+      fi
+      echo "Using Python ${python_version}"
+      hashes=( $(riot list --hash-only --python="${python_version}" appsec_integrations_django | sort) )
+      if [[ ${#hashes[@]} -eq 0 ]]; then
+        echo "No riot hashes found"
+        exit 1
+      fi
+      # One django version per node, so the whole matrix gets covered without re-running riot's
+      # resolution for each of them.
+      node="${CI_NODE_INDEX:-1}"
+      hash="${hashes[$(( (node - 1) % ${#hashes[@]} ))]}"
+      riot list "${hash}"
+
+      stress_pids=()
+      if (( node % 3 == 0 )); then
+        for _ in $(seq 1 "${REPRO_STRESS}"); do
+          ( while :; do :; done ) &
+          stress_pids+=( $! )
+        done
+        echo "Running under CPU contention (${REPRO_STRESS} busy loops)"
+      fi
+      trap '[[ ${#stress_pids[@]} -gt 0 ]] && kill "${stress_pids[@]}" 2>/dev/null' EXIT
+
+      for i in $(seq 1 "${REPRO_ITERATIONS}"); do
+        echo "=== node ${node} hash ${hash} iteration ${i}/${REPRO_ITERATIONS} ==="
+        if ! riot -P -v run --pass-env -s "${hash}" -- \
+            -k "test_iast_vulnerable_request_downstream_django and (config3 or config4 or config5)" \
+            -p no:randomly -x -q; then
+          echo "=== REPRODUCED on node ${node}, hash ${hash}, iteration ${i} ==="
+          echo "=== after_script turns these cores into backtraces; both are kept as artifacts ==="
+          ls -la core core.* 2>/dev/null || echo "no core file"
+          exit 1
+        fi
+      done
+      echo "=== No reproduction in ${REPRO_ITERATIONS} iterations on node ${node} (hash ${hash}) ==="
+
 # Required jobs will appear here

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -127,6 +127,12 @@ core/repro_iast_django_shutdown:
         exit 1
       fi
       echo "Using Python ${python_version}"
+      # A reproduction produced faulthandler stacks but no core at all, and the core.* artifact then
+      # had nothing to upload. core_pattern is host-wide and a container cannot change it, so record
+      # what this runner is actually configured to do before spending an hour looping.
+      echo "core_pattern: $(cat /proc/sys/kernel/core_pattern 2>&1)"
+      echo "core_uses_pid: $(cat /proc/sys/kernel/core_uses_pid 2>&1)"
+      echo "ulimit -c: $(ulimit -c)  hard: $(ulimit -Hc)"
       hashes=( $(riot list --hash-only --python="${python_version}" appsec_integrations_django | sort) )
       if [[ ${#hashes[@]} -eq 0 ]]; then
         echo "No riot hashes found"

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -180,9 +180,10 @@ core/repro_iast_django_shutdown:
       echo "=== ${unrelated} of them failed for unrelated reasons ==="
   # A gunicorn worker with the native extensions loaded cores out at hundreds of MB. The artifact
   # path is core.*, so keeping the raw dumps risks the upload failing and taking the .bt.txt
-  # backtraces — the only thing we actually need — down with them.
+  # backtraces — the only thing we actually need — down with them. Delete by exclusion rather than
+  # with a core.[0-9]* glob, which would also match core.<pid>.bt.txt and throw away the output.
   after_script:
     - !reference [.testrunner, after_script]
-    - rm -f core core.[0-9]*
+    - find . -maxdepth 1 \( -name 'core' -o -name 'core.*' \) ! -name '*.bt.txt' -print -delete
 
 # Required jobs will appear here

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -103,7 +103,10 @@ core/repro_iast_django_shutdown:
     # Preference order: py3.13 and py3.11 carry the most observed failures in CI Visibility.
     # Whichever base venv build_base_venvs actually produced wins.
     REPRO_PYTHONS: "3.13 3.11 3.12 3.10"
-    REPRO_ITERATIONS: "120"
+    # Upper bound only; REPRO_DEADLINE_SECONDS is what actually ends the loop, so the job always
+    # gets to print how many iterations it managed instead of being killed mid-run by GitLab.
+    REPRO_ITERATIONS: "400"
+    REPRO_DEADLINE_SECONDS: "3900"
     # Every third node runs under CPU contention: the failing CI runs were on a machine roughly
     # 2x slower than normal (~11.6s before gunicorn even started, against 5-6s when healthy).
     REPRO_STRESS: "4"
@@ -145,17 +148,41 @@ core/repro_iast_django_shutdown:
       fi
       trap '[[ ${#stress_pids[@]} -gt 0 ]] && kill "${stress_pids[@]}" 2>/dev/null' EXIT
 
+      # These three params carry unrelated flakes of their own ("Incorrect number of spans",
+      # "X-Datadog-Origin" KeyError). Stopping on any non-zero exit would end the job on one of
+      # those long before the hang shows up, so we only stop on the hang's own signature — the
+      # message _dump_hung_server prints. Note the absence of --ddtrace: Auto Test Retries would
+      # otherwise turn a hit into a green run and swallow it, which is how this flake stayed hidden.
+      deadline=$(( SECONDS + REPRO_DEADLINE_SECONDS ))
+      unrelated=0
+      completed=0
       for i in $(seq 1 "${REPRO_ITERATIONS}"); do
+        if (( SECONDS >= deadline )); then
+          echo "=== Wall-clock budget exhausted after ${completed} iterations ==="
+          break
+        fi
         echo "=== node ${node} hash ${hash} iteration ${i}/${REPRO_ITERATIONS} ==="
         if ! riot -P -v run --pass-env -s "${hash}" -- \
             -k "test_iast_vulnerable_request_downstream_django and (config3 or config4 or config5)" \
-            -p no:randomly -x -q; then
-          echo "=== REPRODUCED on node ${node}, hash ${hash}, iteration ${i} ==="
-          echo "=== after_script turns these cores into backtraces; both are kept as artifacts ==="
-          ls -la core core.* 2>/dev/null || echo "no core file"
-          exit 1
+            -p no:randomly -x -q 2>&1 | tee /tmp/repro_iteration.log; then
+          if grep -q "did not answer /shutdown" /tmp/repro_iteration.log; then
+            echo "=== REPRODUCED on node ${node}, hash ${hash}, iteration ${i} ==="
+            echo "=== after_script turns these cores into backtraces, kept as artifacts ==="
+            ls -la core core.* 2>/dev/null || echo "no core file"
+            exit 1
+          fi
+          unrelated=$(( unrelated + 1 ))
+          echo "=== Unrelated failure on iteration ${i} (${unrelated} so far), continuing ==="
         fi
+        completed=$(( completed + 1 ))
       done
-      echo "=== No reproduction in ${REPRO_ITERATIONS} iterations on node ${node} (hash ${hash}) ==="
+      echo "=== No reproduction in ${completed} iterations on node ${node} (hash ${hash}),"
+      echo "=== ${unrelated} of them failed for unrelated reasons ==="
+  # A gunicorn worker with the native extensions loaded cores out at hundreds of MB. The artifact
+  # path is core.*, so keeping the raw dumps risks the upload failing and taking the .bt.txt
+  # backtraces — the only thing we actually need — down with them.
+  after_script:
+    - !reference [.testrunner, after_script]
+    - rm -f core core.[0-9]*
 
 # Required jobs will appear here

--- a/tests/appsec/appsec_utils.py
+++ b/tests/appsec/appsec_utils.py
@@ -256,6 +256,84 @@ def uvicorn_server(
     )
 
 
+def _describe_server_output(server_process) -> str:
+    stdout = getattr(server_process, "stdout", None)
+    stderr = getattr(server_process, "stderr", None)
+    if stdout is None and stderr is None:
+        return "The server inherited the test runner's stdout/stderr; its output is in the surrounding log."
+    return (
+        "\n=== Captured STDOUT ===\n%s=== End of captured STDOUT ==="
+        "\n=== Captured STDERR ===\n%s=== End of captured STDERR ===" % (stdout, stderr)
+    )
+
+
+def _dump_hung_server(server_process, known_worker_pids=()) -> None:
+    """Dump every stack of a server that would not shut down, so the hang can be diagnosed.
+
+    Opt-in through _DD_TEST_ABORT_HUNG_SERVER because it is expensive. SIGABRT is the whole
+    mechanism: the server runs with PYTHONFAULTHANDLER=1, so it prints every thread's Python stack
+    to stderr, and it then leaves a core file behind for the native backtrace — the only way to see
+    the Rust/Tokio threads. Attaching gdb to the live process is not an option: kernel.yama
+    .ptrace_scope is 1 on the runners and gdb would be a sibling of the target, not an ancestor.
+
+    Only the workers are aborted; killing the arbiter would reap them mid-dump.
+    """
+    if os.environ.get("_DD_TEST_ABORT_HUNG_SERVER", "") != "1":
+        return
+    try:
+        parent = psutil.Process(server_process.pid)
+        workers = [proc for proc in parent.children(recursive=True) if proc.is_running()]
+    except Exception:
+        workers = []
+    if not workers:
+        # The arbiter may already have reaped and replaced them; fall back to the pids seen at startup.
+        for pid in known_worker_pids:
+            try:
+                workers.append(psutil.Process(pid))
+            except Exception:
+                pass
+
+    aborted = []
+    for proc in workers:
+        print("=== SIGABRT on hung worker %s (faulthandler python stacks follow) ===" % proc.pid, flush=True)
+        try:
+            cwd = proc.cwd()
+        except Exception:
+            cwd = os.getcwd()
+        try:
+            proc.send_signal(signal.SIGABRT)
+        except Exception:
+            continue
+        aborted.append((proc.pid, cwd))
+    # Let the faulthandler output reach stderr and the kernel finish writing the cores.
+    time.sleep(10)
+    _collect_cores(aborted)
+
+
+def _collect_cores(aborted) -> None:
+    """Move the cores the aborted workers left behind where .gitlab/scripts/generate-core-backtraces.sh looks.
+
+    That script globs core.* in CI_PROJECT_DIR, which assumes kernel.core_pattern = core.%p. Some
+    hosts use a bare "core" instead, and the worker's cwd is not necessarily the project directory.
+    """
+    target_dir = os.environ.get("CI_PROJECT_DIR") or os.getcwd()
+    for pid, cwd in aborted:
+        for name in ("core.%d" % pid, "core"):
+            source = os.path.join(cwd, name)
+            if not os.path.isfile(source):
+                continue
+            destination = os.path.join(target_dir, "core.%d" % pid)
+            try:
+                if source != destination:
+                    os.replace(source, destination)
+                print("Core dump of worker %s available at %s" % (pid, destination), flush=True)
+            except Exception as exc:
+                print("Could not move core dump %s: %r" % (source, exc), flush=True)
+            break
+        else:
+            print("No core dump found for worker %s in %s" % (pid, cwd), flush=True)
+
+
 def appsec_application_server(
     cmd: _t.Sequence[str],
     appsec_enabled: str = "true",
@@ -372,37 +450,29 @@ def appsec_application_server(
             else:
                 client.wait(max_tries=120, delay=0.1, initial_wait=1.0)
                 print("Server started")
-        except RetryError:
-            raise AssertionError(
-                "Server failed to start, see stdout and stderr logs"
-                "\n=== Captured STDOUT ===\n%s=== End of captured STDOUT ==="
-                "\n=== Captured STDERR ===\n%s=== End of captured STDERR ==="
-                % (getattr(server_process, "stdout", None), getattr(server_process, "stderr", None))
-            )
-        except Exception:
-            raise AssertionError(
-                "Server FAILED, see stdout and stderr logs"
-                "\n=== Captured STDOUT ===\n%s=== End of captured STDOUT ==="
-                "\n=== Captured STDERR ===\n%s=== End of captured STDERR ==="
-                % (getattr(server_process, "stdout", None), getattr(server_process, "stderr", None))
-            )
+        except RetryError as exc:
+            raise AssertionError("Server failed to start. %s" % _describe_server_output(server_process)) from exc
+        except Exception as exc:
+            raise AssertionError("Server FAILED: %r\n%s" % (exc, _describe_server_output(server_process))) from exc
 
         # If we run a Gunicorn application, we want to get the child's pid, see test_flask_remoteconfig.py
         # Obtain child PID tree for gunicorn when possible
         parent = psutil.Process(server_process.pid)
         children = parent.children(recursive=True)
 
+        worker_pids = [child.pid for child in children]
+
         yield server_process, client, (children[1].pid if len(children) > 1 else None)
         try:
             client.get_ignored("/shutdown", timeout=10)
         except ConnectionError:
             pass
-        except Exception:
+        except Exception as exc:
+            _dump_hung_server(server_process, worker_pids)
             raise AssertionError(
-                "\n=== Captured STDOUT ===\n%s=== End of captured STDOUT ==="
-                "\n=== Captured STDERR ===\n%s=== End of captured STDERR ==="
-                % (getattr(server_process, "stdout", None), getattr(server_process, "stderr", None))
-            )
+                "The application server did not answer /shutdown: %r\n%s"
+                % (exc, _describe_server_output(server_process))
+            ) from exc
     finally:
         try:
             if use_multiprocess:

--- a/tests/appsec/appsec_utils.py
+++ b/tests/appsec/appsec_utils.py
@@ -267,6 +267,51 @@ def _describe_server_output(server_process) -> str:
     )
 
 
+def _dump_server_greenlets(client) -> None:
+    """Ask a hung gevent server to describe its own greenlets, over a second HTTP request.
+
+    This works precisely because the hang does not stop the hub: on a real reproduction the main
+    thread was in gevent's hub run(), still turning the event loop, so a second connection is still
+    accepted and served while /shutdown is stuck. That makes it the only way to see the stack of the
+    suspended greenlet, which faulthandler cannot reach.
+
+    Best effort by design. If the hub is wedged after all, this request times out too, and that
+    negative result is itself worth printing.
+    """
+    if os.environ.get("_DD_TEST_ABORT_HUNG_SERVER", "") != "1":
+        return
+    print("=== Asking the hung server for its greenlet stacks ===", flush=True)
+    try:
+        response = client.get_ignored("/debug/greenlets", timeout=10)
+    except Exception as exc:
+        print("=== The hung server did not answer /debug/greenlets either: %r ===" % (exc,), flush=True)
+        print("=== That means the hub itself is not turning, not just one greenlet ===", flush=True)
+        return
+    print("=== /debug/greenlets responded %s ===" % response.status_code, flush=True)
+    print(response.text, flush=True)
+
+
+def _describe_core_dump_environment() -> None:
+    """Print why a core dump would or would not appear, so a missing core is never a mystery.
+
+    A reproduction produced faulthandler stacks but no core at all, and the artifact upload then had
+    nothing to pick up. core_pattern is host-wide and a container cannot change it, so it has to be
+    read rather than assumed.
+    """
+    try:
+        with open("/proc/sys/kernel/core_pattern") as core_pattern:
+            print("core_pattern: %r" % core_pattern.read().strip(), flush=True)
+    except Exception as exc:
+        print("core_pattern: unreadable (%r)" % (exc,), flush=True)
+    try:
+        import resource
+
+        soft, hard = resource.getrlimit(resource.RLIMIT_CORE)
+        print("RLIMIT_CORE: soft=%s hard=%s" % (soft, hard), flush=True)
+    except Exception as exc:
+        print("RLIMIT_CORE: unreadable (%r)" % (exc,), flush=True)
+
+
 def _dump_hung_server(server_process, known_worker_pids=()) -> None:
     """Dump every stack of a server that would not shut down, so the hang can be diagnosed.
 
@@ -274,17 +319,19 @@ def _dump_hung_server(server_process, known_worker_pids=()) -> None:
     PYTHONFAULTHANDLER=1, so a fatal signal makes it print every thread's Python stack to stderr and
     leave a core file behind for the native backtrace — the only way to see the Rust/Tokio threads.
 
-    The signal has to be SIGSEGV, not SIGABRT. Gunicorn's worker replaces faulthandler's SIGABRT
-    handler with its own Python-level handle_abort (gunicorn/workers/base.py init_signals), and a
-    Python-level handler can never run here: the thread we want to dump is blocked inside native
-    code while still holding the GIL, so the interpreter never reaches a point where it would run
-    pending signal handlers. Measured in the testrunner image: SIGABRT leaves the process alive with
-    no output and no core, while SIGSEGV dumps every thread — including one wedged in C holding the
-    GIL — because faulthandler's SIGSEGV handler runs at the C level and needs no GIL. Gunicorn does
-    not touch SIGSEGV.
+    The signal has to be SIGSEGV, not SIGABRT. Gunicorn's worker installs its own Python-level
+    handle_abort over faulthandler's SIGABRT handler (gunicorn/workers/base.py init_signals), and
+    that handler just calls sys.exit(1): the worker dies quietly with no stacks and no core, which is
+    what CI showed. Gunicorn does not touch SIGSEGV, so faulthandler still services it.
 
     Attaching gdb to the live process is not an option either: kernel.yama.ptrace_scope is 1 on the
     runners and gdb would be a sibling of the target, not an ancestor.
+
+    What this can and cannot show, measured on a real reproduction (job 1921342140): faulthandler
+    dumps one stack per OS thread, and during this hang the main thread is sitting in the gevent
+    hub's run(). The greenlet that was serving /shutdown is suspended, so it appears nowhere. Use
+    _dump_server_greenlets for that side; this function is for the OS threads, including the ones
+    with no Python frame at all, which are only identifiable from the native backtrace.
 
     Only the workers are signalled; killing the arbiter would reap them mid-dump.
     """
@@ -532,6 +579,9 @@ def appsec_application_server(
         except ConnectionError:
             pass
         except Exception as exc:
+            # Order matters: the greenlet dump needs a live worker, and the signal below kills it.
+            _dump_server_greenlets(client)
+            _describe_core_dump_environment()
             _dump_hung_server(server_process, worker_pids)
             raise AssertionError(
                 "The application server did not answer /shutdown: %r\n%s"

--- a/tests/appsec/appsec_utils.py
+++ b/tests/appsec/appsec_utils.py
@@ -315,8 +315,11 @@ def _dump_hung_server(server_process, known_worker_pids=()) -> None:
         except Exception:
             continue
         aborted.append((proc.pid, cwd))
-    # Let the faulthandler output reach stderr and the kernel finish writing the cores.
-    time.sleep(10)
+    # Let the faulthandler output reach stderr, then wait for the kernel to finish writing. A worker
+    # with the native extensions loaded dumps hundreds of MB, so a fixed sleep can easily glob a core
+    # that is still growing and hand gdb a truncated file.
+    time.sleep(5)
+    _wait_for_cores(aborted)
     for pid, _ in aborted:
         try:
             if psutil.Process(pid).is_running():
@@ -327,6 +330,53 @@ def _dump_hung_server(server_process, known_worker_pids=()) -> None:
     _collect_cores(aborted)
 
 
+def _find_core(pid, cwd):
+    """Return the path of the core the given worker left in cwd, or None.
+
+    core_pattern is core.%p on some hosts and a bare "core" on others, so both names are candidates.
+    """
+    for name in ("core.%d" % pid, "core"):
+        candidate = os.path.join(cwd, name)
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def _wait_for_cores(aborted, timeout=180.0) -> None:
+    """Block until every core stops growing, so gdb is never handed a half-written file.
+
+    Size stability is the only signal available: the kernel gives no notification that a dump is
+    complete, and the file appears at full inode size immediately on some filesystems.
+    """
+    deadline = time.time() + timeout
+    for pid, cwd in aborted:
+        previous = -1
+        stable_for = 0
+        while time.time() < deadline:
+            path = _find_core(pid, cwd)
+            if path is None:
+                time.sleep(1)
+                continue
+            try:
+                current = os.path.getsize(path)
+            except OSError:
+                time.sleep(1)
+                continue
+            if current == previous and current > 0:
+                stable_for += 1
+                if stable_for >= 3:
+                    break
+            else:
+                stable_for = 0
+            previous = current
+            time.sleep(1)
+        path = _find_core(pid, cwd)
+        if path is None:
+            print("=== No core appeared for worker %s within %.0fs ===" % (pid, timeout), flush=True)
+        else:
+            print("=== Core for worker %s settled at %d bytes ===" % (pid, os.path.getsize(path)), flush=True)
+
+
 def _collect_cores(aborted) -> None:
     """Move the cores the aborted workers left behind where .gitlab/scripts/generate-core-backtraces.sh looks.
 
@@ -335,20 +385,17 @@ def _collect_cores(aborted) -> None:
     """
     target_dir = os.environ.get("CI_PROJECT_DIR") or os.getcwd()
     for pid, cwd in aborted:
-        for name in ("core.%d" % pid, "core"):
-            source = os.path.join(cwd, name)
-            if not os.path.isfile(source):
-                continue
-            destination = os.path.join(target_dir, "core.%d" % pid)
-            try:
-                if source != destination:
-                    os.replace(source, destination)
-                print("Core dump of worker %s available at %s" % (pid, destination), flush=True)
-            except Exception as exc:
-                print("Could not move core dump %s: %r" % (source, exc), flush=True)
-            break
-        else:
+        source = _find_core(pid, cwd)
+        if source is None:
             print("No core dump found for worker %s in %s" % (pid, cwd), flush=True)
+            continue
+        destination = os.path.join(target_dir, "core.%d" % pid)
+        try:
+            if source != destination:
+                os.replace(source, destination)
+            print("Core dump of worker %s available at %s" % (pid, destination), flush=True)
+        except Exception as exc:
+            print("Could not move core dump %s: %r" % (source, exc), flush=True)
 
 
 def appsec_application_server(

--- a/tests/appsec/appsec_utils.py
+++ b/tests/appsec/appsec_utils.py
@@ -270,13 +270,23 @@ def _describe_server_output(server_process) -> str:
 def _dump_hung_server(server_process, known_worker_pids=()) -> None:
     """Dump every stack of a server that would not shut down, so the hang can be diagnosed.
 
-    Opt-in through _DD_TEST_ABORT_HUNG_SERVER because it is expensive. SIGABRT is the whole
-    mechanism: the server runs with PYTHONFAULTHANDLER=1, so it prints every thread's Python stack
-    to stderr, and it then leaves a core file behind for the native backtrace — the only way to see
-    the Rust/Tokio threads. Attaching gdb to the live process is not an option: kernel.yama
-    .ptrace_scope is 1 on the runners and gdb would be a sibling of the target, not an ancestor.
+    Opt-in through _DD_TEST_ABORT_HUNG_SERVER because it is expensive. The server runs with
+    PYTHONFAULTHANDLER=1, so a fatal signal makes it print every thread's Python stack to stderr and
+    leave a core file behind for the native backtrace — the only way to see the Rust/Tokio threads.
 
-    Only the workers are aborted; killing the arbiter would reap them mid-dump.
+    The signal has to be SIGSEGV, not SIGABRT. Gunicorn's worker replaces faulthandler's SIGABRT
+    handler with its own Python-level handle_abort (gunicorn/workers/base.py init_signals), and a
+    Python-level handler can never run here: the thread we want to dump is blocked inside native
+    code while still holding the GIL, so the interpreter never reaches a point where it would run
+    pending signal handlers. Measured in the testrunner image: SIGABRT leaves the process alive with
+    no output and no core, while SIGSEGV dumps every thread — including one wedged in C holding the
+    GIL — because faulthandler's SIGSEGV handler runs at the C level and needs no GIL. Gunicorn does
+    not touch SIGSEGV.
+
+    Attaching gdb to the live process is not an option either: kernel.yama.ptrace_scope is 1 on the
+    runners and gdb would be a sibling of the target, not an ancestor.
+
+    Only the workers are signalled; killing the arbiter would reap them mid-dump.
     """
     if os.environ.get("_DD_TEST_ABORT_HUNG_SERVER", "") != "1":
         return
@@ -295,18 +305,25 @@ def _dump_hung_server(server_process, known_worker_pids=()) -> None:
 
     aborted = []
     for proc in workers:
-        print("=== SIGABRT on hung worker %s (faulthandler python stacks follow) ===" % proc.pid, flush=True)
+        print("=== SIGSEGV on hung worker %s (faulthandler python stacks follow) ===" % proc.pid, flush=True)
         try:
             cwd = proc.cwd()
         except Exception:
             cwd = os.getcwd()
         try:
-            proc.send_signal(signal.SIGABRT)
+            proc.send_signal(signal.SIGSEGV)
         except Exception:
             continue
         aborted.append((proc.pid, cwd))
     # Let the faulthandler output reach stderr and the kernel finish writing the cores.
     time.sleep(10)
+    for pid, _ in aborted:
+        try:
+            if psutil.Process(pid).is_running():
+                # Nothing dumped, so record that rather than let the caller assume the probe worked.
+                print("=== Worker %s survived SIGSEGV; no stacks were produced ===" % pid, flush=True)
+        except Exception:
+            pass
     _collect_cores(aborted)
 
 

--- a/tests/appsec/integrations/django_tests/django_app/urls.py
+++ b/tests/appsec/integrations/django_tests/django_app/urls.py
@@ -19,9 +19,23 @@ def shutdown(request):
     return HttpResponse(status=200)
 
 
+# AIDEV-NOTE: Diagnostic endpoint for the flaky /shutdown hang under `-w 1 --threads 1 -k gevent`.
+# When tracer.shutdown() above never returns, the gevent hub keeps turning, so this second request is
+# still served and reports the stack of the suspended greenlet — which faulthandler cannot show,
+# because a suspended greenlet is not on any OS thread. Called by _dump_server_greenlets in
+# tests/appsec/appsec_utils.py. Delete together with that helper once the hang is understood.
+def debug_greenlets(request):
+    try:
+        from gevent.util import format_run_info
+    except ImportError:
+        return HttpResponse("gevent is not in use in this configuration\n", content_type="text/plain")
+    return HttpResponse("\n".join(format_run_info()), content_type="text/plain")
+
+
 urlpatterns = [
     handler(r"^$", views.index),
     handler(r"^shutdown$", shutdown),
+    handler(r"^debug/greenlets$", debug_greenlets),
     handler(r"^iast-enabled/$", views.iast_enabled),
     handler(r"^vulnerablerequestdownstream/$", views.vulnerable_request_downstream),
     # This must precede composed-view.


### PR DESCRIPTION
**DO NOT MERGE.** This branch exists only to run CI. It carries a temporary
investigation job and must be deleted, not merged.

## Why

`test_iast_vulnerable_request_downstream_django[gunicorn_django_server-config3/4/5]`
flakes on py3.10–3.14 at roughly **0.1% per run** (≈18 failures against ≈17,400 passes
over 30 days), with a hard onset on **2026-05-07**. Auto Test Retries hides it: the test
fails then passes inside the same pytest run, so the GitLab job is green and junit
reports `failed=0`.

The symptom is always identical — the `/shutdown` view calls `tracer.shutdown()` with no
timeout, and under `-w 1 --threads 1 -k gevent` that C-level
`std::condition_variable::wait()` in `PeriodicThread_join` freezes the whole hub, so the
worker never writes the response and the client's 10s read timeout fires. The assertion
message is empty because the harness builds it from `server_process.stdout`, which is
`None` unless `assert_debug` is set.

What we still do not know is **which wait** passes 10s. ~80 local iterations under
contention never reproduced it — instrumented `tracer.shutdown()` never exceeded 23 ms.
The leading hypothesis is that the periodic worker never returns from
`NativeWriter.on_shutdown` → `_exporter.shutdown(3s)`, because that 3s budget is a Tokio
timer on the shared runtime added in #17403 (2026-04-28, one week before the onset), and
libdatadog's `after_fork_child` rebuilds the runtime **only if the slot is `None`** — so
a child can hold a runtime whose worker threads did not survive `fork()`, on which no
timer ever fires.

## What this PR does

- `.gitlab/tests.yml`: adds `core/repro_iast_django_shutdown`. 21 nodes × 120 iterations
  × 3 params ≈ 7,500 samples, one django version per node, every third node under CPU
  contention (the failing runs were on hosts roughly 2x slower than normal).
  `allow_failure: true`.
- `tests/appsec/appsec_utils.py`: when `/shutdown` times out and
  `_DD_TEST_ABORT_HUNG_SERVER=1`, `SIGABRT` the gunicorn workers. The server already runs
  with `PYTHONFAULTHANDLER=1`, so that prints every thread's Python stack *and* leaves a
  core, which `.gitlab/scripts/generate-core-backtraces.sh` (already in `after_script`)
  turns into `thread apply all bt full`. The native backtrace is the only way to see the
  Tokio threads. Also fixes the empty assertion messages, which is a real harness bug
  regardless of this investigation.

**It builds nothing.** The job `needs: build_base_venvs` with `artifacts: true` and
reuses those venvs; no compilation is added.

Verified by hand in the testrunner image rather than assumed: `SIGABRT` under
`PYTHONFAULTHANDLER=1` does print the per-thread stacks and dump core; attaching gdb to
the live worker is impossible (`kernel.yama.ptrace_scope=1`, gdb is a sibling, and it
exits 0 while failing); and `kernel.core_pattern` can be a bare `core`, which the
`core.*` glob would miss — hence the rename to `${CI_PROJECT_DIR}/core.<pid>`.

## Checklist

- [x] Change is not user-facing (CI/test infrastructure only)
- [x] Title follows Conventional Commits
- [x] `changelog/no-changelog` label
