### PR TITLE
chore(ci): macos wheels ci fix

### DIFF
--- a/.gitlab/multi-os-tests.yml
+++ b/.gitlab/multi-os-tests.yml
@@ -38,7 +38,9 @@ os tests macos:
   extends: .multi_os_test_base
   image: "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/ci-platform-machine-images/tart-vm:dd-trace-py-sonoma-latest"
   tags: ["macos:tart"]
-  needs: [ "build macos arm64" ]
+  needs:
+    - "build macos arm64: [3.9 3.10 3.11]"
+    - "build macos arm64: [3.12 3.13 3.14]"
   variables:
     WHEEL_PATTERN: "macosx*arm64.whl"
     PLATFORM: "macOS"

--- a/.gitlab/scripts/multi-os-tests.sh
+++ b/.gitlab/scripts/multi-os-tests.sh
@@ -15,11 +15,19 @@ export PATH="$HOME/.local/bin:$PATH"
 export TMPDIR=$(mktemp -d)
 cd "$TMPDIR"
 export WHEEL_TAG="cp${PYTHON_VERSION//./}"
+echo "Contents of $CI_PROJECT_DIR/pywheels:"
+ls -la "$CI_PROJECT_DIR/pywheels" 2>&1 || echo "(pywheels directory does not exist)"
 echo "Installing Python $PYTHON_VERSION and dependencies in $TMPDIR..."
 uv python install $PYTHON_VERSION
 uv venv --python $PYTHON_VERSION .venv
-WHEEL_PATH="$CI_PROJECT_DIR/pywheels/ddtrace*${WHEEL_TAG}*${WHEEL_PATTERN}"
-uv pip install --python $PYTHON_VERSION -r "$CI_PROJECT_DIR/.gitlab/requirements/multi-os-tests.txt" $WHEEL_PATH
+shopt -s nullglob
+WHEEL_MATCHES=("$CI_PROJECT_DIR"/pywheels/ddtrace*"${WHEEL_TAG}"*${WHEEL_PATTERN})
+shopt -u nullglob
+if [ "${#WHEEL_MATCHES[@]}" -ne 1 ]; then
+  echo "Expected exactly one wheel matching ddtrace*${WHEEL_TAG}*${WHEEL_PATTERN} in $CI_PROJECT_DIR/pywheels, found ${#WHEEL_MATCHES[@]}: ${WHEEL_MATCHES[*]}"
+  exit 1
+fi
+uv pip install --python $PYTHON_VERSION -r "$CI_PROJECT_DIR/.gitlab/requirements/multi-os-tests.txt" "${WHEEL_MATCHES[0]}"
 
 # Run tests
 export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
## Description

closing as this is a duplicate of [ci: resolve macOS multi-os test wheel lookup](https://github.com/DataDog/dd-trace-py/pull/19493)

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
