### PR TITLE
ci: fix microbenchmark-noop image

### DIFF
--- a/scripts/gen_gitlab_config.py
+++ b/scripts/gen_gitlab_config.py
@@ -375,7 +375,6 @@ def _gen_benchmarks(suites: dict, required_suites: list[str]) -> None:
         MICROBENCHMARKS_GEN.write_text(
             """
 microbenchmark-noop:
-  image: $GITHUB_CLI_IMAGE
   tags: [ "arch:amd64" ]
   script: |
     echo "noop"


### PR DESCRIPTION
## Description

A missed refactor from #19518 

We don't need to define an image here, if we don't the default image will be used, which is small and fairly fast to load since it generally exists on all runners.


Without this, any PRs which don't modify anything needing benchmark runs at all are going to fail.

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
