### PR TITLE
ci: add code-coverage.datadog.yml to ignore .riot directory

### DIFF
--- a/code-coverage.datadog.yml
+++ b/code-coverage.datadog.yml
@@ -1,0 +1,3 @@
+schema-version: v1
+ignore:
+  - ".riot/"


### PR DESCRIPTION
Use path_prefix pattern with trailing slash per Datadog docs to exclude files under .riot/ from code coverage reporting.
