### PR TITLE
fix(llmobs): clear stale agent attribution before propagating

### DIFF
--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -486,8 +486,15 @@ def _stamp_agent_attribution(meta: dict, agent_name: Optional[str], agent_span_i
       4. neither when even the id would exceed the budget.
 
     ``meta`` must already carry the other ``_dd.p.*`` tags so the budget check sees the full tagset.
+
+    Both keys describe the span being injected, but ``meta`` is trace-scoped and shared by every
+    span in the trace, so a value written by an earlier span outlives it. Whatever does not apply
+    to this span is cleared, or it would be propagated as if it did.
     """
+    if agent_name is None:
+        meta.pop(PROPAGATED_PARENT_AGENT_NAME_KEY, None)
     if agent_span_id is None:
+        meta.pop(PROPAGATED_PARENT_AGENT_ID_KEY, None)
         return
     meta[PROPAGATED_PARENT_AGENT_ID_KEY] = agent_span_id
     if agent_name is not None:

--- a/releasenotes/notes/fix-llmobs-stale-agent-attribution-propagation-3b7e21c94af6d158.yaml
+++ b/releasenotes/notes/fix-llmobs-stale-agent-attribution-propagation-3b7e21c94af6d158.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixes an issue where agent attribution was propagated to downstream services
+    from spans that had no agent ancestor. Because the propagated ``_dd.p.*`` values are stored on
+    trace-level state shared by every span in the trace, the attribution written while inside an
+    agent span outlived it, so any later span in the same trace that injected distributed headers or
+    crossed a thread/asyncio boundary sent that agent's name and span ID as its own. Work unrelated
+    to an agent was therefore attributed to whichever agent had most recently propagated context.

--- a/tests/llmobs/test_propagation.py
+++ b/tests/llmobs/test_propagation.py
@@ -19,6 +19,7 @@ from ddtrace.llmobs._constants import PROPAGATED_SAMPLING_DECISION
 from ddtrace.llmobs._constants import PROPAGATED_SESSION_ID_KEY
 from ddtrace.llmobs._constants import ROOT_PARENT_ID
 from ddtrace.llmobs._constants import LLMObsSamplingDecision
+from ddtrace.llmobs._utils import _stamp_agent_attribution
 from ddtrace.llmobs._utils import get_llmobs_ml_app
 from ddtrace.llmobs._utils import get_llmobs_parent_id
 from ddtrace.llmobs._utils import get_llmobs_sample_rate
@@ -1029,3 +1030,65 @@ def test_agent_attribution_propagates_across_asyncio_task(llmobs, llmobs_events,
         "pagent_name": "my_agent",
         "pagent_span_id": holder["span_id"],
     }
+
+
+def test_inject_no_stale_agent_attribution_after_agent_finishes(llmobs):
+    """A sibling with no agent ancestor must not inherit the agent that injected before it.
+
+    ``Context._meta`` is trace-scoped and shared, so attribution written while inside the agent
+    outlives the agent span unless it is cleared.
+    """
+    with llmobs.workflow(name="handle_request"):
+        with llmobs.agent(name="triage"):
+            llmobs.inject_distributed_headers({})
+        with llmobs.tool(name="write_audit_log"):
+            headers = llmobs.inject_distributed_headers({})
+    tags_header = headers.get("x-datadog-tags", "")
+    assert "_dd.p.llmobs_pagent_span_id" not in tags_header
+    assert "_dd.p.llmobs_pagent_name" not in tags_header
+
+
+def test_inject_no_stale_agent_attribution_across_asyncio_task(llmobs, patched_asyncio):
+    """Same guard for the in-process task path, which stamps via _current_trace_context()."""
+    import asyncio
+
+    holder = {}
+
+    async def main():
+        with llmobs.workflow(name="root"):
+            with llmobs.agent(name="triage"):
+
+                async def under_agent():
+                    with llmobs.tool(name="agent_tool"):
+                        pass
+
+                await asyncio.create_task(under_agent())
+            with llmobs.tool(name="sibling"):
+                holder["ctx"] = llmobs._instance._current_trace_context()
+
+    asyncio.run(main())
+    assert holder["ctx"]._meta.get(PROPAGATED_PARENT_AGENT_ID_KEY) is None
+    assert holder["ctx"]._meta.get(PROPAGATED_PARENT_AGENT_NAME_KEY) is None
+
+
+def test_inject_stale_agent_name_not_paired_with_new_id(llmobs):
+    """An id-only upstream must not pick up a name left behind by an earlier agent."""
+    with llmobs.workflow(name="root"):
+        with llmobs.agent(name="first_agent"):
+            llmobs.inject_distributed_headers({})
+        ctx = Context(trace_id=1, span_id=2)
+        ctx._meta[PROPAGATED_PARENT_AGENT_NAME_KEY] = "first_agent"
+        _stamp_agent_attribution(ctx._meta, None, "987654321")
+    assert ctx._meta.get(PROPAGATED_PARENT_AGENT_ID_KEY) == "987654321"
+    assert ctx._meta.get(PROPAGATED_PARENT_AGENT_NAME_KEY) is None
+
+
+def test_inject_agent_attribution_still_set_for_child_inside_agent(llmobs):
+    """No over-clearing: a child inside the agent still propagates the agent."""
+    with llmobs.workflow(name="root"):
+        with llmobs.agent(name="triage") as agent_span:
+            with llmobs.tool(name="agent_tool"):
+                headers = llmobs.inject_distributed_headers({})
+    tags_header = headers.get("x-datadog-tags", "")
+    assert "_dd.p.llmobs_pagent_span_id={}".format(agent_span.span_id) in tags_header
+    assert "_dd.p.llmobs_pagent_name=triage" in tags_header


### PR DESCRIPTION
## Description

Agent attribution (`_dd.p.llmobs_pagent_span_id` / `_dd.p.llmobs_pagent_name`) is a per-span fact, but it lives in `Context._meta`, which is trace-scoped. `_stamp_agent_attribution` only ever wrote, never cleared, so whatever the last agent-bearing span stamped stayed for the rest of the trace:

```python
with LLMObs.workflow(name="handle_request"):
    with LLMObs.agent(name="triage"):
        requests.get(...)          # correct: propagates triage
    with LLMObs.tool(name="write_audit_log"):
        requests.get(...)          # WRONG: still propagates triage
```

`write_audit_log` has no agent ancestor, so nothing is written, but the stale keys are still in the shared dict and the propagator encodes whatever is there. Audit-log work is attributed to the triage agent, inflating its cost and latency with unrelated work. 

## The fix

Two changes, because the shared dict is read at two different times.

**Clear what does not describe the current span.** Handles the injection path above, in both directions: a missing span id used to return early and leave the keys behind, and a missing name used to leave a stale name paired with a fresh id.

**Copy the context for in-process propagation.** The task and thread hooks store the object returned by `_current_trace_context()` — `active.context`, not a copy — and read attribution out of `_meta` at activation time, not at submit, so any later write reaches work that was already queued. Returning a copy with a private `_meta` makes the stored context a snapshot of attribution as it was at submit time:

```python
context = active.context.copy(active.trace_id, active.span_id)
context._meta = dict(context._meta)
```

`Context.copy` is the same call `Span.context` makes to derive a child (`span.py:145`), so the lock stays with the members it guards. The second line is load-bearing — every copy mechanism shares `_meta` by design, so without it the copy still mutates trace-level state and the fix is a no-op.

This also fixes a **pre-existing** bug: on `main`, work queued under one agent already activates as a *different* agent if a second agent runs before it executes. Clearing alone does nothing for that, and would have introduced a new variant where the queued work loses attribution entirely — caught by the Codex P2 review.

## Testing

Six tests in `tests/llmobs/test_propagation.py` cover the sibling case on both the injection and task paths, the mismatched id/name pair, queued work surviving a sibling's clear, and the invariant that trace-level `_meta` is never written, plus a guard that a child *inside* an agent still propagates.

## Additional Notes

Found while reviewing #19490 (manual agent versioning), which adds a third propagated key and would inherit the same leak. Split out because this half is **already shipped**, so it deserves its own fix and release note. #19490 will pick this up on merge.