### PR TITLE
refactor: factor out import cycle in aiguard

### DIFF
--- a/ddtrace/aiguard/_api_client.py
+++ b/ddtrace/aiguard/_api_client.py
@@ -6,12 +6,16 @@ from typing import Any
 from typing import Literal
 from typing import Optional  # noqa:F401
 from typing import TypedDict
-from typing import Union
 
 from ddtrace import config
 from ddtrace.aiguard._constants import AI_GUARD
 from ddtrace.aiguard._redaction import redact_messages
 from ddtrace.aiguard._trace_utils import _aiguard_manual_keep
+from ddtrace.aiguard._types import ContentPart  # noqa:F401
+from ddtrace.aiguard._types import Function  # noqa:F401
+from ddtrace.aiguard._types import ImageURL  # noqa:F401
+from ddtrace.aiguard._types import Message
+from ddtrace.aiguard._types import ToolCall  # noqa:F401
 from ddtrace.ext import http
 from ddtrace.internal import core
 from ddtrace.internal import span_bus
@@ -32,33 +36,6 @@ ALLOW = "ALLOW"
 DENY = "DENY"
 ABORT = "ABORT"
 ACTIONS = [ALLOW, DENY, ABORT]
-
-
-class Function(TypedDict):
-    name: str
-    arguments: str
-
-
-class ToolCall(TypedDict):
-    id: str
-    function: Function
-
-
-class ImageURL(TypedDict, total=False):
-    url: str
-
-
-class ContentPart(TypedDict, total=False):
-    type: str
-    text: Optional[str]
-    image_url: Optional[ImageURL]
-
-
-class Message(TypedDict, total=False):
-    role: str
-    content: Union[str, list[ContentPart]]
-    tool_call_id: str
-    tool_calls: list[ToolCall]
 
 
 class Evaluation(TypedDict):

--- a/ddtrace/aiguard/_api_client.py
+++ b/ddtrace/aiguard/_api_client.py
@@ -30,6 +30,9 @@ from ddtrace.internal.utils.http import get_connection
 from ddtrace.version import __version__
 
 
+__all__ = ["ToolCall", "Message", "Function", "ContentPart", "ImageURL"]
+
+
 logger = ddlogger.get_logger(__name__)
 
 ALLOW = "ALLOW"

--- a/ddtrace/aiguard/_redaction.py
+++ b/ddtrace/aiguard/_redaction.py
@@ -8,16 +8,12 @@ from collections.abc import Mapping
 from collections.abc import MutableMapping
 from copy import deepcopy
 import re
-from typing import TYPE_CHECKING
 from typing import Any
 from typing import Optional
 from typing import Union
 
+from ddtrace.aiguard._types import Message
 import ddtrace.internal.logger as ddlogger
-
-
-if TYPE_CHECKING:
-    from ddtrace.aiguard._api_client import Message
 
 
 logger = ddlogger.get_logger(__name__)
@@ -139,7 +135,7 @@ def _collect_replacements(replacements: object) -> dict[str, object]:
     return by_path
 
 
-def redact_messages(messages: "list[Message]", replacements: object) -> "list[Message]":
+def redact_messages(messages: list[Message], replacements: object) -> list[Message]:
     """Apply the replacements to the messages and return the redacted list.
 
     Copy-on-write: the caller's messages are never mutated, and the very same list object is returned

--- a/ddtrace/aiguard/_types.py
+++ b/ddtrace/aiguard/_types.py
@@ -1,0 +1,36 @@
+"""Shared message types for AI Guard evaluation and redaction.
+
+Split out from ``_api_client`` so that ``_redaction`` can depend on ``Message`` without
+creating an import cycle back into ``_api_client``.
+"""
+
+from typing import Optional
+from typing import TypedDict
+from typing import Union
+
+
+class Function(TypedDict):
+    name: str
+    arguments: str
+
+
+class ToolCall(TypedDict):
+    id: str
+    function: Function
+
+
+class ImageURL(TypedDict, total=False):
+    url: str
+
+
+class ContentPart(TypedDict, total=False):
+    type: str
+    text: Optional[str]
+    image_url: Optional[ImageURL]
+
+
+class Message(TypedDict, total=False):
+    role: str
+    content: Union[str, list[ContentPart]]
+    tool_call_id: str
+    tool_calls: list[ToolCall]


### PR DESCRIPTION
The `ddtrace.aiguard._api_client ↔ ddtrace.aiguard._redaction` cycle is fixed via Pattern 1 (extract shared type):

  - New `ddtrace/aiguard/_types.py` holds the Message, ContentPart, ImageURL, ToolCall, Function TypedDicts that both
  modules need.
  - `_api_client.py` now imports these from `_types.py` (and still re-exports them, so `ddtrace/aiguard/__init__.py`'s lazy
  `getattr(_api_client, name)` re-export mechanism keeps working unchanged).
  - `_redaction.py` imports Message directly from `_types.py` — no more `TYPE_CHECKING`-only import back to `_api_client`.

