### PR TITLE
ci: segment version-update PR creation

### DIFF
--- a/.github/actions/generated-change-patch/action.yml
+++ b/.github/actions/generated-change-patch/action.yml
@@ -1,0 +1,112 @@
+name: Generated change patch
+description: Create or safely apply a patch containing generated version updates
+
+inputs:
+  mode:
+    description: Whether to create or apply the patch
+    required: true
+  patch-file:
+    description: Path to the patch artifact
+    required: true
+  profile:
+    description: Allowlist of generated paths to enforce
+    required: true
+
+outputs:
+  changed:
+    description: Whether the generated patch contains changes
+    value: ${{ steps.patch.outputs.changed }}
+
+runs:
+  using: composite
+  steps:
+    # AIDEV-NOTE: Keep patch application and validation in this single shell step.
+    # The patch is untrusted data and must not replace code that is executed later.
+    - id: patch
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+        PATCH_FILE: ${{ inputs.patch-file }}
+        PROFILE: ${{ inputs.profile }}
+      run: |
+        set -euo pipefail
+
+        validate_path() {
+          local path=$1
+
+          case "$PROFILE" in
+            package-versions)
+              case "$path" in
+                .riot/requirements/*.txt|supported_versions.json|scripts/integration_registry/registry.yaml) return ;;
+              esac
+              ;;
+            supported-versions)
+              if [[ "$path" == "supported_versions.json" ]]; then
+                return
+              fi
+              ;;
+            *)
+              printf '::error::Unknown generated-change profile: %q\n' "$PROFILE"
+              exit 1
+              ;;
+          esac
+
+          printf '::error::Unexpected generated change: %q\n' "$path"
+          exit 1
+        }
+
+        validate_mode() {
+          local path=$1
+          local mode
+          mode=$(git ls-files -s -- "$path" | awk '{print $1}')
+          if [[ -n "$mode" && "$mode" != "100644" ]]; then
+            printf '::error::Unexpected file mode %q for %q\n' "$mode" "$path"
+            exit 1
+          fi
+        }
+
+        if [[ "$MODE" == "create" ]]; then
+          while IFS= read -r -d '' path; do
+            validate_path "$path"
+            git add --intent-to-add -- "$path"
+          done < <(git ls-files --others --exclude-standard -z)
+
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          while IFS= read -r -d '' path; do
+            validate_path "$path"
+            validate_mode "$path"
+          done < <(git diff --name-only -z)
+
+          git diff --check
+          git diff --binary --full-index --no-ext-diff > "$PATCH_FILE"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ "$MODE" == "apply" ]]; then
+          git apply --check --index "$PATCH_FILE"
+          git apply --index "$PATCH_FILE"
+
+          changed=false
+          while IFS= read -r -d '' path; do
+            changed=true
+            validate_path "$path"
+            validate_mode "$path"
+          done < <(git diff --cached --name-only -z)
+
+          if [[ "$changed" != "true" ]]; then
+            echo "::error::Generated patch contains no changes"
+            exit 1
+          fi
+
+          git diff --cached --check
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        printf '::error::Unknown generated-change mode: %q\n' "$MODE"
+        exit 1

--- a/.github/actions/generated-change-patch/action.yml
+++ b/.github/actions/generated-change-patch/action.yml
@@ -20,7 +20,8 @@ outputs:
 runs:
   using: composite
   steps:
-    # AIDEV-NOTE: Keep patch application and validation in this single shell step.
+    # AIDEV-NOTE: Keep patch application and validation in this single shell step,
+    # and do not add repository-mutating steps between this action and PR creation.
     # The patch is untrusted data and must not replace code that is executed later.
     - id: patch
       shell: bash
@@ -36,9 +37,11 @@ runs:
 
           case "$PROFILE" in
             package-versions)
-              case "$path" in
-                .riot/requirements/*.txt|supported_versions.json|scripts/integration_registry/registry.yaml) return ;;
-              esac
+              if [[ "$path" =~ ^\.riot/requirements/[^/]+\.txt$ ]] ||
+                [[ "$path" == "supported_versions.json" ]] ||
+                [[ "$path" == "scripts/integration_registry/registry.yaml" ]]; then
+                return
+              fi
               ;;
             supported-versions)
               if [[ "$path" == "supported_versions.json" ]]; then
@@ -71,7 +74,7 @@ runs:
             git add --intent-to-add -- "$path"
           done < <(git ls-files --others --exclude-standard -z)
 
-          if git diff --quiet; then
+          if git diff --quiet HEAD --; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -79,10 +82,11 @@ runs:
           while IFS= read -r -d '' path; do
             validate_path "$path"
             validate_mode "$path"
-          done < <(git diff --name-only -z)
+          done < <(git diff --name-only -z HEAD --)
 
-          git diff --check
-          git diff --binary --full-index --no-ext-diff > "$PATCH_FILE"
+          # Keep generated artifacts clean before they cross into the PR-creation job.
+          git diff --check HEAD --
+          git diff --binary --full-index --no-ext-diff HEAD -- > "$PATCH_FILE"
           echo "changed=true" >> "$GITHUB_OUTPUT"
           exit 0
         fi

--- a/.github/chainguard/self.generate-supported-versions.create-pr.sts.yaml
+++ b/.github/chainguard/self.generate-supported-versions.create-pr.sts.yaml
@@ -1,13 +1,14 @@
+# Policy for: create-pull-request in .github/workflows/generate-supported-versions.yml
 issuer: https://token.actions.githubusercontent.com
 
 subject: repo:DataDog/dd-trace-py:ref:refs/heads/main
 
 claim_pattern:
   event_name: workflow_dispatch
-  ref: refs/heads/main
-  ref_protected: "true"
   job_workflow_ref: DataDog/dd-trace-py/\.github/workflows/generate-supported-versions\.yml@refs/heads/main
+  ref: refs/heads/main
+  repository: DataDog/dd-trace-py
 
 permissions:
   contents: write
-  pull_requests: write 
+  pull_requests: write

--- a/.github/chainguard/self.update-package-version.create-pr.sts.yaml
+++ b/.github/chainguard/self.update-package-version.create-pr.sts.yaml
@@ -1,11 +1,11 @@
-# Policy for: create-pull-request in .github/workflows/generate-package-versions.yml
+# Policy for: create-pull-request in .github/workflows/update-package-version.yml
 issuer: https://token.actions.githubusercontent.com
 
 subject: repo:DataDog/dd-trace-py:ref:refs/heads/main
 
 claim_pattern:
-  event_name: (workflow_dispatch|schedule)
-  job_workflow_ref: DataDog/dd-trace-py/\.github/workflows/generate-package-versions\.yml@refs/heads/main
+  event_name: workflow_dispatch
+  job_workflow_ref: DataDog/dd-trace-py/\.github/workflows/update-package-version\.yml@refs/heads/main
   ref: refs/heads/main
   repository: DataDog/dd-trace-py
 

--- a/.github/workflows/generate-package-versions.yml
+++ b/.github/workflows/generate-package-versions.yml
@@ -10,10 +10,13 @@ jobs:
     name: Update riot lockfiles
     if: github.event_name != 'schedule' || github.event.repository.fork == false
     runs-on: ubuntu-22.04
+    outputs:
+      changed: ${{ steps.patch.outputs.changed }}
+      new_latest: ${{ steps.new-latest.outputs.new_latest }}
+      venv_name: ${{ steps.new-latest.outputs.venv_name }}
     permissions:
       actions: read
-      contents: write
-      id-token: write
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -104,7 +107,52 @@ jobs:
         id: new-latest
         run: |
           NEW_LATEST=$(python scripts/get_latest_version.py ${{ env.VENV_NAME }})
-          echo "NEW_LATEST=$NEW_LATEST" >> $GITHUB_ENV
+          echo "new_latest=$NEW_LATEST" >> "$GITHUB_OUTPUT"
+          echo "venv_name=$VENV_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare generated changes
+        id: patch
+        uses: ./.github/actions/generated-change-patch
+        with:
+          mode: create
+          patch-file: generated.patch
+          profile: package-versions
+
+      - name: Upload generated changes
+        if: steps.patch.outputs.changed == 'true'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: generated-package-versions
+          path: generated.patch
+          retention-days: 1
+
+  create-pull-request:
+    name: Create pull request
+    needs: update-riot-lockfiles
+    if: needs.update-riot-lockfiles.outputs.changed == 'true'
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download generated changes
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: generated-package-versions
+          path: ${{ runner.temp }}/generated-package-versions
+
+      - name: Apply and validate generated changes
+        uses: ./.github/actions/generated-change-patch
+        with:
+          mode: apply
+          patch-file: ${{ runner.temp }}/generated-package-versions/generated.patch
+          profile: package-versions
 
       - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts
@@ -118,14 +166,14 @@ jobs:
         with:
           token: ${{ steps.octo-sts.outputs.token }}
           sign-commits: true
-          branch: "upgrade-latest-${{ env.VENV_NAME }}-version"
+          branch: "upgrade-latest-${{ needs.update-riot-lockfiles.outputs.venv_name }}-version"
           commit-message: "Update package version"
           delete-branch: true
           base: main
-          title: "chore: update ${{ env.VENV_NAME }} latest version to ${{ env.NEW_LATEST }}"
+          title: "chore: update ${{ needs.update-riot-lockfiles.outputs.venv_name }} latest version to ${{ needs.update-riot-lockfiles.outputs.new_latest }}"
           labels: changelog/no-changelog
           body: |
-            Update ${{ env.VENV_NAME }} lockfiles and dependency package lockfiles.
+            Update ${{ needs.update-riot-lockfiles.outputs.venv_name }} lockfiles and dependency package lockfiles.
             This performs the following updates:
-              1) Some ${{ env.VENV_NAME }} lockfiles use ${{ env.VENV_NAME }} `latest`. This will update ${{ env.VENV_NAME }} and dependencies.
-              2) Some ${{ env.VENV_NAME }} lockfiles use a pinned (non-latest) version of ${{ env.VENV_NAME }}, but require the `latest` version of another package. This will update all such packages.
+              1) Some ${{ needs.update-riot-lockfiles.outputs.venv_name }} lockfiles use ${{ needs.update-riot-lockfiles.outputs.venv_name }} `latest`. This will update ${{ needs.update-riot-lockfiles.outputs.venv_name }} and dependencies.
+              2) Some ${{ needs.update-riot-lockfiles.outputs.venv_name }} lockfiles use a pinned (non-latest) version of ${{ needs.update-riot-lockfiles.outputs.venv_name }}, but require the `latest` version of another package. This will update all such packages.

--- a/.github/workflows/generate-supported-versions.yml
+++ b/.github/workflows/generate-supported-versions.yml
@@ -7,10 +7,11 @@ jobs:
   generate-supported-versions:
     name: Generate supported integration versions
     runs-on: ubuntu-22.04
+    outputs:
+      changed: ${{ steps.patch.outputs.changed }}
     permissions:
       actions: read
-      contents: write
-      id-token: write
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -78,7 +79,52 @@ jobs:
           print(json.dumps(supported_versions[:3], indent=2))
           PY
 
-      - run: git diff
+      - name: Preview changes
+        run: git diff
+
+      - name: Prepare generated changes
+        id: patch
+        uses: ./.github/actions/generated-change-patch
+        with:
+          mode: create
+          patch-file: generated.patch
+          profile: supported-versions
+
+      - name: Upload generated changes
+        if: steps.patch.outputs.changed == 'true'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: generated-supported-versions
+          path: generated.patch
+          retention-days: 1
+
+  create-pull-request:
+    name: Create pull request
+    needs: generate-supported-versions
+    if: needs.generate-supported-versions.outputs.changed == 'true'
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download generated changes
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: generated-supported-versions
+          path: ${{ runner.temp }}/generated-supported-versions
+
+      - name: Apply and validate generated changes
+        uses: ./.github/actions/generated-change-patch
+        with:
+          mode: apply
+          patch-file: ${{ runner.temp }}/generated-supported-versions/generated.patch
+          profile: supported-versions
 
       - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts

--- a/.github/workflows/update-package-version.yml
+++ b/.github/workflows/update-package-version.yml
@@ -16,10 +16,12 @@ jobs:
   update-riot-package-lockfiles:
     name: Update riot package lockfiles
     runs-on: ubuntu-22.04
+    outputs:
+      changed: ${{ steps.patch.outputs.changed }}
+      new_latest: ${{ steps.new-latest.outputs.new_latest }}
     permissions:
       actions: read
-      contents: write
-      id-token: write
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -115,24 +117,57 @@ jobs:
           NEW_LATEST=$(python scripts/get_latest_version.py "$TARGET_PACKAGE")
           echo "new_latest=$NEW_LATEST" >> "$GITHUB_OUTPUT"
 
-      - name: Check for changes
-        id: changes
-        run: |
-          if git diff --quiet; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Prepare generated changes
+        id: patch
+        uses: ./.github/actions/generated-change-patch
+        with:
+          mode: create
+          patch-file: generated.patch
+          profile: package-versions
+
+      - name: Upload generated changes
+        if: steps.patch.outputs.changed == 'true'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: generated-package-version
+          path: generated.patch
+          retention-days: 1
+
+  create-pull-request:
+    name: Create pull request
+    needs: update-riot-package-lockfiles
+    if: needs.update-riot-package-lockfiles.outputs.changed == 'true'
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download generated changes
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: generated-package-version
+          path: ${{ runner.temp }}/generated-package-version
+
+      - name: Apply and validate generated changes
+        uses: ./.github/actions/generated-change-patch
+        with:
+          mode: apply
+          patch-file: ${{ runner.temp }}/generated-package-version/generated.patch
+          profile: package-versions
 
       - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
-        if: steps.changes.outputs.changed == 'true'
         id: octo-sts
         with:
           scope: DataDog/dd-trace-py
-          policy: self.generate-package-versions.create-pr
+          policy: self.update-package-version.create-pr
 
       - name: Create Pull Request
-        if: steps.changes.outputs.changed == 'true'
         id: pr
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
@@ -142,7 +177,7 @@ jobs:
           commit-message: "Update package version"
           delete-branch: true
           base: main
-          title: "chore: update ${{ inputs.package_name }} latest version to ${{ steps.new-latest.outputs.new_latest }}"
+          title: "chore: update ${{ inputs.package_name }} latest version to ${{ needs.update-riot-package-lockfiles.outputs.new_latest }}"
           labels: changelog/no-changelog
           body: |
             Update ${{ inputs.package_name }} lockfiles.


### PR DESCRIPTION
## Description

Segment the version-generation workflows so dependency installation and generated-file production run separately from pull request publication.

The generation jobs now pass a short-lived patch artifact to a minimal publication job. Before creating a pull request, that job verifies the patch only touches the expected generated files and preserves regular file modes. Each workflow also has a dedicated, tightly matched STS policy.

This improves the credential boundary while preserving the existing generated pull request behavior.

Tracks [APMSP-3144](https://datadoghq.atlassian.net/browse/APMSP-3144).

## Testing

- `scripts/lint checks`
- Parsed all changed workflow, composite-action, and STS policy files as YAML
- Verified the embedded Bash syntax
- Exercised the patch gate in an isolated Git repository:
  - accepted and round-tripped an allowed `supported_versions.json` change
  - rejected an unexpected `.gitlab-ci.yml` change
- `scripts/run-tests --list ...` found no applicable product test suites for these workflow-only changes

## Risks

The artifact handoff and cross-job output propagation could affect the generated PR workflows. The patch gate checks applicability, changed paths, file modes, non-empty content, and whitespace before the publication credential is requested.

## Additional Notes

No customer-facing behavior changes; no release note is needed.


[APMSP-3144]: https://datadoghq.atlassian.net/browse/APMSP-3144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ