### PR TITLE
fix(tracing): invalid v0.5 payload with more than 65k tags

### DIFF
--- a/ddtrace/internal/_encoding.pyx
+++ b/ddtrace/internal/_encoding.pyx
@@ -95,7 +95,7 @@ cdef size_t _ORIGIN_KEY_LEN = <size_t> len(ORIGIN_KEY)
 cdef inline int array_prefix_size(stdint.uint32_t l):
     if l < 16:
         return 1
-    elif l < (2<<16):
+    elif l < (1<<16):
         return 3
     return MSGPACK_ARRAY_LENGTH_PREFIX_SIZE
 

--- a/releasenotes/notes/fix-v05-encoder-string-table-corruption-a7d57bcb4bca75bd.yaml
+++ b/releasenotes/notes/fix-v05-encoder-string-table-corruption-a7d57bcb4bca75bd.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    tracing: Fixes an issue where the ``v0.5`` trace API (``DD_TRACE_API_VERSION=v0.5``)
+    drops traces when a single payload contains between 65,536 and 131,071 unique tag
+    keys and values.

--- a/tests/tracer/test_encoders.py
+++ b/tests/tracer/test_encoders.py
@@ -918,6 +918,31 @@ def test_encoder_buffer_item_size_limit(encoder_cls):
         encoder.put([span])
 
 
+def test_v05_encoding_string_table_between_65536_and_131072_entries():
+    # A string table with 65536 to 131071 entries needs a 5-byte array32 header, not a
+    # 3-byte array16 header. A narrower header overwrites the start of the table and
+    # corrupts the payload.
+    encoder = MsgpackEncoderV05(128 << 20, 128 << 20)
+
+    span = Span("s1", service="svc", resource="res")
+    for i in range(35000):
+        span.set_tag("k%d" % i, "v%d" % i)
+    span.finish()
+
+    encoder.put([span])
+    [(payload, num_traces)] = encoder.encode()
+    assert num_traces == 1
+
+    string_table = msgpack.unpackb(payload, raw=True, strict_map_key=False)[0]
+    assert 65536 <= len(string_table) < 131072
+
+    decoded_trace = decode(payload)
+    assert len(decoded_trace) == 1
+    decoded_tags = decoded_trace[0][0][9]
+    for i in range(35000):
+        assert decoded_tags[("k%d" % i).encode()] == ("v%d" % i).encode()
+
+
 def test_custom_msgpack_encode_v05():
     encoder = MsgpackEncoderV05(2 << 20, 2 << 20)
     assert encoder.max_size == 2 << 20


### PR DESCRIPTION
## Description

`array_prefix_size()` in `ddtrace/internal/_encoding.pyx` used `2<<16` (131072) instead of `1<<16` (65536) as the array16/array32 boundary. For a v0.5 string table with 65,536–131,071 entries, this under-reported the header size, so the backwritten header overwrote the start of the table and corrupted the payload. The Datadog Agent rejects the corrupted payload, silently dropping the trace.

Fix: change the boundary to `1<<16`.


## Testing

Added a regression test that builds a span with enough unique tags to push the string table past 65,536 entries, then decodes the payload. Fails with `msgpack.exceptions.ExtraData` before the fix, passes after.

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

Fixes #19515
