### PR TITLE
ci(sca): fix flaky SCA extended heartbeat test

### DIFF
--- a/tests/appsec/integrations/flask_tests/test_sca_flask_testagent.py
+++ b/tests/appsec/integrations/flask_tests/test_sca_flask_testagent.py
@@ -478,9 +478,9 @@ class TestSCAFlaskExtendedHeartbeat:
             _, flask_client, pid = context
             response = flask_client.get("/", headers={"X-Datadog-Test-Session-Token": iast_test_token})
             assert response.status_code == 200
-            # Wait for at least one extended-heartbeat tick — bounded poll
-            # avoids racing slow-CI startup against a fixed sleep window.
-            events = _wait_for_extended_heartbeat_events(iast_test_token, min_count=1, timeout=20.0)
+            # Wait for a heartbeat tick whose snapshot includes the dependency
+            # deltas emitted after the request.
+            _, events = _wait_for_extended_snapshot_covers_delta(iast_test_token, timeout=20.0)
 
         assert len(events) > 0, "No app-extended-heartbeat events found"
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"6827440f-12a9-4dae-bbf6-89264441a0a8","source":"chat","resourceId":"2c6f0491-915c-46b4-bb2d-9d732a271d5d","workflowId":"98866a48-038d-41a1-b985-d759820b16e0","codeChangeId":"98866a48-038d-41a1-b985-d759820b16e0","sourceType":"test-optimization"} -->
## Description

Fixing `TestSCAFlaskExtendedHeartbeat::test_extended_heartbeat_includes_dependencies_with_metadata_key[py3.13]` • **Questions?** Ask in #code-gen-flaky-tests

Motivation/Summary: `TestSCAFlaskExtendedHeartbeat::test_extended_heartbeat_includes_dependencies_with_metadata_key[py3.13]` was flaky in the `environment_dependency` category because it accepted the first `app-extended-heartbeat` event after the Flask request. The observed failure payload had extended heartbeat `configuration` data but no `dependencies`, so the test could assert against an early heartbeat before the dependency delta had been reflected in the snapshot.

Changes:
- Updated the test to wait for the existing synchronization condition where dependency deltas are covered by the latest extended-heartbeat snapshot.
- Kept the test assertion intent unchanged: SCA-enabled extended heartbeat payloads must include dependencies with preserved metadata.

## Testing

- `git diff --check` passed.
- Attempted focused validation with `scripts/run-tests --venv 42964a4 -- -- -k 'TestSCAFlaskExtendedHeartbeat and test_extended_heartbeat_includes_dependencies_with_metadata_key' --tb=short`; the test did not run because the Python 3.13 riot venv failed during editable `ddtrace` build while downloading `libddwaf` after repeated `502 Bad Gateway` tunnel errors.
- Attempted `scripts/lint format_check tests/appsec/integrations/flask_tests/test_sca_flask_testagent.py`; this could not start because uv failed to download its Python runtime due to a tunnel error.

## Risks

Low. This is a test-only synchronization change that reuses an existing helper in the same file and does not relax the dependency or metadata assertions.

## Additional Notes

Fix flaky tests DD_MDSP9X DD_TME76Z

No production code was changed.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/2c6f0491-915c-46b4-bb2d-9d732a271d5d)

Comment @datadog to request changes