### PR TITLE
chore(openfeature): give FFE sole ownership of native bridge and benchmark

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -254,9 +254,11 @@ ddtrace/internal/remoteconfig       @DataDog/remote-config @DataDog/apm-core-pyt
 tests/internal/remoteconfig         @DataDog/remote-config @DataDog/apm-core-python
 
 # Feature Flags
+benchmarks/openfeature_flagevaluation/       @DataDog/feature-flagging-and-experimentation-sdk @DataDog/apm-core-python
 ddtrace/openfeature/                      @DataDog/feature-flagging-and-experimentation-sdk
 ddtrace/internal/openfeature/             @DataDog/feature-flagging-and-experimentation-sdk
 ddtrace/internal/settings/openfeature.py  @DataDog/feature-flagging-and-experimentation-sdk
+src/native/ffe.rs                         @DataDog/feature-flagging-and-experimentation-sdk @DataDog/apm-core-python
 tests/openfeature/                        @DataDog/feature-flagging-and-experimentation-sdk
 
 # API SDK


### PR DESCRIPTION
## Description

Give FFE sole ownership of its native bridge and OpenFeature benchmark.

### Motivation

Route review and test attribution for dedicated FFE product work to the FFE SDK team.

### Changes

Add FFE-only ownership for `src/native/ffe.rs` and `benchmarks/openfeature_flagevaluation/`.

### Decisions

Match the existing FFE-only ownership of the OpenFeature implementation and tests.

## Testing

Validated effective ownership of 65 dedicated FFE paths and checked all 9,950 tracked files for unintended ownership changes; none found. `git diff --check` passed. The PR patch applies cleanly to current `main`; the ownership check also passes on that merged result. `scripts/lint spelling -- .github/CODEOWNERS` passed.

## Risks

Changes review/test attribution only.

## Additional Notes

No customer-facing release note is needed.
