### PR TITLE
fix(profiling): scope stack snapshots to sampling cycles [backport 4.11]

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
@@ -111,6 +111,7 @@ class ThreadInfo
     };
 
   private:
+    void reset_cycle_state() noexcept;
     [[nodiscard]] Result<void> unwind_tasks(EchionSampler&, PyThreadState*);
     void unwind_greenlets(EchionSampler&, PyThreadState*, unsigned long);
     [[nodiscard]] Result<std::vector<TaskInfo::Ptr>> get_all_tasks(EchionSampler&, PyThreadState* tstate);

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -4,12 +4,24 @@
 
 #include <echion/echion_sampler.h>
 
+#include "dd_wrapper/include/defer.hpp"
+
 #include <algorithm>
 #include <optional>
 
 void
+ThreadInfo::reset_cycle_state() noexcept
+{
+    current_tasks.clear();
+    current_greenlets.clear();
+}
+
+void
 ThreadInfo::unwind(EchionSampler& echion, PyThreadState* tstate)
 {
+    // This entry reset is a precondition for a new snapshot: never append to logical state from an earlier cycle.
+    reset_cycle_state();
+
     unwind_python_stack(echion, tstate, python_stack);
 
     if (asyncio_loop) {
@@ -704,6 +716,14 @@ Result<void>
 ThreadInfo::sample(EchionSampler& echion, PyThreadState* tstate, microsecond_t delta)
 {
     auto& renderer = echion.renderer();
+
+    // This exit reset complements unwind's entry reset. It covers returns before unwind and exceptions after partial
+    // task or greenlet state has been populated, so no logical snapshot survives the cycle that created it.
+    defer
+    {
+        reset_cycle_state();
+    };
+
     renderer.render_thread_begin(tstate, name, delta, thread_id, native_id);
 
     microsecond_t previous_cpu_time = cpu_time;
@@ -734,8 +754,6 @@ ThreadInfo::sample(EchionSampler& echion, PyThreadState* tstate, microsecond_t d
 
             renderer.render_stack_end();
         }
-
-        current_tasks.clear();
     } else if (!current_greenlets.empty()) {
         for (auto& greenlet_stack : current_greenlets) {
             auto maybe_task_name = echion.string_table().lookup(greenlet_stack->task_name);
@@ -751,8 +769,6 @@ ThreadInfo::sample(EchionSampler& echion, PyThreadState* tstate, microsecond_t d
 
             renderer.render_stack_end();
         }
-
-        current_greenlets.clear();
     } else {
         python_stack.render(echion);
         renderer.render_stack_end();

--- a/ddtrace/internal/datadog/profiling/stack/test/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/stack/test/CMakeLists.txt
@@ -97,3 +97,6 @@ endfunction()
 dd_wrapper_add_test(test_sample_lifecycle test_sample_lifecycle.cpp)
 target_link_libraries(test_sample_lifecycle PRIVATE dd_wrapper)
 configure_stack_internal_test(test_sample_lifecycle)
+
+dd_wrapper_add_test(test_sampling_cycle_state test_sampling_cycle_state.cpp)
+configure_stack_internal_test(test_sampling_cycle_state)

--- a/ddtrace/internal/datadog/profiling/stack/test/test_sampling_cycle_state.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/test/test_sampling_cycle_state.cpp
@@ -1,0 +1,24 @@
+#include "echion/echion_sampler.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+TEST(SamplingCycleState, UnwindReplacesTaskAndGreenletStacksFromPriorCycle)
+{
+    EchionSampler echion;
+#if defined PL_LINUX
+    ThreadInfo thread(1, 1, "test-thread", CLOCK_THREAD_CPUTIME_ID);
+#elif defined PL_DARWIN
+    ThreadInfo thread(1, 1, "test-thread", mach_thread_self());
+#endif
+    PyThreadState empty_tstate{};
+
+    thread.current_tasks.push_back(std::make_unique<StackInfo>(StringTable::UNKNOWN, false));
+    thread.current_greenlets.push_back(std::make_unique<StackInfo>(StringTable::UNKNOWN, false));
+
+    thread.unwind(echion, &empty_tstate);
+
+    EXPECT_TRUE(thread.current_tasks.empty());
+    EXPECT_TRUE(thread.current_greenlets.empty());
+}

--- a/releasenotes/notes/fix-stack-snapshot-state-retention-b80a9ba859a84585.yaml
+++ b/releasenotes/notes/fix-stack-snapshot-state-retention-b80a9ba859a84585.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: Fixes potential process memory growth in asyncio and gevent workloads after stack profiling sampling
+    cycles exit before completion.


### PR DESCRIPTION
## Description

Backports #19497 to the 4.11 release branch after the merged #19633.

This scopes retained asyncio task and gevent greenlet snapshots to one sampling cycle. The release-line implementation keeps rendering in the existing `ThreadInfo::sample()` flow while adding the same entry and exit cleanup invariants as the source fix.

## Testing

- Python 3.13 Debug native stack suite passed, 5/5 tests, on the combined #19436 and #19497 backports for 4.11.
- Added and ran the release-line-compatible stale snapshot regression test.
- C and C++ formatting passed.
- CMake formatting passed.
- Release-note spelling passed.
- `git diff --check` passed.

## Risks

The change clears logical snapshot contents at cycle boundaries. It does not change vector capacity, frame limits, sampling frequency, or successful profile output.

## Additional Notes

- Source PR: #19497.
- Source merge commit: `f0ea6d93108d1d2c8ba27efc8a4d049b399b76d5`.
- Release note: `releasenotes/notes/fix-stack-snapshot-state-retention-b80a9ba859a84585.yaml`.
- Rebased onto the updated 4.11 release branch after #19633 merged. The resulting source tree is unchanged from the previously tested head.
