### PR TITLE
fix(llmobs): drop partial streaming events from google_adk agent span output

### DIFF
--- a/ddtrace/llmobs/_integrations/google_utils.py
+++ b/ddtrace/llmobs/_integrations/google_utils.py
@@ -391,7 +391,23 @@ def extract_messages_from_adk_events(events) -> list[Message]:
     if not isinstance(events, list):
         events = [events]
 
+    # Streaming yields partial text chunks plus a non-partial event carrying the assembled text, so
+    # skip partials only when assembled text exists. Runs without it (e.g. run_live turns, whose
+    # non-partial events are contentless control events or tool calls) keep all events as before.
+    has_assembled_text = False
     for event in events:
+        if _get_attr(event, "partial", False):
+            continue
+        parts = _get_attr(_get_attr(event, "content", None), "parts", None) or []
+        if not isinstance(parts, list):
+            parts = [parts]
+        if any(_get_attr(part, "text", None) for part in parts):
+            has_assembled_text = True
+            break
+
+    for event in events:
+        if has_assembled_text and _get_attr(event, "partial", False):
+            continue
         content = _get_attr(event, "content", None)
         if not content:
             continue

--- a/releasenotes/notes/google-adk-drop-partial-streaming-events-81f6818da10e6bf2.yaml
+++ b/releasenotes/notes/google-adk-drop-partial-streaming-events-81f6818da10e6bf2.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixes an issue where the Google ADK integration recorded every streaming
+    partial chunk as a separate output message on the agent span, duplicating the final response.

--- a/tests/contrib/google_adk/test_google_adk_llmobs.py
+++ b/tests/contrib/google_adk/test_google_adk_llmobs.py
@@ -5,6 +5,7 @@ import pytest
 
 from ddtrace.llmobs._constants import CACHED_LLMOBS_EVENT_CTX_KEY
 from ddtrace.llmobs._integrations import GoogleAdkIntegration
+from ddtrace.llmobs._integrations.google_utils import extract_messages_from_adk_events
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import get_llmobs_parent_id
@@ -43,6 +44,81 @@ AGENT_MANIFEST_METADATA = {
         }
     }
 }
+
+
+def _adk_text_event(text, partial=None):
+    from google.adk.events import Event
+    from google.genai import types
+
+    return Event(
+        author="model",
+        content=types.Content(role="model", parts=[types.Part(text=text)]),
+        partial=partial,
+    )
+
+
+def test_extract_messages_drops_streaming_partials():
+    """Streaming runs yield each partial chunk plus a final assembled event; only the
+    assembled message should be recorded, not every chunk followed by the full text again."""
+    events = [
+        _adk_text_event("Hello ", partial=True),
+        _adk_text_event("from ", partial=True),
+        _adk_text_event("ADK.", partial=True),
+        _adk_text_event("Hello from ADK."),
+    ]
+    assert extract_messages_from_adk_events(events) == [{"role": "assistant", "content": "Hello from ADK."}]
+
+
+def test_extract_messages_keeps_partials_without_assembled_event():
+    """run_live yields only partial events, so those must not be dropped."""
+    events = [
+        _adk_text_event("Hello ", partial=True),
+        _adk_text_event("live.", partial=True),
+    ]
+    assert extract_messages_from_adk_events(events) == [
+        {"role": "assistant", "content": "Hello "},
+        {"role": "assistant", "content": "live."},
+    ]
+
+
+def test_extract_messages_keeps_partials_with_contentless_control_events():
+    """run_live control events (e.g. turn_complete) are non-partial but carry no content;
+    they must not cause the partial text to be dropped."""
+    from google.adk.events import Event
+
+    events = [
+        _adk_text_event("Hello ", partial=True),
+        _adk_text_event("live.", partial=True),
+        Event(author="model", turn_complete=True),
+    ]
+    assert extract_messages_from_adk_events(events) == [
+        {"role": "assistant", "content": "Hello "},
+        {"role": "assistant", "content": "live."},
+    ]
+
+
+def test_extract_messages_keeps_partials_when_only_tool_call_is_assembled():
+    """A live turn can mix partial text with a non-partial function-call event; the partial
+    chunks are the only record of the text, so a non-partial event without an assembled text
+    part must not suppress them."""
+    from google.adk.events import Event
+    from google.genai import types
+
+    tool_call_event = Event(
+        author="model",
+        content=types.Content(
+            role="model",
+            parts=[types.Part(function_call=types.FunctionCall(name="lookup", args={"q": "x"}))],
+        ),
+    )
+    events = [
+        _adk_text_event("Hello ", partial=True),
+        _adk_text_event("live.", partial=True),
+        tool_call_event,
+    ]
+    messages = extract_messages_from_adk_events(events)
+    assert [m.get("content") for m in messages[:2]] == ["Hello ", "live."]
+    assert messages[2]["tool_calls"][0]["name"] == "lookup"
 
 
 class TestLLMObsGoogleADK:

--- a/tests/contrib/google_adk/test_google_adk_llmobs.py
+++ b/tests/contrib/google_adk/test_google_adk_llmobs.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from ddtrace.llmobs._constants import CACHED_LLMOBS_EVENT_CTX_KEY
+from ddtrace.llmobs._integrations.google_utils import extract_messages_from_adk_events
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import get_llmobs_parent_id
@@ -38,6 +39,81 @@ AGENT_MANIFEST_METADATA = {
         }
     }
 }
+
+
+def _adk_text_event(text, partial=None):
+    from google.adk.events import Event
+    from google.genai import types
+
+    return Event(
+        author="model",
+        content=types.Content(role="model", parts=[types.Part(text=text)]),
+        partial=partial,
+    )
+
+
+def test_extract_messages_drops_streaming_partials():
+    """Streaming runs yield each partial chunk plus a final assembled event; only the
+    assembled message should be recorded, not every chunk followed by the full text again."""
+    events = [
+        _adk_text_event("Hello ", partial=True),
+        _adk_text_event("from ", partial=True),
+        _adk_text_event("ADK.", partial=True),
+        _adk_text_event("Hello from ADK."),
+    ]
+    assert extract_messages_from_adk_events(events) == [{"role": "assistant", "content": "Hello from ADK."}]
+
+
+def test_extract_messages_keeps_partials_without_assembled_event():
+    """run_live yields only partial events, so those must not be dropped."""
+    events = [
+        _adk_text_event("Hello ", partial=True),
+        _adk_text_event("live.", partial=True),
+    ]
+    assert extract_messages_from_adk_events(events) == [
+        {"role": "assistant", "content": "Hello "},
+        {"role": "assistant", "content": "live."},
+    ]
+
+
+def test_extract_messages_keeps_partials_with_contentless_control_events():
+    """run_live control events (e.g. turn_complete) are non-partial but carry no content;
+    they must not cause the partial text to be dropped."""
+    from google.adk.events import Event
+
+    events = [
+        _adk_text_event("Hello ", partial=True),
+        _adk_text_event("live.", partial=True),
+        Event(author="model", turn_complete=True),
+    ]
+    assert extract_messages_from_adk_events(events) == [
+        {"role": "assistant", "content": "Hello "},
+        {"role": "assistant", "content": "live."},
+    ]
+
+
+def test_extract_messages_keeps_partials_when_only_tool_call_is_assembled():
+    """A live turn can mix partial text with a non-partial function-call event; the partial
+    chunks are the only record of the text, so a non-partial event without an assembled text
+    part must not suppress them."""
+    from google.adk.events import Event
+    from google.genai import types
+
+    tool_call_event = Event(
+        author="model",
+        content=types.Content(
+            role="model",
+            parts=[types.Part(function_call=types.FunctionCall(name="lookup", args={"q": "x"}))],
+        ),
+    )
+    events = [
+        _adk_text_event("Hello ", partial=True),
+        _adk_text_event("live.", partial=True),
+        tool_call_event,
+    ]
+    messages = extract_messages_from_adk_events(events)
+    assert [m.get("content") for m in messages[:2]] == ["Hello ", "live."]
+    assert messages[2]["tool_calls"][0]["name"] == "lookup"
 
 
 class TestLLMObsGoogleADK:


### PR DESCRIPTION
## Description

Fixes #19537.

In streaming mode the `google_adk` integration records every ADK event as a message on the agent span's output, including every `partial=True` chunk. Since ADK ends each streamed turn with a final event carrying the assembled text, the response appears once per chunk *and* once in full.

This change makes `extract_messages_from_adk_events` drop partial events whenever at least one non-partial event is present. `run_live` (wrapped by the same `_traced_agent_run_async`) yields only partial events, so the guard keeps live runs from losing their output entirely.

## Testing

Two unit tests added in `tests/contrib/google_adk/test_google_adk_llmobs.py` against real ADK `Event` objects: streamed partials followed by an assembled event yield only the assembled message, and an all-partial (`run_live`-shaped) event list is kept as-is.

## Risks

None expected; the extraction output is unchanged for non-streaming runs and for all-partial event lists.

## Additional Notes

Filtering downstream via `LLMObs.register_processor` is not viable, since agent span output reaches processors as a single JSON-blob message and `Event.partial` is gone by then, so the integration is the only reliable filter point.
