### PR TITLE
fix(profiling): clean up failed profiler starts

### DIFF
--- a/ddtrace/internal/README.md
+++ b/ddtrace/internal/README.md
@@ -303,12 +303,16 @@ the parent.
 A start requested while the fork protocol is in phase 1 is queued by the Python
 `PeriodicThread` wrapper instead of starting a native worker. The component that
 owns the thread can cancel a queued start or restart by calling
-`_cancel_deferred_start()`. Cancellation and after-fork processing are
-serialized: cancellation either removes the pending work, or waits for the
-native worker to be created so the owner can stop and join it. A canceled
-running worker remains in the pre-fork stop/join snapshot but is removed from
-the after-fork restart set. Before `fork()` the queue is shared; afterwards
-cancellation affects only the calling process's copy.
+`_cancel_deferred_start()`. If the start was still queued, cancellation removes
+it and no native worker is ever created. Otherwise the native worker had
+already started (or is racing to start) by the time cancellation ran, so
+cancellation only clears the after-fork restart flag; the caller is
+responsible for stopping and joining that worker itself, retrying if it hits a
+"not started" `RuntimeError` from a start that is still in flight (see
+`Scheduler._rollback_start` for this retry pattern). A canceled running worker
+remains in the pre-fork stop/join snapshot but is removed from the after-fork
+restart set. Before `fork()` the queue is shared; afterwards cancellation
+affects only the calling process's copy.
 
 **Phase 2 — after fork**
 

--- a/ddtrace/internal/README.md
+++ b/ddtrace/internal/README.md
@@ -300,6 +300,16 @@ the parent.
 > must use their own timeouts — an unbounded block will prevent `fork()` from
 > returning until the operation completes, which can hang pre-fork servers.
 
+A start requested while the fork protocol is in phase 1 is queued by the Python
+`PeriodicThread` wrapper instead of starting a native worker. The component that
+owns the thread can cancel a queued start or restart by calling
+`_cancel_deferred_start()`. Cancellation and after-fork processing are
+serialized: cancellation either removes the pending work, or waits for the
+native worker to be created so the owner can stop and join it. A canceled
+running worker remains in the pre-fork stop/join snapshot but is removed from
+the after-fork restart set. Before `fork()` the queue is shared; afterwards
+cancellation affects only the calling process's copy.
+
 **Phase 2 — after fork**
 
 Both the parent and the child call `_after_fork()` on every thread. In the

--- a/ddtrace/internal/forksafe.py
+++ b/ddtrace/internal/forksafe.py
@@ -160,7 +160,11 @@ class ResetLock(ResetObject[_unpatched.threading_Lock]):
 
     def __init__(self) -> None:
         super().__init__(_unpatched.threading_Lock)
-        self._self_context_depths: dict[int, int] = {}
+        # AIDEV-NOTE: A primitive Lock can be released by a thread other than its acquirer, so
+        # ownership is a single value that every successful release clears. The separate fork
+        # depth only makes the inherited acquisition reentrant for the forking thread while
+        # child hooks and the pre-fork call stack unwind.
+        self._self_owner: typing.Optional[int] = None
         self._self_fork_owner: typing.Optional[int] = None
         self._self_fork_depth = 0
 
@@ -169,10 +173,14 @@ class ResetLock(ResetObject[_unpatched.threading_Lock]):
         if self._self_fork_owner == thread_id:
             self._self_fork_depth += 1
             return True
-        return self.__wrapped__.acquire(blocking, timeout)
+        acquired = self.__wrapped__.acquire(blocking, timeout)
+        if acquired:
+            self._self_owner = thread_id
+        return acquired
 
     def release(self) -> None:
-        if self._self_fork_owner == get_ident():
+        self._self_owner = None
+        if self._self_fork_owner is not None:
             self._self_fork_depth -= 1
             if self._self_fork_depth == 0:
                 self._self_fork_owner = None
@@ -181,18 +189,9 @@ class ResetLock(ResetObject[_unpatched.threading_Lock]):
         self.__wrapped__.release()
 
     def __enter__(self) -> typing.Any:
-        entered = self.acquire()
-        thread_id = get_ident()
-        self._self_context_depths[thread_id] = self._self_context_depths.get(thread_id, 0) + 1
-        return entered
+        return self.acquire()
 
     def __exit__(self, *args: typing.Any) -> typing.Any:
-        thread_id = get_ident()
-        context_depth = self._self_context_depths[thread_id] - 1
-        if context_depth:
-            self._self_context_depths[thread_id] = context_depth
-        else:
-            del self._self_context_depths[thread_id]
         self.release()
         return None
 
@@ -201,17 +200,17 @@ class ResetLock(ResetObject[_unpatched.threading_Lock]):
 
     def _reset_object(self) -> None:
         thread_id = get_ident()
-        context_depth = self._self_context_depths.get(thread_id, 0)
         if self._self_fork_owner == thread_id:
-            fork_depth = max(context_depth, self._self_fork_depth)
+            fork_depth = self._self_fork_depth
         else:
-            fork_depth = context_depth
-        self._self_context_depths = {thread_id: context_depth} if context_depth else {}
+            fork_depth = int(self._self_owner == thread_id)
         super()._reset_object()
+        self._self_owner = None
         self._self_fork_owner = None
         self._self_fork_depth = 0
         if fork_depth:
             self.__wrapped__.acquire()
+            self._self_owner = thread_id
             self._self_fork_owner = thread_id
             self._self_fork_depth = fork_depth
 
@@ -231,7 +230,7 @@ register(_reset_objects)
 
 
 def Lock() -> _unpatched.threading_Lock:
-    return ResetLock()
+    return ResetObject(_unpatched.threading_Lock)
 
 
 def Event() -> _unpatched.threading_Event:

--- a/ddtrace/internal/forksafe.py
+++ b/ddtrace/internal/forksafe.py
@@ -2,6 +2,7 @@
 An API to provide fork-safe functions.
 """
 
+from _thread import get_ident
 import functools
 import logging
 import os
@@ -154,6 +155,67 @@ class ResetObject(wrapt.ObjectProxy, typing.Generic[_T]):
         return self.__reduce__()
 
 
+class ResetLock(ResetObject[_unpatched.threading_Lock]):
+    """A lock that resets after fork while active contexts unwind safely."""
+
+    def __init__(self) -> None:
+        super().__init__(_unpatched.threading_Lock)
+        self._self_context_depths: dict[int, int] = {}
+        self._self_fork_owner: typing.Optional[int] = None
+        self._self_fork_depth = 0
+
+    def acquire(self, blocking: bool = True, timeout: float = -1) -> bool:
+        thread_id = get_ident()
+        if self._self_fork_owner == thread_id:
+            self._self_fork_depth += 1
+            return True
+        return self.__wrapped__.acquire(blocking, timeout)
+
+    def release(self) -> None:
+        if self._self_fork_owner == get_ident():
+            self._self_fork_depth -= 1
+            if self._self_fork_depth == 0:
+                self._self_fork_owner = None
+                self.__wrapped__.release()
+            return
+        self.__wrapped__.release()
+
+    def __enter__(self) -> typing.Any:
+        entered = self.acquire()
+        thread_id = get_ident()
+        self._self_context_depths[thread_id] = self._self_context_depths.get(thread_id, 0) + 1
+        return entered
+
+    def __exit__(self, *args: typing.Any) -> typing.Any:
+        thread_id = get_ident()
+        context_depth = self._self_context_depths[thread_id] - 1
+        if context_depth:
+            self._self_context_depths[thread_id] = context_depth
+        else:
+            del self._self_context_depths[thread_id]
+        self.release()
+        return None
+
+    def __reduce__(self) -> typing.Any:
+        return (ResetLock, ())
+
+    def _reset_object(self) -> None:
+        thread_id = get_ident()
+        context_depth = self._self_context_depths.get(thread_id, 0)
+        if self._self_fork_owner == thread_id:
+            fork_depth = max(context_depth, self._self_fork_depth)
+        else:
+            fork_depth = context_depth
+        self._self_context_depths = {thread_id: context_depth} if context_depth else {}
+        super()._reset_object()
+        self._self_fork_owner = None
+        self._self_fork_depth = 0
+        if fork_depth:
+            self.__wrapped__.acquire()
+            self._self_fork_owner = thread_id
+            self._self_fork_depth = fork_depth
+
+
 _resetable_objects: weakref.WeakSet[ResetObject] = weakref.WeakSet()
 
 
@@ -169,7 +231,7 @@ register(_reset_objects)
 
 
 def Lock() -> _unpatched.threading_Lock:
-    return ResetObject(_unpatched.threading_Lock)
+    return ResetLock()
 
 
 def Event() -> _unpatched.threading_Event:

--- a/ddtrace/internal/service.py
+++ b/ddtrace/internal/service.py
@@ -2,7 +2,7 @@ import abc
 import enum
 import typing  # noqa:F401
 
-from ddtrace.internal.threads import Lock
+from ddtrace.internal import forksafe
 
 
 class ServiceStatus(enum.Enum):
@@ -29,7 +29,9 @@ class Service(metaclass=abc.ABCMeta):
 
     def __init__(self) -> None:
         self.status: ServiceStatus = ServiceStatus.STOPPED
-        self._service_lock: typing.ContextManager = Lock()
+        # AIDEV-NOTE: Lifecycle methods can release the GIL while holding this lock, so a child
+        # must reset it instead of inheriting ownership from a thread that disappeared at fork.
+        self._service_lock: typing.ContextManager = forksafe.Lock()
 
     def __repr__(self):
         class_name = self.__class__.__name__

--- a/ddtrace/internal/service.py
+++ b/ddtrace/internal/service.py
@@ -31,7 +31,7 @@ class Service(metaclass=abc.ABCMeta):
         self.status: ServiceStatus = ServiceStatus.STOPPED
         # AIDEV-NOTE: Lifecycle methods can release the GIL while holding this lock, so a child
         # must reset it instead of inheriting ownership from a thread that disappeared at fork.
-        self._service_lock: typing.ContextManager = forksafe.Lock()
+        self._service_lock = forksafe.ResetLock()
 
     def __repr__(self):
         class_name = self.__class__.__name__

--- a/ddtrace/internal/threads.py
+++ b/ddtrace/internal/threads.py
@@ -32,6 +32,14 @@ __all__ = [
     "RLock",
 ]
 
+# AIDEV-NOTE: Exact text of the RuntimeErrors ddtrace/internal/_threads.cpp raises for a
+# thread/periodic-thread that was never started (via PyErr_SetString(PyExc_RuntimeError, ...)).
+# Callers such as ddtrace.profiling.scheduler.Scheduler._rollback_start match on these strings to
+# tell "never started" apart from a real failure; keep all three in sync if the native messages
+# change.
+THREAD_NOT_STARTED_ERROR = "Thread not started"
+PERIODIC_THREAD_NOT_STARTED_ERROR = "Periodic thread not started"
+
 
 # Forking state management. This is a barrier to either prevent new threads
 # from being started while forking, or to allow a thread to be started
@@ -87,6 +95,12 @@ class PeriodicThread(_PeriodicThread):
             return self._cancel_deferred_start_unlocked()
 
     def _cancel_deferred_start_unlocked(self) -> bool:
+        # AIDEV-NOTE: Callers outside this module (ddtrace.profiling.scheduler.Scheduler
+        # ._rollback_start) call this `_unlocked` variant directly while holding
+        # `_forking_lock` themselves, instead of `_cancel_deferred_start()`, because they need
+        # the decision made here (deferred vs. already-running) to stay atomic with a fallback
+        # stop/join they run under the same lock. If this method's contract (return value
+        # semantics, or what state it mutates) changes, update that call site too.
         retained_starts = [start for start in _threads_to_start_after_fork if start.__self__ is not self]
         start_was_deferred = len(retained_starts) != len(_threads_to_start_after_fork)
         _threads_to_start_after_fork[:] = retained_starts

--- a/ddtrace/internal/threads.py
+++ b/ddtrace/internal/threads.py
@@ -37,7 +37,7 @@ __all__ = [
 # from being started while forking, or to allow a thread to be started
 # completely if a fork comes in the middle of it.
 _forking = False
-_forking_lock = Lock()
+_forking_lock = forksafe.Lock()
 
 
 class BoundMethod(t.Protocol):
@@ -73,6 +73,7 @@ class PeriodicThread(_PeriodicThread):
 
     def start(self) -> None:
         with _forking_lock:
+            self._restart_cancelled = False
             # We cannot start a new thread while we are forking, because we are
             # trying to stop them all. In that case, we take note of the thread
             # and start it after the fork.
@@ -80,6 +81,21 @@ class PeriodicThread(_PeriodicThread):
                 super().start()
             else:
                 _threads_to_start_after_fork.append(t.cast(BoundMethod, super().start))
+
+    def _cancel_deferred_start(self) -> bool:
+        with _forking_lock:
+            return self._cancel_deferred_start_unlocked()
+
+    def _cancel_deferred_start_unlocked(self) -> bool:
+        retained_starts = [start for start in _threads_to_start_after_fork if start.__self__ is not self]
+        start_was_deferred = len(retained_starts) != len(_threads_to_start_after_fork)
+        _threads_to_start_after_fork[:] = retained_starts
+
+        # AIDEV-NOTE: A running worker still needs pre-fork stop/join, but its owner can
+        # prevent the completed fork protocol from restarting it.
+        self._restart_cancelled = True
+        _threads_to_restart_after_fork.discard(self)
+        return start_was_deferred
 
 
 # Set of running periodic threads that need to be restarted after a fork.
@@ -160,26 +176,27 @@ class ThreadRestartTimer(PeriodicThread):
 def _after_fork_child():
     global _forking
 
-    _forking = False
+    with _forking_lock:
+        _forking = False
 
-    # Restart the threads immediately. It is unlikely that there will be another
-    # call to fork here. _after_fork() (without force=True) respects
-    # __autorestart__: cleanup always runs, but the thread is only restarted
-    # when __autorestart__ is True. This is intentional in the child — threads
-    # with __autorestart__ = False (e.g. RemoteConfigPoller) should not run in
-    # forked workers.
-    for thread in _threads_to_restart_after_fork.copy():
-        log.debug("Restarting thread %s after fork in child", thread.name)
-        try:
-            thread._after_fork()
-        except Exception as e:
-            log.error("failed to restart periodic thread %s after fork in child: %s", thread.name, e)
-    _threads_to_restart_after_fork.clear()
+        # Restart the threads immediately. It is unlikely that there will be another
+        # call to fork here. _after_fork() (without force=True) respects
+        # __autorestart__: cleanup always runs, but the thread is only restarted
+        # when __autorestart__ is True. This is intentional in the child — threads
+        # with __autorestart__ = False (e.g. RemoteConfigPoller) should not run in
+        # forked workers.
+        for thread in _threads_to_restart_after_fork.copy():
+            log.debug("Restarting thread %s after fork in child", thread.name)
+            try:
+                thread._after_fork()
+            except Exception as e:
+                log.error("failed to restart periodic thread %s after fork in child: %s", thread.name, e)
+        _threads_to_restart_after_fork.clear()
 
-    for thread_start in _threads_to_start_after_fork.copy():
-        log.debug("Starting thread %s after fork in child", thread_start.__self__.name)
-        _safe_restart(thread_start, thread_start.__self__.name)
-    _threads_to_start_after_fork.clear()
+        for thread_start in _threads_to_start_after_fork.copy():
+            log.debug("Starting thread %s after fork in child", thread_start.__self__.name)
+            _safe_restart(thread_start, thread_start.__self__.name)
+        _threads_to_start_after_fork.clear()
 
 
 @forksafe.register_after_parent
@@ -201,18 +218,24 @@ def _before_fork() -> None:
     with _forking_lock:
         _forking = True
 
-    # Take note of all the periodic threads that are running and will need to be
-    # restarted.
-    _threads_to_restart_after_fork.update(periodic_threads.values())
+        # AIDEV-NOTE: Native starts and restarts finish registration before the wrapper releases
+        # _forking_lock, so this snapshot includes every worker that can be running at fork time.
+        threads_to_stop = set(periodic_threads.values())
+        threads_to_stop.update(_threads_to_restart_after_fork)
+
+        _threads_to_restart_after_fork.update(
+            thread for thread in threads_to_stop if not getattr(thread, "_restart_cancelled", False)
+        )
+        threads_to_stop_snapshot = tuple(threads_to_stop)
 
     # Stop all the periodic threads that are still running, without executing
     # the shutdown methods, if any. This ensures that we can stop the threads
     # more promptly.
-    for thread in _threads_to_restart_after_fork:
+    for thread in threads_to_stop_snapshot:
         log.debug("Stopping thread %s before fork", thread.name)
         thread._before_fork()
 
     # Join all the threads to ensure they are stopped before the fork.
-    for thread in _threads_to_restart_after_fork:
+    for thread in threads_to_stop_snapshot:
         log.debug("Joining thread %s before fork", thread.name)
         thread.join()

--- a/ddtrace/profiling/collector/__init__.py
+++ b/ddtrace/profiling/collector/__init__.py
@@ -52,6 +52,11 @@ class Collector(service.Service):
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         super().__init__(*args, **kwargs)
 
+    def _rollback_start(self) -> None:
+        with self._service_lock:
+            self._stop_service()
+            self.status = service.ServiceStatus.STOPPED
+
     @staticmethod
     def snapshot() -> None:
         """Take a snapshot of collected data, to be exported."""

--- a/ddtrace/profiling/collector/_exception.pyx
+++ b/ddtrace/profiling/collector/_exception.pyx
@@ -182,11 +182,14 @@ class ExceptionCollector(collector.Collector):
                     sys.monitoring.events.RAISE,
                     _on_exception,
                 )
-            except ValueError:
+            except ValueError as e:
                 LOG.exception("Failed to set up exception monitoring")
                 if monitoring_claimed:
                     self._stop_service()
-                return
+                # AIDEV-NOTE: Raise instead of returning so Service.start() does not mark this
+                # collector RUNNING when monitoring was never actually installed (e.g. the tool ID
+                # is still held by a previous instance that failed to free it on stop).
+                raise collector.CollectorUnavailable from e
             except BaseException:
                 self._stop_service()
                 raise

--- a/ddtrace/profiling/collector/_exception.pyx
+++ b/ddtrace/profiling/collector/_exception.pyx
@@ -147,6 +147,7 @@ cpdef void _on_exception(object code, int instruction_offset, object exception):
     finally:
         _collecting = False
 
+
 class ExceptionCollector(collector.Collector):
     """Collects exception samples using sys.monitoring (Python 3.12+)."""
 
@@ -167,10 +168,14 @@ class ExceptionCollector(collector.Collector):
             return
 
         if HAS_MONITORING:
+            state = _SamplerState(self._sampling_interval, self._collect_message)
+            monitoring_claimed = False
             try:
                 # Claim the tool ID *before* writing _state so that a ValueError
                 # (tool ID already in use) leaves the existing _state untouched.
                 sys.monitoring.use_tool_id(_MONITORING_TOOL_ID, "dd-trace-exception-profiler")
+                monitoring_claimed = True
+                self._monitoring_registered = True
                 sys.monitoring.set_events(_MONITORING_TOOL_ID, sys.monitoring.events.RAISE)
                 sys.monitoring.register_callback(
                     _MONITORING_TOOL_ID,
@@ -179,10 +184,14 @@ class ExceptionCollector(collector.Collector):
                 )
             except ValueError:
                 LOG.exception("Failed to set up exception monitoring")
+                if monitoring_claimed:
+                    self._stop_service()
                 return
+            except BaseException:
+                self._stop_service()
+                raise
 
-            _state = _SamplerState(self._sampling_interval, self._collect_message)
-            self._monitoring_registered = True
+            _state = state
         else:
             LOG.debug("Exception profiling only supports Python 3.12+, skipping")
             return
@@ -219,6 +228,8 @@ class ExceptionCollector(collector.Collector):
             sys.monitoring.free_tool_id(_MONITORING_TOOL_ID)
         except Exception:
             LOG.debug("Failed to free exception monitoring tool_id", exc_info=True)
-
-        self._monitoring_registered = False
-        _state = None
+            raise
+        else:
+            self._monitoring_registered = False
+        finally:
+            _state = None

--- a/ddtrace/profiling/collector/_lock.pyx
+++ b/ddtrace/profiling/collector/_lock.pyx
@@ -607,6 +607,15 @@ class LockCollector(collector.CaptureSamplerCollector):
             ModuleWatchdog.unregister_module_hook(self.MODULE.__name__, self._reimport_hook)
             self._reimport_hook = None
 
+    def _rollback_start(self) -> None:
+        # AIDEV-NOTE: unpatch() sets the module attribute to self._original_lock. If _start_service
+        # failed before patch() ever ran (e.g. _c_initialize_gevent_support() raised), that field is
+        # still None, so the default Collector._rollback_start()'s _stop_service() -> unpatch() call
+        # would clobber the module attribute with None instead of leaving it untouched.
+        if self._original_lock is None:
+            return
+        super()._rollback_start()
+
     def patch(self) -> None:
         """Patch the module for tracking lock allocation."""
         original_lock: Callable[..., Any] = self._get_patch_target()

--- a/ddtrace/profiling/collector/asyncio.py
+++ b/ddtrace/profiling/collector/asyncio.py
@@ -22,14 +22,7 @@ class _ProfiledAsyncioCondition(_lock._ProfiledLock):
     pass
 
 
-class _LockCollector(_lock.LockCollector):
-    def _rollback_start(self) -> None:
-        if self._original_lock is None:
-            return
-        super()._rollback_start()
-
-
-class AsyncioLockCollector(_LockCollector):
+class AsyncioLockCollector(_lock.LockCollector):
     """Record asyncio.Lock usage."""
 
     PROFILED_LOCK_CLASS: type[_ProfiledAsyncioLock] = _ProfiledAsyncioLock
@@ -37,7 +30,7 @@ class AsyncioLockCollector(_LockCollector):
     PATCHED_LOCK_NAME: str = "Lock"
 
 
-class AsyncioSemaphoreCollector(_LockCollector):
+class AsyncioSemaphoreCollector(_lock.LockCollector):
     """Record asyncio.Semaphore usage."""
 
     PROFILED_LOCK_CLASS: type[_ProfiledAsyncioSemaphore] = _ProfiledAsyncioSemaphore
@@ -45,7 +38,7 @@ class AsyncioSemaphoreCollector(_LockCollector):
     PATCHED_LOCK_NAME: str = "Semaphore"
 
 
-class AsyncioBoundedSemaphoreCollector(_LockCollector):
+class AsyncioBoundedSemaphoreCollector(_lock.LockCollector):
     """Record asyncio.BoundedSemaphore usage."""
 
     PROFILED_LOCK_CLASS: type[_ProfiledAsyncioBoundedSemaphore] = _ProfiledAsyncioBoundedSemaphore
@@ -53,7 +46,7 @@ class AsyncioBoundedSemaphoreCollector(_LockCollector):
     PATCHED_LOCK_NAME: str = "BoundedSemaphore"
 
 
-class AsyncioConditionCollector(_LockCollector):
+class AsyncioConditionCollector(_lock.LockCollector):
     """Record asyncio.Condition usage."""
 
     PROFILED_LOCK_CLASS: type[_ProfiledAsyncioCondition] = _ProfiledAsyncioCondition

--- a/ddtrace/profiling/collector/asyncio.py
+++ b/ddtrace/profiling/collector/asyncio.py
@@ -22,7 +22,14 @@ class _ProfiledAsyncioCondition(_lock._ProfiledLock):
     pass
 
 
-class AsyncioLockCollector(_lock.LockCollector):
+class _LockCollector(_lock.LockCollector):
+    def _rollback_start(self) -> None:
+        if self._original_lock is None:
+            return
+        super()._rollback_start()
+
+
+class AsyncioLockCollector(_LockCollector):
     """Record asyncio.Lock usage."""
 
     PROFILED_LOCK_CLASS: type[_ProfiledAsyncioLock] = _ProfiledAsyncioLock
@@ -30,7 +37,7 @@ class AsyncioLockCollector(_lock.LockCollector):
     PATCHED_LOCK_NAME: str = "Lock"
 
 
-class AsyncioSemaphoreCollector(_lock.LockCollector):
+class AsyncioSemaphoreCollector(_LockCollector):
     """Record asyncio.Semaphore usage."""
 
     PROFILED_LOCK_CLASS: type[_ProfiledAsyncioSemaphore] = _ProfiledAsyncioSemaphore
@@ -38,7 +45,7 @@ class AsyncioSemaphoreCollector(_lock.LockCollector):
     PATCHED_LOCK_NAME: str = "Semaphore"
 
 
-class AsyncioBoundedSemaphoreCollector(_lock.LockCollector):
+class AsyncioBoundedSemaphoreCollector(_LockCollector):
     """Record asyncio.BoundedSemaphore usage."""
 
     PROFILED_LOCK_CLASS: type[_ProfiledAsyncioBoundedSemaphore] = _ProfiledAsyncioBoundedSemaphore
@@ -46,7 +53,7 @@ class AsyncioBoundedSemaphoreCollector(_lock.LockCollector):
     PATCHED_LOCK_NAME: str = "BoundedSemaphore"
 
 
-class AsyncioConditionCollector(_lock.LockCollector):
+class AsyncioConditionCollector(_LockCollector):
     """Record asyncio.Condition usage."""
 
     PROFILED_LOCK_CLASS: type[_ProfiledAsyncioCondition] = _ProfiledAsyncioCondition

--- a/ddtrace/profiling/collector/memalloc.py
+++ b/ddtrace/profiling/collector/memalloc.py
@@ -85,6 +85,14 @@ class MemoryCollector:
             except RuntimeError:
                 LOG.debug("Failed to stop memalloc profiling on shutdown", exc_info=True)
 
+    def _rollback_start(self) -> None:
+        if _memalloc is not None:
+            try:
+                _memalloc.stop()
+            except RuntimeError as error:
+                if str(error) != "the memalloc module was not started":
+                    raise
+
     def snapshot(self) -> None:
         """Take a snapshot of collected data, to be exported."""
 

--- a/ddtrace/profiling/collector/memalloc.py
+++ b/ddtrace/profiling/collector/memalloc.py
@@ -29,6 +29,13 @@ from ddtrace.profiling import collector
 
 LOG = logging.getLogger(__name__)
 
+# AIDEV-NOTE: Exact text of the RuntimeError _memalloc.stop() raises when the module was never
+# started (see PyErr_SetString(PyExc_RuntimeError, ...) in
+# ddtrace/profiling/collector/_memalloc.cpp). _rollback_start() below matches on this string to
+# tell "already stopped" apart from a real failure; keep both in sync if the native message
+# changes.
+_NOT_STARTED_ERROR = "the memalloc module was not started"
+
 
 class MemoryCollector:
     """Memory allocation collector."""
@@ -90,7 +97,7 @@ class MemoryCollector:
             try:
                 _memalloc.stop()
             except RuntimeError as error:
-                if str(error) != "the memalloc module was not started":
+                if str(error) != _NOT_STARTED_ERROR:
                     raise
 
     def snapshot(self) -> None:

--- a/ddtrace/profiling/collector/pytorch.py
+++ b/ddtrace/profiling/collector/pytorch.py
@@ -89,7 +89,9 @@ class MLProfilerCollector(collector.CaptureSamplerCollector):
 
     def unpatch(self) -> None:
         """Unpatch the torch.profiler module for tracking profiling data."""
-        self._set_patch_target(self._original)
+        if self._original is not None:
+            self._set_patch_target(self._original)
+            self._original = None
 
 
 class TorchProfilerCollector(MLProfilerCollector):

--- a/ddtrace/profiling/collector/stack.py
+++ b/ddtrace/profiling/collector/stack.py
@@ -89,8 +89,7 @@ class StackCollector(collector.Collector):
         # TODO take the `threading` import out of here and just handle it in v2 startup
         threading.init_stack()
 
-        # Register only after every fallible initialization step. A failed collector is dropped without
-        # _stop_service(), so registering earlier could leave process-wide tracing listeners behind.
+        # Register only after every fallible initialization step so rollback can remove every listener.
         if self.tracer is not None:
             try:
                 core.on("ddtrace.context_provider.activate", self._link_span)

--- a/ddtrace/profiling/collector/threading.py
+++ b/ddtrace/profiling/collector/threading.py
@@ -29,7 +29,14 @@ class _ProfiledThreadingCondition(_lock._ProfiledLock):
     pass
 
 
-class ThreadingLockCollector(_lock.LockCollector):
+class _LockCollector(_lock.LockCollector):
+    def _rollback_start(self) -> None:
+        if self._original_lock is None:
+            return
+        super()._rollback_start()
+
+
+class ThreadingLockCollector(_LockCollector):
     """Record threading.Lock usage."""
 
     PROFILED_LOCK_CLASS: type[_ProfiledThreadingLock] = _ProfiledThreadingLock
@@ -37,7 +44,7 @@ class ThreadingLockCollector(_lock.LockCollector):
     PATCHED_LOCK_NAME: str = "Lock"
 
 
-class ThreadingRLockCollector(_lock.LockCollector):
+class ThreadingRLockCollector(_LockCollector):
     """Record threading.RLock usage."""
 
     PROFILED_LOCK_CLASS: type[_ProfiledThreadingRLock] = _ProfiledThreadingRLock
@@ -45,7 +52,7 @@ class ThreadingRLockCollector(_lock.LockCollector):
     PATCHED_LOCK_NAME: str = "RLock"
 
 
-class ThreadingSemaphoreCollector(_lock.LockCollector):
+class ThreadingSemaphoreCollector(_LockCollector):
     """Record threading.Semaphore usage."""
 
     PROFILED_LOCK_CLASS: type[_ProfiledThreadingSemaphore] = _ProfiledThreadingSemaphore
@@ -53,7 +60,7 @@ class ThreadingSemaphoreCollector(_lock.LockCollector):
     PATCHED_LOCK_NAME: str = "Semaphore"
 
 
-class ThreadingBoundedSemaphoreCollector(_lock.LockCollector):
+class ThreadingBoundedSemaphoreCollector(_LockCollector):
     """Record threading.BoundedSemaphore usage."""
 
     PROFILED_LOCK_CLASS: type[_ProfiledThreadingBoundedSemaphore] = _ProfiledThreadingBoundedSemaphore
@@ -61,7 +68,7 @@ class ThreadingBoundedSemaphoreCollector(_lock.LockCollector):
     PATCHED_LOCK_NAME: str = "BoundedSemaphore"
 
 
-class ThreadingConditionCollector(_lock.LockCollector):
+class ThreadingConditionCollector(_LockCollector):
     """Record threading.Condition usage."""
 
     PROFILED_LOCK_CLASS: type[_ProfiledThreadingCondition] = _ProfiledThreadingCondition

--- a/ddtrace/profiling/collector/threading.py
+++ b/ddtrace/profiling/collector/threading.py
@@ -29,14 +29,7 @@ class _ProfiledThreadingCondition(_lock._ProfiledLock):
     pass
 
 
-class _LockCollector(_lock.LockCollector):
-    def _rollback_start(self) -> None:
-        if self._original_lock is None:
-            return
-        super()._rollback_start()
-
-
-class ThreadingLockCollector(_LockCollector):
+class ThreadingLockCollector(_lock.LockCollector):
     """Record threading.Lock usage."""
 
     PROFILED_LOCK_CLASS: type[_ProfiledThreadingLock] = _ProfiledThreadingLock
@@ -44,7 +37,7 @@ class ThreadingLockCollector(_LockCollector):
     PATCHED_LOCK_NAME: str = "Lock"
 
 
-class ThreadingRLockCollector(_LockCollector):
+class ThreadingRLockCollector(_lock.LockCollector):
     """Record threading.RLock usage."""
 
     PROFILED_LOCK_CLASS: type[_ProfiledThreadingRLock] = _ProfiledThreadingRLock
@@ -52,7 +45,7 @@ class ThreadingRLockCollector(_LockCollector):
     PATCHED_LOCK_NAME: str = "RLock"
 
 
-class ThreadingSemaphoreCollector(_LockCollector):
+class ThreadingSemaphoreCollector(_lock.LockCollector):
     """Record threading.Semaphore usage."""
 
     PROFILED_LOCK_CLASS: type[_ProfiledThreadingSemaphore] = _ProfiledThreadingSemaphore
@@ -60,7 +53,7 @@ class ThreadingSemaphoreCollector(_LockCollector):
     PATCHED_LOCK_NAME: str = "Semaphore"
 
 
-class ThreadingBoundedSemaphoreCollector(_LockCollector):
+class ThreadingBoundedSemaphoreCollector(_lock.LockCollector):
     """Record threading.BoundedSemaphore usage."""
 
     PROFILED_LOCK_CLASS: type[_ProfiledThreadingBoundedSemaphore] = _ProfiledThreadingBoundedSemaphore
@@ -68,7 +61,7 @@ class ThreadingBoundedSemaphoreCollector(_LockCollector):
     PATCHED_LOCK_NAME: str = "BoundedSemaphore"
 
 
-class ThreadingConditionCollector(_LockCollector):
+class ThreadingConditionCollector(_lock.LockCollector):
     """Record threading.Condition usage."""
 
     PROFILED_LOCK_CLASS: type[_ProfiledThreadingCondition] = _ProfiledThreadingCondition

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -16,7 +16,6 @@ from ddtrace.internal import process_tags
 from ddtrace.internal import service
 from ddtrace.internal import uwsgi
 from ddtrace.internal.datadog.profiling import ddup
-from ddtrace.internal.forksafe import Lock
 from ddtrace.internal.module import ModuleWatchdog
 from ddtrace.internal.settings import env as _env
 from ddtrace.internal.settings.profiling import config as profiling_config
@@ -45,7 +44,7 @@ class Profiler(object):
     """
 
     _active_instance: Optional["Profiler"] = None
-    _active_lock = Lock()
+    _active_lock = forksafe.ResetLock()
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._profiler: "_ProfilerInstance" = _ProfilerInstance(*args, **kwargs)
@@ -134,7 +133,11 @@ class Profiler(object):
     def _stop_with_active_lock(self, flush: bool = True) -> None:
         atexit.unregister(self.stop)
         if self._profiler._start_cleanup_pending:
-            self._profiler._rollback_start(flush=flush)
+            try:
+                self._profiler._rollback_start(flush=flush)
+            except BaseException:
+                LOG.debug("Failed to finish pending profiler cleanup during stop", exc_info=True)
+                raise
             self._finalize_stop_with_active_lock()
             return
         try:
@@ -167,6 +170,15 @@ class Profiler(object):
             return True
         # AIDEV-NOTE: A child can inherit ownership while another thread is rolling startup back.
         # Finish that inherited transaction before deciding whether a replacement may start.
+        # This is deliberately scoped to the cross-fork case: within the same process, a pending
+        # cleanup belongs to a start()/stop() call already in flight elsewhere (impossible here,
+        # since Profiler._active_lock serializes all callers) or one that gave up and left the
+        # profiler wedged. Racing that owner's own retry by attempting rollback inline here would
+        # make two callers contend over the same non-reentrant collector/scheduler rollback; the
+        # owner's own next start()/stop() call is the one that should finish it. Verified by
+        # tests/profiling/test_profiler.py::test_restart_finishes_failed_scheduler_cleanup_before_restarting_collectors
+        # and friends, which assert a competing start() must not touch the collectors while cleanup
+        # is pending in the same process.
         cleanup_generation = getattr(active._profiler, "_start_cleanup_generation", None)
         if (
             active._profiler._start_cleanup_pending
@@ -213,6 +225,9 @@ class Profiler(object):
             pass
         except Exception:
             LOG.debug("Exception while stopping profiler on exit signal", exc_info=True)
+            # AIDEV-NOTE: A pre-existing callable signal handler can keep the process alive after
+            # this handler returns. Preserve ownership when cleanup is incomplete so a later
+            # profiler cannot adopt shared native resources; this instance can retry stop().
         finally:
             Profiler._active_lock.release()
 

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -11,6 +11,7 @@ from typing import cast
 import ddtrace
 from ddtrace import config
 from ddtrace.internal import atexit
+from ddtrace.internal import forksafe
 from ddtrace.internal import process_tags
 from ddtrace.internal import service
 from ddtrace.internal import uwsgi
@@ -52,59 +53,137 @@ class Profiler(object):
     def start(self) -> None:
         """Start the profiler."""
         with Profiler._active_lock:
-            active = Profiler._active_instance
-            if active is not None and active is not self and active._profiler.status == service.ServiceStatus.RUNNING:
-                LOG.error(
-                    "A profiler is already running. Only one profiler instance can be active at a time. "
-                    "The second profiler will not be started."
-                )
-                return
+            self._start_with_active_lock()
 
+    def _start_with_active_lock(self, register_on_exit_signal: bool = True) -> None:
+        if not self._active_instance_available_with_active_lock():
+            return
+
+        try:
+            uwsgi.check_uwsgi(self._start_on_fork, atexit=self.stop)
+        except uwsgi.uWSGIMasterProcess:
+            # Do nothing in master, the profiler will be started in each worker via _start_on_fork
+            return
+        except uwsgi.uWSGIConfigDeprecationWarning:
+            LOG.warning("uWSGI configuration deprecation warning", exc_info=True)
+            # Turn off profiling in this case, this is mostly for
+            # uwsgi<2.0.30 when --skip-atexit is not set with --lazy-apps
+            # or --lazy. See uwsgi.check_uwsgi() for details.
+            return
+
+        # AIDEV-NOTE: Process-global ownership remains reserved until startup rollback succeeds.
+        Profiler._active_instance = self
+        self._start_profiler_with_active_lock()
+
+        telemetry_activation_attempted = False
+        try:
+            atexit.register(self.stop)
+
+            telemetry_activation_attempted = True
+            telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.PROFILER, True)
+
+            # register_on_exit_signal is needed for processes terminated via SIGTERM (e.g.
+            # Ray workers, Kubernetes pods). Python atexit handlers do NOT run on SIGTERM by default,
+            # so without this the last partial profile window is silently lost.
+            # We register _stop_on_signal (not stop) to avoid deadlocking when SIGTERM arrives while
+            # _active_lock is already held by the main thread (e.g. during start or stop).
+            if register_on_exit_signal:
+                atexit.register_on_exit_signal(self._stop_on_signal)
+
+            # Note: For regular fork(), native pthread_atfork handlers restart the sampling thread
+            # and PeriodicThread auto-restart handles the Scheduler. No explicit forksafe hook needed.
+            # For uWSGI, _start_on_fork is registered via uwsgidecorators.postfork() in check_uwsgi().
+
+        except BaseException:
+            # AIDEV-NOTE: Startup bookkeeping failure triggers rollback; process ownership remains
+            # reserved until rollback succeeds, including while a cleanup retry is pending.
+            if telemetry_activation_attempted:
+                try:
+                    telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.PROFILER, False)
+                except BaseException:
+                    LOG.debug("Failed to deactivate profiler telemetry after startup failed", exc_info=True)
             try:
-                uwsgi.check_uwsgi(self._start_on_fork, atexit=self.stop)
-            except uwsgi.uWSGIMasterProcess:
-                # Do nothing in master, the profiler will be started in each worker via _start_on_fork
-                return
-            except uwsgi.uWSGIConfigDeprecationWarning:
-                LOG.warning("uWSGI configuration deprecation warning", exc_info=True)
-                # Turn off profiling in this case, this is mostly for
-                # uwsgi<2.0.30 when --skip-atexit is not set with --lazy-apps
-                # or --lazy. See uwsgi.check_uwsgi() for details.
-                return
+                self._rollback_start_with_active_lock()
+            except BaseException:
+                LOG.debug("Failed to clean up profiler after startup bookkeeping failed", exc_info=True)
+            raise
 
+    def _start_profiler_with_active_lock(self) -> None:
+        try:
             self._profiler.start()
-            Profiler._active_instance = self
-
-        atexit.register(self.stop)
-
-        # register_on_exit_signal is needed for processes terminated via SIGTERM (e.g.
-        # Ray workers, Kubernetes pods). Python atexit handlers do NOT run on SIGTERM by default,
-        # so without this the last partial profile window is silently lost.
-        # We register _stop_on_signal (not stop) to avoid deadlocking when SIGTERM arrives while
-        # _active_lock is already held by the main thread (e.g. during start or stop).
-        atexit.register_on_exit_signal(self._stop_on_signal)
-
-        # Note: For regular fork(), native pthread_atfork handlers restart the sampling thread
-        # and PeriodicThread auto-restart handles the Scheduler. No explicit forksafe hook needed.
-        # For uWSGI, _start_on_fork is registered via uwsgidecorators.postfork() in check_uwsgi().
-
-        telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.PROFILER, True)
+        except BaseException:
+            if self._profiler.status == service.ServiceStatus.STOPPED:
+                try:
+                    self._rollback_start_with_active_lock()
+                except BaseException:
+                    LOG.debug("Failed to clean up partially started profiler", exc_info=True)
+            raise
 
     def stop(self, flush: bool = True) -> None:
         """Stop the profiler.
 
         :param flush: Flush last profile.
         """
-        atexit.unregister(self.stop)
         try:
             with Profiler._active_lock:
-                self._profiler.stop(flush)
-                if Profiler._active_instance is self:
-                    Profiler._active_instance = None
-            telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.PROFILER, False)
+                self._stop_with_active_lock(flush)
         except service.ServiceStatusError:
             # Not a best practice, but for backward API compatibility that allowed to call `stop` multiple times.
             pass
+
+    def _stop_with_active_lock(self, flush: bool = True) -> None:
+        atexit.unregister(self.stop)
+        if self._profiler._start_cleanup_pending:
+            self._profiler._rollback_start(flush=flush)
+            self._finalize_stop_with_active_lock()
+            return
+        try:
+            self._profiler.stop(flush)
+        except BaseException:
+            if self._profiler.status == service.ServiceStatus.RUNNING:
+                try:
+                    self._profiler._rollback_start(flush=flush)
+                except BaseException:
+                    LOG.debug("Failed to finish profiler cleanup", exc_info=True)
+                else:
+                    self._finalize_stop_with_active_lock()
+            raise
+        self._finalize_stop_with_active_lock()
+
+    def _finalize_stop_with_active_lock(self) -> None:
+        if Profiler._active_instance is self:
+            Profiler._active_instance = None
+        telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.PROFILER, False)
+
+    def _rollback_start_with_active_lock(self) -> None:
+        atexit.unregister(self.stop)
+        self._profiler._rollback_start(flush=False)
+        if Profiler._active_instance is self:
+            Profiler._active_instance = None
+
+    def _active_instance_available_with_active_lock(self) -> bool:
+        active = Profiler._active_instance
+        if active is None or active is self:
+            return True
+        # AIDEV-NOTE: A child can inherit ownership while another thread is rolling startup back.
+        # Finish that inherited transaction before deciding whether a replacement may start.
+        cleanup_generation = getattr(active._profiler, "_start_cleanup_generation", None)
+        if (
+            active._profiler._start_cleanup_pending
+            and isinstance(cleanup_generation, int)
+            and cleanup_generation != forksafe.get_generation()
+        ):
+            try:
+                active._rollback_start_with_active_lock()
+            except BaseException:
+                LOG.debug("Failed to clean up the active profiler before starting another", exc_info=True)
+                return False
+            return True
+        LOG.error(
+            "A profiler is already running. Only one profiler instance can be active at a time. "
+            "The second profiler will not be started."
+        )
+        return False
 
     def _stop_on_signal(self) -> None:
         """Flush and stop the profiler when an exit signal (SIGTERM/SIGINT) is received.
@@ -129,29 +208,29 @@ class Profiler(object):
             return
 
         try:
-            self._profiler.stop(flush=True)
+            self._stop_with_active_lock(flush=True)
         except service.ServiceStatusError:
             pass
         except Exception:
             LOG.debug("Exception while stopping profiler on exit signal", exc_info=True)
         finally:
-            if Profiler._active_instance is self:
-                Profiler._active_instance = None
-            telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.PROFILER, False)
             Profiler._active_lock.release()
 
     def _start_on_fork(self) -> None:
         """Start a fresh profiler in child process after fork. This is needed for uWSGI support."""
         with Profiler._active_lock:
-            if Profiler._active_instance is not None:
-                LOG.error(
-                    "A profiler is already running. Only one profiler instance can be active at a time. "
-                    "The second profiler will not be started."
-                )
+            if not self._active_instance_available_with_active_lock():
+                return
+            active = Profiler._active_instance
+            if (
+                active is self
+                and self._profiler.status == service.ServiceStatus.RUNNING
+                and not self._profiler._start_cleanup_pending
+            ):
                 return
 
-            self._profiler.start()
             Profiler._active_instance = self
+            self._start_profiler_with_active_lock()
 
     def __getattr__(self, key: str) -> Any:
         return getattr(self._profiler, key)
@@ -200,13 +279,28 @@ class _ProfilerInstance(service.Service):
         # Note: memalloc.MemoryCollector is not a subclass of collector.Collector, so we need to use a union type.
         #       This is because its snapshot method cannot be static.
         self._collectors: list[collector.Collector | memalloc.MemoryCollector] = []
-        self._collectors_on_import: Optional[list[tuple[str, Callable[[Any], None]]]] = None
+        self._collectors_pending_cleanup: list[collector.Collector | memalloc.MemoryCollector] = []
+        # AIDEV-NOTE: Retry cleanup completes before any profiler component is restarted.
+        self._start_cleanup_pending = False
+        self._start_cleanup_generation = forksafe.get_generation()
+        # AIDEV-NOTE: Retried teardown must attempt to flush each profiling session at most once.
+        self._stop_flush_attempted = False
+        self._collectors_on_import: list[tuple[str, Callable[[Any], None]]] = []
+        self._collectors_on_import_registered: list[tuple[str, Callable[[Any], None]]] = []
         self._scheduler: Optional[Union[scheduler.Scheduler, scheduler.ServerlessScheduler]] = None
         self._lambda_function_name: Optional[str] = _env.get("AWS_LAMBDA_FUNCTION_NAME")
 
         self.process_tags: Optional[str] = process_tags.process_tags or None
 
-        self.__post_init__()
+        try:
+            self.__post_init__()
+        except BaseException:
+            for error in self._unregister_import_hooks():
+                LOG.debug(
+                    "Failed to clean up partially constructed profiler",
+                    exc_info=(type(error), error, error.__traceback__),
+                )
+            raise
 
     def __eq__(self, other: Any) -> bool:
         for k, v in vars(self).items():
@@ -277,9 +371,9 @@ class _ProfilerInstance(service.Service):
         if self._lock_collector_enabled:
             # These collectors require the import of modules, so we create them
             # if their import is detected at runtime.
-            def start_collector(collector_class: type[collector.Collector]) -> None:
+            def start_lock_collector(collector_class: type[collector.Collector]) -> None:
                 with self._service_lock:
-                    if any(type(c) is collector_class for c in self._collectors):
+                    if self._has_collector_type(collector_class):
                         return
                     col = collector_class(tracer=self.tracer)
 
@@ -290,33 +384,40 @@ class _ProfilerInstance(service.Service):
                             LOG.debug("Started collector %r", col)
                         except collector.CollectorUnavailable:
                             LOG.debug("Collector %r is unavailable, disabling", col)
+                            if self._rollback_collector_start(col) is not None:
+                                self._collectors_pending_cleanup.append(col)
                             return
                         except Exception:
                             LOG.error("Failed to start collector %r, disabling.", col, exc_info=True)
+                            if self._rollback_collector_start(col) is not None:
+                                self._collectors_pending_cleanup.append(col)
                             return
+                        except BaseException:
+                            if self._rollback_collector_start(col) is not None:
+                                self._collectors_pending_cleanup.append(col)
+                            raise
 
                     self._collectors.append(col)
 
-            self._collectors_on_import = [
-                ("threading", lambda _: start_collector(threading.ThreadingLockCollector)),
-                ("threading", lambda _: start_collector(threading.ThreadingRLockCollector)),
-                ("threading", lambda _: start_collector(threading.ThreadingSemaphoreCollector)),
-                ("threading", lambda _: start_collector(threading.ThreadingBoundedSemaphoreCollector)),
-                ("threading", lambda _: start_collector(threading.ThreadingConditionCollector)),
-                ("asyncio", lambda _: start_collector(asyncio.AsyncioLockCollector)),
-                ("asyncio", lambda _: start_collector(asyncio.AsyncioSemaphoreCollector)),
-                ("asyncio", lambda _: start_collector(asyncio.AsyncioBoundedSemaphoreCollector)),
-                ("asyncio", lambda _: start_collector(asyncio.AsyncioConditionCollector)),
-            ]
-
-            for module, hook in self._collectors_on_import:
-                ModuleWatchdog.register_module_hook(module, hook)
+            self._collectors_on_import.extend(
+                [
+                    ("threading", lambda _: start_lock_collector(threading.ThreadingLockCollector)),
+                    ("threading", lambda _: start_lock_collector(threading.ThreadingRLockCollector)),
+                    ("threading", lambda _: start_lock_collector(threading.ThreadingSemaphoreCollector)),
+                    ("threading", lambda _: start_lock_collector(threading.ThreadingBoundedSemaphoreCollector)),
+                    ("threading", lambda _: start_lock_collector(threading.ThreadingConditionCollector)),
+                    ("asyncio", lambda _: start_lock_collector(asyncio.AsyncioLockCollector)),
+                    ("asyncio", lambda _: start_lock_collector(asyncio.AsyncioSemaphoreCollector)),
+                    ("asyncio", lambda _: start_lock_collector(asyncio.AsyncioBoundedSemaphoreCollector)),
+                    ("asyncio", lambda _: start_lock_collector(asyncio.AsyncioConditionCollector)),
+                ]
+            )
 
         if self._pytorch_collector_enabled:
 
-            def start_collector(collector_class: type[collector.Collector]) -> None:
+            def start_pytorch_collector(collector_class: type[collector.Collector]) -> None:
                 with self._service_lock:
-                    if any(type(c) is collector_class for c in self._collectors):
+                    if self._has_collector_type(collector_class):
                         return
                     col = collector_class()
 
@@ -327,23 +428,26 @@ class _ProfilerInstance(service.Service):
                             LOG.debug("Started pytorch collector %r", col)
                         except collector.CollectorUnavailable:
                             LOG.debug("Collector %r pytorch is unavailable, disabling", col)
+                            if self._rollback_collector_start(col) is not None:
+                                self._collectors_pending_cleanup.append(col)
                             return
                         except Exception:
                             LOG.error("Failed to start collector %r pytorch, disabling.", col, exc_info=True)
+                            if self._rollback_collector_start(col) is not None:
+                                self._collectors_pending_cleanup.append(col)
                             return
+                        except BaseException:
+                            if self._rollback_collector_start(col) is not None:
+                                self._collectors_pending_cleanup.append(col)
+                            raise
 
                     self._collectors.append(col)
 
-            if self._collectors_on_import is None:
-                self._collectors_on_import = []
+            self._collectors_on_import.append(
+                ("torch", lambda _: start_pytorch_collector(pytorch.TorchProfilerCollector))
+            )
 
-            torch_hooks: list[tuple[str, Callable[[Any], None]]] = [
-                ("torch", lambda _: start_collector(pytorch.TorchProfilerCollector)),
-            ]
-            self._collectors_on_import.extend(torch_hooks)
-
-            for module, hook in torch_hooks:
-                ModuleWatchdog.register_module_hook(module, hook)
+        self._register_import_hooks()
 
         if self._memory_collector_enabled:
             self._collectors.append(memalloc.MemoryCollector())
@@ -377,8 +481,32 @@ class _ProfilerInstance(service.Service):
             }
         )
 
+    def start(self, *args: Any, **kwargs: Any) -> None:
+        with self._service_lock:
+            if self._start_cleanup_pending:
+                self._stop_service(flush=False, join=True, _partial_start=True)
+                self.status = service.ServiceStatus.STOPPED
+                self._start_cleanup_pending = False
+            if self.status == service.ServiceStatus.RUNNING:
+                raise service.ServiceStatusError(self.__class__, self.status)
+
+        self._register_import_hooks()
+        super().start(*args, **kwargs)
+
+    def _has_collector_type(self, collector_class: type[collector.Collector]) -> bool:
+        if any(type(col) is collector_class for col in self._collectors):
+            return True
+        return self.status == service.ServiceStatus.RUNNING and any(
+            type(col) is collector_class for col in self._collectors_pending_cleanup
+        )
+
     def _start_service(self) -> None:
         """Start the profiler."""
+        cleanup_errors = self._cleanup_pending_collectors()
+        if cleanup_errors:
+            raise cleanup_errors[0]
+        self._stop_flush_attempted = False
+
         # See DD_PROFILING_NATIVE_HEAP_ENABLED. install() is permanent; children
         # inherit the patched GOT (and the activator skips a redundant re-install).
         if profiling_config.native_heap.enabled:
@@ -392,14 +520,30 @@ class _ProfilerInstance(service.Service):
             except Exception:
                 LOG.error("Failed to arm native heap profiling", exc_info=True)
 
-        collectors = []
-        for col in self._collectors:
+        collectors_to_start = self._collectors
+        collectors: list[collector.Collector | memalloc.MemoryCollector] = []
+        for index, col in enumerate(collectors_to_start):
             try:
                 col.start()
             except collector.CollectorUnavailable:
                 LOG.debug("Collector %r is unavailable, disabling", col)
+                cleanup_error = self._rollback_collector_start(col)
+                if cleanup_error is not None:
+                    self._collectors = collectors + collectors_to_start[index + 1 :]
+                    self._collectors_pending_cleanup.append(col)
+                    raise cleanup_error
             except Exception:
                 LOG.error("Failed to start collector %r, disabling.", col, exc_info=True)
+                cleanup_error = self._rollback_collector_start(col)
+                if cleanup_error is not None:
+                    self._collectors = collectors + collectors_to_start[index + 1 :]
+                    self._collectors_pending_cleanup.append(col)
+                    raise cleanup_error
+            except BaseException:
+                if self._rollback_collector_start(col) is not None:
+                    self._collectors_pending_cleanup.append(col)
+                self._collectors = collectors + collectors_to_start[index:]
+                raise
             else:
                 collectors.append(col)
         self._collectors = collectors
@@ -407,36 +551,126 @@ class _ProfilerInstance(service.Service):
         if self._scheduler is not None:
             self._scheduler.start()
 
-    def _stop_service(self, flush: bool = True, join: bool = True) -> None:
+    @staticmethod
+    def _rollback_collector_start(
+        col: Union[collector.Collector, memalloc.MemoryCollector],
+    ) -> Optional[BaseException]:
+        try:
+            col._rollback_start()
+        except BaseException as error:
+            LOG.debug("Failed to clean up partially started collector %r", col, exc_info=True)
+            return error
+        return None
+
+    def _cleanup_pending_collectors(self) -> list[BaseException]:
+        errors: list[BaseException] = []
+        collectors_pending_cleanup: list[collector.Collector | memalloc.MemoryCollector] = []
+        for col in self._collectors_pending_cleanup:
+            cleanup_error = self._rollback_collector_start(col)
+            if cleanup_error is not None:
+                collectors_pending_cleanup.append(col)
+                errors.append(cleanup_error)
+        self._collectors_pending_cleanup = collectors_pending_cleanup
+        return errors
+
+    def _rollback_start(self, flush: bool = True, join: bool = True) -> None:
+        with self._service_lock:
+            self._start_cleanup_pending = True
+            self._start_cleanup_generation = forksafe.get_generation()
+            try:
+                self._stop_service(flush=flush, join=join, _partial_start=True)
+            except BaseException:
+                raise
+            self.status = service.ServiceStatus.STOPPED
+            self._start_cleanup_pending = False
+
+    def _register_import_hooks(self) -> None:
+        for module, hook in self._collectors_on_import:
+            if (module, hook) not in self._collectors_on_import_registered:
+                self._collectors_on_import_registered.append((module, hook))
+                ModuleWatchdog.register_module_hook(module, hook)
+
+    def _unregister_import_hooks(self) -> list[BaseException]:
+        errors: list[BaseException] = []
+        hooks_pending_cleanup: list[tuple[str, Callable[[Any], None]]] = []
+        for module, hook in self._collectors_on_import_registered:
+            try:
+                ModuleWatchdog.unregister_module_hook(module, hook)
+            except BaseException as error:
+                errors.append(error)
+                hooks_pending_cleanup.append((module, hook))
+        self._collectors_on_import_registered = hooks_pending_cleanup
+        return errors
+
+    def _stop_service(self, flush: bool = True, join: bool = True, _partial_start: bool = False) -> None:
         """Stop the profiler.
 
         :param flush: Flush a last profile.
         """
         LOG.debug("Stopping profiler")
 
-        # Prevent doing more initialisation now that we are shutting down.
-        if self._collectors_on_import:
-            for module, hook in self._collectors_on_import:
-                ModuleWatchdog.unregister_module_hook(module, hook)
-            self._collectors_on_import = None
+        errors = self._unregister_import_hooks()
 
         if self._scheduler is not None:
-            self._scheduler.stop()
-            # Wait for the export to be over: export might need collectors (e.g., for snapshot) so we can't stop
-            # collectors before the possibly running flush is finished.
-            if join:
-                self._scheduler.join()
-            if flush:
+            scheduler_stopped = (
+                self.status == service.ServiceStatus.RUNNING and self._scheduler.status == service.ServiceStatus.STOPPED
+            )
+            if not scheduler_stopped:
+                try:
+                    if _partial_start:
+                        self._scheduler._rollback_start()
+                    else:
+                        self._scheduler.stop()
+                except BaseException as error:
+                    errors.append(error)
+                else:
+                    scheduler_stopped = True
+            if scheduler_stopped:
+                # Wait for the export to be over: export might need collectors (e.g., for snapshot) so we can't stop
+                # collectors before the possibly running flush is finished.
+                if join:
+                    try:
+                        self._scheduler.join()
+                    except BaseException as error:
+                        errors.append(error)
+                        scheduler_stopped = False
+            if not scheduler_stopped:
+                raise errors[0]
+            if flush and not self._stop_flush_attempted:
                 # Do not stop the collectors before flushing, they might be needed (snapshot)
-                self._scheduler.flush()
+                self._stop_flush_attempted = True
+                try:
+                    self._scheduler.flush()
+                except BaseException as error:
+                    errors.append(error)
 
+        errors.extend(self._cleanup_pending_collectors())
+
+        collectors_stopped: list[collector.Collector | memalloc.MemoryCollector] = []
         for col in reversed(self._collectors):
             try:
+                if (
+                    _partial_start
+                    and isinstance(col, collector.Collector)
+                    and col.status == service.ServiceStatus.STOPPED
+                ):
+                    collectors_stopped.append(col)
+                    continue
                 col.stop()
             except service.ServiceStatusError:
                 # It's possible some collector failed to start, ignore failure to stop
-                pass
+                collectors_stopped.append(col)
+            except BaseException as error:
+                errors.append(error)
+            else:
+                collectors_stopped.append(col)
 
         if join:
-            for col in reversed(self._collectors):
-                col.join()
+            for col in collectors_stopped:
+                try:
+                    col.join()
+                except BaseException as error:
+                    errors.append(error)
+
+        if errors:
+            raise errors[0]

--- a/ddtrace/profiling/scheduler.py
+++ b/ddtrace/profiling/scheduler.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 import ddtrace
 from ddtrace.internal import periodic
+from ddtrace.internal import service
+from ddtrace.internal import threads as internal_threads
 from ddtrace.internal.datadog.profiling import ddup
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings.profiling import config
@@ -37,6 +39,29 @@ class Scheduler(periodic.PeriodicService):
         super(Scheduler, self)._start_service()
         self._last_export = time.time_ns()
         LOG.debug("Scheduler started")
+
+    def _rollback_start(self) -> None:
+        with self._service_lock:
+            if self._worker is not None:
+                # AIDEV-NOTE: The fork lock makes cancellation and native-worker classification atomic with restart.
+                with internal_threads._forking_lock:
+                    if self._worker._cancel_deferred_start_unlocked():
+                        self._worker = None
+                    else:
+                        try:
+                            self._stop_service()
+                        except RuntimeError as error:
+                            if str(error) != "Thread not started":
+                                raise
+                            try:
+                                self._worker.join(0)
+                            except RuntimeError as join_error:
+                                if str(join_error) != "Periodic thread not started":
+                                    raise
+                                self._worker = None
+                            else:
+                                self._stop_service()
+            self.status = service.ServiceStatus.STOPPED
 
     def flush(self) -> None:
         """Flush events from recorder to exporters."""

--- a/ddtrace/profiling/scheduler.py
+++ b/ddtrace/profiling/scheduler.py
@@ -44,6 +44,8 @@ class Scheduler(periodic.PeriodicService):
         with self._service_lock:
             if self._worker is not None:
                 # AIDEV-NOTE: The fork lock makes cancellation and native-worker classification atomic with restart.
+                # See the AIDEV-NOTE on PeriodicThread._cancel_deferred_start_unlocked for why this
+                # calls the `_unlocked` variant directly instead of `_cancel_deferred_start()`.
                 with internal_threads._forking_lock:
                     if self._worker._cancel_deferred_start_unlocked():
                         self._worker = None
@@ -51,12 +53,12 @@ class Scheduler(periodic.PeriodicService):
                         try:
                             self._stop_service()
                         except RuntimeError as error:
-                            if str(error) != "Thread not started":
+                            if str(error) != internal_threads.THREAD_NOT_STARTED_ERROR:
                                 raise
                             try:
                                 self._worker.join(0)
                             except RuntimeError as join_error:
-                                if str(join_error) != "Periodic thread not started":
+                                if str(join_error) != internal_threads.PERIODIC_THREAD_NOT_STARTED_ERROR:
                                     raise
                                 self._worker = None
                             else:

--- a/releasenotes/notes/cleanup-failed-profiler-start-e1fc0980277bba91.yaml
+++ b/releasenotes/notes/cleanup-failed-profiler-start-e1fc0980277bba91.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    profiling: Fixes an issue where failed profiler initialization can leave profiling work active in the application process.

--- a/tests/internal/test_forksafe.py
+++ b/tests/internal/test_forksafe.py
@@ -233,6 +233,119 @@ def test_event_fork():
     assert exit_code == 12
 
 
+@pytest.mark.subprocess(timeout=15)
+def test_service_lock_is_reset_after_fork():
+    import os
+    import threading
+
+    from ddtrace.internal import service
+
+    class TestService(service.Service):
+        def _start_service(self):
+            pass
+
+        def _stop_service(self):
+            pass
+
+    test_service = TestService()
+    lock_acquired = threading.Event()
+    release_lock = threading.Event()
+
+    def hold_service_lock():
+        with test_service._service_lock:
+            lock_acquired.set()
+            release_lock.wait()
+
+    owner = threading.Thread(target=hold_service_lock)
+    owner.start()
+    assert lock_acquired.wait(1)
+
+    child = os.fork()
+    if child == 0:
+        acquired_in_child = test_service._service_lock.acquire(timeout=1)
+        os._exit(0 if acquired_in_child else 1)
+
+    release_lock.set()
+    owner.join(1)
+    assert not owner.is_alive()
+    _, status = os.waitpid(child, 0)
+    assert os.WIFEXITED(status)
+    assert os.WEXITSTATUS(status) == 0
+
+
+@pytest.mark.subprocess(timeout=15)
+def test_service_lock_held_by_forking_thread_unwinds_in_child():
+    import os
+    import threading
+
+    from ddtrace.internal import forksafe
+    from ddtrace.internal import service
+
+    class TestService(service.Service):
+        child_pid = None
+        start_count = 0
+
+        def _start_service(self):
+            self.start_count += 1
+            if self.start_count == 1:
+                self.child_pid = os.fork()
+
+        def _stop_service(self):
+            pass
+
+    test_service = TestService()
+    parent_pid = os.getpid()
+
+    def competing_acquire():
+        acquired = test_service._service_lock.acquire(blocking=False)
+        test_service.competing_thread_acquired_lock = acquired
+        if acquired:
+            test_service._service_lock.release()
+
+    def acquire_after_unwind():
+        acquired = test_service._service_lock.acquire(blocking=False)
+        test_service.post_unwind_thread_acquired_lock = acquired
+        if acquired:
+            test_service._service_lock.release()
+
+    @forksafe.register
+    def acquire_service_lock_in_child():
+        if os.getpid() == parent_pid:
+            return
+        acquired = test_service._service_lock.acquire(timeout=1)
+        if acquired:
+            test_service._service_lock.release()
+        test_service.child_hook_acquired_lock = acquired
+        test_service.competing_thread = threading.Thread(target=competing_acquire)
+        test_service.competing_thread.start()
+        test_service.competing_thread.join(1)
+
+    try:
+        test_service.start()
+    except RuntimeError:
+        if test_service.child_pid == 0:
+            os._exit(1)
+        raise
+
+    if test_service.child_pid == 0:
+        post_unwind_thread = threading.Thread(target=acquire_after_unwind)
+        post_unwind_thread.start()
+        post_unwind_thread.join(1)
+        child_ok = (
+            test_service.child_hook_acquired_lock
+            and not test_service.competing_thread.is_alive()
+            and not test_service.competing_thread_acquired_lock
+            and not post_unwind_thread.is_alive()
+            and test_service.post_unwind_thread_acquired_lock
+            and test_service.start_count == 1
+        )
+        os._exit(0 if child_ok else 1)
+
+    _, status = os.waitpid(test_service.child_pid, 0)
+    assert os.WIFEXITED(status)
+    assert os.WEXITSTATUS(status) == 0
+
+
 @pytest.mark.subprocess
 def test_double_fork():
     import os
@@ -372,7 +485,7 @@ def test_lock_pickle_roundtrip(serializer: ModuleType) -> None:
     data: bytes = serializer.dumps(lock)
     restored: threading.Lock = serializer.loads(data)
 
-    assert isinstance(restored, forksafe.ResetObject)
+    assert isinstance(restored, forksafe.ResetLock)
     assert restored.acquire(blocking=False) is True
     restored.release()
     assert restored in forksafe._resetable_objects

--- a/tests/internal/test_forksafe.py
+++ b/tests/internal/test_forksafe.py
@@ -346,6 +346,79 @@ def test_service_lock_held_by_forking_thread_unwinds_in_child():
     assert os.WEXITSTATUS(status) == 0
 
 
+@pytest.mark.subprocess(timeout=15)
+def test_reset_lock_raw_acquire_held_by_forking_thread_unwinds_in_child():
+    import os
+    import threading
+
+    from ddtrace.internal import forksafe
+
+    lock = forksafe.ResetLock()
+    lock.acquire()
+    child = os.fork()
+
+    if child == 0:
+        acquired_before_release = []
+        contender = threading.Thread(target=lambda: acquired_before_release.append(lock.acquire(blocking=False)))
+        contender.start()
+        contender.join(1)
+
+        lock.release()
+
+        acquired_after_release = []
+
+        def acquire_after_release():
+            acquired = lock.acquire(blocking=False)
+            acquired_after_release.append(acquired)
+            if acquired:
+                lock.release()
+
+        contender = threading.Thread(target=acquire_after_release)
+        contender.start()
+        contender.join(1)
+        child_ok = acquired_before_release == [False] and acquired_after_release == [True]
+        os._exit(0 if child_ok else 1)
+
+    lock.release()
+    _, status = os.waitpid(child, 0)
+    assert os.WIFEXITED(status)
+    assert os.WEXITSTATUS(status) == 0
+
+
+@pytest.mark.subprocess(timeout=15)
+def test_reset_lock_cross_thread_release_clears_fork_owner():
+    import os
+    import threading
+
+    from ddtrace.internal import forksafe
+
+    lock = forksafe.ResetLock()
+    lock.acquire()
+    releaser = threading.Thread(target=lock.release)
+    releaser.start()
+    releaser.join(1)
+    assert not releaser.is_alive()
+
+    child = os.fork()
+    if child == 0:
+        acquired = []
+
+        def acquire_in_child():
+            did_acquire = lock.acquire(blocking=False)
+            acquired.append(did_acquire)
+            if did_acquire:
+                lock.release()
+
+        contender = threading.Thread(target=acquire_in_child)
+        contender.start()
+        contender.join(1)
+        os._exit(0 if acquired == [True] else 1)
+
+    _, status = os.waitpid(child, 0)
+    assert os.WIFEXITED(status)
+    assert os.WEXITSTATUS(status) == 0
+
+
 @pytest.mark.subprocess
 def test_double_fork():
     import os
@@ -484,6 +557,21 @@ def test_lock_pickle_roundtrip(serializer: ModuleType) -> None:
 
     data: bytes = serializer.dumps(lock)
     restored: threading.Lock = serializer.loads(data)
+
+    assert isinstance(restored, forksafe.ResetObject)
+    assert not isinstance(restored, forksafe.ResetLock)
+    assert restored.acquire(blocking=False) is True
+    restored.release()
+    assert restored in forksafe._resetable_objects
+
+
+@pytest.mark.parametrize("serializer", [pickle, cloudpickle], ids=["pickle", "cloudpickle"])
+def test_reset_lock_pickle_roundtrip(serializer: ModuleType) -> None:
+    lock = forksafe.ResetLock()
+    lock.acquire()
+
+    data = serializer.dumps(lock)
+    restored = serializer.loads(data)
 
     assert isinstance(restored, forksafe.ResetLock)
     assert restored.acquire(blocking=False) is True

--- a/tests/internal/test_periodic.py
+++ b/tests/internal/test_periodic.py
@@ -4,6 +4,7 @@ import os
 import platform
 from threading import Barrier
 from threading import Event
+from threading import Lock
 from threading import Thread
 from time import monotonic
 from time import sleep
@@ -13,6 +14,131 @@ import pytest
 
 from ddtrace.internal import periodic
 from ddtrace.internal import service
+from ddtrace.internal import threads as internal_threads
+
+
+def test_before_fork_stops_cancelled_workers_without_restarting_them(monkeypatch):
+    events = []
+
+    class ForkWorker:
+        def __init__(self, name, restart_cancelled=False):
+            self.name = name
+            self._restart_cancelled = restart_cancelled
+
+        def _before_fork(self):
+            events.append(("stop", self))
+
+        def join(self):
+            events.append(("join", self))
+
+    active_worker = ForkWorker("active")
+    cancelled_worker = ForkWorker("cancelled", restart_cancelled=True)
+    deferred_restarts = set()
+    monkeypatch.setattr(internal_threads, "_forking", False)
+    monkeypatch.setattr(internal_threads, "periodic_threads", {1: active_worker, 2: cancelled_worker})
+    monkeypatch.setattr(internal_threads, "_threads_to_restart_after_fork", deferred_restarts)
+
+    internal_threads._before_fork()
+
+    assert {thread for operation, thread in events if operation == "stop"} == {active_worker, cancelled_worker}
+    assert {thread for operation, thread in events if operation == "join"} == {active_worker, cancelled_worker}
+    assert deferred_restarts == {active_worker}
+
+
+def test_before_fork_stop_snapshot_tolerates_concurrent_restart_cancellation(monkeypatch):
+    events = []
+    deferred_restarts = set()
+    stop_started = Event()
+    allow_stop = Event()
+
+    class ForkWorker:
+        _restart_cancelled = False
+
+        def __init__(self, name):
+            self.name = name
+
+        def _before_fork(self):
+            events.append(("stop", self))
+            stop_started.set()
+            assert allow_stop.wait(1)
+
+        def join(self):
+            events.append(("join", self))
+
+    active_worker = ForkWorker("active")
+    cancelled_worker = ForkWorker("cancelled")
+    workers = {active_worker, cancelled_worker}
+    monkeypatch.setattr(internal_threads, "_forking", False)
+    monkeypatch.setattr(internal_threads, "periodic_threads", dict(enumerate(workers)))
+    monkeypatch.setattr(internal_threads, "_threads_to_restart_after_fork", deferred_restarts)
+
+    errors = []
+
+    def prepare_for_fork():
+        try:
+            internal_threads._before_fork()
+        except BaseException as error:
+            errors.append(error)
+
+    fork_thread = Thread(target=prepare_for_fork)
+    fork_thread.start()
+    assert stop_started.wait(1)
+    with internal_threads._forking_lock:
+        cancelled_worker._restart_cancelled = True
+        deferred_restarts.discard(cancelled_worker)
+    allow_stop.set()
+    fork_thread.join(1)
+
+    assert not fork_thread.is_alive()
+    assert errors == []
+    assert {thread for operation, thread in events if operation == "stop"} == workers
+    assert {thread for operation, thread in events if operation == "join"} == workers
+    assert max(index for index, event in enumerate(events) if event[0] == "stop") < min(
+        index for index, event in enumerate(events) if event[0] == "join"
+    )
+    assert deferred_restarts == {active_worker}
+
+
+def test_after_fork_child_serializes_restarts_and_deferred_starts(monkeypatch):
+    fork_lock = Lock()
+    restarted = []
+
+    class DeferredThread:
+        name = "deferred thread"
+
+        def _after_fork(self, force=False):
+            assert force is False
+            assert fork_lock.locked()
+            restarted.append(self)
+
+        def start(self):
+            assert fork_lock.locked()
+
+    deferred_thread = DeferredThread()
+    deferred_starts = [deferred_thread.start]
+    deferred_restarts = {deferred_thread}
+    monkeypatch.setattr(internal_threads, "_forking", True)
+    monkeypatch.setattr(internal_threads, "_forking_lock", fork_lock)
+    monkeypatch.setattr(internal_threads, "_threads_to_start_after_fork", deferred_starts)
+    monkeypatch.setattr(internal_threads, "_threads_to_restart_after_fork", deferred_restarts)
+
+    internal_threads._after_fork_child()
+
+    assert not internal_threads._forking
+    assert deferred_starts == []
+    assert deferred_restarts == set()
+    assert restarted == [deferred_thread]
+
+
+def test_forking_lock_is_reset_before_child_hooks():
+    fork_lock = internal_threads._forking_lock
+    fork_lock.acquire()
+    try:
+        internal_threads.forksafe._reset_objects()
+        assert fork_lock.acquire(blocking=False)
+    finally:
+        if fork_lock.locked():
+            fork_lock.release()
 
 
 def test_periodic():

--- a/tests/profiling/collector/test_exception.py
+++ b/tests/profiling/collector/test_exception.py
@@ -10,6 +10,7 @@ from unittest import mock
 
 import pytest
 
+from ddtrace.internal import service
 from ddtrace.internal.datadog.profiling import ddup
 from ddtrace.profiling.collector import exception
 from ddtrace.trace import Tracer
@@ -158,6 +159,123 @@ def test_exception_config_defaults() -> None:
     assert profiling_config.exception.enabled is True
     assert profiling_config.exception.sampling_interval == 100
     assert profiling_config.exception.collect_message is False
+
+
+def test_exception_monitoring_setup_failure_releases_tool_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_set_events = sys.monitoring.set_events
+    failed = False
+
+    def fail_first_enable(tool_id: int, events: int) -> None:
+        nonlocal failed
+        if events == sys.monitoring.events.RAISE and not failed:
+            failed = True
+            raise RuntimeError("set events failed")
+        real_set_events(tool_id, events)
+
+    monkeypatch.setattr(sys.monitoring, "set_events", fail_first_enable)
+    first = exception.ExceptionCollector(sampling_interval=1)
+
+    with pytest.raises(RuntimeError, match="set events failed"):
+        first.start()
+
+    assert sys.monitoring.get_tool(4) is None
+
+    second = exception.ExceptionCollector(sampling_interval=1)
+    second.start()
+    try:
+        assert second.status == service.ServiceStatus.RUNNING
+        assert sys.monitoring.get_tool(4) == "dd-trace-exception-profiler"
+    finally:
+        second.stop()
+
+
+@pytest.mark.parametrize("setup_method", ["set_events", "register_callback"])
+def test_exception_monitoring_setup_cleanup_retries_free_tool_id(
+    monkeypatch: pytest.MonkeyPatch, setup_method: str
+) -> None:
+    real_setup = getattr(sys.monitoring, setup_method)
+    real_free_tool_id = sys.monitoring.free_tool_id
+    setup_failed = False
+    free_failed = False
+
+    def fail_first_setup(*args: object) -> object:
+        nonlocal setup_failed
+        if not setup_failed:
+            setup_failed = True
+            raise RuntimeError("monitoring setup failed")
+        return real_setup(*args)
+
+    def fail_first_free(tool_id: int) -> None:
+        nonlocal free_failed
+        if not free_failed:
+            free_failed = True
+            raise RuntimeError("free tool failed")
+        real_free_tool_id(tool_id)
+
+    monkeypatch.setattr(sys.monitoring, setup_method, fail_first_setup)
+    monkeypatch.setattr(sys.monitoring, "free_tool_id", fail_first_free)
+    first = exception.ExceptionCollector(sampling_interval=1)
+
+    with pytest.raises(RuntimeError, match="free tool failed"):
+        first.start()
+
+    assert sys.monitoring.get_tool(4) == "dd-trace-exception-profiler"
+    first._rollback_start()
+    assert sys.monitoring.get_tool(4) is None
+
+    second = exception.ExceptionCollector(sampling_interval=1)
+    second.start()
+    try:
+        assert second.status == service.ServiceStatus.RUNNING
+        assert sys.monitoring.get_tool(4) == "dd-trace-exception-profiler"
+    finally:
+        second.stop()
+
+
+def test_exception_monitoring_stop_retries_free_tool_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_free_tool_id = sys.monitoring.free_tool_id
+    free_failed = False
+
+    def fail_first_free(tool_id: int) -> None:
+        nonlocal free_failed
+        if not free_failed:
+            free_failed = True
+            raise RuntimeError("free tool failed")
+        real_free_tool_id(tool_id)
+
+    monkeypatch.setattr(sys.monitoring, "free_tool_id", fail_first_free)
+    collector = exception.ExceptionCollector(sampling_interval=1)
+    collector.start()
+
+    with pytest.raises(RuntimeError, match="free tool failed"):
+        collector.stop()
+
+    assert collector.status == service.ServiceStatus.RUNNING
+    assert sys.monitoring.get_tool(4) == "dd-trace-exception-profiler"
+
+    collector.stop()
+    assert collector.status == service.ServiceStatus.STOPPED
+    assert sys.monitoring.get_tool(4) is None
+
+
+def test_exception_sampler_setup_failure_does_not_claim_tool_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_urandom = os.urandom
+    monkeypatch.setattr(os, "urandom", mock.Mock(side_effect=RuntimeError("sampler setup failed")))
+    first = exception.ExceptionCollector(sampling_interval=1)
+
+    with pytest.raises(RuntimeError, match="sampler setup failed"):
+        first.start()
+
+    assert sys.monitoring.get_tool(4) is None
+
+    monkeypatch.setattr(os, "urandom", real_urandom)
+    second = exception.ExceptionCollector(sampling_interval=1)
+    second.start()
+    try:
+        assert second.status == service.ServiceStatus.RUNNING
+        assert sys.monitoring.get_tool(4) == "dd-trace-exception-profiler"
+    finally:
+        second.stop()
 
 
 def test_poisson_sampling_distribution() -> None:

--- a/tests/profiling/test_main.py
+++ b/tests/profiling/test_main.py
@@ -70,6 +70,7 @@ def test_call_script_pprof_output(tmp_path: Path) -> None:
 def test_fork(tmp_path: Path) -> None:
     filename = str(tmp_path / "pprof")
     env = os.environ.copy()
+    env["DD_APPSEC_ENABLED"] = "true"
     env["DD_PROFILING_OUTPUT_PPROF"] = filename
     env["DD_PROFILING_CAPTURE_PCT"] = "100"
     stdout, stderr, exitcode, pid = call_program(

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -7,11 +7,14 @@ from unittest import mock
 import pytest
 
 import ddtrace
+from ddtrace.internal import service
+from ddtrace.internal import threads as internal_threads
 from ddtrace.internal.compat import PYTHON_VERSION_INFO
 from ddtrace.profiling import collector
 from ddtrace.profiling import profiler
 from ddtrace.profiling import scheduler
 from ddtrace.profiling.collector import asyncio
+from ddtrace.profiling.collector import memalloc
 from ddtrace.profiling.collector import stack
 from ddtrace.profiling.collector import threading
 
@@ -40,6 +43,209 @@ def test_restart():
     p.stop(flush=False)
     p.start()
     p.stop(flush=False)
+
+
+def test_duplicate_start_does_not_stop_active_profiler():
+    p = profiler.Profiler()
+
+    with mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated") as product_activated:
+        p.start()
+        with pytest.raises(service.ServiceStatusError):
+            p.start()
+
+        assert p.status == service.ServiceStatus.RUNNING
+        assert profiler.Profiler._active_instance is p
+        product_activated.assert_called_once_with(profiler.TELEMETRY_APM_PRODUCT.PROFILER, True)
+        p.stop(flush=False)
+
+
+@pytest.mark.parametrize("failure_point", ["atexit", "telemetry", "signal"])
+def test_start_bookkeeping_failure_rolls_back_profiler(failure_point):
+    internal = mock.Mock(status=service.ServiceStatus.STOPPED)
+    internal.start.side_effect = lambda: setattr(internal, "status", service.ServiceStatus.RUNNING)
+    internal._rollback_start.side_effect = lambda **kwargs: setattr(internal, "status", service.ServiceStatus.STOPPED)
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.atexit.register") as register,
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister") as unregister,
+        mock.patch("ddtrace.profiling.profiler.atexit.register_on_exit_signal") as register_on_exit_signal,
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated") as product_activated,
+    ):
+        if failure_point == "atexit":
+            register.side_effect = RuntimeError("bookkeeping failed")
+        elif failure_point == "telemetry":
+            product_activated.side_effect = [RuntimeError("bookkeeping failed"), None]
+        else:
+            register_on_exit_signal.side_effect = RuntimeError("bookkeeping failed")
+
+        with pytest.raises(RuntimeError, match="bookkeeping failed"):
+            wrapped.start()
+
+    internal._rollback_start.assert_called_once_with(flush=False)
+    unregister.assert_called_once_with(wrapped.stop)
+    assert internal.status == service.ServiceStatus.STOPPED
+    assert profiler.Profiler._active_instance is None
+    if failure_point == "atexit":
+        product_activated.assert_not_called()
+    else:
+        product_activated.assert_has_calls(
+            [
+                mock.call(profiler.TELEMETRY_APM_PRODUCT.PROFILER, True),
+                mock.call(profiler.TELEMETRY_APM_PRODUCT.PROFILER, False),
+            ]
+        )
+
+
+def test_start_retries_cleanup_after_bookkeeping_rollback_fails():
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    test_scheduler = mock.Mock(status=service.ServiceStatus.STOPPED)
+    test_scheduler.start.side_effect = lambda: setattr(test_scheduler, "status", service.ServiceStatus.RUNNING)
+    rollback_attempts = 0
+
+    def rollback_scheduler():
+        nonlocal rollback_attempts
+        rollback_attempts += 1
+        if rollback_attempts == 1:
+            raise RuntimeError("cleanup failed")
+        test_scheduler.status = service.ServiceStatus.STOPPED
+
+    test_scheduler._rollback_start.side_effect = rollback_scheduler
+    test_scheduler.stop.side_effect = lambda: setattr(test_scheduler, "status", service.ServiceStatus.STOPPED)
+    internal._scheduler = test_scheduler
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+    activation_attempts = 0
+
+    def activate_profiler(_, active):
+        nonlocal activation_attempts
+        if active:
+            activation_attempts += 1
+            if activation_attempts == 1:
+                raise RuntimeError("bookkeeping failed")
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.atexit.register"),
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        mock.patch("ddtrace.profiling.profiler.atexit.register_on_exit_signal"),
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated", side_effect=activate_profiler),
+    ):
+        with pytest.raises(RuntimeError, match="bookkeeping failed"):
+            wrapped.start()
+
+        assert internal._start_cleanup_pending is True
+        assert internal.status == service.ServiceStatus.RUNNING
+        assert profiler.Profiler._active_instance is wrapped
+
+        wrapped.start()
+
+        assert rollback_attempts == 2
+        assert internal._start_cleanup_pending is False
+        assert internal.status == service.ServiceStatus.RUNNING
+        assert profiler.Profiler._active_instance is wrapped
+        wrapped.stop(flush=False)
+
+
+def test_stop_retries_pending_cleanup_when_profiler_is_stopped():
+    internal = mock.Mock(status=service.ServiceStatus.STOPPED, _start_cleanup_pending=True)
+    internal.stop.side_effect = service.ServiceStatusError(internal.__class__, internal.status)
+
+    def rollback_start(**kwargs):
+        internal._start_cleanup_pending = False
+
+    internal._rollback_start.side_effect = rollback_start
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+    profiler.Profiler._active_instance = wrapped
+    competing = object.__new__(profiler.Profiler)
+    competing._profiler = mock.Mock(status=service.ServiceStatus.STOPPED, _start_cleanup_pending=False)
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.atexit.register"),
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        mock.patch("ddtrace.profiling.profiler.atexit.register_on_exit_signal"),
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated"),
+    ):
+        wrapped.stop(flush=False)
+        competing.start()
+
+    internal._rollback_start.assert_called_once_with(flush=False)
+    competing._profiler.start.assert_called_once_with()
+    assert internal._start_cleanup_pending is False
+    assert profiler.Profiler._active_instance is competing
+
+
+def test_restart_failure_rolls_back_after_pending_cleanup_changes_status():
+    events = []
+
+    class RecordingCollector(collector.Collector):
+        def _start_service(self):
+            events.append("collector start")
+
+        def _stop_service(self):
+            events.append("collector stop")
+
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    recording_collector = RecordingCollector()
+    recording_collector.start()
+    events.clear()
+    internal._collectors = [recording_collector]
+    test_scheduler = mock.Mock(status=service.ServiceStatus.RUNNING)
+
+    def rollback_scheduler():
+        events.append("scheduler rollback")
+        test_scheduler.status = service.ServiceStatus.STOPPED
+
+    def fail_scheduler_start():
+        events.append("scheduler start")
+        raise RuntimeError("scheduler start failed")
+
+    test_scheduler._rollback_start.side_effect = rollback_scheduler
+    test_scheduler.start.side_effect = fail_scheduler_start
+    internal._scheduler = test_scheduler
+    internal.status = service.ServiceStatus.RUNNING
+    internal._start_cleanup_pending = True
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        pytest.raises(RuntimeError, match="scheduler start failed"),
+    ):
+        wrapped.start()
+
+    assert events == [
+        "scheduler rollback",
+        "collector stop",
+        "collector start",
+        "scheduler start",
+        "scheduler rollback",
+        "collector stop",
+    ]
+    assert internal.status == service.ServiceStatus.STOPPED
+    assert internal._start_cleanup_pending is False
+    assert profiler.Profiler._active_instance is None
 
 
 def test_multiple_stop():
@@ -139,7 +345,9 @@ def test_failed_start_collector(caplog, monkeypatch):
             return None
 
     p = TestProfiler()
-    err_collector = mock.MagicMock(wraps=ErrCollect())
+    err_collector = ErrCollect()
+    snapshot = mock.Mock(wraps=err_collector.snapshot)
+    monkeypatch.setattr(err_collector, "snapshot", snapshot)
     p._collectors = [err_collector]
     p.start()
 
@@ -151,10 +359,1310 @@ def test_failed_start_collector(caplog, monkeypatch):
     ]
     time.sleep(2)
     p.stop()
-    assert err_collector.snapshot.call_count == 0
+    assert snapshot.call_count == 0
     assert profiling_tuples(caplog.record_tuples) == [
         ("ddtrace.profiling.profiler", logging.ERROR, "Failed to start collector %r, disabling." % err_collector)
     ]
+
+
+def test_failed_start_collector_cleans_up_partial_resources():
+    class FailingCollector(collector.Collector):
+        def __init__(self):
+            super().__init__()
+            self.resource_active = False
+
+        def _start_service(self):
+            self.resource_active = True
+            raise RuntimeError("start failed")
+
+        def _stop_service(self):
+            self.resource_active = False
+
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    p = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    failed_collector = FailingCollector()
+    p._collectors = [failed_collector]
+    p._scheduler = None
+
+    p.start()
+
+    assert failed_collector.resource_active is False
+    assert failed_collector.status == service.ServiceStatus.STOPPED
+    assert p._collectors == []
+    p.stop(flush=False)
+
+
+def test_cancelled_collector_start_cleans_up_partial_resources():
+    class CancelledCollector(collector.Collector):
+        def __init__(self):
+            super().__init__()
+            self.resource_active = False
+            self.start_attempts = 0
+
+        def _start_service(self):
+            self.start_attempts += 1
+            self.resource_active = True
+            if self.start_attempts == 1:
+                raise KeyboardInterrupt
+
+        def _stop_service(self):
+            self.resource_active = False
+
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    cancelled_collector = CancelledCollector()
+    internal._collectors = [cancelled_collector]
+    internal._scheduler = mock.Mock()
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+
+    with pytest.raises(KeyboardInterrupt):
+        wrapped.start()
+
+    assert cancelled_collector.resource_active is False
+    assert cancelled_collector.status == service.ServiceStatus.STOPPED
+    internal._scheduler.start.assert_not_called()
+    assert profiler.Profiler._active_instance is None
+
+    internal._scheduler.start.side_effect = lambda: setattr(
+        internal._scheduler, "status", service.ServiceStatus.RUNNING
+    )
+    wrapped.start()
+
+    assert cancelled_collector.start_attempts == 2
+    assert cancelled_collector.resource_active is True
+    assert cancelled_collector.status == service.ServiceStatus.RUNNING
+    assert cancelled_collector in internal._collectors
+    wrapped.stop(flush=False)
+
+
+def test_failed_collector_cleanup_is_retried_by_profiler_rollback():
+    class RetryCleanupCollector(collector.Collector):
+        def __init__(self):
+            super().__init__()
+            self.resource_active = False
+            self.stop_attempts = 0
+
+        def _start_service(self):
+            self.resource_active = True
+            raise RuntimeError("start failed")
+
+        def _stop_service(self):
+            self.stop_attempts += 1
+            if self.stop_attempts == 1:
+                raise RuntimeError("cleanup failed")
+            self.resource_active = False
+
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    failed_collector = RetryCleanupCollector()
+    internal._collectors = [failed_collector]
+    internal._scheduler = None
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        wrapped.start()
+
+    assert failed_collector.stop_attempts == 2
+    assert failed_collector.resource_active is False
+    assert internal.status == service.ServiceStatus.STOPPED
+    assert profiler.Profiler._active_instance is None
+
+
+def test_failed_memory_collector_start_cleanup_is_retried_before_restart():
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    memory_collector = memalloc.MemoryCollector()
+    internal._collectors = [memory_collector]
+    test_scheduler = mock.Mock(status=service.ServiceStatus.STOPPED)
+    test_scheduler.start.side_effect = lambda: setattr(test_scheduler, "status", service.ServiceStatus.RUNNING)
+    test_scheduler.stop.side_effect = lambda: setattr(test_scheduler, "status", service.ServiceStatus.STOPPED)
+    internal._scheduler = test_scheduler
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+    native_memalloc = mock.Mock()
+    native_memalloc.start.side_effect = [RuntimeError("already started"), RuntimeError("start failed")]
+    native_memalloc.stop.side_effect = [None, RuntimeError("cleanup failed"), RuntimeError("cleanup failed"), None]
+
+    with (
+        mock.patch.object(memalloc, "_memalloc", native_memalloc),
+        mock.patch("ddtrace.profiling.profiler.atexit.register"),
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        mock.patch("ddtrace.profiling.profiler.atexit.register_on_exit_signal"),
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated"),
+    ):
+        with pytest.raises(RuntimeError, match="cleanup failed"):
+            wrapped.start()
+
+        assert internal._collectors_pending_cleanup == [memory_collector]
+        assert profiler.Profiler._active_instance is wrapped
+        test_scheduler.start.assert_not_called()
+
+        wrapped.start()
+        wrapped.stop(flush=False)
+
+    assert native_memalloc.stop.call_count == 4
+    assert internal._collectors_pending_cleanup == []
+    assert profiler.Profiler._active_instance is None
+
+
+def test_restart_drains_pending_collector_cleanup_before_starting_scheduler():
+    events = []
+
+    class RetryCleanupCollector(collector.Collector):
+        def __init__(self):
+            super().__init__()
+            self.resource_active = False
+            self.stop_attempts = 0
+
+        def _start_service(self):
+            events.append("collector start")
+            self.resource_active = True
+            raise RuntimeError("start failed")
+
+        def _stop_service(self):
+            self.stop_attempts += 1
+            events.append(f"collector cleanup {self.stop_attempts}")
+            if self.stop_attempts < 3:
+                raise RuntimeError("cleanup failed")
+            self.resource_active = False
+
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    failed_collector = RetryCleanupCollector()
+    internal._collectors = [failed_collector]
+    test_scheduler = mock.Mock(status=service.ServiceStatus.STOPPED)
+
+    def start_scheduler():
+        assert failed_collector.resource_active is False
+        events.append("scheduler start")
+        test_scheduler.status = service.ServiceStatus.RUNNING
+
+    test_scheduler.start.side_effect = start_scheduler
+    test_scheduler.stop.side_effect = lambda: setattr(test_scheduler, "status", service.ServiceStatus.STOPPED)
+    internal._scheduler = test_scheduler
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.atexit.register"),
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        mock.patch("ddtrace.profiling.profiler.atexit.register_on_exit_signal"),
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated"),
+    ):
+        with pytest.raises(RuntimeError, match="cleanup failed"):
+            wrapped.start()
+
+        assert failed_collector.stop_attempts == 2
+        assert failed_collector.resource_active is True
+        test_scheduler.start.assert_not_called()
+        assert profiler.Profiler._active_instance is wrapped
+
+        competing = object.__new__(profiler.Profiler)
+        competing._profiler = mock.Mock(status=service.ServiceStatus.STOPPED)
+        competing.start()
+        competing._profiler.start.assert_not_called()
+        assert profiler.Profiler._active_instance is wrapped
+
+        wrapped.start()
+        wrapped.stop(flush=False)
+
+    assert events == [
+        "collector start",
+        "collector cleanup 1",
+        "collector cleanup 2",
+        "collector cleanup 3",
+        "scheduler start",
+    ]
+    assert failed_collector.resource_active is False
+    assert internal._collectors_pending_cleanup == []
+
+
+def test_restart_finishes_failed_scheduler_cleanup_before_restarting_collectors():
+    events = []
+
+    class RecordingCollector(collector.Collector):
+        def _start_service(self):
+            events.append("collector start")
+
+        def _stop_service(self):
+            events.append("collector stop")
+
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    recording_collector = RecordingCollector()
+    internal._collectors = [recording_collector]
+    test_scheduler = mock.Mock(status=service.ServiceStatus.STOPPED)
+    scheduler_start_attempts = 0
+    scheduler_cleanup_attempts = 0
+
+    def start_scheduler():
+        nonlocal scheduler_start_attempts
+        scheduler_start_attempts += 1
+        events.append(f"scheduler start {scheduler_start_attempts}")
+        if scheduler_start_attempts == 1:
+            raise RuntimeError("scheduler start failed")
+        test_scheduler.status = service.ServiceStatus.RUNNING
+
+    def cleanup_scheduler():
+        nonlocal scheduler_cleanup_attempts
+        scheduler_cleanup_attempts += 1
+        events.append(f"scheduler cleanup {scheduler_cleanup_attempts}")
+        if scheduler_cleanup_attempts == 1:
+            raise RuntimeError("scheduler cleanup failed")
+        test_scheduler.status = service.ServiceStatus.STOPPED
+
+    test_scheduler.start.side_effect = start_scheduler
+    test_scheduler._rollback_start.side_effect = cleanup_scheduler
+    test_scheduler.stop.side_effect = lambda: setattr(test_scheduler, "status", service.ServiceStatus.STOPPED)
+    internal._scheduler = test_scheduler
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.atexit.register"),
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        mock.patch("ddtrace.profiling.profiler.atexit.register_on_exit_signal"),
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated"),
+    ):
+        with pytest.raises(RuntimeError, match="scheduler start failed"):
+            wrapped.start()
+
+        assert internal._start_cleanup_pending is True
+        assert recording_collector.status == service.ServiceStatus.RUNNING
+        assert profiler.Profiler._active_instance is wrapped
+
+        competing = object.__new__(profiler.Profiler)
+        competing._profiler = mock.Mock(status=service.ServiceStatus.STOPPED)
+        competing.start()
+        competing._profiler.start.assert_not_called()
+
+        wrapped.start()
+        wrapped.stop(flush=False)
+
+    assert events == [
+        "collector start",
+        "scheduler start 1",
+        "scheduler cleanup 1",
+        "scheduler cleanup 2",
+        "collector stop",
+        "collector start",
+        "scheduler start 2",
+        "collector stop",
+    ]
+    assert internal._start_cleanup_pending is False
+    assert profiler.Profiler._active_instance is None
+
+
+def test_restart_preserves_collectors_after_failed_collector():
+    events = []
+
+    class RecordingCollector(collector.Collector):
+        def __init__(self, name):
+            super().__init__()
+            self.name = name
+
+        def _start_service(self):
+            events.append(f"{self.name} start")
+
+        def _stop_service(self):
+            events.append(f"{self.name} stop")
+
+    class FailingCollector(collector.Collector):
+        def __init__(self):
+            super().__init__()
+            self.stop_attempts = 0
+
+        def _start_service(self):
+            events.append("failed start")
+            raise RuntimeError("start failed")
+
+        def _stop_service(self):
+            self.stop_attempts += 1
+            events.append(f"failed cleanup {self.stop_attempts}")
+            if self.stop_attempts == 1:
+                raise RuntimeError("cleanup failed")
+
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    first = RecordingCollector("first")
+    failed = FailingCollector()
+    third = RecordingCollector("third")
+    internal._collectors = [first, failed, third]
+    test_scheduler = mock.Mock(status=service.ServiceStatus.STOPPED)
+    test_scheduler.start.side_effect = lambda: setattr(test_scheduler, "status", service.ServiceStatus.RUNNING)
+    test_scheduler.stop.side_effect = lambda: setattr(test_scheduler, "status", service.ServiceStatus.STOPPED)
+    internal._scheduler = test_scheduler
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.atexit.register"),
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        mock.patch("ddtrace.profiling.profiler.atexit.register_on_exit_signal"),
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated"),
+    ):
+        with pytest.raises(RuntimeError, match="cleanup failed"):
+            wrapped.start()
+
+        wrapped.start()
+        wrapped.stop(flush=False)
+
+    assert events == [
+        "first start",
+        "failed start",
+        "failed cleanup 1",
+        "failed cleanup 2",
+        "first stop",
+        "first start",
+        "third start",
+        "third stop",
+        "first stop",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("module_name", "collector_module", "collector_name"),
+    [
+        ("threading", profiler.threading, "ThreadingLockCollector"),
+        ("torch", profiler.pytorch, "TorchProfilerCollector"),
+    ],
+)
+@pytest.mark.parametrize("failure_type", [RuntimeError, KeyboardInterrupt])
+def test_runtime_collector_start_failure_cleans_up_partial_resources(
+    monkeypatch, module_name, collector_module, collector_name, failure_type
+):
+    registered_hooks = []
+    instances = []
+
+    class WatchdogMock(object):
+        @staticmethod
+        def register_module_hook(module, hook):
+            registered_hooks.append((module, hook))
+
+        @staticmethod
+        def unregister_module_hook(module, hook):
+            pass
+
+    class FailingCollector(collector.Collector):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+            self.resource_active = False
+            instances.append(self)
+
+        def _start_service(self):
+            self.resource_active = True
+            raise failure_type("start failed")
+
+        def _stop_service(self):
+            self.resource_active = False
+
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    monkeypatch.setattr(profiler, "ModuleWatchdog", WatchdogMock)
+    monkeypatch.setattr(collector_module, collector_name, FailingCollector)
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=True,
+        _pytorch_collector_enabled=True,
+        _exception_profiling_enabled=False,
+    )
+    internal.status = service.ServiceStatus.RUNNING
+    hook = next(hook for module, hook in registered_hooks if module == module_name)
+
+    if issubclass(failure_type, Exception):
+        hook(None)
+    else:
+        with pytest.raises(failure_type):
+            hook(None)
+
+    assert instances[-1].resource_active is False
+    assert instances[-1].status == service.ServiceStatus.STOPPED
+    assert instances[-1] not in internal._collectors
+
+
+def test_runtime_collector_hook_does_not_duplicate_pending_cleanup(monkeypatch):
+    registered_hooks = []
+    instances = []
+
+    class WatchdogMock(object):
+        @staticmethod
+        def register_module_hook(module, hook):
+            registered_hooks.append((module, hook))
+
+        @staticmethod
+        def unregister_module_hook(module, hook):
+            pass
+
+    class FailingCollector(collector.Collector):
+        def __init__(self):
+            super().__init__()
+            instances.append(self)
+
+        def _start_service(self):
+            raise RuntimeError("start failed")
+
+        def _stop_service(self):
+            raise RuntimeError("cleanup failed")
+
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    monkeypatch.setattr(profiler, "ModuleWatchdog", WatchdogMock)
+    monkeypatch.setattr(profiler.pytorch, "TorchProfilerCollector", FailingCollector)
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=True,
+        _exception_profiling_enabled=False,
+    )
+    internal.status = service.ServiceStatus.RUNNING
+    hook = next(hook for module, hook in registered_hooks if module == "torch")
+
+    hook(None)
+    hook(None)
+
+    assert len(instances) == 1
+    assert internal._collectors_pending_cleanup == instances
+
+
+def test_failed_start_reregisters_deferred_collector_hooks(monkeypatch):
+    registered_hooks = []
+    unregistered_hooks = []
+
+    class WatchdogMock(object):
+        @staticmethod
+        def register_module_hook(module, hook):
+            registered_hooks.append((module, hook))
+
+        @staticmethod
+        def unregister_module_hook(module, hook):
+            unregistered_hooks.append((module, hook))
+
+    class TorchCollector(collector.Collector):
+        def _start_service(self):
+            pass
+
+        def _stop_service(self):
+            pass
+
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    monkeypatch.setattr(profiler, "ModuleWatchdog", WatchdogMock)
+    monkeypatch.setattr(profiler.pytorch, "TorchProfilerCollector", TorchCollector)
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=True,
+        _exception_profiling_enabled=False,
+    )
+    start_attempts = 0
+    test_scheduler = mock.Mock(status=service.ServiceStatus.STOPPED)
+
+    def start_scheduler():
+        nonlocal start_attempts
+        start_attempts += 1
+        if start_attempts == 1:
+            raise RuntimeError("scheduler start failed")
+        test_scheduler.status = service.ServiceStatus.RUNNING
+
+    test_scheduler.start.side_effect = start_scheduler
+    test_scheduler._rollback_start.side_effect = lambda: setattr(
+        test_scheduler, "status", service.ServiceStatus.STOPPED
+    )
+    test_scheduler.stop.side_effect = lambda: setattr(test_scheduler, "status", service.ServiceStatus.STOPPED)
+    internal._scheduler = test_scheduler
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.atexit.register"),
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        mock.patch("ddtrace.profiling.profiler.atexit.register_on_exit_signal"),
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated"),
+    ):
+        with pytest.raises(RuntimeError, match="scheduler start failed"):
+            wrapped.start()
+
+        assert registered_hooks == [("torch", registered_hooks[0][1])]
+        assert unregistered_hooks == registered_hooks
+
+        wrapped.start()
+        assert registered_hooks == [("torch", registered_hooks[0][1]), ("torch", registered_hooks[0][1])]
+        registered_hooks[-1][1](None)
+
+        assert any(type(col) is TorchCollector for col in internal._collectors)
+        wrapped.stop(flush=False)
+
+
+def test_failed_lock_collector_start_preserves_patch_target():
+    original_lock = profiler.threading.ThreadingLockCollector.MODULE.Lock
+
+    class FailingLockCollector(profiler.threading.ThreadingLockCollector):
+        def patch(self):
+            raise RuntimeError("patch failed")
+
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    internal._collectors = [FailingLockCollector()]
+    internal._scheduler = None
+
+    try:
+        internal.start()
+        installed_lock = profiler.threading.ThreadingLockCollector.MODULE.Lock
+    finally:
+        profiler.threading.ThreadingLockCollector.MODULE.Lock = original_lock
+
+    assert installed_lock is original_lock
+    internal.stop(flush=False)
+
+
+def test_failed_pytorch_collector_start_preserves_patch_target():
+    original_target = object()
+
+    class FailingMLCollector(profiler.pytorch.MLProfilerCollector):
+        PROFILED_TORCH_CLASS = object
+
+        def __init__(self):
+            super().__init__()
+            self.target = original_target
+
+        def _get_patch_target(self):
+            raise RuntimeError("patch failed")
+
+        def _set_patch_target(self, value):
+            self.target = value
+
+        def _start_service(self):
+            self.patch()
+
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    failed_collector = FailingMLCollector()
+    internal._collectors = [failed_collector]
+    internal._scheduler = None
+
+    internal.start()
+
+    assert failed_collector.target is original_target
+    internal.stop(flush=False)
+
+
+def test_partial_start_rollback_stops_components():
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    p = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    scheduler = mock.Mock(status=service.ServiceStatus.STOPPED)
+    started_collector = mock.Mock(status=service.ServiceStatus.RUNNING)
+    p._scheduler = scheduler
+    p._collectors = [started_collector]
+
+    p._rollback_start(flush=True)
+
+    scheduler._rollback_start.assert_called_once_with()
+    scheduler.stop.assert_not_called()
+    scheduler.join.assert_called_once_with()
+    scheduler.flush.assert_called_once_with()
+    started_collector.stop.assert_called_once_with()
+    started_collector.join.assert_called_once_with()
+
+
+def test_partial_start_rollback_finalizes_failed_stop():
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.atexit.register"),
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        mock.patch("ddtrace.profiling.profiler.atexit.register_on_exit_signal"),
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated") as product_activated,
+        mock.patch("ddtrace.profiling.profiler.ddup.upload"),
+    ):
+        wrapped.start()
+        assert internal.status == service.ServiceStatus.RUNNING
+        assert internal._scheduler.status == service.ServiceStatus.RUNNING
+
+        original_stop_service = internal._scheduler._stop_service
+        stop_attempts = 0
+
+        def fail_once(*args, **kwargs):
+            nonlocal stop_attempts
+            stop_attempts += 1
+            if stop_attempts == 1:
+                raise RuntimeError("stop failed")
+            return original_stop_service(*args, **kwargs)
+
+        with mock.patch.object(internal._scheduler, "_stop_service", side_effect=fail_once):
+            with pytest.raises(RuntimeError, match="stop failed"):
+                wrapped.stop()
+
+    assert internal.status == service.ServiceStatus.STOPPED
+    assert internal._scheduler.status == service.ServiceStatus.STOPPED
+    assert profiler.Profiler._active_instance is None
+    product_activated.assert_has_calls(
+        [
+            mock.call(profiler.TELEMETRY_APM_PRODUCT.PROFILER, True),
+            mock.call(profiler.TELEMETRY_APM_PRODUCT.PROFILER, False),
+        ]
+    )
+
+
+def test_stop_releases_ownership_after_failed_deferred_scheduler_start(monkeypatch):
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    internal._collectors = []
+    internal._scheduler = scheduler.Scheduler()
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+    deferred_starts = []
+    monkeypatch.setattr(internal_threads, "_forking", True)
+    monkeypatch.setattr(internal_threads, "_threads_to_start_after_fork", deferred_starts)
+
+    class FailedRestart:
+        name = "failed restart"
+
+        def start(self):
+            raise OSError("thread creation failed")
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.atexit.register"),
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        mock.patch("ddtrace.profiling.profiler.atexit.register_on_exit_signal"),
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated"),
+    ):
+        wrapped.start()
+        assert profiler.Profiler._active_instance is wrapped
+        assert deferred_starts
+
+        deferred_starts[:] = [FailedRestart().start]
+        internal_threads._after_fork_child()
+
+        with pytest.raises(RuntimeError, match="Thread not started"):
+            wrapped.stop(flush=False)
+
+    assert deferred_starts == []
+    assert internal._scheduler._worker is None
+    assert internal._scheduler.status == service.ServiceStatus.STOPPED
+    assert internal.status == service.ServiceStatus.STOPPED
+    assert profiler.Profiler._active_instance is None
+
+
+def test_stop_retry_skips_scheduler_that_already_stopped():
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    test_scheduler = mock.Mock(status=service.ServiceStatus.RUNNING)
+
+    def stop_scheduler():
+        if test_scheduler.status == service.ServiceStatus.STOPPED:
+            raise service.ServiceStatusError(type(test_scheduler), test_scheduler.status)
+        test_scheduler.status = service.ServiceStatus.STOPPED
+
+    test_scheduler.stop.side_effect = stop_scheduler
+    test_scheduler.join.side_effect = [RuntimeError("join failed"), RuntimeError("join failed")]
+    internal._scheduler = test_scheduler
+    internal._collectors = []
+    internal.status = service.ServiceStatus.RUNNING
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+    profiler.Profiler._active_instance = wrapped
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated") as product_activated,
+    ):
+        with pytest.raises(RuntimeError, match="join failed"):
+            wrapped.stop()
+
+        assert internal.status == service.ServiceStatus.RUNNING
+        assert profiler.Profiler._active_instance is wrapped
+        test_scheduler.join.side_effect = None
+        wrapped.stop()
+
+    assert test_scheduler.stop.call_count == 1
+    test_scheduler._rollback_start.assert_not_called()
+    assert internal.status == service.ServiceStatus.STOPPED
+    assert profiler.Profiler._active_instance is None
+    product_activated.assert_called_once_with(profiler.TELEMETRY_APM_PRODUCT.PROFILER, False)
+
+
+def test_signal_stop_recovers_failed_scheduler_transition():
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    test_scheduler = mock.Mock(status=service.ServiceStatus.RUNNING)
+    test_scheduler.stop.side_effect = RuntimeError("stop failed")
+    test_scheduler._rollback_start.side_effect = lambda: setattr(
+        test_scheduler, "status", service.ServiceStatus.STOPPED
+    )
+    internal._scheduler = test_scheduler
+    internal._collectors = []
+    internal.status = service.ServiceStatus.RUNNING
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+    profiler.Profiler._active_instance = wrapped
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated") as product_activated,
+    ):
+        wrapped._stop_on_signal()
+
+    test_scheduler._rollback_start.assert_called_once_with()
+    test_scheduler.join.assert_called_once_with()
+    test_scheduler.flush.assert_called_once_with()
+    assert internal.status == service.ServiceStatus.STOPPED
+    assert profiler.Profiler._active_instance is None
+    product_activated.assert_called_once_with(profiler.TELEMETRY_APM_PRODUCT.PROFILER, False)
+
+
+def test_constructor_failure_rolls_back_partial_instance(monkeypatch):
+    registered_hooks = []
+    unregistered_hooks = []
+    partial_instances = []
+
+    class WatchdogMock(object):
+        @staticmethod
+        def register_module_hook(module, hook):
+            registered_hooks.append((module, hook))
+
+        @staticmethod
+        def unregister_module_hook(module, hook):
+            unregistered_hooks.append((module, hook))
+
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+        def __post_init__(self):
+            super().__post_init__()
+            partial_instances.append(self)
+            raise RuntimeError("late constructor failure")
+
+    monkeypatch.setattr(profiler, "ModuleWatchdog", WatchdogMock)
+    with (
+        mock.patch.object(profiler.ddup, "upload") as upload,
+        pytest.raises(RuntimeError, match="late constructor failure"),
+    ):
+        TestProfiler(
+            _memory_collector_enabled=False,
+            _stack_collector_enabled=False,
+            _lock_collector_enabled=True,
+            _pytorch_collector_enabled=True,
+            _exception_profiling_enabled=False,
+        )
+
+    assert registered_hooks
+    assert unregistered_hooks == registered_hooks
+    assert partial_instances[0]._collectors_on_import_registered == []
+    upload.assert_not_called()
+
+
+def test_import_hook_registration_failure_unregisters_installed_hook(monkeypatch):
+    registered_hooks = []
+    unregistered_hooks = []
+
+    class WatchdogMock(object):
+        @staticmethod
+        def register_module_hook(module, hook):
+            registered_hooks.append((module, hook))
+            raise RuntimeError("hook callback failed")
+
+        @staticmethod
+        def unregister_module_hook(module, hook):
+            unregistered_hooks.append((module, hook))
+
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    monkeypatch.setattr(profiler, "ModuleWatchdog", WatchdogMock)
+
+    with pytest.raises(RuntimeError, match="hook callback failed"):
+        TestProfiler(
+            _memory_collector_enabled=False,
+            _stack_collector_enabled=False,
+            _lock_collector_enabled=False,
+            _pytorch_collector_enabled=True,
+            _exception_profiling_enabled=False,
+        )
+
+    assert len(registered_hooks) == 1
+    assert unregistered_hooks == registered_hooks
+
+
+def test_restart_replaces_import_hook_collector_after_pending_cleanup(monkeypatch):
+    instances = []
+
+    class RetryCleanupCollector(collector.Collector):
+        def __init__(self):
+            super().__init__()
+            self.stop_attempts = 0
+            instances.append(self)
+
+        def _start_service(self):
+            if self is instances[0]:
+                raise RuntimeError("start failed")
+
+        def _stop_service(self):
+            self.stop_attempts += 1
+            if self is instances[0] and self.stop_attempts < 3:
+                raise RuntimeError("cleanup failed")
+
+    class WatchdogMock(object):
+        @staticmethod
+        def register_module_hook(module, hook):
+            hook(None)
+
+        @staticmethod
+        def unregister_module_hook(module, hook):
+            return None
+
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    monkeypatch.setattr(profiler, "ModuleWatchdog", WatchdogMock)
+    monkeypatch.setattr(profiler.pytorch, "TorchProfilerCollector", RetryCleanupCollector)
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=True,
+        _exception_profiling_enabled=False,
+    )
+    test_scheduler = mock.Mock(status=service.ServiceStatus.STOPPED)
+    test_scheduler.start.side_effect = lambda: setattr(test_scheduler, "status", service.ServiceStatus.RUNNING)
+    test_scheduler.stop.side_effect = lambda: setattr(test_scheduler, "status", service.ServiceStatus.STOPPED)
+    internal._scheduler = test_scheduler
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.atexit.register"),
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        mock.patch("ddtrace.profiling.profiler.atexit.register_on_exit_signal"),
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated"),
+    ):
+        with pytest.raises(RuntimeError, match="cleanup failed"):
+            wrapped.start()
+
+        assert len(instances) == 1
+        assert internal._collectors_pending_cleanup == [instances[0]]
+
+        wrapped.start()
+
+        assert len(instances) == 2
+        assert instances[1].status == service.ServiceStatus.RUNNING
+        wrapped.stop(flush=False)
+
+    assert instances[0].stop_attempts == 3
+    assert internal._collectors_pending_cleanup == []
+
+
+@pytest.mark.parametrize("start_method", ["start", "_start_on_fork"])
+def test_failed_profiler_start_rolls_back_started_components(start_method):
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    started_collector = mock.Mock(status=service.ServiceStatus.STOPPED)
+    started_collector.start.side_effect = lambda: setattr(started_collector, "status", service.ServiceStatus.RUNNING)
+    started_collector.stop.side_effect = lambda: setattr(started_collector, "status", service.ServiceStatus.STOPPED)
+    failed_scheduler = mock.Mock(status=service.ServiceStatus.STOPPED)
+    failed_scheduler.start.side_effect = RuntimeError("scheduler start failed")
+    internal._collectors = [started_collector]
+    internal._scheduler = failed_scheduler
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.atexit.register"),
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        mock.patch("ddtrace.profiling.profiler.atexit.register_on_exit_signal"),
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated") as product_activated,
+        pytest.raises(RuntimeError, match="scheduler start failed"),
+    ):
+        getattr(wrapped, start_method)()
+
+    assert internal.status == service.ServiceStatus.STOPPED
+    assert started_collector.status == service.ServiceStatus.STOPPED
+    started_collector.stop.assert_called_once_with()
+    failed_scheduler._rollback_start.assert_called_once_with()
+    assert profiler.Profiler._active_instance is None
+    product_activated.assert_not_called()
+
+
+def test_failed_fork_start_reserves_profiler_until_cleanup_retry():
+    internal = mock.Mock(status=service.ServiceStatus.STOPPED)
+    internal.start.side_effect = RuntimeError("start failed")
+    internal._rollback_start.side_effect = [RuntimeError("cleanup failed"), None]
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+
+    with pytest.raises(RuntimeError, match="start failed"):
+        wrapped._start_on_fork()
+
+    assert profiler.Profiler._active_instance is wrapped
+
+    competing = object.__new__(profiler.Profiler)
+    competing._profiler = mock.Mock(status=service.ServiceStatus.STOPPED)
+    competing._start_on_fork()
+    competing._profiler.start.assert_not_called()
+    assert profiler.Profiler._active_instance is wrapped
+
+    with profiler.Profiler._active_lock:
+        wrapped._rollback_start_with_active_lock()
+
+    assert internal._rollback_start.call_count == 2
+    assert profiler.Profiler._active_instance is None
+
+
+def test_partial_start_rollback_preserves_collectors_until_scheduler_stops():
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    failed_scheduler = mock.Mock(status=service.ServiceStatus.STOPPED)
+    failed_scheduler._rollback_start.side_effect = RuntimeError("scheduler cleanup failed")
+    first_collector = mock.Mock()
+    first_collector.stop.side_effect = RuntimeError("collector cleanup failed")
+    second_collector = mock.Mock()
+    internal._scheduler = failed_scheduler
+    internal._collectors = [second_collector, first_collector]
+
+    with pytest.raises(RuntimeError, match="scheduler cleanup failed"):
+        internal._rollback_start(flush=True)
+
+    failed_scheduler.join.assert_not_called()
+    failed_scheduler.flush.assert_not_called()
+    first_collector.stop.assert_not_called()
+    second_collector.stop.assert_not_called()
+    first_collector.join.assert_not_called()
+    second_collector.join.assert_not_called()
+
+
+def test_stop_preserves_collectors_until_scheduler_stops():
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    test_scheduler = mock.Mock(status=service.ServiceStatus.RUNNING)
+    test_scheduler.stop.side_effect = RuntimeError("scheduler stop failed")
+    test_collector = mock.Mock()
+    internal._scheduler = test_scheduler
+    internal._collectors = [test_collector]
+    internal.status = service.ServiceStatus.RUNNING
+
+    with pytest.raises(RuntimeError, match="scheduler stop failed"):
+        internal._stop_service(flush=False)
+
+    test_collector.stop.assert_not_called()
+    test_collector.join.assert_not_called()
+
+    def stop_scheduler():
+        test_scheduler.status = service.ServiceStatus.STOPPED
+
+    test_scheduler.stop.side_effect = stop_scheduler
+    internal._stop_service(flush=False)
+
+    test_collector.stop.assert_called_once_with()
+    test_collector.join.assert_called_once_with()
+
+
+def test_stop_does_not_join_collector_whose_stop_failed():
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    failed_collector = mock.Mock()
+    failed_collector.stop.side_effect = RuntimeError("collector stop failed")
+    stopped_collector = mock.Mock()
+    internal._scheduler = None
+    internal._collectors = [stopped_collector, failed_collector]
+
+    with pytest.raises(RuntimeError, match="collector stop failed"):
+        internal._stop_service(flush=False)
+
+    failed_collector.join.assert_not_called()
+    stopped_collector.join.assert_called_once_with()
+
+    failed_collector.stop.side_effect = None
+    internal._stop_service(flush=False)
+
+    failed_collector.join.assert_called_once_with()
+
+
+def test_stop_retry_does_not_flush_twice_after_collector_failure():
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    events = []
+    test_scheduler = mock.Mock(status=service.ServiceStatus.RUNNING)
+
+    def stop_scheduler():
+        events.append("scheduler stop")
+        test_scheduler.status = service.ServiceStatus.STOPPED
+
+    test_scheduler.stop.side_effect = stop_scheduler
+    test_scheduler.flush.side_effect = lambda: events.append("flush")
+    test_collector = mock.Mock()
+    collector_stop_attempts = 0
+
+    def stop_collector():
+        nonlocal collector_stop_attempts
+        collector_stop_attempts += 1
+        if collector_stop_attempts == 1:
+            raise RuntimeError("collector stop failed")
+        events.append("collector stop")
+
+    test_collector.stop.side_effect = stop_collector
+    internal._scheduler = test_scheduler
+    internal._collectors = [test_collector]
+    internal.status = service.ServiceStatus.RUNNING
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+    profiler.Profiler._active_instance = wrapped
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated"),
+        pytest.raises(RuntimeError, match="collector stop failed"),
+    ):
+        wrapped.stop()
+
+    assert events == ["scheduler stop", "flush", "collector stop"]
+    test_scheduler.flush.assert_called_once_with()
+    assert test_collector.stop.call_count == 2
+    assert internal.status == service.ServiceStatus.STOPPED
+    assert profiler.Profiler._active_instance is None
+
+
+def test_stop_does_not_retry_flush_after_upload_may_have_succeeded():
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    class TestCollector(collector.Collector):
+        def _start_service(self):
+            pass
+
+        def _stop_service(self):
+            events.append("collector stop")
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    events = []
+    flush_error = RuntimeError("flush failed")
+    test_scheduler = mock.Mock(status=service.ServiceStatus.RUNNING)
+
+    def stop_scheduler():
+        events.append("scheduler stop")
+        test_scheduler.status = service.ServiceStatus.STOPPED
+
+    def flush_scheduler():
+        events.append("upload")
+        raise flush_error
+
+    test_scheduler.stop.side_effect = stop_scheduler
+    test_scheduler.flush.side_effect = flush_scheduler
+    test_collector = TestCollector()
+    test_collector.status = service.ServiceStatus.RUNNING
+    internal._scheduler = test_scheduler
+    internal._collectors = [test_collector]
+    internal.status = service.ServiceStatus.RUNNING
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+    profiler.Profiler._active_instance = wrapped
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated"),
+        pytest.raises(RuntimeError, match="flush failed") as raised,
+    ):
+        wrapped.stop()
+
+    assert raised.value is flush_error
+    assert events == ["scheduler stop", "upload", "collector stop"]
+    test_scheduler.flush.assert_called_once_with()
+    assert test_collector.status == service.ServiceStatus.STOPPED
+    assert internal.status == service.ServiceStatus.STOPPED
+    assert profiler.Profiler._active_instance is None
 
 
 def test_default_collectors():
@@ -171,6 +1679,54 @@ def test_default_collectors():
         assert any(isinstance(c, asyncio.AsyncioBoundedSemaphoreCollector) for c in p._profiler._collectors)
         assert any(isinstance(c, asyncio.AsyncioConditionCollector) for c in p._profiler._collectors)
     p.stop(flush=False)
+
+
+def test_stop_retries_failed_import_hook_cleanup(monkeypatch):
+    hook = mock.Mock()
+    unregister_attempts = 0
+
+    class WatchdogMock(object):
+        @staticmethod
+        def unregister_module_hook(module, registered_hook):
+            nonlocal unregister_attempts
+            unregister_attempts += 1
+            if unregister_attempts == 1:
+                raise RuntimeError("unregister failed")
+            assert module == "threading"
+            assert registered_hook is hook
+
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    monkeypatch.setattr(profiler, "ModuleWatchdog", WatchdogMock)
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    internal._collectors_on_import = [("threading", hook)]
+    internal._collectors_on_import_registered = [("threading", hook)]
+    internal._scheduler = None
+    internal.status = service.ServiceStatus.RUNNING
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+    profiler.Profiler._active_instance = wrapped
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated") as product_activated,
+        pytest.raises(RuntimeError, match="unregister failed"),
+    ):
+        wrapped.stop(flush=False)
+
+    assert unregister_attempts == 2
+    assert internal._collectors_on_import_registered == []
+    assert internal.status == service.ServiceStatus.STOPPED
+    assert profiler.Profiler._active_instance is None
+    product_activated.assert_called_once_with(profiler.TELEMETRY_APM_PRODUCT.PROFILER, False)
 
 
 def test_stop_unregisters_pytorch_hook_when_lock_collector_disabled(monkeypatch):
@@ -586,6 +2142,30 @@ def test_start_registers_sigterm_handler() -> None:
         p.stop(flush=False)
 
 
+def test_internal_start_can_skip_sigterm_handler() -> None:
+    from unittest import mock
+
+    from ddtrace.internal import atexit
+    from ddtrace.profiling import profiler
+
+    with mock.patch.object(atexit, "register_on_exit_signal") as mock_reg:
+        p = profiler.Profiler()
+        with profiler.Profiler._active_lock:
+            p._start_with_active_lock(register_on_exit_signal=False)
+        mock_reg.assert_not_called()
+        p.stop(flush=False)
+
+
+def test_signal_stop_skips_profiler_lifecycle_owned_by_current_thread() -> None:
+    p = object.__new__(profiler.Profiler)
+    p._profiler = mock.Mock()
+
+    with profiler.Profiler._active_lock:
+        p._stop_on_signal()
+
+    p._profiler.stop.assert_not_called()
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="SIGTERM not supported on Windows")
 @pytest.mark.subprocess(status=-15, out=lambda s: s.count("flushed") == 1, err=None)
 def test_profiler_flushes_on_sigterm() -> None:
@@ -676,6 +2256,84 @@ def test_profiler_singleton_after_fork():
         _, status = os.waitpid(pid, 0)
         assert os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0, f"Child exited with status {status}"
         p.stop(flush=False)
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="fork test only on linux")
+@pytest.mark.subprocess(timeout=15, err=None)
+def test_profiler_child_recovers_ownership_inherited_during_start_rollback():
+    import os
+    import threading
+    from unittest import mock
+
+    from ddtrace.internal import service
+    from ddtrace.profiling import profiler
+
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    parent_pid = os.getpid()
+    rollback_started = threading.Event()
+    finish_rollback = threading.Event()
+    failed_scheduler = mock.Mock(status=service.ServiceStatus.STOPPED)
+    failed_scheduler.start.side_effect = RuntimeError("start failed")
+
+    def rollback_scheduler():
+        if os.getpid() == parent_pid:
+            rollback_started.set()
+            finish_rollback.wait()
+        failed_scheduler.status = service.ServiceStatus.STOPPED
+
+    failed_scheduler._rollback_start.side_effect = rollback_scheduler
+    internal._scheduler = failed_scheduler
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+
+    competing_internal = mock.Mock(status=service.ServiceStatus.STOPPED, _start_cleanup_pending=False)
+    competing_internal.start.side_effect = lambda: setattr(competing_internal, "status", service.ServiceStatus.RUNNING)
+    competing = object.__new__(profiler.Profiler)
+    competing._profiler = competing_internal
+    start_error = []
+
+    def fail_start():
+        try:
+            wrapped.start()
+        except RuntimeError as error:
+            start_error.append(error)
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.uwsgi.check_uwsgi"),
+        mock.patch("ddtrace.profiling.profiler.atexit.register"),
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated"),
+    ):
+        starter = threading.Thread(target=fail_start)
+        starter.start()
+        assert rollback_started.wait(1)
+
+        child_pid = os.fork()
+        if child_pid == 0:
+            try:
+                competing.start()
+                child_started = profiler.Profiler._active_instance is competing
+            except BaseException:
+                child_started = False
+            os._exit(0 if child_started else 1)
+
+        finish_rollback.set()
+        starter.join(1)
+        assert not starter.is_alive()
+        assert len(start_error) == 1
+        _, status = os.waitpid(child_pid, 0)
+        assert os.WIFEXITED(status)
+        assert os.WEXITSTATUS(status) == 0
 
 
 @pytest.mark.skipif(not TESTING_GEVENT, reason="gevent is not available")

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -1250,6 +1250,44 @@ def test_signal_stop_recovers_failed_scheduler_transition():
     product_activated.assert_called_once_with(profiler.TELEMETRY_APM_PRODUCT.PROFILER, False)
 
 
+def test_signal_stop_preserves_ownership_when_cleanup_fails():
+    class TestProfiler(profiler._ProfilerInstance):
+        def _build_default_exporters(self, *args, **kwargs):
+            return None
+
+    internal = TestProfiler(
+        _memory_collector_enabled=False,
+        _stack_collector_enabled=False,
+        _lock_collector_enabled=False,
+        _pytorch_collector_enabled=False,
+        _exception_profiling_enabled=False,
+    )
+    test_scheduler = mock.Mock(status=service.ServiceStatus.RUNNING)
+    test_scheduler.stop.side_effect = RuntimeError("stop failed")
+    test_scheduler._rollback_start.side_effect = RuntimeError("cleanup failed")
+    internal._scheduler = test_scheduler
+    internal._collectors = []
+    internal.status = service.ServiceStatus.RUNNING
+    wrapped = object.__new__(profiler.Profiler)
+    wrapped._profiler = internal
+    profiler.Profiler._active_instance = wrapped
+
+    competing = object.__new__(profiler.Profiler)
+    competing._profiler = mock.Mock(status=service.ServiceStatus.STOPPED)
+
+    with (
+        mock.patch("ddtrace.profiling.profiler.atexit.unregister"),
+        mock.patch("ddtrace.profiling.profiler.telemetry_writer.product_activated") as product_activated,
+    ):
+        wrapped._stop_on_signal()
+        competing.start()
+
+    assert internal._start_cleanup_pending is True
+    assert profiler.Profiler._active_instance is wrapped
+    competing._profiler.start.assert_not_called()
+    product_activated.assert_not_called()
+
+
 def test_constructor_failure_rolls_back_partial_instance(monkeypatch):
     registered_hooks = []
     unregistered_hooks = []

--- a/tests/profiling/test_scheduler.py
+++ b/tests/profiling/test_scheduler.py
@@ -1,7 +1,12 @@
 # -*- encoding: utf-8 -*-
 import logging
+import threading
 from unittest import mock
 
+import pytest
+
+from ddtrace.internal import service
+from ddtrace.internal import threads as internal_threads
 from ddtrace.profiling import scheduler
 
 
@@ -38,6 +43,150 @@ def test_before_flush_failure(caplog):
     assert caplog.record_tuples == [
         (("ddtrace.profiling.scheduler", logging.ERROR, "Scheduler before_flush hook failed"))
     ]
+
+
+def test_partial_start_rollback_handles_unstarted_worker():
+    worker = mock.Mock()
+    worker.start.side_effect = OSError("thread creation failed")
+    worker.stop.side_effect = RuntimeError("Thread not started")
+    worker.join.side_effect = RuntimeError("Periodic thread not started")
+    worker._cancel_deferred_start_unlocked.return_value = False
+    s = scheduler.Scheduler()
+
+    with (
+        mock.patch("ddtrace.internal.periodic.PeriodicThread", return_value=worker),
+        pytest.raises(OSError, match="thread creation failed"),
+    ):
+        s.start()
+
+    s._rollback_start()
+    s._rollback_start()
+    s.join()
+
+    worker.stop.assert_called_once_with()
+    worker.join.assert_called_once_with(0)
+    assert s._worker is None
+    assert s.status == service.ServiceStatus.STOPPED
+
+
+def test_partial_start_rollback_retains_started_worker_until_joined():
+    worker = mock.Mock()
+    worker.stop.side_effect = [KeyboardInterrupt(), RuntimeError("Thread not started"), None]
+    worker._cancel_deferred_start_unlocked.return_value = False
+    s = scheduler.Scheduler()
+
+    with mock.patch("ddtrace.internal.periodic.PeriodicThread", return_value=worker):
+        s.start()
+
+    with pytest.raises(KeyboardInterrupt):
+        s._rollback_start()
+
+    s._rollback_start()
+    s.join()
+
+    assert s._worker is worker
+    assert worker.join.call_args_list == [mock.call(0), mock.call(None)]
+    assert s.status == service.ServiceStatus.STOPPED
+
+
+def test_partial_start_rollback_stops_worker_created_during_cleanup():
+    worker = mock.Mock()
+    worker.stop.side_effect = [RuntimeError("Thread not started"), None]
+    worker._cancel_deferred_start_unlocked.return_value = False
+    s = scheduler.Scheduler()
+
+    with mock.patch("ddtrace.internal.periodic.PeriodicThread", return_value=worker):
+        s.start()
+
+    s._rollback_start()
+    s.join()
+
+    assert worker.stop.call_count == 2
+    assert worker.join.call_args_list == [mock.call(0), mock.call(None)]
+    assert s._worker is worker
+    assert s.status == service.ServiceStatus.STOPPED
+
+
+def test_partial_start_rollback_serializes_with_fork_restart(monkeypatch):
+    fork_lock = threading.Lock()
+    monkeypatch.setattr(internal_threads, "_forking_lock", fork_lock)
+    worker = mock.Mock()
+
+    def cancel_deferred_start():
+        assert fork_lock.locked()
+        return False
+
+    def stop():
+        assert fork_lock.locked()
+        raise RuntimeError("Thread not started")
+
+    def join(timeout):
+        assert timeout == 0
+        assert fork_lock.locked()
+        raise RuntimeError("Periodic thread not started")
+
+    worker._cancel_deferred_start_unlocked.side_effect = cancel_deferred_start
+    worker.stop.side_effect = stop
+    worker.join.side_effect = join
+    s = scheduler.Scheduler()
+    s._worker = worker
+
+    s._rollback_start()
+
+    assert s._worker is None
+    assert s.status == service.ServiceStatus.STOPPED
+
+
+def test_partial_start_rollback_clears_failed_deferred_worker(monkeypatch):
+    deferred_starts = []
+    monkeypatch.setattr(internal_threads, "_forking", True)
+    monkeypatch.setattr(internal_threads, "_threads_to_start_after_fork", deferred_starts)
+    s = scheduler.Scheduler()
+
+    s.start()
+    worker = s._worker
+    assert deferred_starts
+
+    class FailedRestart:
+        name = "failed restart"
+
+        def start(self):
+            raise OSError("thread creation failed")
+
+    deferred_starts[:] = [FailedRestart().start]
+    internal_threads._after_fork_child()
+    s._rollback_start()
+    s.join()
+
+    assert deferred_starts == []
+    assert s._worker is None
+    assert worker is not None
+    assert worker not in internal_threads.periodic_threads.values()
+    assert s.status == service.ServiceStatus.STOPPED
+
+
+def test_partial_start_rollback_cancels_deferred_worker(monkeypatch):
+    deferred_starts = []
+    deferred_restarts = set()
+    monkeypatch.setattr(internal_threads, "_forking", True)
+    monkeypatch.setattr(internal_threads, "_threads_to_start_after_fork", deferred_starts)
+    monkeypatch.setattr(internal_threads, "_threads_to_restart_after_fork", deferred_restarts)
+    s = scheduler.Scheduler()
+
+    s.start()
+    worker = s._worker
+    assert deferred_starts
+    assert worker is not None
+    deferred_restarts.add(worker)
+
+    s._rollback_start()
+    internal_threads._after_fork_child()
+
+    assert deferred_starts == []
+    assert deferred_restarts == set()
+    assert s._worker is None
+    assert worker not in internal_threads.periodic_threads.values()
+    assert s.status == service.ServiceStatus.STOPPED
 
 
 @mock.patch("ddtrace.profiling.scheduler.Scheduler.periodic")

--- a/tests/profiling/test_uwsgi.py
+++ b/tests/profiling/test_uwsgi.py
@@ -102,6 +102,31 @@ def test_uwsgi_postfork_start_sets_active_instance(monkeypatch: pytest.MonkeyPat
     p.stop(flush=False)  # type: ignore[unreachable]
 
 
+def test_duplicate_uwsgi_postfork_callbacks_do_not_restart_profiler(monkeypatch: pytest.MonkeyPatch) -> None:
+    postfork_callbacks = []
+
+    def _register_postfork(callback, atexit=None):
+        postfork_callbacks.append(callback)
+        raise profiler.uwsgi.uWSGIMasterProcess()
+
+    monkeypatch.setattr(profiler.uwsgi, "check_uwsgi", _register_postfork)  # type: ignore[attr-defined]
+
+    p = profiler.Profiler()
+    p.start()
+    p.start()
+
+    assert len(postfork_callbacks) == 2
+    try:
+        postfork_callbacks[0]()
+        postfork_callbacks[1]()
+
+        assert profiler.Profiler._active_instance is p
+        assert p.status == profiler.service.ServiceStatus.RUNNING
+    finally:
+        if p.status == profiler.service.ServiceStatus.RUNNING:
+            p.stop(flush=False)
+
+
 def test_uwsgi_worker_blocks_second_profiler_start(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
## Description

[Before/after lifecycle report (Chonk)](https://chonk.us1.prod.dog/v2/get/chonk-uploads-prod/brian.marks/5a1e2dca-0abb-4b55-bde3-a02da0fb4b0d) _(AppGate required)_

This fixes profiler cleanup when start or stop fails. Startup now reserves process-global ownership before components start and treats collectors, the scheduler, import hooks, signal and atexit handlers, and telemetry activation as one transaction. Rollback preserves the original startup error, and unfinished cleanup remains available for a later `start()` or `stop()` retry.

Scheduler cleanup finishes before collectors are stopped or restarted. Collectors are joined only after they stop, the final flush is attempted at most once, and failed native memalloc, import-hook, collector, scheduler, and Python exception-monitoring cleanup is retried before another profiling session starts. If cleanup remains incomplete, another profiler cannot adopt shared native resources.

Fork handling now serializes periodic-thread restart cancellation with child restarts. Service lifecycle locks replace the inherited primitive after fork. When the forking thread held the lock, the fresh child lock remains logically held until the inherited lifecycle context unwinds: same-thread child hooks can re-enter it, while new child threads remain excluded. A child that inherits profiler ownership during rollback finishes cleanup from the earlier fork generation before starting a replacement. Duplicate starts and duplicate uWSGI post-fork callbacks leave the running profiler unchanged.

## Testing

- `scripts/run-tests --venv 9710280 -- -s` (427 passed, 35 skipped, 2 xfailed)
- `scripts/run-tests --venv 1cdebe0 -- -s` before the final test-only assertion hardening (782 passed, 22 skipped, 1 xfailed)
- Exact-head internal reruns (781 passed, 22 skipped, 1 xfailed; the remaining Symbol DB fork-upload test received a local test-agent 404 and passed immediately in isolation)
- Focused reset-lock tests for vanished-thread reset, same-thread child-hook re-entry, child-thread exclusion before unwind, fresh-thread acquisition after unwind, and pickle/cloudpickle round trips (4 passed)
- Focused inherited-rollback ownership test (passed)
- Focused Python 3.12+ exception-monitoring cleanup tests (3 passed)
- Real-fork profiler test with tracing and AppSec enabled (passed)
- `scripts/lint checks`
- `scripts/check-releasenotes`
- Circular-import analysis: 8 existing cycles, 0 added
- `scripts/run-benchmarks --list ddtrace/profiling/collector/_exception.pyx` found no matching benchmark suite

## Risks

This changes profiler start, stop, fork, and failure-cleanup paths, and changes the lifecycle lock shared by internal `Service` subclasses from a regular lock to a fork-resettable lock. Failure-injection tests cover collectors, schedulers, deferred starts, native monitoring state, import hooks, signal shutdown, duplicate starts, process ownership, final-flush failures, and forked-child lock recovery.

## Additional Notes

The Cython change only adjusts Python exception-monitoring setup and cleanup order. It does not change Cython signatures, GIL boundaries, allocator hooks, FFI, ABI, linking, build layout, or platform conditionals.

This is the second PR in a two-PR split. The remote-config POC will be stacked on this PR.
