### PR TITLE
fix(openfeature): prevent remote config startup race

### DIFF
--- a/ddtrace/internal/README.md
+++ b/ddtrace/internal/README.md
@@ -143,6 +143,14 @@ dispatched by the RC subscriber, as well as periodic calls.  If this is the
 first callback being registered, the RC poller is started automatically (if
 `DD_REMOTE_CONFIGURATION_ENABLED` is set).
 
+During automatic instrumentation bootstrap, the remote-configuration product
+temporarily defers that automatic start. The product manager releases the
+barrier through the product's optional `post_start()` hook, after all enabled
+products have started. This lets dependent products register and enable their
+RC subscriptions before the poller's immediate first request, including when
+products start after a uWSGI fork. Outside product bootstrap, first-callback
+registration continues to start the poller immediately.
+
 Registering a callback **does not** enable the product: the product name will
 **not** appear in client payloads until `enable_product()` is called.
 

--- a/ddtrace/internal/products.py
+++ b/ddtrace/internal/products.py
@@ -157,6 +157,7 @@ class ProductManager:
 
     def start_products(self) -> None:
         failed: set[str] = set()
+        started: list[tuple[str, Product]] = []
 
         for name, product in self.products:
             # Check that no required products have failed
@@ -175,9 +176,22 @@ class ProductManager:
                 product.start()
                 log.debug("Started product '%s'", name)
                 telemetry_writer.product_activated(name.replace("-", "_"), True)
+                started.append((name, product))
             except Exception:
                 log.exception("Failed to start product '%s'", name)
                 failed.add(name)
+
+        # AIDEV-NOTE: Keep post_start hooks after the full start loop. RC uses
+        # this barrier to collect dependent products before its first poll, and
+        # start_products() may run only after a uWSGI fork.
+        for name, product in started:
+            try:
+                if (hook := getattr(product, "post_start", None)) is None:
+                    continue
+                hook()
+                log.debug("Post-start product '%s' done", name)
+            except Exception:
+                log.exception("Failed to post-start product '%s'", name)
 
     def before_fork(self) -> None:
         for name, product in self.products:

--- a/ddtrace/internal/remoteconfig/products/client.py
+++ b/ddtrace/internal/remoteconfig/products/client.py
@@ -39,6 +39,12 @@ def post_preload():
     pass
 
 
+def post_start():
+    from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
+
+    remoteconfig_poller.start_deferred()
+
+
 def enabled():
     return config._remote_config_enabled
 
@@ -46,7 +52,10 @@ def enabled():
 def start():
     from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
 
-    remoteconfig_poller.enable()
+    # AIDEV-NOTE: Keep the poller behind this barrier until post_start. Product
+    # dependencies start after remote-configuration and must advertise their RC
+    # products before the no-wait polling thread sends its first request.
+    remoteconfig_poller.defer_start()
     _register_rc_products()
 
 

--- a/ddtrace/internal/remoteconfig/worker.py
+++ b/ddtrace/internal/remoteconfig/worker.py
@@ -102,17 +102,19 @@ class RemoteConfigPoller(periodic.PeriodicService):
         # TODO: this is only temporary. DD_REMOTE_CONFIGURATION_ENABLED variable will be deprecated
         rc_env_enabled = ddconfig._remote_config_enabled
         if rc_env_enabled and self._enable:
-            if self._start_deferred:
-                return False
-
             if self.status == ServiceStatus.RUNNING:
                 return True
 
             if not self._before_fork_registered:
-                # Initialize early to avoid race-conditions with forking operations.
+                # AIDEV-NOTE: Initialize and register the fork hook before honoring
+                # the startup barrier. Polling can wait for product registration,
+                # but fork safety must be established as early as possible.
                 self._client.ensure_native()
                 forksafe.register_before_fork(self._before_fork)
                 self._before_fork_registered = True
+
+            if self._start_deferred:
+                return False
 
             self.start()
 

--- a/ddtrace/internal/remoteconfig/worker.py
+++ b/ddtrace/internal/remoteconfig/worker.py
@@ -48,6 +48,7 @@ class RemoteConfigPoller(periodic.PeriodicService):
         # single-process case, where the poller dispatches directly.
         self._subscriber: Optional["RemoteConfigSubscriber"] = None
         self._before_fork_registered = False
+        self._start_deferred = False
 
     def _agent_check(self) -> None:
         try:
@@ -101,6 +102,9 @@ class RemoteConfigPoller(periodic.PeriodicService):
         # TODO: this is only temporary. DD_REMOTE_CONFIGURATION_ENABLED variable will be deprecated
         rc_env_enabled = ddconfig._remote_config_enabled
         if rc_env_enabled and self._enable:
+            if self._start_deferred:
+                return False
+
             if self.status == ServiceStatus.RUNNING:
                 return True
 
@@ -114,6 +118,19 @@ class RemoteConfigPoller(periodic.PeriodicService):
 
             return True
         return False
+
+    def defer_start(self) -> None:
+        """Delay polling so bootstrap can register every enabled product first."""
+        if self.status != ServiceStatus.RUNNING:
+            self._start_deferred = True
+
+    def start_deferred(self) -> bool:
+        """Release the bootstrap barrier and start polling."""
+        if not self._start_deferred:
+            return self.status == ServiceStatus.RUNNING
+
+        self._start_deferred = False
+        return self.enable()
 
     def _before_fork(self) -> None:
         """Origin hook: enable SHM before forking so children inherit the SHM."""
@@ -177,6 +194,7 @@ class RemoteConfigPoller(periodic.PeriodicService):
     def disable(self, join: bool = False) -> None:
         self.stop_subscriber(join=join)
         self._client.reset_products()
+        self._start_deferred = False
 
         if self._before_fork_registered:
             forksafe.unregister_before_fork(self._before_fork)

--- a/releasenotes/notes/fix-openfeature-remote-config-startup-race-6b53ced3010fcb71.yaml
+++ b/releasenotes/notes/fix-openfeature-remote-config-startup-race-6b53ced3010fcb71.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    openfeature: Fixes an issue where flag evaluations return local defaults and the provider
+    remains not ready when Remote Configuration completes its first poll during application startup.

--- a/tests/internal/remoteconfig/test_remoteconfig_native.py
+++ b/tests/internal/remoteconfig/test_remoteconfig_native.py
@@ -23,6 +23,7 @@ from ddtrace.internal.native import RemoteConfigCapabilities
 from ddtrace.internal.native import RemoteConfigProduct
 from ddtrace.internal.remoteconfig import RCCallback
 from ddtrace.internal.remoteconfig.client import RemoteConfigClient
+from ddtrace.internal.service import ServiceStatus
 
 
 HERE = os.path.dirname(__file__)
@@ -153,6 +154,60 @@ def test_enabled_products_reported_to_agent():
     assert agent.requests, "agent received no request"
     products = agent.requests[0]["client"]["products"]
     assert "ASM_FEATURES" in products
+
+
+def test_remoteconfig_product_defers_start_until_all_products_registered(monkeypatch):
+    from ddtrace.internal.remoteconfig import worker as worker_module
+    from ddtrace.internal.remoteconfig.products import client as product
+    from ddtrace.internal.remoteconfig.worker import RemoteConfigPoller
+    from tests.utils import override_global_config
+
+    poller = RemoteConfigPoller()
+    started_with_products = []
+
+    monkeypatch.setattr(worker_module, "remoteconfig_poller", poller)
+    monkeypatch.setattr(poller._client, "ensure_native", lambda: None)
+
+    def capture_start():
+        started_with_products.extend(poller._client._enabled_products)
+        poller.status = ServiceStatus.RUNNING
+
+    def register_agent_config():
+        poller.register_callback(RemoteConfigProduct.AgentConfig, _Sink())
+        poller.enable_product(RemoteConfigProduct.AgentConfig)
+
+    monkeypatch.setattr(poller, "start", capture_start)
+    monkeypatch.setattr(product, "_register_rc_products", register_agent_config)
+
+    with override_global_config(dict(_remote_config_enabled=True)):
+        product.start()
+        poller.register_callback(RemoteConfigProduct.FfeFlags, _Sink())
+        poller.enable_product(RemoteConfigProduct.FfeFlags)
+
+        assert poller.status == ServiceStatus.STOPPED
+        assert started_with_products == []
+
+        product.post_start()
+    assert set(started_with_products) == {
+        RemoteConfigProduct.AgentConfig,
+        RemoteConfigProduct.FfeFlags,
+    }
+
+
+def test_start_deferred_does_not_start_without_barrier(monkeypatch):
+    from ddtrace.internal.remoteconfig import worker as worker_module
+    from ddtrace.internal.remoteconfig.products import client as product
+    from ddtrace.internal.remoteconfig.worker import RemoteConfigPoller
+    from tests.utils import override_global_config
+
+    poller = RemoteConfigPoller()
+    starts = []
+    monkeypatch.setattr(worker_module, "remoteconfig_poller", poller)
+    monkeypatch.setattr(poller, "start", lambda: starts.append(1))
+
+    with override_global_config(dict(_remote_config_enabled=True)):
+        product.post_start()
+    assert starts == []
 
 
 def test_capabilities_reported_to_agent():

--- a/tests/internal/remoteconfig/test_remoteconfig_native.py
+++ b/tests/internal/remoteconfig/test_remoteconfig_native.py
@@ -164,11 +164,18 @@ def test_remoteconfig_product_defers_start_until_all_products_registered(monkeyp
 
     poller = RemoteConfigPoller()
     started_with_products = []
+    startup_events = []
 
     monkeypatch.setattr(worker_module, "remoteconfig_poller", poller)
-    monkeypatch.setattr(poller._client, "ensure_native", lambda: None)
+    monkeypatch.setattr(poller._client, "ensure_native", lambda: startup_events.append("native"))
+    monkeypatch.setattr(
+        worker_module.forksafe,
+        "register_before_fork",
+        lambda hook: startup_events.append("before-fork"),
+    )
 
     def capture_start():
+        startup_events.append("poller")
         started_with_products.extend(poller._client._enabled_products)
         poller.status = ServiceStatus.RUNNING
 
@@ -186,8 +193,10 @@ def test_remoteconfig_product_defers_start_until_all_products_registered(monkeyp
 
         assert poller.status == ServiceStatus.STOPPED
         assert started_with_products == []
+        assert startup_events == ["native", "before-fork"]
 
         product.post_start()
+    assert startup_events == ["native", "before-fork", "poller"]
     assert set(started_with_products) == {
         RemoteConfigProduct.AgentConfig,
         RemoteConfigProduct.FfeFlags,

--- a/tests/internal/test_products.py
+++ b/tests/internal/test_products.py
@@ -18,7 +18,7 @@ class BaseProduct(Product):
     requires = []
 
     def __init__(self) -> None:
-        self.started = self.restarted = self.stopped = self.exited = self.post_preloaded = False
+        self.started = self.post_started = self.restarted = self.stopped = self.exited = self.post_preloaded = False
 
     def post_preload(self) -> None:
         self.post_preloaded = True
@@ -28,6 +28,9 @@ class BaseProduct(Product):
 
     def start(self) -> None:
         self.started = True
+
+    def post_start(self) -> None:
+        self.post_started = True
 
     def restart(self, join: bool = False) -> None:
         self.restarted = True
@@ -94,9 +97,11 @@ def test_product_manager_start_fail():
 
     # a will start
     assert a.started
+    assert a.post_started
 
     # b fails to start, so c won't start because it depends on b
     assert not b.started and not c.started
+    assert not b.post_started and not c.post_started
 
 
 def test_product_manager_start():
@@ -104,6 +109,32 @@ def test_product_manager_start():
     manager = ProductManagerTest({"a": a})
     manager.run_protocol()
     assert a.started
+    assert a.post_started
+
+
+def test_product_manager_post_start_runs_after_all_products_start():
+    events = []
+
+    class A(BaseProduct):
+        def start(self) -> None:
+            events.append("a-start")
+
+        def post_start(self) -> None:
+            events.append("a-post-start")
+
+    class B(BaseProduct):
+        requires = ["a"]
+
+        def start(self) -> None:
+            events.append("b-start")
+
+        def post_start(self) -> None:
+            events.append("b-post-start")
+
+    manager = ProductManagerTest({"a": A(), "b": B()})
+    manager.run_protocol()
+
+    assert events == ["a-start", "b-start", "a-post-start", "b-post-start"]
 
 
 @pytest.mark.subprocess


### PR DESCRIPTION
## Description

Fixes [FFL-2958](https://datadoghq.atlassian.net/browse/FFL-2958).

Remote Configuration starts with an immediate first poll. During automatic instrumentation bootstrap, that poll could complete before dependent products—most notably `FFE_FLAGS`—registered and enabled their subscriptions. The client could then retain incremental state without the initial feature-flag configuration, leaving the OpenFeature provider not ready and returning local defaults.

The immediate native poll can also hold the Remote Configuration client mutex across the Agent HTTP request while later products synchronously register capabilities. Deferring the first poll prevents Agent latency from serializing the rest of product bootstrap.

This change adds an optional product `post_start()` phase. The Remote Configuration product arms a startup barrier during `start()` and releases it only after all enabled products have started, so the first request advertises the complete product set. Registration outside product bootstrap still starts the poller immediately, and the same ordering applies to post-fork product startup.

If Remote Configuration product registration raises after partially modifying the poller, startup disables the partial registration and clears the barrier. If releasing the barrier fails while starting the poller, `post_start()` performs the same cleanup before re-raising. This leaves the poller clean and retryable instead of permanently deferring future registration.

This is complementary to the newer `switch_to_agentless()` path: that method changes and rebuilds the Remote Configuration transport, while this barrier guarantees that the first Agent or agentless request sees the complete startup product set. Switching transports while startup is deferred does not release the barrier.

The barrier delays only the polling thread. Native Remote Configuration client initialization and registration of the pre-fork hook still happen eagerly before the barrier is honored, preserving the existing shared-memory and fork-safety guarantees.

A customer-facing release note is included.

## Testing

- `./scripts/lint checks`
- `./scripts/run-tests --venv 3434170 -- tests/internal/test_products.py tests/internal/remoteconfig/test_remoteconfig_native.py` on Python 3.12: 40 passed
- OpenFeature suite on Python 3.12 from the original barrier implementation: 528 passed

## Risks

The first Remote Configuration request now occurs after enabled products finish their startup hooks instead of at the beginning of product bootstrap. A slow product can therefore delay the first Remote Configuration request, but the barrier performs no network wait and does not block beyond the existing synchronous product startup sequence.

Failure cleanup clears partially registered Remote Configuration callbacks and products only when Remote Configuration startup has already failed. The healthy startup path and steady-state polling behavior are unchanged.

The optional product-manager hook is shared infrastructure, but Remote Configuration is the only product using it in this change. Native initialization and the pre-fork hook remain eager, polling remains non-blocking once released, and public APIs are unchanged.

## Additional Notes

Regression coverage verifies that:

- native initialization and fork-hook registration happen before polling is deferred;
- `FFE_FLAGS` is present before the poller starts;
- releasing an inactive barrier does not start polling;
- partial registration failure clears the startup barrier and leaves the poller retryable;
- failure while `post_start()` starts the poller cleans up callbacks, products, the barrier, and the fork hook before re-raising; and
- switching to agentless transport does not release the barrier before all startup products register.

[FFL-2958]: https://datadoghq.atlassian.net/browse/FFL-2958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
