### PR TITLE
chore(runtime-metrics): deprecate unused tracer argument

### DIFF
--- a/ddtrace/runtime/__init__.py
+++ b/ddtrace/runtime/__init__.py
@@ -1,15 +1,15 @@
-from typing import TYPE_CHECKING
+from typing import Any
 from typing import Optional  # noqa:F401
 
 from ddtrace.internal.runtime import runtime_metrics
 from ddtrace.internal.telemetry import telemetry_writer
-
-
-if TYPE_CHECKING:
-    from ddtrace.trace import Tracer
+from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
+from ddtrace.vendor.debtcollector import deprecate
 
 
 TELEMETRY_RUNTIMEMETRICS_ENABLED = "DD_RUNTIME_METRICS_ENABLED"
+
+_TRACER_NOT_SET = object()
 
 
 class _RuntimeMetricsStatus(type):
@@ -35,7 +35,7 @@ class RuntimeMetrics(metaclass=_RuntimeMetricsStatus):
 
     @staticmethod
     def enable(
-        tracer: Optional["Tracer"] = None,
+        tracer: Any = _TRACER_NOT_SET,
         dogstatsd_url: Optional[str] = None,
     ) -> None:
         """
@@ -43,8 +43,15 @@ class RuntimeMetrics(metaclass=_RuntimeMetricsStatus):
         nothing. Use ``disable`` to turn off the runtime metric collection
         service.
 
-        :param tracer: The tracer instance to correlate with.
+        :param tracer: Deprecated and unused.
         """
+        if tracer is not _TRACER_NOT_SET:
+            deprecate(  # type: ignore[no-untyped-call]
+                prefix="The tracer parameter to RuntimeMetrics.enable is deprecated",
+                message="It is not used and will be removed in a future version.",
+                removal_version="5.0.0",
+                category=DDTraceDeprecationWarning,
+            )
         telemetry_writer.add_configuration(TELEMETRY_RUNTIMEMETRICS_ENABLED, True, origin="code")
         runtime_metrics.RuntimeWorker.enable(dogstatsd_url=dogstatsd_url)
 

--- a/releasenotes/notes/deprecate-runtimemetrics-enable-tracer-param-3c8e94c13b8f2518.yaml
+++ b/releasenotes/notes/deprecate-runtimemetrics-enable-tracer-param-3c8e94c13b8f2518.yaml
@@ -1,0 +1,5 @@
+---
+deprecations:
+  - |
+    tracing: The ``tracer`` parameter of ``ddtrace.runtime.RuntimeMetrics.enable`` is deprecated
+    and will be removed in a future version. It has no effect.


### PR DESCRIPTION
## Description

We deprecate the unused tracer argument in the runtime metrics interface.