### PR TITLE
feat(profiling): add birth timestamp to alloc samples

### DIFF
--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -14,6 +14,7 @@
 #include "_memalloc_reentrant.h"
 #include "_memalloc_tb.h"
 #include "_pymacro.h"
+#include "clock.hpp"
 
 /* Use Abseil's flat_hash_map for tracking sampled allocations.
  * flat_hash_map provides excellent performance with low memory overhead,
@@ -423,6 +424,10 @@ memalloc_heap_track_invokes_cpython(uint16_t max_nframe, void* ptr, size_t size,
 
     auto tb =
       heap_tracker_t::instance->pool_get_with_alloc_data_invokes_cpython(size, allocated_memory_val, max_nframe);
+
+    // Stamp the birth time once. it persists across all future export_sample() calls.
+    tb->birth_ns = Datadog::get_monotonic_ns();
+    tb->sample.push_monotonic_ns(tb->birth_ns);
 
     // Export allocation sample right away to avoid holding it
     tb->sample.export_sample();

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -14,6 +14,7 @@
 #include "_memalloc_reentrant.h"
 #include "_memalloc_tb.h"
 #include "_pymacro.h"
+#include "clock.hpp"
 
 /* Use Abseil's flat_hash_map for tracking sampled allocations.
  * flat_hash_map provides excellent performance with low memory overhead,
@@ -426,6 +427,10 @@ memalloc_heap_track_invokes_cpython(uint16_t max_nframe, void* ptr, size_t size,
 
     auto tb = heap_tracker_t::instance->pool_get_with_alloc_data_invokes_cpython(
       size, allocated_memory_val, max_nframe, domain);
+
+    // Stamp the birth time once. it persists across all future export_sample() calls.
+    tb->birth_ns = Datadog::get_monotonic_ns();
+    tb->sample.push_monotonic_ns(tb->birth_ns);
 
     // Export allocation sample right away to avoid holding it
     tb->sample.export_sample();

--- a/ddtrace/profiling/collector/_memalloc_tb.h
+++ b/ddtrace/profiling/collector/_memalloc_tb.h
@@ -14,6 +14,10 @@ class traceback_t
     /* Sample object storing the stacktrace */
     Datadog::Sample sample;
 
+    /* Monotonic timestamp of when this allocation was sampled.
+     * Used at export time to compute object age for lifecycle analysis. */
+    int64_t birth_ns = 0;
+
     /* Constructor - also collects frames from the current Python frame chain. */
     traceback_t(size_t size, size_t weighted_size, uint16_t max_nframe, PyMemAllocatorDomain domain);
 

--- a/ddtrace/profiling/collector/_memalloc_tb.h
+++ b/ddtrace/profiling/collector/_memalloc_tb.h
@@ -14,6 +14,10 @@ class traceback_t
     /* Sample object storing the stacktrace */
     Datadog::Sample sample;
 
+    /* Monotonic timestamp of when this allocation was sampled.
+     * Used at export time to compute object age for lifecycle analysis. */
+    int64_t birth_ns = 0;
+
     /* Constructor - also collects frames from the current Python frame chain. */
     traceback_t(size_t size, size_t weighted_size, uint16_t max_nframe);
 

--- a/releasenotes/notes/alloc-birth-ts-39a384b786761e0c.yaml
+++ b/releasenotes/notes/alloc-birth-ts-39a384b786761e0c.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    profiling: This introduces inclusion of birth timestamp to allocation samples.

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -42,7 +42,7 @@ def _allocate_1k() -> list[object]:
 _ALLOC_LINE_NUMBER = _allocate_1k.__code__.co_firstlineno + 1
 
 
-def _setup_profiling_prelude(tmp_path: Path, test_name: str) -> str:
+def _setup_profiling_prelude(tmp_path: Path, test_name: str, timeline_enabled: bool = False) -> str:
     """Setup ddup configuration and return the output filename for pprof parsing.
 
     Args:
@@ -60,6 +60,7 @@ def _setup_profiling_prelude(tmp_path: Path, test_name: str) -> str:
         version="test",
         env="test",
         output_filename=pprof_prefix,
+        timeline_enabled=timeline_enabled,
     )
     ddup.start()
 
@@ -1561,6 +1562,28 @@ def test_obj_and_mem_domain_coexist(tmp_path: Path) -> None:
     samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
     assert len(samples) > 0, "OBJ + MEM coexistence test: expected heap-space samples"
     del d, lst
+
+def test_heap_samples_have_birth_timestamp(tmp_path: Path) -> None:
+    """Every heap live sample must carry a per-sample birth timestamp (end_timestamp_ns label).
+
+    push_monotonic_ns is called once at allocation time, setting endtime_ns which
+    libdatadog serializes as an end_timestamp_ns label on each sample.
+    """
+    output_filename = _setup_profiling_prelude(tmp_path, "test_heap_birth_timestamp", timeline_enabled=True)
+
+    mc = memalloc.MemoryCollector(heap_sample_size=256)
+    with mc:
+        live_objects = _allocate_1k()
+        profile = mc.snapshot_and_parse_pprof(output_filename)
+        del live_objects
+
+    heap_samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
+    assert len(heap_samples) > 0, "Expected heap-space samples in profile"
+
+    for sample in heap_samples:
+        ts_label = pprof_utils.get_label_with_key(profile.string_table, sample, "end_timestamp_ns")
+        assert ts_label is not None, "Heap sample missing 'end_timestamp_ns' label (birth timestamp)"
+        assert ts_label.num > 0, f"Birth timestamp should be positive, got {ts_label.num}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -1562,6 +1562,7 @@ def test_obj_and_mem_domain_coexist(tmp_path: Path) -> None:
     assert len(samples) > 0, "OBJ + MEM coexistence test: expected heap-space samples"
     del d, lst
 
+
 # Subprocess: timeline_enabled is global state that cannot be reset, so this must
 # run in its own process to avoid poisoning other tests.
 @pytest.mark.subprocess(
@@ -1573,6 +1574,7 @@ def test_obj_and_mem_domain_coexist(tmp_path: Path) -> None:
 def test_heap_samples_have_birth_timestamp() -> None:
     """Every heap live sample must carry a per-sample birth timestamp (end_timestamp_ns label)."""
     import os
+
     from ddtrace.profiling.profiler import Profiler
     from tests.profiling.collector import pprof_utils
     from tests.profiling.collector.test_memalloc import _allocate_1k
@@ -1594,6 +1596,7 @@ def test_heap_samples_have_birth_timestamp() -> None:
         assert ts_label is not None, "Heap sample missing 'end_timestamp_ns' label (birth timestamp)"
         assert ts_label.num > 0, f"Birth timestamp should be positive, got {ts_label.num}"
     del live_objects
+
 
 # ---------------------------------------------------------------------------
 # "allocator domain" label tests

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -42,7 +42,7 @@ def _allocate_1k() -> list[object]:
 _ALLOC_LINE_NUMBER = _allocate_1k.__code__.co_firstlineno + 1
 
 
-def _setup_profiling_prelude(tmp_path: Path, test_name: str, timeline_enabled: bool = False) -> str:
+def _setup_profiling_prelude(tmp_path: Path, test_name: str) -> str:
     """Setup ddup configuration and return the output filename for pprof parsing.
 
     Args:
@@ -60,7 +60,6 @@ def _setup_profiling_prelude(tmp_path: Path, test_name: str, timeline_enabled: b
         version="test",
         env="test",
         output_filename=pprof_prefix,
-        timeline_enabled=timeline_enabled,
     )
     ddup.start()
 
@@ -1563,20 +1562,30 @@ def test_obj_and_mem_domain_coexist(tmp_path: Path) -> None:
     assert len(samples) > 0, "OBJ + MEM coexistence test: expected heap-space samples"
     del d, lst
 
-def test_heap_samples_have_birth_timestamp(tmp_path: Path) -> None:
-    """Every heap live sample must carry a per-sample birth timestamp (end_timestamp_ns label).
+# Subprocess: timeline_enabled is global state that cannot be reset, so this must
+# run in its own process to avoid poisoning other tests.
+@pytest.mark.subprocess(
+    env=dict(
+        DD_PROFILING_HEAP_SAMPLE_SIZE="256",
+        DD_PROFILING_OUTPUT_PPROF="/tmp/test_heap_birth_timestamp",
+    )
+)
+def test_heap_samples_have_birth_timestamp() -> None:
+    """Every heap live sample must carry a per-sample birth timestamp (end_timestamp_ns label)."""
+    import os
+    from ddtrace.profiling.profiler import Profiler
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_memalloc import _allocate_1k
 
-    push_monotonic_ns is called once at allocation time, setting endtime_ns which
-    libdatadog serializes as an end_timestamp_ns label on each sample.
-    """
-    output_filename = _setup_profiling_prelude(tmp_path, "test_heap_birth_timestamp", timeline_enabled=True)
+    pprof_prefix = os.environ["DD_PROFILING_OUTPUT_PPROF"]
+    output_filename = pprof_prefix + "." + str(os.getpid())
 
-    mc = memalloc.MemoryCollector(heap_sample_size=256)
-    with mc:
-        live_objects = _allocate_1k()
-        profile = mc.snapshot_and_parse_pprof(output_filename)
-        del live_objects
+    p = Profiler()
+    p.start()
+    live_objects = _allocate_1k()
+    p.stop()
 
+    profile = pprof_utils.parse_newest_profile(output_filename)
     heap_samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
     assert len(heap_samples) > 0, "Expected heap-space samples in profile"
 
@@ -1584,7 +1593,7 @@ def test_heap_samples_have_birth_timestamp(tmp_path: Path) -> None:
         ts_label = pprof_utils.get_label_with_key(profile.string_table, sample, "end_timestamp_ns")
         assert ts_label is not None, "Heap sample missing 'end_timestamp_ns' label (birth timestamp)"
         assert ts_label.num > 0, f"Birth timestamp should be positive, got {ts_label.num}"
-
+    del live_objects
 
 # ---------------------------------------------------------------------------
 # "allocator domain" label tests

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -42,7 +42,7 @@ def _allocate_1k() -> list[object]:
 _ALLOC_LINE_NUMBER = _allocate_1k.__code__.co_firstlineno + 1
 
 
-def _setup_profiling_prelude(tmp_path: Path, test_name: str) -> str:
+def _setup_profiling_prelude(tmp_path: Path, test_name: str, timeline_enabled: bool = False) -> str:
     """Setup ddup configuration and return the output filename for pprof parsing.
 
     Args:
@@ -60,6 +60,7 @@ def _setup_profiling_prelude(tmp_path: Path, test_name: str) -> str:
         version="test",
         env="test",
         output_filename=pprof_prefix,
+        timeline_enabled=timeline_enabled,
     )
     ddup.start()
 
@@ -1571,3 +1572,26 @@ def test_obj_and_mem_domain_coexist(tmp_path: Path) -> None:
     samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
     assert len(samples) > 0, "OBJ + MEM coexistence test: expected heap-space samples"
     del d, lst
+
+
+def test_heap_samples_have_birth_timestamp(tmp_path: Path) -> None:
+    """Every heap live sample must carry a per-sample birth timestamp (end_timestamp_ns label).
+
+    push_monotonic_ns is called once at allocation time, setting endtime_ns which
+    libdatadog serializes as an end_timestamp_ns label on each sample.
+    """
+    output_filename = _setup_profiling_prelude(tmp_path, "test_heap_birth_timestamp", timeline_enabled=True)
+
+    mc = memalloc.MemoryCollector(heap_sample_size=256)
+    with mc:
+        live_objects = _allocate_1k()
+        profile = mc.snapshot_and_parse_pprof(output_filename)
+        del live_objects
+
+    heap_samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
+    assert len(heap_samples) > 0, "Expected heap-space samples in profile"
+
+    for sample in heap_samples:
+        ts_label = pprof_utils.get_label_with_key(profile.string_table, sample, "end_timestamp_ns")
+        assert ts_label is not None, "Heap sample missing 'end_timestamp_ns' label (birth timestamp)"
+        assert ts_label.num > 0, f"Birth timestamp should be positive, got {ts_label.num}"

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -42,7 +42,7 @@ def _allocate_1k() -> list[object]:
 _ALLOC_LINE_NUMBER = _allocate_1k.__code__.co_firstlineno + 1
 
 
-def _setup_profiling_prelude(tmp_path: Path, test_name: str, timeline_enabled: bool = False) -> str:
+def _setup_profiling_prelude(tmp_path: Path, test_name: str) -> str:
     """Setup ddup configuration and return the output filename for pprof parsing.
 
     Args:
@@ -60,7 +60,6 @@ def _setup_profiling_prelude(tmp_path: Path, test_name: str, timeline_enabled: b
         version="test",
         env="test",
         output_filename=pprof_prefix,
-        timeline_enabled=timeline_enabled,
     )
     ddup.start()
 
@@ -1574,20 +1573,31 @@ def test_obj_and_mem_domain_coexist(tmp_path: Path) -> None:
     del d, lst
 
 
-def test_heap_samples_have_birth_timestamp(tmp_path: Path) -> None:
-    """Every heap live sample must carry a per-sample birth timestamp (end_timestamp_ns label).
+# Subprocess: timeline_enabled is global state that cannot be reset, so this must
+# run in its own process to avoid poisoning other tests.
+@pytest.mark.subprocess(
+    env=dict(
+        DD_PROFILING_HEAP_SAMPLE_SIZE="256",
+        DD_PROFILING_OUTPUT_PPROF="/tmp/test_heap_birth_timestamp",
+    )
+)
+def test_heap_samples_have_birth_timestamp() -> None:
+    """Every heap live sample must carry a per-sample birth timestamp (end_timestamp_ns label)."""
+    import os
 
-    push_monotonic_ns is called once at allocation time, setting endtime_ns which
-    libdatadog serializes as an end_timestamp_ns label on each sample.
-    """
-    output_filename = _setup_profiling_prelude(tmp_path, "test_heap_birth_timestamp", timeline_enabled=True)
+    from ddtrace.profiling.profiler import Profiler
+    from tests.profiling.collector import pprof_utils
+    from tests.profiling.collector.test_memalloc import _allocate_1k
 
-    mc = memalloc.MemoryCollector(heap_sample_size=256)
-    with mc:
-        live_objects = _allocate_1k()
-        profile = mc.snapshot_and_parse_pprof(output_filename)
-        del live_objects
+    pprof_prefix = os.environ["DD_PROFILING_OUTPUT_PPROF"]
+    output_filename = pprof_prefix + "." + str(os.getpid())
 
+    p = Profiler()
+    p.start()
+    live_objects = _allocate_1k()
+    p.stop()
+
+    profile = pprof_utils.parse_newest_profile(output_filename)
     heap_samples = pprof_utils.get_samples_with_value_type(profile, "heap-space")
     assert len(heap_samples) > 0, "Expected heap-space samples in profile"
 
@@ -1595,3 +1605,5 @@ def test_heap_samples_have_birth_timestamp(tmp_path: Path) -> None:
         ts_label = pprof_utils.get_label_with_key(profile.string_table, sample, "end_timestamp_ns")
         assert ts_label is not None, "Heap sample missing 'end_timestamp_ns' label (birth timestamp)"
         assert ts_label.num > 0, f"Birth timestamp should be positive, got {ts_label.num}"
+
+    del live_objects


### PR DESCRIPTION
[PROF-15631](https://datadoghq.atlassian.net/jira/software/c/projects/PROF/boards/11?selectedIssue=PROF-15631)

## Description

Add birth ts for an allocation that is sampled. This is added once, and persisted as long as that sample is in the pool.

This will allow for backend and product to understand when the allocation was made, and derive further calculations such as allocation age distribution, and related insights.

## Testing

DOE profile -- [LINK](https://benchmarks.datadoghq.com/profiling/explorer?query=service%3Adoe%2Fpython&event=AwAAAZ_7Jn0vKE65ugAAABhBWl83Sm4yV0FBQzhDRk1ncWE0NUpRQUEAAAAkMTE5ZmZiM2ItMjdiZS00MWJhLWJkMzYtNzc4MDFhODQyMmRiAABJjw&eventScope=profile&fromUser=true&my_code=enabled&profileId=AZ_7Jn2WAAC8CFMgqa45JQAA&refresh_mode=paused&selected_tf=1786624233000%2C1786625125000&viz=stream&from_ts=1786614731564&to_ts=1786629131564&live=false)

DOE profiles without `end_timestamp_ns` with same alloc rate's profile size are ~5.6 MB, the ones with `end_timestamp_ns` are ~5.7 MB.

Sanity check verif I did
```
go tool pprof -raw profile.pprof > raw.txt
awk '{
  if ($0 ~ /^[[:space:]]*[0-9-]+([[:space:]]+[0-9-]+)*:/) {
    n=split($0, arr, ":"); split(arr[1], f, " ");
    print f[10], f[11], NR   # dis is alloc-space, alloc-samples, line number
  }
}' raw.txt | awk '$1!=0 || $2!=0'
```

```
sed -n '134,140p' raw.txt
                thread name:[MainThread] trace endpoint:[GET /load/1] trace type:[web]
                end_timestamp_ns:[1786624971606309796] local root span id:[-1773423375451758303] span id:[-1773423375451758303] thread id:[128445220973440] thread native id:[33]
          0          0          0          0          0          0          0          0          0   12481118         47          0          0          0          0          0          0          0          0: 70 71 29 30 31 32 33 34 35 36 37 38 39 40 41 42 
                allocator domain:[obj] thread name:[128445220973440]
                end_timestamp_ns:[1786624971608217410] thread id:[128445220973440] thread native id:[33]
          0          1    2436000          1          0          0          0          0          0          0          0          0          0          0          0          0          0          0          0: 1 2 3 4 5 6 7 8 9 10 
                thread name:[Thread-1 (always_pong)]
```

From local DOE run. DOE result cleaned up by claude


Test | Metric | Pinned commit | Latest | Latest vs pinned
-- | -- | -- | -- | --
Throughput | p50 latency | 226.93 ms | 225.95 ms | −0.43%
  | p99 latency | 507.26 ms | 510.70 ms | +0.68%
  | CPU | 407.20% | 405.95% | −0.31%
  | Memory | 294.67 MB | 290.03 MB | −1.58%
  | Requests / 30 s | 12,469.2 | 12,457.5 | −0.09%
Idle | p50 latency | 12.234 ms | 12.220 ms | −0.11%
  | p99 latency | 13.260 ms | 13.322 ms | +0.47%
  | CPU | 3.44% | 3.42% | −0.02 percentage points
  | Memory | 186.67 MB | 182.43 MB | −2.27%
Latency | p50 latency | 8.514 ms | 8.514 ms | 0.00%
  | p99 latency | 11.586 ms | 11.612 ms | +0.22%
  | CPU | 319.94% | 319.62% | −0.10%
  | Memory | 505.32 MB | 497.99 MB | −1.45%

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->


[PROF-15631]: https://datadoghq.atlassian.net/browse/PROF-15631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ