### PR TITLE
chore(config): improve Envier typing

### DIFF
--- a/ddtrace/internal/remoteconfig/client.py
+++ b/ddtrace/internal/remoteconfig/client.py
@@ -6,6 +6,8 @@ from typing import Optional
 from typing import Sequence
 import uuid
 
+from envier.env import EnvVariable
+
 import ddtrace
 from ddtrace.internal import gitmetadata
 from ddtrace.internal import process_tags
@@ -53,7 +55,7 @@ class RemoteConfigClientConfig(DDConfig):
 
     log_payloads = DDConfig.v(bool, "log_payloads", default=False)
 
-    _skip_shutdown = DDConfig.v(Optional[bool], "skip_shutdown", default=None)
+    _skip_shutdown: EnvVariable[Optional[bool]] = DDConfig.v(Optional[bool], "skip_shutdown", default=None)
     skip_shutdown = DDConfig.d(bool, derive_skip_shutdown)
 
 

--- a/ddtrace/internal/settings/_agent.py
+++ b/ddtrace/internal/settings/_agent.py
@@ -5,6 +5,8 @@ from typing import TypeVar
 from typing import Union
 from urllib.parse import urlparse
 
+from envier.env import EnvVariable
+
 from ddtrace.internal.constants import DEFAULT_TIMEOUT
 from ddtrace.internal.settings import env
 from ddtrace.internal.settings._core import DDConfig
@@ -85,7 +87,7 @@ def _derive_trace_native_span_events(config: "AgentConfig") -> bool:
 class AgentConfig(DDConfig):
     __prefix__ = "dd"
 
-    _trace_agent_hostname = DDConfig.v(
+    _trace_agent_hostname: EnvVariable[Optional[str]] = DDConfig.v(
         Optional[str],
         "trace_agent_hostname",
         default=None,
@@ -93,7 +95,7 @@ class AgentConfig(DDConfig):
         help="Legacy configuration, stores the hostname of the trace agent",
     )
 
-    _trace_agent_port = DDConfig.v(
+    _trace_agent_port: EnvVariable[Optional[int]] = DDConfig.v(
         Optional[int],
         "trace_agent_port",
         default=None,
@@ -101,7 +103,7 @@ class AgentConfig(DDConfig):
         help="Legacy configuration, stores the port of the trace agent",
     )
 
-    _trace_agent_url = DDConfig.v(
+    _trace_agent_url: EnvVariable[Optional[str]] = DDConfig.v(
         Optional[str],
         "trace_agent_url",
         default=None,
@@ -117,7 +119,7 @@ class AgentConfig(DDConfig):
         help="Stores the timeout in seconds for the trace agent",
     )
 
-    _dogstatsd_host = DDConfig.v(
+    _dogstatsd_host: EnvVariable[Optional[str]] = DDConfig.v(
         Optional[str],
         "dogstatsd_host",
         default=None,
@@ -125,7 +127,7 @@ class AgentConfig(DDConfig):
         help="Stores the hostname of the agent receiving DogStatsD metrics",
     )
 
-    _dogstatsd_port = DDConfig.v(
+    _dogstatsd_port: EnvVariable[Optional[int]] = DDConfig.v(
         Optional[int],
         "dogstatsd_port",
         default=None,
@@ -133,7 +135,7 @@ class AgentConfig(DDConfig):
         help="Stores the port of the agent receiving DogStatsD metrics",
     )
 
-    _dogstatsd_url = DDConfig.v(
+    _dogstatsd_url: EnvVariable[Optional[str]] = DDConfig.v(
         Optional[str],
         "dogstatsd_url",
         default=None,
@@ -141,7 +143,7 @@ class AgentConfig(DDConfig):
         help="Stores the URL of the DogStatsD agent",
     )
 
-    _agent_host = DDConfig.v(
+    _agent_host: EnvVariable[Optional[str]] = DDConfig.v(
         Optional[str],
         "agent_host",
         default=None,
@@ -149,7 +151,7 @@ class AgentConfig(DDConfig):
         help="Stores the hostname of the agent",
     )
 
-    _agent_port = DDConfig.v(
+    _agent_port: EnvVariable[Optional[int]] = DDConfig.v(
         Optional[int],
         "agent_port",
         default=None,
@@ -157,7 +159,7 @@ class AgentConfig(DDConfig):
         help="Stores the port of the agent",
     )
 
-    _trace_agent_protocol_version = DDConfig.v(
+    _trace_agent_protocol_version: EnvVariable[Optional[str]] = DDConfig.v(
         Optional[str],
         "trace_agent_protocol_version",
         default=None,

--- a/ddtrace/internal/settings/_opentelemetry.py
+++ b/ddtrace/internal/settings/_opentelemetry.py
@@ -128,6 +128,9 @@ def _is_otlp_trace_metrics_enabled(
 class OpenTelemetryConfig(DDConfig):
     __prefix__ = "otel"
 
+    if t.TYPE_CHECKING:
+        exporter: "ExporterConfig"
+
 
 class ExporterConfig(DDConfig):
     __prefix__ = "exporter"

--- a/ddtrace/internal/settings/_telemetry.py
+++ b/ddtrace/internal/settings/_telemetry.py
@@ -1,6 +1,8 @@
 import sys
 import typing as t
 
+from envier.env import EnvVariable
+
 from ddtrace.internal.settings._core import DDConfig
 from ddtrace.internal.settings._inferred_base_service import detect_service
 
@@ -8,7 +10,7 @@ from ddtrace.internal.settings._inferred_base_service import detect_service
 class TelemetryConfig(DDConfig):
     __prefix__ = "dd"
 
-    API_KEY = DDConfig.v(t.Optional[str], "api_key", default=None)
+    API_KEY: EnvVariable[t.Optional[str]] = DDConfig.v(t.Optional[str], "api_key", default=None)
     SITE = DDConfig.v(str, "site", default="datadoghq.com")
     ENV = DDConfig.v(str, "env", default="")
     SERVICE = DDConfig.v(str, "service", default=detect_service(sys.argv) or "unnamed-python-service")
@@ -18,9 +20,13 @@ class TelemetryConfig(DDConfig):
     HEARTBEAT_INTERVAL = DDConfig.v(float, "telemetry.heartbeat_interval", default=60.0)
     TELEMETRY_ENABLED = DDConfig.v(bool, "instrumentation_telemetry.enabled", default=True)
     DEPENDENCY_COLLECTION = DDConfig.v(bool, "telemetry.dependency_collection.enabled", default=True)
-    INSTALL_ID = DDConfig.v(t.Optional[str], "instrumentation.install_id", default=None)
-    INSTALL_TYPE = DDConfig.v(t.Optional[str], "instrumentation.install_type", default=None)
-    INSTALL_TIME = DDConfig.v(t.Optional[str], "instrumentation.install_time", default=None)
+    INSTALL_ID: EnvVariable[t.Optional[str]] = DDConfig.v(t.Optional[str], "instrumentation.install_id", default=None)
+    INSTALL_TYPE: EnvVariable[t.Optional[str]] = DDConfig.v(
+        t.Optional[str], "instrumentation.install_type", default=None
+    )
+    INSTALL_TIME: EnvVariable[t.Optional[str]] = DDConfig.v(
+        t.Optional[str], "instrumentation.install_time", default=None
+    )
     FORCE_START = DDConfig.v(bool, "instrumentation_telemetry.tests.force_app_started", default=False, private=True)
     LOG_COLLECTION_ENABLED = DDConfig.v(bool, "telemetry.log_collection.enabled", default=True)
     # Interval should be fixed to 24 hours. The value should only be overridden in tests.

--- a/ddtrace/internal/settings/appsec_telemetry.py
+++ b/ddtrace/internal/settings/appsec_telemetry.py
@@ -1,12 +1,14 @@
 import typing as t
 
+from envier.env import EnvVariable
+
 from ddtrace.internal.settings._core import DDConfig
 
 
 class AppSecTelemetryConfig(DDConfig):
     __prefix__ = "dd"
 
-    SCA_ENABLED = DDConfig.v(t.Optional[bool], "appsec.sca.enabled", default=None)
+    SCA_ENABLED: EnvVariable[t.Optional[bool]] = DDConfig.v(t.Optional[bool], "appsec.sca.enabled", default=None)
     ENDPOINT_COLLECTION_ENABLED = DDConfig.v(bool, "api.security.endpoint.collection.enabled", default=True)
     ENDPOINT_COLLECTION_LIMIT = DDConfig.v(int, "api.security.endpoint.collection.message.limit", default=300)
 

--- a/ddtrace/internal/settings/asm.py
+++ b/ddtrace/internal/settings/asm.py
@@ -4,6 +4,8 @@ from platform import system
 import sys
 from typing import Optional
 
+from envier.env import EnvVariable
+
 from ddtrace.appsec._constants import API_SECURITY
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import DEFAULT
@@ -65,10 +67,7 @@ class ASMConfig(DDConfig):
     _asm_enabled = DDConfig.var(bool, APPSEC_ENV, default=False)
     _asm_enabled_origin = APPSEC.ENABLED_ORIGIN_DEFAULT
     _asm_agentic_onboarding = DDConfig.var(str, APPSEC.AGENTIC_ONBOARDING, default="")
-    _asm_static_rule_file = DDConfig.var(Optional[str], APPSEC.RULE_FILE, default=None)
-    # prevent empty string
-    if _asm_static_rule_file == "":
-        _asm_static_rule_file = None
+    _asm_static_rule_file: EnvVariable[Optional[str]] = DDConfig.var(Optional[str], APPSEC.RULE_FILE, default=None)
     _asm_processed_span_types = {SpanTypes.WEB}
     _asm_http_span_types = {SpanTypes.WEB}
     _iast_enabled = tracer_config._from_endpoint.get("iast_enabled", DDConfig.var(bool, IAST.ENV, default=False))
@@ -188,9 +187,11 @@ class ASMConfig(DDConfig):
 
     # DOWNSTREAM REQUESTS INSTRUMENTATION
     # sample rate for body analysis
-    _dr_sample_rate: float = DDConfig.var(float, "DD_API_SECURITY_DOWNSTREAM_BODY_ANALYSIS_SAMPLE_RATE", default=0.5)
+    _dr_sample_rate: EnvVariable[float] = DDConfig.var(
+        float, "DD_API_SECURITY_DOWNSTREAM_BODY_ANALYSIS_SAMPLE_RATE", default=0.5
+    )
     # max number of downstream requests analysis  with bodies per request
-    _dr_body_limit_per_request: int = DDConfig.var(
+    _dr_body_limit_per_request: EnvVariable[int] = DDConfig.var(
         int, "DD_API_SECURITY_MAX_DOWNSTREAM_REQUEST_BODY_ANALYSIS", default=1
     )
 

--- a/ddtrace/internal/settings/code_origin.py
+++ b/ddtrace/internal/settings/code_origin.py
@@ -25,5 +25,7 @@ class CodeOriginConfig(DDConfig):
             help="Enable code origin for spans",
         )
 
+    span: SpanCodeOriginConfig
+
 
 config = CodeOriginConfig()

--- a/ddtrace/internal/settings/crashtracker.py
+++ b/ddtrace/internal/settings/crashtracker.py
@@ -1,6 +1,8 @@
 import sys
 import typing as t
 
+from envier.env import EnvVariable
+
 from ddtrace.internal.settings._core import DDConfig
 from ddtrace.internal.telemetry import report_configuration
 from ddtrace.internal.utils.formats import parse_tags_str
@@ -61,7 +63,7 @@ class CrashtrackingConfig(DDConfig):
         help="Whether to send crash reports to the errors intake.",
     )
 
-    debug_url = DDConfig.v(
+    debug_url: EnvVariable[t.Optional[str]] = DDConfig.v(
         t.Optional[str],
         "debug_url",
         default=None,
@@ -70,7 +72,7 @@ class CrashtrackingConfig(DDConfig):
         "This is generally useful only for dd-trace-py development.",
     )
 
-    _test_token = DDConfig.v(
+    _test_token: EnvVariable[t.Optional[str]] = DDConfig.v(
         t.Optional[str],
         "test_token",
         default=None,
@@ -80,7 +82,7 @@ class CrashtrackingConfig(DDConfig):
         "This is generally useful only for dd-trace-py development.",
     )
 
-    stdout_filename = DDConfig.v(
+    stdout_filename: EnvVariable[t.Optional[str]] = DDConfig.v(
         t.Optional[str],
         "stdout_filename",
         default=None,
@@ -88,7 +90,7 @@ class CrashtrackingConfig(DDConfig):
         help="The destination filename for crashtracking stdout",
     )
 
-    stderr_filename = DDConfig.v(
+    stderr_filename: EnvVariable[t.Optional[str]] = DDConfig.v(
         t.Optional[str],
         "stderr_filename",
         default=None,
@@ -114,7 +116,7 @@ class CrashtrackingConfig(DDConfig):
         "use_alt_stack to ensure that the altstack is large enough.",
     )
 
-    _stacktrace_resolver = DDConfig.v(
+    _stacktrace_resolver: EnvVariable[t.Optional[str]] = DDConfig.v(
         t.Optional[str],
         "stacktrace_resolver",
         default=resolver_default,
@@ -124,7 +126,7 @@ class CrashtrackingConfig(DDConfig):
     )
     stacktrace_resolver = DDConfig.d(t.Optional[str], _derive_stacktrace_resolver)
 
-    tags = DDConfig.v(
+    tags: EnvVariable[dict[str, str]] = DDConfig.v(
         dict,
         "tags",
         parser=parse_tags_str,

--- a/ddtrace/internal/settings/dynamic_instrumentation.py
+++ b/ddtrace/internal/settings/dynamic_instrumentation.py
@@ -2,6 +2,8 @@ from pathlib import Path
 import re
 import typing as t
 
+from envier.env import EnvVariable
+
 from ddtrace import config as ddconfig
 from ddtrace.internal import gitmetadata
 from ddtrace.internal.constants import DEFAULT_SERVICE_NAME
@@ -28,6 +30,13 @@ def _derive_tags(c: DDConfig) -> str:
     gitmetadata.add_tags(_tags)
 
     return ",".join([":".join((k, v)) for (k, v) in _tags.items() if v is not None])
+
+
+def _derive_redacted_types_re(c: "DynamicInstrumentationConfig") -> t.Optional[re.Pattern[str]]:
+    if not c.redacted_types:
+        return None
+    patterns = (_.replace(".", "[.]").replace("*", ".*") for _ in c.redacted_types)
+    return re.compile(f"^(?:{'|'.join(patterns)})$")
 
 
 def normalize_ident(ident: str) -> str:
@@ -105,7 +114,7 @@ class DynamicInstrumentationConfig(DDConfig):
         help="Interval in seconds for periodically emitting probe diagnostic messages",
     )
 
-    redacted_identifiers = DDConfig.v(
+    redacted_identifiers: EnvVariable[set[str]] = DDConfig.v(
         set,
         "redacted_identifiers",
         map=normalize_ident,
@@ -114,7 +123,7 @@ class DynamicInstrumentationConfig(DDConfig):
         help="List of identifiers/object attributes/dict keys to redact from dynamic logs and snapshots",
     )
 
-    redacted_types = DDConfig.v(
+    redacted_types: EnvVariable[set[str]] = DDConfig.v(
         set,
         "redacted_types",
         map=str.strip,
@@ -126,14 +135,10 @@ class DynamicInstrumentationConfig(DDConfig):
 
     redacted_types_re = DDConfig.d(
         t.Optional[re.Pattern],
-        lambda c: (
-            re.compile(f"^(?:{'|'.join((_.replace('.', '[.]').replace('*', '.*') for _ in c.redacted_types))})$")
-            if c.redacted_types
-            else None
-        ),
+        _derive_redacted_types_re,
     )
 
-    redaction_excluded_identifiers = DDConfig.v(
+    redaction_excluded_identifiers: EnvVariable[set[str]] = DDConfig.v(
         set,
         "redaction_excluded_identifiers",
         map=normalize_ident,
@@ -158,7 +163,7 @@ class DynamicInstrumentationConfig(DDConfig):
         help="Maximum wall-time in milliseconds for condition and template expression evaluation per probe invocation",
     )
 
-    probe_file = DDConfig.v(
+    probe_file: EnvVariable[t.Optional[Path]] = DDConfig.v(
         t.Optional[Path],
         "probe_file",
         default=None,

--- a/ddtrace/internal/settings/profiling.py
+++ b/ddtrace/internal/settings/profiling.py
@@ -8,6 +8,7 @@ import typing as t
 
 from envier import Env
 from envier import validators
+from envier.env import EnvVariable
 
 from ddtrace.ext.git import COMMIT_SHA
 from ddtrace.ext.git import MAIN_PACKAGE
@@ -135,6 +136,14 @@ def _clamp_max_frames(value: str) -> int:
 class ProfilingConfig(DDConfig):
     __prefix__ = "dd.profiling"
 
+    if t.TYPE_CHECKING:
+        stack: ProfilingConfigStack
+        lock: ProfilingConfigLock
+        memory: ProfilingConfigMemory
+        heap: ProfilingConfigHeap
+        pytorch: ProfilingConfigPytorch
+        exception: ProfilingConfigException
+
     # Note that the parser here has a side-effect, since SSI has changed the once-truthy value of the envvar to
     # truthy + "auto", which has a special meaning.
     enabled = DDConfig.v(
@@ -180,7 +189,7 @@ class ProfilingConfig(DDConfig):
         help="Whether to enable the endpoint data collection in profiles",
     )
 
-    output_pprof = DDConfig.v(
+    output_pprof: EnvVariable[t.Optional[str]] = DDConfig.v(
         t.Optional[str],
         "output_pprof",
         default=None,
@@ -260,7 +269,7 @@ class ProfilingConfig(DDConfig):
         ),
     )
 
-    tags = DDConfig.v(
+    tags: EnvVariable[dict[str, str]] = DDConfig.v(
         dict,
         "tags",
         parser=parse_tags_str,
@@ -517,7 +526,7 @@ class ProfilingConfigHeap(DDConfig):
         help="Whether to enable the heap memory profiler",
     )
 
-    _sample_size = DDConfig.v(
+    _sample_size: EnvVariable[t.Optional[int]] = DDConfig.v(
         t.Optional[int],
         "sample_size",
         default=None,

--- a/ddtrace/internal/settings/symbol_db.py
+++ b/ddtrace/internal/settings/symbol_db.py
@@ -1,6 +1,12 @@
 import re
 
+from envier.env import EnvVariable
+
 from ddtrace.internal.settings._core import DDConfig
+
+
+def _derive_includes_re(config: "SymbolDatabaseConfig") -> re.Pattern[str]:
+    return re.compile("(" + "|".join(f"^{p}$|^{p}[.]" for p in config.includes) + ")")
 
 
 class SymbolDatabaseConfig(DDConfig):
@@ -14,16 +20,14 @@ class SymbolDatabaseConfig(DDConfig):
         help="Whether to upload source code symbols to the Datadog backend",
     )
 
-    includes = DDConfig.v(
+    includes: EnvVariable[set[str]] = DDConfig.v(
         set,
         "includes",
         default=set(),
         help_type="List",
         help="List of modules/packages to include in the symbol uploads",
     )
-    _includes_re = DDConfig.d(
-        re.Pattern, lambda c: re.compile("(" + "|".join(f"^{p}$|^{p}[.]" for p in c.includes) + ")")
-    )
+    _includes_re = DDConfig.d(re.Pattern, _derive_includes_re)
 
     # ---- Private settings ----
 

--- a/ddtrace/internal/settings/third_party.py
+++ b/ddtrace/internal/settings/third_party.py
@@ -1,17 +1,19 @@
+from envier.env import EnvVariable
+
 from ddtrace.internal.settings._core import DDConfig
 
 
 class ThirdPartyDetectionConfig(DDConfig):
     __prefix__ = "dd.third_party_detection"
 
-    excludes = DDConfig.v(
+    excludes: EnvVariable[set[str]] = DDConfig.v(
         set,
         "excludes",
         help="List of packages that should not be treated as third-party",
         help_type="List",
         default=set(),
     )
-    includes = DDConfig.v(
+    includes: EnvVariable[set[str]] = DDConfig.v(
         set,
         "includes",
         help="Additional packages to treat as third-party",


### PR DESCRIPTION
## Summary

- annotate Envier class declarations with their descriptor types instead of their parsed value types
- annotate dynamically named nested configurations under `TYPE_CHECKING`
- replace two owner-dependent derivation lambdas with typed helper functions
- remove two unnecessary value annotations and a class-body check that could never observe the parsed ASM value

## Why

Pyright cannot consume Envier's mypy plugin. With the descriptor contract from DataDog/envier#49, ordinary declarations resolve correctly in both Pyright and mypy; optional and parameterized declarations use `EnvVariable[T]`, and the remaining annotations cover only information that neither checker can infer from the class body.

The derivation helpers retain the concrete configuration owner type instead of degrading the callback parameter to `Any`. There are no intended runtime behavior changes.

## Dependency

This draft depends on DataDog/envier#49 and should remain draft until a compatible Envier version is available to dd-trace-py CI.

## Validation

- Ruff format and lint: 12 files clean
- Pyright 1.1.411 with the Envier PR checkout: `0 errors`
- mypy with the Envier PR checkout: only two pre-existing untyped `psutil` diagnostics in `profiling.py`
- Python 3.13 configuration smoke test with the Envier PR checkout
- internal settings and Symbol DB: `31 passed`
- debugger configuration: `31 passed`
- profiling configuration: `21 passed`

