### PR TITLE
chore(crashtracking): don't emit crash in extra config test

### DIFF
--- a/tests/internal/service_name/test_extra_services_names.py
+++ b/tests/internal/service_name/test_extra_services_names.py
@@ -28,20 +28,30 @@ for i in range(10):
             if service_name in set(ddtrace.config._extra_services_queue.peekall()):
                 break
         else:
-            msg = f"extra service name '{service_name}' not emitted by child"
-            raise RuntimeError(msg)
-        sys.exit(0)
+            sys.stderr.write(f"extra service name '{service_name}' not emitted by child\\n")
+            os._exit(1)
+        os._exit(0)
     else:
         # Parent process
         children.append(pid)
 
+failed = []
 for pid in children:
-    os.waitpid(pid, 0)
+    _, status = os.waitpid(pid, 0)
+    if status != 0:
+        failed.append(pid)
+if failed:
+    sys.stderr.write(f"child processes failed: {failed}\\n")
+    sys.exit(1)
 
 extra_services = ddtrace.config._get_extra_services()
 extra_services.discard("sqlite")  # coverage
-assert len(extra_services) == 10, extra_services
-assert all(re.match(r"extra_service_\\d+", service) for service in extra_services), extra_services
+if len(extra_services) != 10:
+    sys.stderr.write(f"expected 10 extra services, got {len(extra_services)}: {extra_services}\\n")
+    sys.exit(1)
+if not all(re.match(r"extra_service_\\d+", service) for service in extra_services):
+    sys.stderr.write(f"unexpected extra service names: {extra_services}\\n")
+    sys.exit(1)
 """
 
     env = os.environ.copy()


### PR DESCRIPTION
## Description

The forked child process in `test_config_extra_service_names_fork` was sending [live crash reports](https://app.datadoghq.com/logs?query=is_crash%3Atrue%20source%3Apython%20%40error.kind%3A%22Error%20UnhandledException%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZ_HvSyUoOMDIQAAABhBWl9IdlN5VUFBQzRKUnFEdU5uSzBRQWEAAAAkMDE5ZmM3YzMtZmIzZC00NmRlLTlmM2UtYTQ2NWY2NTQ3NmRhAAZ0CA&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1785160492000&to_ts=1785765292000&live=false)

When a child raises `RuntimeError`, crashtracking (with `ddtrace.auto`) catches it as an unhandled exception and reports a crash. The fix is to avoid raising an exception and instead print the error and exit with a non-zero code and assert of exit code and stderr

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
