### PR TITLE
test(profiling): unflake Gunicorn request

### DIFF
--- a/tests/profiling/test_gunicorn.py
+++ b/tests/profiling/test_gunicorn.py
@@ -107,7 +107,7 @@ def _test_gunicorn(
 
     debug_print("Making request to gunicorn server")
     try:
-        # AIDEV-NOTE: The response intentionally waits for a CPU-heavy profiling workload. Synchronize on its
+        # The response intentionally waits for a CPU-heavy profiling workload. Synchronize on its
         # completion instead of imposing a wall-clock deadline that fails on slower CI workers.
         with urllib.request.urlopen("http://127.0.0.1:7644") as f:
             status_code = f.getcode()

--- a/tests/profiling/test_gunicorn.py
+++ b/tests/profiling/test_gunicorn.py
@@ -107,7 +107,9 @@ def _test_gunicorn(
 
     debug_print("Making request to gunicorn server")
     try:
-        with urllib.request.urlopen("http://127.0.0.1:7644", timeout=5) as f:
+        # AIDEV-NOTE: The response intentionally waits for a CPU-heavy profiling workload. Synchronize on its
+        # completion instead of imposing a wall-clock deadline that fails on slower CI workers.
+        with urllib.request.urlopen("http://127.0.0.1:7644") as f:
             status_code = f.getcode()
             assert status_code == 200, status_code
             response = f.read().decode()


### PR DESCRIPTION
<!-- dd-meta {"pullId":"6471a7b6-4abe-45dd-a0a0-d1a90a950f03","source":"chat","resourceId":"b5d1c57e-a0bd-45e9-9a47-3b7db5968bc5","workflowId":"445a73a4-c8fb-4e14-b717-c4e8c5183108","codeChangeId":"445a73a4-c8fb-4e14-b717-c4e8c5183108","sourceType":"chat"} -->
## Description

### Motivation

`test_gunicorn[py3.10]` intermittently fails when the intentional CPU-heavy profiling workload takes longer than the HTTP client's five-second response deadline. Datadog records failure rates of 0.53% on main and 1.58% on release branches, with three failed main-branch pipelines.

### Changes

- Wait for the profiling workload response to complete instead of enforcing a wall-clock socket deadline.
- Document why this request must remain completion-based so the timing flake is not reintroduced.

## Testing

- `scripts/ddtest scripts/lint fmt -- tests/profiling/test_gunicorn.py` — passed.
- `scripts/ddtest scripts/lint style -- tests/profiling/test_gunicorn.py` — passed.
- `git diff --check` — passed.
- `scripts/run-tests --venv 95f8b96 -- -- tests/profiling/test_gunicorn.py::test_gunicorn` — blocked before test execution because the sandbox proxy returned HTTP 502 while downloading `libddwaf` for the test environment.

## Risks

The request no longer has its own five-second deadline; a genuinely stuck worker is bounded by the surrounding CI job timeout. Production code is unchanged.

## Additional Notes

This test-only change does not require a release note. Add the `changelog/no-changelog` label.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b5d1c57e-a0bd-45e9-9a47-3b7db5968bc5)

Comment @datadog to request changes