### PR TITLE
fix(llmobs): resolve agent attribution for auto-instrumented agent spans

### DIFF
--- a/.claude/skills/llmobs-integrations/references/implementation-guide.md
+++ b/.claude/skills/llmobs-integrations/references/implementation-guide.md
@@ -135,6 +135,56 @@ Do not dump raw `kwargs` into LLMObs metadata. Prefer shared helpers such as `ge
 
 Normalize `INPUT_TOKENS_METRIC_KEY` to the total input tokens sent to the model, including cached and non-cached tokens. Providers report this differently: Anthropic reports non-cached `input_tokens` separately from cache read/write input tokens, so add `input_tokens + cache_creation_input_tokens + cache_read_input_tokens`; OpenAI reports prompt/input tokens as the combined total and exposes cached tokens separately in details.
 
+## Agent Integrations: Stamp Kind and Name at Span Start
+
+Agent integrations have a critical ordering constraint. `_resolve_parent_agent()` in `ddtrace/llmobs/_utils.py` resolves agent attribution when a **child** span activates, not when the parent finishes. Under LIFO nesting the parent span is still open when the child starts — so any field written at span *finish* time is invisible to children that have already been attributed.
+
+**Contract: any integration that produces `kind="agent"` LLMObs spans must stamp kind at span creation, not at finish.**
+
+`BaseLLMIntegration.trace()` and `LlmTracingSubscriber.on_started` both call `_stamp_llmobs_span_kind_at_start()` automatically. Integrations should not call it directly; instead override the two hooks below.
+
+### Hooks to implement for agent spans
+
+**`_llmobs_span_kind(self, operation_id, span, **kwargs) -> Optional[str]`**
+
+Return `"agent"` when the kwargs signal an agent span. The base-class default returns `"agent"` when `kwargs.get("kind") == "agent"`. Override only when the integration uses a different signal (e.g. `operation="agent"` for CrewAI, `interface_type="agent"` for Bedrock). Must be determinable at `trace()` call time — do NOT rely on data available only at finish.
+
+**`_llmobs_agent_name_at_start(self, span, **kwargs) -> Optional[str]`**
+
+Return the agent's LLMObs display name when it can be determined at `trace()` call time. Return `None` to fall back to the span resource name. Override when the integration can resolve the name from kwargs (e.g. Google ADK passes `_dd_agent=<agent_instance>` and the integration reads `agent.name`).
+
+If the integration's `trace()` captures the instance reference before `**kwargs` (e.g. LangGraph), `_llmobs_agent_name_at_start` cannot reach it through `super().trace()`. In that case, stamp the name directly in the integration's `trace()` override after calling `super()`:
+
+```python
+def trace(self, operation_id, submit_to_llmobs=False, **kwargs):
+    span = super().trace(operation_id, submit_to_llmobs=submit_to_llmobs, **kwargs)
+    # instance captured before **kwargs; stamp name after super() has written the kind
+    if submit_to_llmobs and self.llmobs_enabled and kwargs.get("kind") == "agent":
+        agent_name = getattr(instance, "name", None) if instance else None
+        if agent_name:
+            _annotate_llmobs_span_data(span, name=agent_name)
+    return span
+```
+
+### Example: Google ADK
+
+Patch layer passes the agent object via a private kwarg:
+```python
+span = integration.trace(
+    "%s.%s" % (instance.__class__.__name__, wrapped.__name__),
+    kind="agent",
+    submit_to_llmobs=True,
+    _dd_agent=agent,   # <-- agent instance available at trace() call time
+)
+```
+
+Integration overrides the hook:
+```python
+def _llmobs_agent_name_at_start(self, span: Span, **kwargs: Any) -> Optional[str]:
+    agent = kwargs.get("_dd_agent")
+    return getattr(agent, "name", None) if agent else None
+```
+
 ## LLM-Specific Registration Checklist
 
 In addition to the full checklist in the apm-integrations [Implementation Guide](../../apm-integrations/references/implementation-guide.md):

--- a/ddtrace/_trace/subscribers/llm.py
+++ b/ddtrace/_trace/subscribers/llm.py
@@ -51,6 +51,9 @@ class LlmTracingSubscriber(TracingSubscriber["LlmRequestEvent"]):
         if event.llmobs_integration._is_instrumented_proxy_url(base_url):
             span._set_ctx_item(_PROXY_REQUEST, True)
         event.llmobs_integration._annotate_integration_tag(span)
+        # Event-based spans are created here, not via trace(); stamp the kind at start too. The
+        # integration owns the annotation, so no ddtrace.llmobs import is pulled into this module.
+        event.llmobs_integration._stamp_llmobs_span_kind_at_start(span, event.operation, operation=event.operation)
 
     @classmethod
     def on_ended(

--- a/ddtrace/_trace/subscribers/llm.py
+++ b/ddtrace/_trace/subscribers/llm.py
@@ -51,8 +51,7 @@ class LlmTracingSubscriber(TracingSubscriber["LlmRequestEvent"]):
         if event.llmobs_integration._is_instrumented_proxy_url(base_url):
             span._set_ctx_item(_PROXY_REQUEST, True)
         event.llmobs_integration._annotate_integration_tag(span)
-        # Event-based spans are created here, not via trace(); stamp the kind at start too. The
-        # integration owns the annotation, so no ddtrace.llmobs import is pulled into this module.
+        # Stamp kind at start; no ddtrace.llmobs import pulled into this module.
         event.llmobs_integration._stamp_llmobs_span_kind_at_start(span, event.operation, operation=event.operation)
 
     @classmethod

--- a/ddtrace/contrib/internal/claude_agent_sdk/patch.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/patch.py
@@ -36,6 +36,7 @@ def traced_query_async_generator(func, _instance, args, kwargs):
         "claude_agent_sdk.query",
         submit_to_llmobs=True,
         span_name="claude_agent_sdk.query",
+        kind="agent",  # known at start for agent attribution
     )
 
     if prompt_wrapper:
@@ -66,6 +67,7 @@ async def traced_client_query(func, instance, args, kwargs):
         submit_to_llmobs=True,
         span_name="claude_agent_sdk.ClaudeSDKClient.query",
         instance=instance,
+        kind="agent",  # known at start for agent attribution
     )
 
     if prompt_wrapper:

--- a/ddtrace/contrib/internal/google_adk/patch.py
+++ b/ddtrace/contrib/internal/google_adk/patch.py
@@ -47,6 +47,7 @@ def _traced_agent_run_async(wrapped, instance, args, kwargs):
         model=model_name,
         kind="agent",
         submit_to_llmobs=True,
+        _dd_agent=agent,
         **kwargs,
     )
 

--- a/ddtrace/contrib/internal/langgraph/patch.py
+++ b/ddtrace/contrib/internal/langgraph/patch.py
@@ -262,6 +262,7 @@ def traced_pregel_stream(func, instance, args, kwargs):
         "%s.%s.%s" % (_get_module_name(instance.__module__), instance.__class__.__name__, name),
         submit_to_llmobs=True,
         instance=instance,
+        kind="agent",  # known at start for agent attribution
     )
 
     try:
@@ -309,6 +310,7 @@ def traced_pregel_astream(func, instance, args, kwargs):
         "%s.%s.%s" % (_get_module_name(instance.__module__), instance.__class__.__name__, name),
         submit_to_llmobs=True,
         instance=instance,
+        kind="agent",  # known at start for agent attribution
     )
 
     try:

--- a/ddtrace/llmobs/_integrations/base.py
+++ b/ddtrace/llmobs/_integrations/base.py
@@ -110,7 +110,10 @@ class BaseLLMIntegration:
         if span_kind is None:
             return
         agent_name = self._llmobs_agent_name_at_start(span, **kwargs)
-        _annotate_llmobs_span_data(span, kind=span_kind, **({"name": agent_name} if agent_name else {}))
+        if agent_name:
+            _annotate_llmobs_span_data(span, kind=span_kind, name=agent_name)
+        else:
+            _annotate_llmobs_span_data(span, kind=span_kind)
 
     def _llmobs_agent_name_at_start(self, span: Span, **kwargs: Any) -> Optional[str]:
         """Return the LLMObs name to stamp alongside the agent kind at start, or None to defer to finish.

--- a/ddtrace/llmobs/_integrations/base.py
+++ b/ddtrace/llmobs/_integrations/base.py
@@ -94,7 +94,25 @@ class BaseLLMIntegration:
         span._set_attribute(_SPAN_MEASURED_KEY, 1)
         self._set_base_span_tags(span, **kwargs)
         self._annotate_integration_tag(span)
+        if span_type == SpanTypes.LLM:
+            self._stamp_llmobs_span_kind_at_start(span, operation_id, **kwargs)
         return span
+
+    def _stamp_llmobs_span_kind_at_start(self, span: Span, operation_id: str = "", **kwargs: Any) -> None:
+        """Stamp the span kind at start so a parent agent's kind is visible before its children
+        activate. Agent attribution reads it at child activation; under LIFO nesting a finish-time
+        write lands too late. Called from trace() and from LlmTracingSubscriber.on_started.
+        """
+        span_kind = self._llmobs_span_kind(operation_id, span, **kwargs)
+        if span_kind is not None:
+            _annotate_llmobs_span_data(span, kind=span_kind)
+
+    def _llmobs_span_kind(self, operation_id: str, span: Span, **kwargs: Any) -> Optional[str]:
+        """Return the kind to stamp at start, or None to leave it to _llmobs_set_tags at finish.
+
+        Overridden by integrations that create agent spans; the finish-time write still runs.
+        """
+        return None
 
     def llmobs_set_tags(
         self,

--- a/ddtrace/llmobs/_integrations/base.py
+++ b/ddtrace/llmobs/_integrations/base.py
@@ -99,15 +99,26 @@ class BaseLLMIntegration:
         return span
 
     def _stamp_llmobs_span_kind_at_start(self, span: Span, operation_id: str = "", **kwargs: Any) -> None:
-        """Stamp the span kind at start so a parent agent's kind is visible before its children
-        activate. Agent attribution reads it at child activation; under LIFO nesting a finish-time
-        write lands too late. Called from trace() and from LlmTracingSubscriber.on_started.
+        """Stamp the span kind (and name when available) at start so a parent agent is fully
+        resolvable before its children activate. Agent attribution reads both at child activation;
+        under LIFO nesting a finish-time write lands too late. Called from trace() and from
+        LlmTracingSubscriber.on_started.
         """
         if span.span_type != SpanTypes.LLM:
             return
         span_kind = self._llmobs_span_kind(operation_id, span, **kwargs)
-        if span_kind is not None:
-            _annotate_llmobs_span_data(span, kind=span_kind)
+        if span_kind is None:
+            return
+        agent_name = self._llmobs_agent_name_at_start(span, **kwargs)
+        _annotate_llmobs_span_data(span, kind=span_kind, **({"name": agent_name} if agent_name else {}))
+
+    def _llmobs_agent_name_at_start(self, span: Span, **kwargs: Any) -> Optional[str]:
+        """Return the LLMObs name to stamp alongside the agent kind at start, or None to defer to finish.
+
+        Integrations that have the agent name available at trace()-call time should override this.
+        The finish-time write in _llmobs_set_tags still runs and is idempotent.
+        """
+        return None
 
     def _llmobs_span_kind(self, operation_id: str, span: Span, **kwargs: Any) -> Optional[str]:
         """Return the kind to stamp at start, or None to leave it to _llmobs_set_tags at finish.

--- a/ddtrace/llmobs/_integrations/base.py
+++ b/ddtrace/llmobs/_integrations/base.py
@@ -103,6 +103,8 @@ class BaseLLMIntegration:
         activate. Agent attribution reads it at child activation; under LIFO nesting a finish-time
         write lands too late. Called from trace() and from LlmTracingSubscriber.on_started.
         """
+        if span.span_type != SpanTypes.LLM:
+            return
         span_kind = self._llmobs_span_kind(operation_id, span, **kwargs)
         if span_kind is not None:
             _annotate_llmobs_span_data(span, kind=span_kind)

--- a/ddtrace/llmobs/_integrations/base.py
+++ b/ddtrace/llmobs/_integrations/base.py
@@ -99,10 +99,11 @@ class BaseLLMIntegration:
         return span
 
     def _stamp_llmobs_span_kind_at_start(self, span: Span, operation_id: str = "", **kwargs: Any) -> None:
-        """Stamp the span kind (and name when available) at start so a parent agent is fully
-        resolvable before its children activate. Agent attribution reads both at child activation;
-        under LIFO nesting a finish-time write lands too late. Called from trace() and from
-        LlmTracingSubscriber.on_started.
+        """Stamp span kind (and agent name when available) into the span's LLMObs meta_struct at creation.
+
+        Called automatically by ``BaseLLMIntegration.trace()`` and ``LlmTracingSubscriber.on_started``.
+        Integrations should not call this directly; instead override ``_llmobs_span_kind`` and
+        ``_llmobs_agent_name_at_start``.
         """
         if span.span_type != SpanTypes.LLM:
             return
@@ -124,10 +125,12 @@ class BaseLLMIntegration:
         return None
 
     def _llmobs_span_kind(self, operation_id: str, span: Span, **kwargs: Any) -> Optional[str]:
-        """Return the kind to stamp at start, or None to leave it to _llmobs_set_tags at finish.
+        """Return the LLMObs span kind to stamp at creation, or None to skip start-time stamping.
 
-        Integrations that signal agent spans via a different kwarg should override this.
-        The finish-time write in _llmobs_set_tags still runs regardless.
+        Override in integrations that signal agent spans via a kwarg other than ``kind``
+        (e.g. ``operation="agent"``).  Must be determinable at ``trace()`` call time —
+        do NOT rely on data available only at span finish, because child spans resolve
+        agent attribution when they are activated.
         """
         return "agent" if kwargs.get("kind") == "agent" else None
 

--- a/ddtrace/llmobs/_integrations/base.py
+++ b/ddtrace/llmobs/_integrations/base.py
@@ -110,9 +110,10 @@ class BaseLLMIntegration:
     def _llmobs_span_kind(self, operation_id: str, span: Span, **kwargs: Any) -> Optional[str]:
         """Return the kind to stamp at start, or None to leave it to _llmobs_set_tags at finish.
 
-        Overridden by integrations that create agent spans; the finish-time write still runs.
+        Integrations that signal agent spans via a different kwarg should override this.
+        The finish-time write in _llmobs_set_tags still runs regardless.
         """
-        return None
+        return "agent" if kwargs.get("kind") == "agent" else None
 
     def llmobs_set_tags(
         self,

--- a/ddtrace/llmobs/_integrations/bedrock.py
+++ b/ddtrace/llmobs/_integrations/bedrock.py
@@ -32,6 +32,10 @@ log = get_logger(__name__)
 class BedrockIntegration(BaseLLMIntegration):
     _integration_name = "bedrock"
 
+    def _llmobs_span_kind(self, operation_id: str, span: Span, **kwargs: Any) -> Optional[str]:
+        # interface_type="agent" is set only by the top-level Bedrock agent trace() call.
+        return "agent" if kwargs.get("interface_type") == "agent" else None
+
     def _llmobs_set_tags(
         self,
         span: Span,

--- a/ddtrace/llmobs/_integrations/claude_agent_sdk.py
+++ b/ddtrace/llmobs/_integrations/claude_agent_sdk.py
@@ -32,9 +32,6 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
     # because links are driven by SDK stream events (AssistantMessage / UserMessage / etc.)
     # processed in the per-invocation ClaudeAgentSdkAsyncStreamHandler.
 
-    def _llmobs_span_kind(self, operation_id: str, span: Span, **kwargs: Any) -> Optional[str]:
-        return "agent" if kwargs.get("kind") == "agent" else None
-
     def _llmobs_set_tags(
         self,
         span: Span,

--- a/ddtrace/llmobs/_integrations/claude_agent_sdk.py
+++ b/ddtrace/llmobs/_integrations/claude_agent_sdk.py
@@ -32,6 +32,9 @@ class ClaudeAgentSdkIntegration(BaseLLMIntegration):
     # because links are driven by SDK stream events (AssistantMessage / UserMessage / etc.)
     # processed in the per-invocation ClaudeAgentSdkAsyncStreamHandler.
 
+    def _llmobs_span_kind(self, operation_id: str, span: Span, **kwargs: Any) -> Optional[str]:
+        return "agent" if kwargs.get("kind") == "agent" else None
+
     def _llmobs_set_tags(
         self,
         span: Span,

--- a/ddtrace/llmobs/_integrations/crewai.py
+++ b/ddtrace/llmobs/_integrations/crewai.py
@@ -76,6 +76,9 @@ class CrewAIIntegration(BaseLLMIntegration):
             span_dict.update({"span_id": str(span.span_id)})
         return span
 
+    def _llmobs_span_kind(self, operation_id: str, span: Span, **kwargs: Any) -> Optional[str]:
+        return "agent" if kwargs.get("operation") == "agent" else None
+
     def _get_current_ctx(self):
         """Extract current tracer and llmobs contexts to propagate across threads during async task execution."""
         curr_trace_ctx = tracer.current_trace_context()

--- a/ddtrace/llmobs/_integrations/google_adk.py
+++ b/ddtrace/llmobs/_integrations/google_adk.py
@@ -41,6 +41,10 @@ class GoogleAdkIntegration(BaseLLMIntegration):
             return
         _annotate_llmobs_span_data(span, session_id=session_id)
 
+    def _llmobs_agent_name_at_start(self, span: Span, **kwargs: Any) -> Optional[str]:
+        agent = kwargs.get("_dd_agent")
+        return getattr(agent, "name", None) if agent else None
+
     def _llmobs_set_tags(
         self,
         span: Span,

--- a/ddtrace/llmobs/_integrations/google_adk.py
+++ b/ddtrace/llmobs/_integrations/google_adk.py
@@ -41,6 +41,9 @@ class GoogleAdkIntegration(BaseLLMIntegration):
             return
         _annotate_llmobs_span_data(span, session_id=session_id)
 
+    def _llmobs_span_kind(self, operation_id: str, span: Span, **kwargs: Any) -> Optional[str]:
+        return "agent" if kwargs.get("kind") == "agent" else None
+
     def _llmobs_set_tags(
         self,
         span: Span,

--- a/ddtrace/llmobs/_integrations/google_adk.py
+++ b/ddtrace/llmobs/_integrations/google_adk.py
@@ -41,9 +41,6 @@ class GoogleAdkIntegration(BaseLLMIntegration):
             return
         _annotate_llmobs_span_data(span, session_id=session_id)
 
-    def _llmobs_span_kind(self, operation_id: str, span: Span, **kwargs: Any) -> Optional[str]:
-        return "agent" if kwargs.get("kind") == "agent" else None
-
     def _llmobs_set_tags(
         self,
         span: Span,

--- a/ddtrace/llmobs/_integrations/langgraph.py
+++ b/ddtrace/llmobs/_integrations/langgraph.py
@@ -63,9 +63,6 @@ class LangGraphIntegration(BaseLLMIntegration):
 
         return span
 
-    def _llmobs_span_kind(self, operation_id: str, span: Span, **kwargs: Any) -> Optional[str]:
-        return "agent" if kwargs.get("kind") == "agent" else None
-
     def _llmobs_set_tags(
         self,
         span: Span,

--- a/ddtrace/llmobs/_integrations/langgraph.py
+++ b/ddtrace/llmobs/_integrations/langgraph.py
@@ -63,6 +63,9 @@ class LangGraphIntegration(BaseLLMIntegration):
 
         return span
 
+    def _llmobs_span_kind(self, operation_id: str, span: Span, **kwargs: Any) -> Optional[str]:
+        return "agent" if kwargs.get("kind") == "agent" else None
+
     def _llmobs_set_tags(
         self,
         span: Span,

--- a/ddtrace/llmobs/_integrations/langgraph.py
+++ b/ddtrace/llmobs/_integrations/langgraph.py
@@ -61,6 +61,14 @@ class LangGraphIntegration(BaseLLMIntegration):
         if instance:
             self._graph_spans_to_graph_instances[span] = instance
 
+        # Stamp agent name at start so children resolve the correct pagent_name.
+        # instance is captured before **kwargs so _llmobs_agent_name_at_start can't reach it;
+        # stamp here after super().trace() has already written the kind.
+        if submit_to_llmobs and self.llmobs_enabled and kwargs.get("kind") == "agent":
+            agent_name = getattr(instance, "name", None) if instance else None
+            if agent_name:
+                _annotate_llmobs_span_data(span, name=agent_name)
+
         return span
 
     def _llmobs_set_tags(

--- a/ddtrace/llmobs/_integrations/llama_index.py
+++ b/ddtrace/llmobs/_integrations/llama_index.py
@@ -35,6 +35,10 @@ class LlamaIndexIntegration(BaseLLMIntegration):
         if provider is not None:
             span._set_attribute(PROVIDER, provider)
 
+    def _llmobs_span_kind(self, operation_id: str, span: Span, **kwargs: Any) -> Optional[str]:
+        # Event-based: on_started calls this with operation=event.operation (no trace() path).
+        return "agent" if kwargs.get("operation") == "agent" else None
+
     def _llmobs_set_tags(
         self,
         span: Span,

--- a/ddtrace/llmobs/_integrations/openai_agents.py
+++ b/ddtrace/llmobs/_integrations/openai_agents.py
@@ -68,6 +68,10 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
             self.oai_to_llmobs_span[oai_span.span_id] = llmobs_span
             self._llmobs_update_trace_info_input(oai_span, llmobs_span)
 
+            # Stamp the agent kind at start (child spans resolve agent attribution against it).
+            if oai_span.llmobs_span_kind == "agent":
+                _annotate_llmobs_span_data(llmobs_span, kind="agent")
+
             if oai_span.span_type == "guardrail":
                 core.dispatch(DISPATCH_ON_GUARDRAIL_SPAN_START, (llmobs_span,))
 

--- a/ddtrace/llmobs/_integrations/openai_agents.py
+++ b/ddtrace/llmobs/_integrations/openai_agents.py
@@ -69,7 +69,9 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
             self._llmobs_update_trace_info_input(oai_span, llmobs_span)
 
             # Stamp the agent kind at start (child spans resolve agent attribution against it).
-            if oai_span.llmobs_span_kind == "agent":
+            # Guard on llmobs_enabled: super().trace() returns a plain APM span when LLMObs is
+            # off, and annotating a non-LLM span leaks meta_struct overhead into non-LLMObs traces.
+            if oai_span.llmobs_span_kind == "agent" and self.llmobs_enabled:
                 _annotate_llmobs_span_data(llmobs_span, kind="agent")
 
             if oai_span.span_type == "guardrail":

--- a/releasenotes/notes/fix-llmobs-agent-attribution-auto-instrumented-a6c5d0e65fde98b6.yaml
+++ b/releasenotes/notes/fix-llmobs-agent-attribution-auto-instrumented-a6c5d0e65fde98b6.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixes an issue where spans created under an auto-instrumented agent span
+    (CrewAI, Google ADK, LangGraph, LlamaIndex, Amazon Bedrock Agents, Claude Agent SDK, and
+    OpenAI Agents) were not attributed to that agent, leaving ``agent_attribution`` missing or
+    pointing at the wrong ancestor.

--- a/tests/contrib/botocore/test_bedrock_agents.py
+++ b/tests/contrib/botocore/test_bedrock_agents.py
@@ -47,6 +47,9 @@ def test_agent_invoke_stream(bedrock_agent_client, request_vcr):
         "meta._dd.p.llmobs_parent_id",
         "meta._dd.p.llmobs_sd",
         "meta._dd.p.llmobs_sr",
+        "meta._dd.p.llmobs_pagent_name",
+        "meta._dd.p.llmobs_pagent_span_id",
+        "meta._dd.p.llmobs_trace_id",
         "meta_struct",
     ]
 )
@@ -75,6 +78,9 @@ def test_agent_invoke_with_step_spans(bedrock_agent_client, request_vcr, bedrock
         "meta._dd.p.llmobs_parent_id",
         "meta._dd.p.llmobs_sd",
         "meta._dd.p.llmobs_sr",
+        "meta._dd.p.llmobs_pagent_name",
+        "meta._dd.p.llmobs_pagent_span_id",
+        "meta._dd.p.llmobs_trace_id",
         "meta_struct",
     ],
 )

--- a/tests/llmobs/test_llmobs_agent_attribution.py
+++ b/tests/llmobs/test_llmobs_agent_attribution.py
@@ -8,6 +8,8 @@ is why integrations must have that kind set by the time a child activates (see t
 auto-instrumented regression test below).
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 from ddtrace import config
@@ -149,3 +151,47 @@ def test_event_based_agent_parent_attributes_child(llmobs, llmobs_events):
 
     tool_event = _event_by_name(llmobs_events, "my_tool")
     assert tool_event["meta"]["agent_attribution"]["pagent_span_id"] == str(agent_span.span_id)
+
+
+def test_google_adk_agent_name_stamped_at_start(llmobs, llmobs_events):
+    """Google ADK never passes span_name to trace(); without name-at-start stamping, children
+    attribute to 'google_adk.request' (the APM span name) instead of the actual ADK agent name.
+    Regression guard: _dd_agent kwarg must flow through trace() to _llmobs_agent_name_at_start.
+    """
+    integration = GoogleAdkIntegration(IntegrationConfig(config, "google_adk"))
+    mock_agent = SimpleNamespace(name="my_adk_agent")
+    # Mirrors _traced_agent_run_async: no span_name, passes _dd_agent with the agent object.
+    agent_span = integration.trace("Runner.run_async", kind="agent", submit_to_llmobs=True, _dd_agent=mock_agent)
+    try:
+        with llmobs.tool(name="my_tool"):
+            pass
+    finally:
+        agent_span.finish()
+    tool_event = _event_by_name(llmobs_events, "my_tool")
+    assert tool_event["meta"]["agent_attribution"] == {
+        "pagent_name": "my_adk_agent",
+        "pagent_span_id": str(agent_span.span_id),
+    }
+
+
+def test_langgraph_agent_name_stamped_at_start(llmobs, llmobs_events):
+    """LangGraph's LLMObs agent name is instance.name (short), but the APM span name is
+    '{module}.CompiledGraph.{name}'. Without name-at-start stamping, children attribute to the
+    long composed APM name. Regression guard: LangGraphIntegration.trace() must stamp name.
+    """
+    integration = LangGraphIntegration(IntegrationConfig(config, "langgraph"))
+    mock_graph = SimpleNamespace(name="my_graph")
+    # Mirrors traced_pregel_stream: long operation_id, instance carries the short name.
+    agent_span = integration.trace(
+        "module.CompiledGraph.my_graph", kind="agent", submit_to_llmobs=True, instance=mock_graph
+    )
+    try:
+        with llmobs.tool(name="my_tool"):
+            pass
+    finally:
+        agent_span.finish()
+    tool_event = _event_by_name(llmobs_events, "my_tool")
+    assert tool_event["meta"]["agent_attribution"] == {
+        "pagent_name": "my_graph",
+        "pagent_span_id": str(agent_span.span_id),
+    }

--- a/tests/llmobs/test_llmobs_agent_attribution.py
+++ b/tests/llmobs/test_llmobs_agent_attribution.py
@@ -1,10 +1,34 @@
-"""Tests for LLMObs agent attribution: meta.agent_attribution stamped at span finish.
+"""Tests for LLMObs agent attribution: meta.agent_attribution.
 
 The SDK resolves the nearest agent ancestor at span activation (O(1) one-level lookup,
 inheriting the parent's already-resolved attribution) and surfaces it as
-``meta.agent_attribution`` only on spans that have an agent ancestor. Spans with no agent
-ancestor omit the block entirely.
+``meta.agent_attribution`` at span finish, only on spans that have an agent ancestor. Spans
+with no agent ancestor omit the block entirely. Resolution reads the parent's span kind, which
+is why integrations must have that kind set by the time a child activates (see the
+auto-instrumented regression test below).
 """
+
+import pytest
+
+from ddtrace import config
+from ddtrace.internal.settings.integration import IntegrationConfig
+from ddtrace.llmobs._integrations.bedrock import BedrockIntegration
+from ddtrace.llmobs._integrations.claude_agent_sdk import ClaudeAgentSdkIntegration
+from ddtrace.llmobs._integrations.crewai import CrewAIIntegration
+from ddtrace.llmobs._integrations.google_adk import GoogleAdkIntegration
+from ddtrace.llmobs._integrations.langgraph import LangGraphIntegration
+
+
+# Auto-instrumented integrations that create agent spans via integration.trace(), keyed by the
+# start-time kwarg each one uses to signal "this is an agent span". openai_agents also emits agent
+# spans but only via an OaiSpanAdapter, so it is exercised by its own contrib suite, not here.
+_AUTO_AGENT_CASES = [
+    pytest.param(CrewAIIntegration, "crewai", {"operation": "agent"}, id="crewai"),
+    pytest.param(GoogleAdkIntegration, "google_adk", {"kind": "agent"}, id="google_adk"),
+    pytest.param(BedrockIntegration, "botocore", {"interface_type": "agent"}, id="bedrock"),
+    pytest.param(LangGraphIntegration, "langgraph", {"kind": "agent"}, id="langgraph"),
+    pytest.param(ClaudeAgentSdkIntegration, "claude_agent_sdk", {"kind": "agent"}, id="claude_agent_sdk"),
+]
 
 
 def _event_by_name(llmobs_events, name):
@@ -71,3 +95,57 @@ def test_tool_outside_agent_omits_block(llmobs, llmobs_events):
             pass
     assert "agent_attribution" not in _event_by_name(llmobs_events, "lonely_workflow")["meta"]
     assert "agent_attribution" not in _event_by_name(llmobs_events, "lonely_tool")["meta"]
+
+
+@pytest.mark.parametrize("integration_cls, config_name, agent_trace_kwargs", _AUTO_AGENT_CASES)
+def test_auto_instrumented_agent_parent_attributes_child(
+    llmobs, llmobs_events, integration_cls, config_name, agent_trace_kwargs
+):
+    """A child under an auto-instrumented (trace()-based) agent span must attribute to that agent.
+
+    Regression guard for the LIFO start-vs-finish bug: the agent kind must be known at span start,
+    not finish. Also exercises each integration's start-time signal (operation / kind /
+    interface_type) feeding ``_llmobs_span_kind``.
+    """
+    integration = integration_cls(IntegrationConfig(config, config_name))
+    agent_span = integration.trace("agent_run", span_name="my_agent", submit_to_llmobs=True, **agent_trace_kwargs)
+    try:
+        with llmobs.tool(name="my_tool"):
+            pass
+    finally:
+        agent_span.finish()
+
+    tool_event = _event_by_name(llmobs_events, "my_tool")
+    assert tool_event["meta"]["agent_attribution"] == {
+        "pagent_name": "my_agent",
+        "pagent_span_id": str(agent_span.span_id),
+    }
+
+
+def test_event_based_agent_parent_attributes_child(llmobs, llmobs_events):
+    """Same guard for the event-based path: llama_index creates its agent span via the event
+    subscriber (kind stamped in ``on_started``), not ``trace()``.
+    """
+    from ddtrace.contrib._events.llm import LlmRequestEvent
+    from ddtrace.internal import core
+    from ddtrace.internal.span_bus import span_from_context
+    from ddtrace.llmobs._integrations.llama_index import LlamaIndexIntegration
+
+    integration = LlamaIndexIntegration(IntegrationConfig(config, "llama_index"))
+    event = LlmRequestEvent(
+        component="llama_index",
+        integration_config=integration.integration_config,
+        resource="my_agent",
+        provider="llama_index",
+        llmobs_integration=integration,
+        submit_to_llmobs=True,
+        operation="agent",
+    )
+    with core.context_with_event(event, dispatch_end_event=False) as ctx:
+        agent_span = span_from_context(ctx)
+        with llmobs.tool(name="my_tool"):
+            pass
+        ctx.dispatch_ended_event()
+
+    tool_event = _event_by_name(llmobs_events, "my_tool")
+    assert tool_event["meta"]["agent_attribution"]["pagent_span_id"] == str(agent_span.span_id)


### PR DESCRIPTION
## Description

Agent attribution stamps every LLMObs span with its nearest agent ancestor (`meta.agent_attribution`). It resolves that ancestor **when a child span activates (span start)** by reading the parent span's LLMObs `kind` (`kind == "agent"`).

Auto-instrumented integrations, however, wrote the span `kind` at span **finish** (inside `_llmobs_set_tags`). Because spans nest LIFO (`parent start → child start → child finish → parent finish`), an agent parent's kind is written **after** the child's entire lifetime — so at a child's activation the parent's `kind == "agent"` was invisible, and children of an auto-instrumented agent span were never attributed to it (`agent_attribution` missing at top level, or pointing at the wrong ancestor when agents nest). Manual SDK usage (`LLMObs.agent()`) was unaffected because it sets kind at start; `pydantic_ai` was already immune for the same reason.

This makes the **agent** kind known at span start so children resolve correctly. A new `BaseLLMIntegration._llmobs_span_kind()` hook is stamped at start via `_stamp_llmobs_span_kind_at_start()`, called from both span-creation paths:
- `trace()` — direct integrations (crewai, google_adk, bedrock agents, langgraph, claude_agent_sdk; openai_agents stamps in its own `trace()` override).
- `LlmTracingSubscriber.on_started` — event-based integrations whose spans are not created via `trace()` (llama_index).

Scope is intentionally minimal: only the **agent** kind is stamped early; all other kinds and every finish-time write are left unchanged (the agent kind is simply also stamped at start, an idempotent re-write). `bedrock_agents` child steps and `pydantic_ai` already stamp at start and are untouched.

## Testing

- `tests/llmobs/test_llmobs_agent_attribution.py`: new regression test parametrized over the direct-`trace()` agent emitters (crewai, google_adk, bedrock, langgraph, claude_agent_sdk) plus a dedicated event-path case for llama_index. Each asserts a child span attributes to its auto-instrumented agent parent. Written test-first (fails on `main` with `KeyError: 'agent_attribution'`). openai_agents is exercised by its own contrib suite (it requires an `OaiSpanAdapter`).
- Full `llmobs` suite: 1163 passed (one unrelated periodic-thread evaluator-runner flake that passes in isolation).
- Contrib LLMObs suites run locally: `google_adk` (5), `anthropic` (38 — confirms the shared `on_started` change is a no-op for non-agent event integrations), `llama_index` (61). No snapshot churn.
- `scripts/lint` (ruff format + check, mypy) clean.

Note: agent-attribution fields do not appear in any contrib snapshot fixture, so the parametrized unit test is the guardrail for this behavior; snapshot suites only confirm the start-time stamp introduces no other churn.

## Risks

Low. Purely additive: a new hook defaulting to `None` (no behavior change for integrations that don't override it) and one extra call in `on_started` that is a no-op unless the integration opts in. Finish-time kind writes are unchanged, so emitted spans are identical for every existing case; the agent kind is merely also written at start. The only observable change is that agent-kind spans now carry `meta.span.kind == "agent"` from activation onward, which is what enables correct child attribution.

## Additional Notes

CI should run the crewai, bedrock, langgraph, and claude_agent_sdk contrib suites for full snapshot coverage (google_adk, anthropic, and llama_index were run locally as representatives).
