### PR TITLE
ci(benchmarks): bump forktime-configured SLO from 17ms to 21ms

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -871,7 +871,7 @@ experiments:
               - execution_time < 3.00 ms
           - name: forktime-configured
             thresholds:
-              - execution_time < 17 ms
+              - execution_time < 21 ms
 
           # rand
           - name: rand-rand64bits


### PR DESCRIPTION
Increase the execution_time SLO threshold to accommodate observed benchmark times exceeding the current 17ms limit.

## Description

<!-- Provide an overview of the change and motivation for the change.
     Implementation detail and rationale belong here, not in the release note -
     release notes are customer-facing (see docs/releasenotes.rst). -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
