### PR TITLE
feat(internal): enable sys.monitoring multiplexer on Python 3.12+

### DIFF
--- a/ddtrace/internal/README.md
+++ b/ddtrace/internal/README.md
@@ -385,10 +385,18 @@ monitoring.unregister(code, handler)
 
 ### Local vs. Global Events
 
-All events multiplexed here (`PY_START`, `PY_RETURN`, `PY_UNWIND`, `LINE`) are
-enabled **locally**, per code object, via `set_local_events()` — never
-globally. This keeps monitoring overhead confined to the code objects that
-actually have handlers registered.
+`PY_START`, `PY_RETURN`, and `LINE` are always enabled **locally**, per code
+object, via `set_local_events()`.
+
+`PY_UNWIND` depends on the Python version:
+
+- **3.15+:** local per code object (same as the other events).
+- **3.12–3.14:** global-only via `set_events()`; the multiplexer filters
+  dispatch to registered code objects and never returns `DISABLE` for
+  unregistered frames (which would permanently silence global unwind).
+
+This keeps monitoring overhead confined to code objects that actually have
+handlers registered.
 
 ### `DISABLE` and `refresh()`
 

--- a/ddtrace/internal/monitoring.py
+++ b/ddtrace/internal/monitoring.py
@@ -25,10 +25,10 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.threads import Lock
 
 
-if sys.version_info < (3, 15):
-    raise ImportError("ddtrace.internal.monitoring requires Python 3.15+")
+if sys.version_info < (3, 12):
+    raise ImportError("ddtrace.internal.monitoring requires Python 3.12+")
 
-# mypy's configured python_version is below 3.15, so it considers everything
+# mypy's configured python_version is below 3.12, so it considers everything
 # past the guard above unreachable; that's expected here since the module
 # raises ImportError before this point on unsupported versions.
 log = get_logger(__name__)  # type: ignore[unreachable]
@@ -36,9 +36,18 @@ log = get_logger(__name__)  # type: ignore[unreachable]
 _E = sys.monitoring.events
 _DISABLE = sys.monitoring.DISABLE
 
-# On Python 3.15+, PY_UNWIND is a per-code "other" event and can be enabled via
-# set_local_events alongside PY_START/PY_RETURN/LINE.
-_LOCAL_EVENTS = _E.PY_START | _E.PY_RETURN | _E.LINE | _E.PY_UNWIND
+# sys.monitoring distinguishes "local" events (set_local_events per code object)
+# from global-only events (set_events). PY_UNWIND was global-only on 3.12–3.14;
+# from 3.15 it can be enabled per code object (CPython gh-142186).
+if sys.version_info >= (3, 15):
+    _LOCAL_EVENTS = _E.PY_START | _E.PY_RETURN | _E.LINE | _E.PY_UNWIND
+    _GLOBAL_EVENTS = 0
+else:
+    _LOCAL_EVENTS = _E.PY_START | _E.PY_RETURN | _E.LINE
+    _GLOBAL_EVENTS = _E.PY_UNWIND
+
+# Global-only events currently enabled via sys.monitoring.set_events (3.12–3.14).
+_active_global_events: int = 0
 
 _MULTIPLEXER_TOOL_NAME = "ddtrace"
 # sys.monitoring exposes six tool IDs (0–5). 0/1/2/5 are conventionally reserved
@@ -90,6 +99,11 @@ class _IdentityWeakKeyDictionary:
         if key_id not in self._data:
             raise KeyError(key)
         del self._data[key_id]
+
+    def iter_values(self) -> Any:
+        for ref, value in self._data.values():
+            if ref() is not None:
+                yield value
 
 
 _registry: _IdentityWeakKeyDictionary = _IdentityWeakKeyDictionary()
@@ -242,7 +256,11 @@ def _on_py_return(code: CodeType, instruction_offset: int, retval: object) -> Op
 def _on_py_unwind(code: CodeType, instruction_offset: int, exception: BaseException) -> Optional[object]:
     handlers: Optional[_CodeHandlers] = _registry.get(code)
     if not handlers or not handlers.snapshot:
-        return _DISABLE
+        # On 3.12–3.14 PY_UNWIND is global: returning DISABLE for unregistered code
+        # would permanently silence unwind at that site for all tools.
+        if sys.version_info >= (3, 15):
+            return _DISABLE
+        return None
     for e in handlers.snapshot:
         if e.events & _E.PY_UNWIND:
             try:
@@ -275,6 +293,20 @@ def _on_py_line(code: CodeType, line_number: int) -> Optional[object]:
 
 def _set_local_events(tool_id: int, code: CodeType, events: int) -> None:
     sys.monitoring.set_local_events(tool_id, code, events)
+
+
+def _recompute_global_events() -> None:
+    """Re-derive the set of global-only events from the current registry."""
+    global _active_global_events
+    if _tool_id is None or not _GLOBAL_EVENTS:
+        return
+    needed: int = 0
+    for handlers in _registry.iter_values():
+        needed |= _events_for(handlers)
+    needed &= _GLOBAL_EVENTS
+    if needed != _active_global_events:
+        _active_global_events = needed
+        sys.monitoring.set_events(_tool_id, needed)
 
 
 def _rearm_local_events(tool_id: int, code: CodeType, events: int) -> None:
@@ -314,6 +346,8 @@ def register(code: CodeType, handler: MonitoringEventHandler) -> None:
             _rearm_local_events(tool_id, code, local_events)
         else:
             _set_local_events(tool_id, code, local_events)
+        if _GLOBAL_EVENTS:
+            _recompute_global_events()
 
 
 def refresh(code: CodeType) -> None:
@@ -345,3 +379,5 @@ def unregister(code: CodeType, handler: MonitoringEventHandler) -> None:
         else:
             assert _tool_id is not None  # nosec
             _set_local_events(_tool_id, code, _events_for(handlers) & _LOCAL_EVENTS)
+        if _GLOBAL_EVENTS:
+            _recompute_global_events()

--- a/tests/internal/test_monitoring.py
+++ b/tests/internal/test_monitoring.py
@@ -1,7 +1,7 @@
 """Tests for ddtrace.internal.monitoring, the multiplexed sys.monitoring layer.
 
-On Python 3.15+, PY_UNWIND is a per-code event and is enabled via
-``set_local_events`` together with PY_START/PY_RETURN/LINE.
+On Python 3.15+, PY_UNWIND is a per-code event enabled via set_local_events.
+On Python 3.12–3.14, PY_UNWIND is global-only and filtered in the callback.
 """
 
 import sys
@@ -16,13 +16,17 @@ from typing import cast
 import pytest
 
 
-# The module only imports on 3.15+ (it raises ImportError below that). On older
+# The module only imports on 3.12+ (it raises ImportError below that). On older
 # interpreters importorskip skips the whole module at collection time. Under a
 # type checker we import it directly so member/base-class references resolve.
 if TYPE_CHECKING:
     from ddtrace.internal import monitoring
 else:
     monitoring = pytest.importorskip("ddtrace.internal.monitoring")
+
+
+PY_312_OR_ABOVE = sys.version_info >= (3, 12)
+PY_315_OR_ABOVE = sys.version_info >= (3, 15)
 
 
 class _MonitoringEvents(Protocol):
@@ -33,7 +37,7 @@ class _MonitoringEvents(Protocol):
 
 
 # `_E = sys.monitoring.events` has an indeterminate type when mypy analyzes the
-# source module under a pre-3.15 Python version.
+# source module under a pre-3.12 Python version.
 _E: _MonitoringEvents = cast(_MonitoringEvents, monitoring._E)  # type: ignore[has-type]
 _DISABLE: object = cast(object, monitoring._DISABLE)  # type: ignore[has-type]
 _sys_monitoring: Any = getattr(sys, "monitoring", None)
@@ -95,7 +99,7 @@ def registered() -> Iterator[
 def test_register_unwind_handler_does_not_raise(
     registered: Callable[[CodeType, monitoring.MonitoringEventHandler], monitoring.MonitoringEventHandler],
 ) -> None:
-    """Registering a PY_UNWIND-only handler enables the per-code unwind event."""
+    """Registering a PY_UNWIND-only handler enables the unwind event."""
 
     def boom() -> None:
         raise ValueError("boom")
@@ -103,6 +107,7 @@ def test_register_unwind_handler_does_not_raise(
     registered(boom.__code__, UnwindHandler())
 
 
+@pytest.mark.skipif(not PY_315_OR_ABOVE, reason="PY_UNWIND is local-only on Python 3.15+")
 def test_unwind_enabled_locally(
     registered: Callable[[CodeType, monitoring.MonitoringEventHandler], monitoring.MonitoringEventHandler],
 ) -> None:
@@ -123,14 +128,53 @@ def test_unwind_enabled_locally(
     assert not (global_events & _E.PY_UNWIND), "PY_UNWIND must not be enabled globally"
 
 
+@pytest.mark.skipif(
+    PY_315_OR_ABOVE,
+    reason="On 3.12–3.14 PY_UNWIND is global; unregistered unwind must not return DISABLE",
+)
+def test_unwind_enabled_globally_on_pre_315(
+    registered: Callable[[CodeType, monitoring.MonitoringEventHandler], monitoring.MonitoringEventHandler],
+) -> None:
+    """PY_UNWIND is enabled globally on Python 3.12–3.14 when a handler needs it."""
+
+    def boom() -> None:
+        raise ValueError("boom")
+
+    registered(boom.__code__, UnwindHandler())
+
+    tool_id: int | None = monitoring._tool_id
+    assert tool_id is not None
+
+    local_events: int = _sys_monitoring.get_local_events(tool_id, boom.__code__)
+    global_events: int = _sys_monitoring.get_events(tool_id)
+
+    assert not (local_events & _E.PY_UNWIND), "PY_UNWIND must not be a local event before 3.15"
+    assert global_events & _E.PY_UNWIND, "PY_UNWIND must be enabled globally"
+
+
+@pytest.mark.skipif(not PY_315_OR_ABOVE, reason="DISABLE-for-unregistered applies only when PY_UNWIND is local")
 def test_on_py_unwind_disables_unregistered_code() -> None:
-    """The unwind callback returns DISABLE when no handler is registered."""
+    """The unwind callback returns DISABLE when no handler is registered (3.15+)."""
 
     def unrelated() -> None:
         pass
 
     result: object | None = monitoring._on_py_unwind(unrelated.__code__, 0, ValueError("x"))
     assert result is _DISABLE
+
+
+@pytest.mark.skipif(
+    PY_315_OR_ABOVE,
+    reason="On 3.12–3.14 global PY_UNWIND must not DISABLE unregistered code",
+)
+def test_on_py_unwind_does_not_disable_unregistered_code_pre_315() -> None:
+    """Global PY_UNWIND must return None for unregistered code on 3.12–3.14."""
+
+    def unrelated() -> None:
+        pass
+
+    result: object | None = monitoring._on_py_unwind(unrelated.__code__, 0, ValueError("x"))
+    assert result is None
 
 
 def test_unwind_callback_fires_on_exception(
@@ -151,6 +195,7 @@ def test_unwind_callback_fires_on_exception(
     )
 
 
+@pytest.mark.skipif(not PY_315_OR_ABOVE, reason="local PY_UNWIND clearing applies on 3.15+")
 def test_unregister_clears_local_unwind() -> None:
     """Unregistering the last unwind handler clears the per-code PY_UNWIND event."""
 
@@ -171,10 +216,34 @@ def test_unregister_clears_local_unwind() -> None:
     )
 
 
+@pytest.mark.skipif(
+    PY_315_OR_ABOVE,
+    reason="global PY_UNWIND clearing applies on 3.12–3.14",
+)
+def test_unregister_clears_global_unwind_pre_315() -> None:
+    """Unregistering the last unwind handler clears global PY_UNWIND on 3.12–3.14."""
+
+    def boom() -> None:
+        raise ValueError("boom")
+
+    handler: UnwindHandler = UnwindHandler()
+    monitoring.register(boom.__code__, handler)
+
+    tool_id: int | None = monitoring._tool_id
+    assert tool_id is not None
+    assert _sys_monitoring.get_events(tool_id) & _E.PY_UNWIND
+
+    monitoring.unregister(boom.__code__, handler)
+
+    assert not (_sys_monitoring.get_events(tool_id) & _E.PY_UNWIND), (
+        "global PY_UNWIND should be disabled once no handlers need it"
+    )
+
+
 def test_mixed_local_events(
     registered: Callable[[CodeType, monitoring.MonitoringEventHandler], monitoring.MonitoringEventHandler],
 ) -> None:
-    """A handler overriding both PY_START and PY_UNWIND gets each as local events."""
+    """A handler overriding both PY_START and PY_UNWIND gets each event enabled."""
 
     def fn() -> None:
         raise ValueError("mixed")
@@ -185,9 +254,14 @@ def test_mixed_local_events(
     assert tool_id is not None
 
     local_events: int = _sys_monitoring.get_local_events(tool_id, fn.__code__)
+    global_events: int = _sys_monitoring.get_events(tool_id)
     assert local_events & _E.PY_START, "PY_START must be a local event"
-    assert local_events & _E.PY_UNWIND, "PY_UNWIND must be a local event on 3.15+"
-    assert not (_sys_monitoring.get_events(tool_id) & _E.PY_UNWIND), "PY_UNWIND must not be global"
+    if PY_315_OR_ABOVE:
+        assert local_events & _E.PY_UNWIND, "PY_UNWIND must be a local event on 3.15+"
+        assert not (global_events & _E.PY_UNWIND), "PY_UNWIND must not be global on 3.15+"
+    else:
+        assert not (local_events & _E.PY_UNWIND), "PY_UNWIND must not be local before 3.15"
+        assert global_events & _E.PY_UNWIND, "PY_UNWIND must be global on 3.12–3.14"
 
     with pytest.raises(ValueError):
         fn()


### PR DESCRIPTION
Restore global PY_UNWIND on 3.12–3.14 while keeping per-code local PY_UNWIND on 3.15+, so internal subsystems can share one tool ID without permanently silencing global unwind for unregistered code.

## Description

<!-- Provide an overview of the change and motivation for the change.
     Implementation detail and rationale belong here, not in the release note -
     release notes are customer-facing (see docs/releasenotes.rst). -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
