### PR TITLE
ci: wait for reliability environment wheels

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -670,6 +670,12 @@ configure_system_tests:
 system_tests:
   needs: ["configure_system_tests", "oci-internal-test-publish", "kubernetes-injection-test-ecr-publish"]
 
+# The reliability environment installs commit-scoped wheels from the CI index.
+deploy_to_reliability_env:
+  needs:
+    - job: "upload all"
+      artifacts: false
+
 # Clear the one-pipeline publishing-gate's `needs: []` so it falls back to
 # stage-based ordering and waits for all prior stages before publishing.
 publishing-gate:


### PR DESCRIPTION
## Description

Make the reliability-environment trigger wait for the `upload all` job. The related reliability-env change installs candidate deployments from the commit-scoped wheel index, so the downstream pipeline must not start before that index has been published.

Related PR: https://github.com/DataDog/datadog-reliability-env/pull/1347

Artifact download is disabled because the trigger only needs publication ordering, not the wheel artifacts themselves.

## Testing

- Parsed `.gitlab-ci.yml` successfully with Ruby's YAML parser.
- Ran `git diff --check`.
- Verified that `upload all` is an unconditional package-stage job.

The GitLab content-lint API could not resolve local includes because the internal mirror still uses `2.x` as its default branch. The draft PR pipeline will validate the complete merged configuration.

## Risks

Low. Manual and scheduled reliability-environment triggers will remain blocked when wheel publication fails, which is required because the downstream deployment now consumes those wheels.

## Additional Notes

No customer-facing behavior changes; no release note is needed.
