### PR TITLE
fix(openfeature): accept floats for agentless interval/timeout env vars

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -145,6 +145,7 @@ jobs:
       binaries_artifact: wheels-manylinux_x86_64
       desired_execution_time: 900
       scenarios_groups: tracer-release
+      scenarios: FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS  # this scenario is not yet in tracer-release
       skip_empty_scenarios: ${{github.event_name == 'pull_request'}}
       push_to_test_optimization: true
 

--- a/ddtrace/internal/settings/openfeature.py
+++ b/ddtrace/internal/settings/openfeature.py
@@ -93,16 +93,16 @@ class OpenFeatureConfig(DDConfig):
 
     # Agentless UFC polling interval in seconds, capped at one hour by the source.
     configuration_source_agentless_poll_interval_seconds = DDConfig.var(
-        int,
+        float,
         "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS",
-        default=30,
+        default=30.0,
     )
 
     # Agentless UFC per-request timeout in seconds.
     configuration_source_agentless_request_timeout_seconds = DDConfig.var(
-        int,
+        float,
         "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_REQUEST_TIMEOUT_SECONDS",
-        default=5,
+        default=5.0,
     )
 
     _openfeature_config_keys = [


### PR DESCRIPTION

## Description

<!-- Provide an overview of the change and motivation for the change.
     Implementation detail and rationale belong here, not in the release note -
     release notes are customer-facing (see docs/releasenotes.rst). -->

System tests fail with the following exception: 
```
Traceback (most recent call last):
  File "/app/main.py", line 25, in <module>
    from ddtrace.openfeature import DataDogProvider
  File "/usr/local/lib/python3.14/site-packages/ddtrace/openfeature/__init__.py", line 18, in <module>
    from ddtrace.internal.openfeature._provider import DataDogProvider as DataDogProvider
  File "/usr/local/lib/python3.14/site-packages/ddtrace/internal/openfeature/_provider.py", line 31, in <module>
    from ddtrace.internal.openfeature._exposure import build_exposure_event
  File "/usr/local/lib/python3.14/site-packages/ddtrace/internal/openfeature/_exposure.py", line 11, in <module>
    from ddtrace.internal.openfeature.writer import ExposureEvent
  File "/usr/local/lib/python3.14/site-packages/ddtrace/internal/openfeature/writer.py", line 19, in <module>
    from ddtrace.internal.settings.openfeature import config as ffe_config
  File "/usr/local/lib/python3.14/site-packages/ddtrace/internal/settings/openfeature.py", line 124, in <module>
    config = OpenFeatureConfig()
  File "/usr/local/lib/python3.14/site-packages/ddtrace/internal/settings/_core.py", line 64, in __init__
    super().__init__(source=full_source, parent=parent, dynamic=dynamic)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/envier/env.py", line 272, in __init__
    setattr(self, name, e(self, self._full_prefix))
                        ~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/envier/env.py", line 169, in __call__
    value = self._retrieve(env, prefix)
  File "/usr/local/lib/python3.14/site-packages/envier/env.py", line 166, in _retrieve
    return self._cast(self.type, raw, env)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/envier/env.py", line 105, in _cast
    raise TypeError(msg) from e
TypeError: cannot cast 0.2 to <class 'int'>
```

This is likely caused by timeout/interval vars being declared as ints instead of floats.


## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
- The initial implementation of the feature hasn't been released yet, so skipping the changelog
