### PR TITLE
fix(iast): repair native ownership leaks

### DIFF
--- a/ddtrace/appsec/_iast/_ast/iastpatch.c
+++ b/ddtrace/appsec/_iast/_ast/iastpatch.c
@@ -332,12 +332,14 @@ static char**
 get_list_from_env(const char* env_var_name, size_t* count)
 {
     const char* env_value = getenv(env_var_name);
-    static char** modules_list = NULL;
+    char** modules_list = NULL;
     size_t count_tmp = 0;
     if (env_value && env_value[0] != '\0') {
         char* env_copy = strdup(env_value);
-        if (!env_copy)
+        if (!env_copy) {
+            PyErr_NoMemory();
             return NULL;
+        }
         char* token = strtok(env_copy, ",");
         while (token) {
             count_tmp++;
@@ -354,7 +356,7 @@ get_list_from_env(const char* env_var_name, size_t* count)
             env_copy = strdup(env_value);
             if (!env_copy) {
                 free(modules_list);
-                modules_list = NULL;
+                PyErr_NoMemory();
                 return NULL;
             }
             count_tmp = 0;
@@ -366,8 +368,8 @@ get_list_from_env(const char* env_var_name, size_t* count)
                         free(modules_list[j]);
                     }
                     free(modules_list);
-                    modules_list = NULL;
                     free(env_copy);
+                    PyErr_NoMemory();
                     return NULL;
                 }
                 for (char* p = dup; *p; p++) {
@@ -555,22 +557,27 @@ py_should_iast_patch(PyObject* Py_UNUSED(self), PyObject* args)
 int
 build_list_from_env(const char* env_var_name)
 {
-    size_t count = 0;
-    char** result_list = get_list_from_env(env_var_name, &count);
-    if (result_list == NULL) {
-        return 0;
-    }
-
+    char*** destination;
+    size_t* destination_count;
     if (strcmp(env_var_name, "_DD_IAST_PATCH_MODULES") == 0) {
-        user_allowlist = result_list;
-        user_allowlist_count = count;
+        destination = &user_allowlist;
+        destination_count = &user_allowlist_count;
     } else if (strcmp(env_var_name, "_DD_IAST_DENY_MODULES") == 0) {
-        user_denylist = result_list;
-        user_denylist_count = count;
+        destination = &user_denylist;
+        destination_count = &user_denylist_count;
     } else {
-        free_list(result_list, count);
         return -1;
     }
+
+    size_t count = 0;
+    char** result_list = get_list_from_env(env_var_name, &count);
+    if (result_list == NULL && PyErr_Occurred()) {
+        return -1;
+    }
+
+    free_list(*destination, *destination_count);
+    *destination = result_list;
+    *destination_count = count;
 
     return 0;
 }
@@ -583,10 +590,13 @@ py_build_list_from_env(PyObject* Py_UNUSED(self), PyObject* args)
         return NULL;
     }
     int result = build_list_from_env(env_var_name);
-    if (result >= 0) {
-        Py_RETURN_TRUE;
+    if (result < 0) {
+        if (PyErr_Occurred()) {
+            return NULL;
+        }
+        Py_RETURN_FALSE;
     }
-    Py_RETURN_FALSE;
+    Py_RETURN_TRUE;
 }
 
 /* --- Exported Function:  to return the user_allowlist as a Python list --- */

--- a/ddtrace/appsec/_iast/_taint_tracking/native.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/native.cpp
@@ -188,6 +188,18 @@ reset_native_state_after_fork()
     initialize_native_state();
 }
 
+static void
+reset_native_state()
+{
+    if (taint_engine_context) {
+        taint_engine_context->clear_all_request_context_slots();
+        taint_engine_context.reset();
+    }
+    initializer.reset();
+    TaintEngineContext::set_shutting_down(false);
+    initialize_native_state();
+}
+
 /**
  * This function initializes the native module.
  */
@@ -237,10 +249,8 @@ PYBIND11_MODULE(_native, m)
 
     // Export fork-safety functions
     m.def("reset_native_state",
-          &reset_native_state_after_fork,
-          "Reset native IAST state after fork. "
-          "This recreates all global C++ singletons with fresh state, "
-          "clearing any inherited PyObject pointers or corrupted memory from parent process.");
+          &reset_native_state,
+          "Reset native IAST state by cleaning up and recreating the global singletons.");
 
     m.def("initialize_native_state",
           &initialize_native_state,
@@ -263,9 +273,15 @@ PYBIND11_MODULE(_native, m)
     // Note: the order of these definitions matter. For example,
     // stacktrace_element definitions must be before the ones of the
     // classes inheriting from it.
-    PyObject* hm_aspects = PyModule_Create(&aspects);
+    py::module_ hm_aspects = py::reinterpret_steal<py::module_>(PyModule_Create(&aspects));
+    if (!hm_aspects) {
+        throw py::error_already_set();
+    }
     m.add_object("aspects", hm_aspects);
 
-    PyObject* hm_ops = PyModule_Create(&ops);
+    py::module_ hm_ops = py::reinterpret_steal<py::module_>(PyModule_Create(&ops));
+    if (!hm_ops) {
+        throw py::error_already_set();
+    }
     m.add_object("ops", hm_ops);
 }

--- a/tests/appsec/iast/test_safe_wrappers_and_initialization.py
+++ b/tests/appsec/iast/test_safe_wrappers_and_initialization.py
@@ -14,6 +14,26 @@ import sys
 import pytest
 
 
+@pytest.mark.subprocess
+def test_native_helper_modules_do_not_keep_unowned_references():
+    import sys
+
+    from ddtrace.appsec._iast import _taint_tracking
+    from ddtrace.appsec._iast._taint_tracking import _native
+
+    for name in ("aspects", "ops"):
+        helper_module = getattr(_native, name)
+        sys.modules.pop(helper_module.__name__, None)
+        delattr(_native, name)
+        if hasattr(_taint_tracking, name):
+            delattr(_taint_tracking, name)
+
+        method_references = sum(
+            getattr(value, "__self__", None) is helper_module for value in vars(helper_module).values()
+        )
+        assert sys.getrefcount(helper_module) == method_references + 2
+
+
 @pytest.mark.skip_iast_check_logs
 class TestUninitializedStateHandling:
     """Test that IAST functions handle uninitialized state gracefully."""

--- a/tests/appsec/iast_memcheck/test_iast_mem_check.py
+++ b/tests/appsec/iast_memcheck/test_iast_mem_check.py
@@ -4,11 +4,14 @@ import pytest
 from pytest_memray import LeaksFilterFunction
 from pytest_memray import Stack
 
+from ddtrace.appsec._constants import IAST
+from ddtrace.appsec._iast._ast import iastpatch
 from ddtrace.appsec._iast._iast_request_context import get_iast_reporter
 from ddtrace.appsec._iast._iast_request_context_base import _iast_finish_request
 from ddtrace.appsec._iast._iast_request_context_base import _iast_start_request
 from ddtrace.appsec._iast._iast_request_context_base import _num_objects_tainted_in_request
 from ddtrace.appsec._iast._taint_tracking import OriginType
+from ddtrace.appsec._iast._taint_tracking import reset_native_state
 from ddtrace.appsec._iast._taint_tracking._context import debug_context_array_size
 from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 from ddtrace.appsec._iast._taint_tracking._taint_objects_base import get_tainted_ranges
@@ -56,6 +59,28 @@ class IASTFilter(LeaksFilterFunction):
                     return True
 
         return False
+
+
+@pytest.mark.limit_leaks("1.0 KB", filter_fn=IASTFilter())
+def test_rebuilding_iast_module_list_does_not_leak():
+    env_name = IAST.PATCH_MODULES
+    previous_value = os.environ.get(env_name)
+    try:
+        os.environ[env_name] = "iast_test_module." * 8
+        for _ in range(20):
+            assert iastpatch.build_list_from_env(env_name)
+    finally:
+        if previous_value is None:
+            os.environ.pop(env_name, None)
+        else:
+            os.environ[env_name] = previous_value
+        iastpatch.build_list_from_env(env_name)
+
+
+@pytest.mark.limit_leaks("2.0 MB", filter_fn=IASTFilter())
+def test_repeated_native_state_reset_does_not_leak():
+    for _ in range(4):
+        reset_native_state()
 
 
 @pytest.mark.limit_leaks("8.8 KB", filter_fn=IASTFilter())


### PR DESCRIPTION
## Description

Repair three native IAST ownership issues found during a memory-ownership audit:

- replace the previous user allowlist or denylist allocation when module configuration is rebuilt
- separate ordinary explicit native-state reset cleanup from the fork-specific discard path, which must continue abandoning inherited objects without running unsafe destructors
- give the native `aspects` and `ops` helper submodules explicit owned references and propagate creation failures

The corresponding regressions exercise the changes through normal Python entry points, direct reference-count observation, and memcheck. This work was identified proactively and is not tied to a specific production bug report.

## Testing

- 186 native C++ tests passed; 3 tests remain disabled
- 10 focused native initialization, reset, fork, and helper-module tests passed
- 2 focused memcheck regressions passed
- full `scripts/lint checks` passed
- exact-main `appsec_iast_propagation` comparison:
  - propagation enabled: -0.25%, statistically unchanged
  - propagation disabled: -5.72%, but the baseline was unstable
  - no actionable performance regression demonstrated

A broader IAST run completed with 19,584 passed and 38 skipped tests, plus one unrelated failure in `test_as_formatted_evidence_convert_escaped_text_to_tainted_text`: the expected randomized mapper identifier differed. None of this PR's modified paths participate in that formatter.

## Risks

Low to moderate. The changes affect native module configuration, explicit reset, and module initialization. They do not change the public Python API or the fork handler's intentional no-destructor behavior. Focused refcount and memcheck tests cover the changed ownership contracts.

## Additional Notes

No release note is proposed because this is internal ownership maintenance with no intended customer-visible behavior change. Apply `changelog/no-changelog`.
