### PR TITLE
feat(llmobs): support evaluator sampling percentage

### DIFF
--- a/ddtrace/llmobs/_evaluators/llm_judge.py
+++ b/ddtrace/llmobs/_evaluators/llm_judge.py
@@ -710,6 +710,7 @@ class LLMJudge(BaseEvaluator):
         ml_app: str,
         eval_name: Optional[str] = None,
         variable_mapping: Optional[dict[str, str]] = None,
+        sampling_percentage: Optional[float] = None,
     ) -> dict[str, Any]:
         if not isinstance(ml_app, str) or not ml_app.strip():
             raise ValueError("ml_app must be a non-empty string")
@@ -762,6 +763,12 @@ class LLMJudge(BaseEvaluator):
             "model_provider": integration_provider,
             "byop_config": byop_config,
         }
+        if sampling_percentage is not None:
+            if isinstance(sampling_percentage, bool) or not isinstance(sampling_percentage, (int, float)):
+                raise TypeError("sampling_percentage must be a number")
+            if not 0 < sampling_percentage <= 100:
+                raise ValueError("sampling_percentage must be greater than 0 and at most 100")
+            app_payload["sampling_percentage"] = float(sampling_percentage)
         model_name = self._model.strip() if isinstance(self._model, str) else ""
         if model_name:
             app_payload["model_name"] = model_name

--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -357,6 +357,7 @@ class BaseEvaluator(ABC):
         ml_app: str,
         eval_name: Optional[str] = None,
         variable_mapping: Optional[dict[str, str]] = None,
+        sampling_percentage: Optional[float] = None,
     ) -> dict[str, Any]:
         raise NotImplementedError("This evaluator does not support publishing.")
 

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -1138,6 +1138,7 @@ class LLMObs(Service):
         eval_name: Optional[str] = None,
         variable_mapping: Optional[dict[str, str]] = None,
         agent_service: Optional[str] = None,
+        sampling_percentage: Optional[float] = None,
     ) -> dict[str, str]:
         """
         Publish a custom evaluator configuration.
@@ -1147,6 +1148,8 @@ class LLMObs(Service):
         :param str eval_name: The name to use for the published evaluator. Defaults to the evaluator name.
         :param dict variable_mapping: A mapping from evaluator variables to span fields.
         :param str agent_service: The agent service for this evaluator. Required if ``ml_app`` is not provided.
+        :param float sampling_percentage: The percentage of matching spans to evaluate. Must be greater than 0 and
+                                          at most 100. If omitted, Datadog applies its default sampling percentage.
         :returns: A dictionary containing the evaluator configuration UI URL.
         """
         if not cls._instance or not cls._instance.enabled:
@@ -1157,7 +1160,10 @@ class LLMObs(Service):
             raise ValueError("`agent_service` must be provided as a non-empty string.")
         ml_app = resolved_agent_service.strip()
         evaluation_payload = evaluator._build_publish_payload(
-            ml_app=ml_app, eval_name=eval_name, variable_mapping=variable_mapping
+            ml_app=ml_app,
+            eval_name=eval_name,
+            variable_mapping=variable_mapping,
+            sampling_percentage=sampling_percentage,
         )
 
         cls._instance._dne_client.publish_custom_evaluator(evaluation_payload)

--- a/releasenotes/notes/llmobs-publish-evaluator-sampling-percentage.yaml
+++ b/releasenotes/notes/llmobs-publish-evaluator-sampling-percentage.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    LLM Observability: Adds the optional ``sampling_percentage`` argument to
+    ``LLMObs.publish_evaluator()`` to configure the percentage of matching spans evaluated by a published evaluator.

--- a/tests/llmobs/test_llm_judge.py
+++ b/tests/llmobs/test_llm_judge.py
@@ -330,6 +330,63 @@ class TestLLMJudgePublish:
         payload = mock_publish.call_args.args[0]
         assert payload["applications"][0]["application_name"] == "test-agent-service"
 
+    @pytest.mark.parametrize("sampling_percentage", [0.1, 10, 100.0])
+    def test_publish_sends_sampling_percentage(self, sampling_percentage, monkeypatch, llmobs):
+        mock_publish = self._mock_publish_backend(monkeypatch, llmobs)
+        judge = LLMJudge(
+            client=lambda *args, **kwargs: "",
+            provider="openai",
+            user_prompt="Evaluate: {{output_data}}",
+            structured_output=BooleanStructuredOutput("Correctness", pass_when=True),
+            name="quality_eval",
+        )
+
+        llmobs.publish_evaluator(
+            judge,
+            agent_service="test-agent-service",
+            sampling_percentage=sampling_percentage,
+        )
+
+        app_payload = mock_publish.call_args.args[0]["applications"][0]
+        assert app_payload["sampling_percentage"] == float(sampling_percentage)
+        assert app_payload["enabled"] is False
+
+    def test_publish_omits_sampling_percentage_by_default(self, monkeypatch, llmobs):
+        mock_publish = self._mock_publish_backend(monkeypatch, llmobs)
+        judge = LLMJudge(
+            client=lambda *args, **kwargs: "",
+            provider="openai",
+            user_prompt="Evaluate: {{output_data}}",
+            structured_output=BooleanStructuredOutput("Correctness", pass_when=True),
+            name="quality_eval",
+        )
+
+        llmobs.publish_evaluator(judge, agent_service="test-agent-service")
+
+        app_payload = mock_publish.call_args.args[0]["applications"][0]
+        assert "sampling_percentage" not in app_payload
+
+    @pytest.mark.parametrize("sampling_percentage", [True, "10", 0, -1, 100.1])
+    def test_publish_rejects_invalid_sampling_percentage(self, sampling_percentage, monkeypatch, llmobs):
+        mock_publish = self._mock_publish_backend(monkeypatch, llmobs)
+        judge = LLMJudge(
+            client=lambda *args, **kwargs: "",
+            provider="openai",
+            user_prompt="Evaluate: {{output_data}}",
+            structured_output=BooleanStructuredOutput("Correctness", pass_when=True),
+            name="quality_eval",
+        )
+
+        expected_error = TypeError if isinstance(sampling_percentage, (bool, str)) else ValueError
+        with pytest.raises(expected_error, match="sampling_percentage"):
+            llmobs.publish_evaluator(
+                judge,
+                agent_service="test-agent-service",
+                sampling_percentage=sampling_percentage,
+            )
+
+        mock_publish.assert_not_called()
+
     def test_publish_score_output_includes_threshold_assessment_criteria(self, monkeypatch, llmobs):
         mock_publish = self._mock_publish_backend(monkeypatch, llmobs)
 


### PR DESCRIPTION
## What changed

- Add an optional `sampling_percentage` argument to `LLMObs.publish_evaluator()`.
- Include the percentage in the managed evaluator application payload when supplied.
- Validate that values are numeric, greater than 0, and at most 100.
- Preserve the existing Datadog default when the argument is omitted.
- Add unit coverage and a release note.

## Why

Datadog's custom evaluator configuration supports a per-application `sampling_percentage`, but `ddtrace` does not currently expose it when publishing an evaluator. Callers therefore cannot configure managed evaluator sampling at publish time without bypassing the SDK.

## Impact

Users can now configure the percentage of matching spans evaluated by each published managed evaluator:

```python
LLMObs.publish_evaluator(
    evaluator,
    agent_service="my-agent-service",
    sampling_percentage=10,
)
```

The evaluator remains disabled/draft after publication, preserving the existing behavior.

## Validation

- `scripts/lint fmt -- ddtrace/llmobs/_llmobs.py ddtrace/llmobs/_experiment.py ddtrace/llmobs/_evaluators/llm_judge.py tests/llmobs/test_llm_judge.py`
- Targeted `TestLLMJudgePublish`: 30 passed.
- Full `tests/llmobs` run: 1,217 passed, 3 skipped, with one unrelated timing-sensitive failure in `test_evaluator_runner_periodic_enqueues_eval_metric`.
- Manually published a Morpheus evaluator to Datadog using `sampling_percentage=10.0`; Datadog accepted the configuration (`1 published, 0 failed`).