### PR TITLE
test(profiling): deflake concurrent faulthandler enable test

### DIFF
--- a/tests/profiling/test_faulthandler.py
+++ b/tests/profiling/test_faulthandler.py
@@ -369,7 +369,9 @@ def test_uninstall_not_called_on_pause_timeout() -> None:
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Signal handling not supported on Windows")
 @pytest.mark.subprocess(
-    env={"_DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED": "0", "_DD_PROFILING_STACK_FAST_COPY": "1"}, err=None
+    env={"_DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED": "0", "_DD_PROFILING_STACK_FAST_COPY": "1"},
+    err=None,
+    timeout=30,
 )
 def test_faulthandler_enable_concurrent_threads() -> None:
     """Calling faulthandler.enable from two threads simultaneously must not deadlock or crash.
@@ -398,9 +400,8 @@ def test_faulthandler_enable_concurrent_threads() -> None:
 
         def _enable() -> None:
             try:
-                barrier.wait(timeout=5)
-                for _ in range(20):
-                    faulthandler.enable()
+                barrier.wait()
+                faulthandler.enable()
             except BaseException as exc:
                 errors.append(exc)
 
@@ -408,10 +409,8 @@ def test_faulthandler_enable_concurrent_threads() -> None:
         for t in threads:
             t.start()
         for t in threads:
-            t.join(timeout=10)
+            t.join()
 
-        still_alive = [t for t in threads if t.is_alive()]
-        assert not still_alive, f"{len(still_alive)} thread(s) deadlocked"
         assert not errors, f"Thread errors: {errors}"
         assert faulthandler.is_enabled()
         time.sleep(0.05)


### PR DESCRIPTION
## Description

Fixes `test_faulthandler_enable_concurrent_threads` intermittently reporting a slow worker as deadlocked.

The test now performs one concurrent `faulthandler.enable()` call per worker, which is sufficient to exercise lock contention without adding 80 serialized sampler pause and resume cycles. A single 30-second subprocess timeout detects actual deadlocks instead of separate barrier and thread timing deadlines.

## Testing

- `scripts/run-tests --venv 9710280 -- -- -q -k test_faulthandler_enable_concurrent_threads`
- `DD_TEST_CPUS=0.1 DD_TEST_MEMORY=1g scripts/run-tests --venv 9710280 -- -s -- -q -k test_faulthandler_enable_concurrent_threads`
- `scripts/lint checks`

## Risks

None. This is a test-only change.

## Additional Notes

No release note is needed for a test-only change.
