### PR TITLE
fix(profiling): release abandoned stack samples [backport 4.10]

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/include/stack_renderer.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/stack_renderer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <string_view>
 
@@ -62,7 +63,14 @@ struct ThreadState
 
 class StackRenderer
 {
-    Sample* sample = nullptr;
+    struct SampleDropper
+    {
+        void operator()(Sample* _sample) const noexcept;
+    };
+
+    using SampleHandle = std::unique_ptr<Sample, SampleDropper>;
+
+    SampleHandle sample;
     ThreadState thread_state = {};
 
     // Caches for interned strings and function IDs. These are used to avoid
@@ -88,6 +96,9 @@ class StackRenderer
     void render_cpu_time(microsecond_t cpu_time_us);
     void render_native_frame(const std::string& name, const std::string& module);
     void render_stack_end();
+
+    // Drop a partially-built sample without flushing it.
+    void abort_sample();
 
     // Clear caches after fork to avoid using stale interned string/function IDs
     void postfork_child();

--- a/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack_renderer.cpp
@@ -14,6 +14,12 @@
 using namespace Datadog;
 
 void
+StackRenderer::SampleDropper::operator()(Sample* _sample) const noexcept
+{
+    SampleManager::drop_sample(_sample);
+}
+
+void
 StackRenderer::render_thread_begin(PyThreadState* tstate,
                                    std::string_view name,
                                    int64_t wall_time_us,
@@ -25,7 +31,11 @@ StackRenderer::render_thread_begin(PyThreadState* tstate,
     if (failed) {
         return;
     }
-    sample = SampleManager::start_sample();
+
+    // Return an incomplete Sample before asking the pool for its replacement.
+    sample.reset();
+    // Keep acquisition separate from the reset above so start_sample() can reuse the slot we just returned.
+    sample.reset(SampleManager::start_sample());
     if (sample == nullptr) {
         std::cerr << "Failed to create a sample.  Stack v2 sampler will be disabled." << std::endl;
         failed = true;
@@ -71,7 +81,7 @@ StackRenderer::render_task_begin(const std::string& task_name, bool on_cpu)
         // The very first task on a thread will already have a sample, since there's no way to deduce whether
         // a thread has tasks without checking, and checking before populating the sample would make the state
         // management very complicated.  The rest of the tasks will not have samples and will hit this code path.
-        sample = SampleManager::start_sample();
+        sample.reset(SampleManager::start_sample());
         if (sample == nullptr) {
             std::cerr << "Failed to create a sample.  Stack v2 sampler will be disabled." << std::endl;
             failed = true;
@@ -261,8 +271,14 @@ StackRenderer::render_stack_end()
     }
 
     sample->flush_sample();
-    SampleManager::drop_sample(sample);
-    sample = nullptr;
+    sample.reset();
+}
+
+void
+StackRenderer::abort_sample()
+{
+    // Return the partially-built sample to the pool without flushing it.
+    sample.reset();
 }
 
 Datadog::StackRenderer::StackRenderer()
@@ -283,5 +299,8 @@ Datadog::StackRenderer::postfork_child()
     new (&string_id_cache) std::unordered_map<StringTable::Key, string_id>();
     new (&function_id_cache)
       std::unordered_map<internal::PtrPair, function_id, internal::PtrPairHash, internal::PtrPairEq>();
-    sample = nullptr;
+
+    // The vanished sampling thread may have been mutating this Sample when fork captured it. Clearing or returning the
+    // child copy could traverse inconsistent vectors, so intentionally abandon at most this one in-flight child copy.
+    [[maybe_unused]] Sample* abandoned_sample = sample.release();
 }

--- a/ddtrace/internal/datadog/profiling/stack/test/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/stack/test/CMakeLists.txt
@@ -78,3 +78,22 @@ endfunction()
 
 # Add the tests
 dd_wrapper_add_test(test_thread_span_links test_thread_span_links.cpp)
+
+function(configure_stack_internal_test name)
+    target_include_directories(${name} PRIVATE ../..)
+    target_include_directories(
+        ${name} SYSTEM
+        PRIVATE ${Python3_INCLUDE_DIRS} ../echion ../include/vendored ../include/util
+                ../../../../../../src/native/target${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/include)
+    target_compile_definitions(${name} PRIVATE "$<TARGET_PROPERTY:${EXTENSION_NAME},COMPILE_DEFINITIONS>")
+    if(LIB_INSTALL_DIR)
+        set_property(
+            TARGET ${name}
+            APPEND
+            PROPERTY INSTALL_RPATH "${LIB_INSTALL_DIR}")
+    endif()
+endfunction()
+
+dd_wrapper_add_test(test_sample_lifecycle test_sample_lifecycle.cpp)
+target_link_libraries(test_sample_lifecycle PRIVATE dd_wrapper)
+configure_stack_internal_test(test_sample_lifecycle)

--- a/ddtrace/internal/datadog/profiling/stack/test/test_sample_lifecycle.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/test/test_sample_lifecycle.cpp
@@ -1,0 +1,95 @@
+#include "stack_renderer.hpp"
+
+#include "dd_wrapper/include/ddup_interface.hpp"
+#include "dd_wrapper/include/sample_manager.hpp"
+#include "dd_wrapper/include/static_sample_pool.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+using namespace Datadog;
+
+namespace {
+
+void
+fill_sample_pool()
+{
+    std::vector<Sample*> samples;
+    samples.reserve(StaticSamplePool::CAPACITY);
+    for (size_t i = 0; i < StaticSamplePool::CAPACITY; ++i) {
+        samples.push_back(SampleManager::start_sample());
+    }
+    for (auto* sample : samples) {
+        SampleManager::drop_sample(sample);
+    }
+}
+
+size_t
+count_available_samples()
+{
+    std::vector<Sample*> samples;
+    while (auto sample = StaticSamplePool::take_sample()) {
+        samples.push_back(*sample);
+    }
+
+    for (auto* sample : samples) {
+        auto leftover = StaticSamplePool::return_sample(sample);
+        EXPECT_FALSE(leftover.has_value());
+        if (leftover.has_value()) {
+            delete *leftover; // NOLINT(cppcoreguidelines-owning-memory)
+        }
+    }
+    return samples.size();
+}
+
+class StackRendererSampleLifecycle : public ::testing::Test
+{
+  protected:
+    static void SetUpTestSuite()
+    {
+        ddup_config_service("test_service");
+        ddup_config_env("test_env");
+        ddup_config_version("0.0.1");
+        ddup_config_url("http://localhost:8126");
+        ddup_config_max_nframes(64);
+        ddup_start();
+    }
+
+    void SetUp() override
+    {
+        fill_sample_pool();
+        ASSERT_EQ(count_available_samples(), StaticSamplePool::CAPACITY);
+    }
+};
+
+} // namespace
+
+TEST_F(StackRendererSampleLifecycle, StartingNextCycleRecoversAbandonedSample)
+{
+    StackRenderer renderer;
+
+    // Simulate ThreadInfo::sample() returning after render_thread_begin() without reaching render_stack_end().
+    // ThreadInfo::update_cpu_time() normalizes deterministically constructible invalid-clock errors to success, so
+    // exercise the renderer lifecycle directly rather than relying on platform-specific syscall interposition.
+    for (size_t i = 0; i < StaticSamplePool::CAPACITY * 4; ++i) {
+        renderer.render_thread_begin(nullptr, "test-thread", 0, i + 1, i + 1);
+    }
+    renderer.abort_sample();
+
+    EXPECT_EQ(count_available_samples(), StaticSamplePool::CAPACITY)
+      << "starting a new render cycle leaked the Sample abandoned by the previous cycle";
+}
+
+TEST_F(StackRendererSampleLifecycle, DestructionRecoversAbandonedSample)
+{
+    {
+        StackRenderer renderer;
+        renderer.render_thread_begin(nullptr, "test-thread", 0, 1, 1);
+    }
+
+    EXPECT_EQ(count_available_samples(), StaticSamplePool::CAPACITY)
+      << "renderer destruction leaked an in-flight Sample";
+}

--- a/releasenotes/notes/fix-stack-profiler-memory-growth-d5948e37e25f44da.yaml
+++ b/releasenotes/notes/fix-stack-profiler-memory-growth-d5948e37e25f44da.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: Fixes potential process memory growth when a stack profiling sampling cycle exits before completing a
+    sample.


### PR DESCRIPTION
## Description

Backports #19436 to the 4.10 release branch.

This hardens native stack sample ownership so incomplete sampling cycles return abandoned samples to the static pool instead of allowing process memory growth. The backport adds the minimal release-line compatibility changes needed for the existing renderer interface.

## Testing

- Python 3.13 Debug native stack suite passed, 5/5 tests, on the combined #19436 and #19497 backports for 4.10.
- C and C++ formatting passed.
- CMake formatting passed.
- Release-note spelling passed.
- `git diff --check` passed.
- Full `scripts/lint checks` reaches 86 existing mypy errors in unrelated bytecode wrapping files on the 4.10 branch.

## Risks

The successful path replaces raw-pointer assignment and explicit pool returns with a custom-deleter unique pointer. It adds no per-frame allocation. The post-fork child preserves the existing safety tradeoff by abandoning at most one copied in-flight sample.

## Additional Notes

- Source PR: #19436.
- Source merge commit: `a51bc20f051fb7e3fef0accb164815aa2dfe4426`.
- Release note: `releasenotes/notes/fix-stack-profiler-memory-growth-d5948e37e25f44da.yaml`.
- #19497 is required for complete incomplete-cycle cleanup and will be opened as a stacked backport.
