### PR TITLE
test(crashtracker): accept SIGBUS in runtime stack test

### DIFF
--- a/tests/crashtracker/test_crashtracker.py
+++ b/tests/crashtracker/test_crashtracker.py
@@ -497,7 +497,8 @@ def test_crashtracker_runtime_stacktrace_required(run_python_code_in_subprocess)
         # Check for expected exit condition
         assert not stdout
         assert not stderr
-        assert exitcode == -11
+        # ctypes.string_at(0) can produce SIGBUS (-7) instead of SIGSEGV (-11).
+        assert exitcode in (-11, -7), f"Expected crash signal, got {exitcode}"
 
         # Check for crash ping
         _ping = utils.get_crash_ping(client, service=service)


### PR DESCRIPTION
## Description

`ctypes.string_at(0)` can terminate with SIGBUS instead of SIGSEGV on some Linux configurations. Accept both crash signals in `test_crashtracker_runtime_stacktrace_required`, matching the existing handling in the adjacent no-stack test.

## Testing

- `scripts/lint fmt -- tests/crashtracker/test_crashtracker.py`
- `scripts/lint checks`
- `scripts/run-tests --venv 5ea1f55 -- -- tests/crashtracker/test_crashtracker.py::test_crashtracker_runtime_stacktrace_required`

## Risks

None. This only relaxes the expected process signal while preserving the crash report assertions.

## Additional Notes

No release note is needed because this is a test-only change.
