### PR TITLE
ci(macos): revert os macos tests as allowed to fail

### DIFF
--- a/.gitlab/multi-os-tests.yml
+++ b/.gitlab/multi-os-tests.yml
@@ -39,7 +39,6 @@ os tests macos:
   image: "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/ci-platform-machine-images/tart-vm:dd-trace-py-sonoma-latest"
   tags: ["macos:tart"]
   needs: [ "build macos arm64" ]
-  allow_failure: true
   variables:
     WHEEL_PATTERN: "macosx*arm64.whl"
     PLATFORM: "macOS"


### PR DESCRIPTION
Reverts DataDog/dd-trace-py#19505