### PR TITLE
fix(internal): prevent periodic thread cleanup crash [backport 4.10]

### DIFF
--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -241,8 +241,29 @@ class GILGuard
     }
     inline ~GILGuard()
     {
-        if (_acquired && !_mstate->is_finalizing() && PyGILState_Check())
-            PyGILState_Release(_gil_state);
+        if (!_acquired || _mstate->is_finalizing() || !PyGILState_Check())
+            return;
+
+#if PY_VERSION_HEX < 0x030D0000
+        // Work around CPython GH-119585, which was not fixed on 3.9-3.11.
+        // A cp312 wheel must also apply the workaround to the entire 3.12 ABI
+        // because a wheel built on 3.12.4+ can run on affected 3.12.0-3.12.3.
+        // Mirror the fixed CPython 3.12.4 release sequence by clearing the
+        // complete state, including its context, while gilstate_counter is
+        // still nonzero.
+        PyThreadState* tstate = PyThreadState_Get();
+        // An auto-created state has counter 1 here. PyGILState_Ensure raises a
+        // pre-existing state's initial counter from 1 to at least 2, so it must
+        // use the normal release path below instead of being deleted.
+        if (_gil_state == PyGILState_UNLOCKED && tstate->gilstate_counter == 1) {
+            PyThreadState_Clear(tstate);
+            --tstate->gilstate_counter;
+            PyThreadState_DeleteCurrent();
+            return;
+        }
+#endif
+
+        PyGILState_Release(_gil_state);
     }
 
     GILGuard(const GILGuard&) = delete;
@@ -310,13 +331,16 @@ class PyRef
     // destruction, resulting in a double-decrement (use-after-free).
     PyRef(const PyRef&) = delete;
     PyRef& operator=(const PyRef&) = delete;
-    inline ~PyRef()
+    inline ~PyRef() { reset(); }
+    inline void reset()
     {
+        PyObject* obj = _obj;
+        _obj = nullptr;
         // Avoid calling Py_DECREF during finalization as the thread state
         // may be NULL, causing crashes in Python 3.14+ where _Py_Dealloc
         // dereferences tstate immediately.
-        if (_obj != nullptr && !_mstate->is_finalizing())
-            Py_DECREF(_obj);
+        if (obj != nullptr && !_mstate->is_finalizing())
+            Py_DECREF(obj);
     }
 
   private:
@@ -653,15 +677,15 @@ _PeriodicThread_do_start(PeriodicThread* self, bool reset_next_call_time = false
             // DEV: GILGuard and PyRef are in an inner scope that exits BEFORE
             // stopped_event->set(). This ensures that all Python VM interactions
             // (Py_DECREF, PyGILState_Release) complete before the join() caller is
-            // unblocked. The inner scope also means ~PyRef may trigger
+            // unblocked. The inner scope also allows PyRef::reset() to trigger
             // PeriodicThread_dealloc (if this thread held the last reference),
             // which is safe because stopped_event is a captured shared_ptr
             // independent of self's lifetime.
             {
                 GILGuard _gil(state);
 
-                // Move ref into this scope so ~PyRef (and thus Py_DECREF) fires
-                // while the GIL is still held, before stopped_event->set().
+                // Move ref into this scope so PyRef::reset() can release it while
+                // the GIL is still held, before stopped_event->set().
                 PyRef _ref = std::move(ref);
 
                 // Retrieve the thread ID
@@ -754,9 +778,13 @@ _PeriodicThread_do_start(PeriodicThread* self, bool reset_next_call_time = false
                     unregister_periodic_thread_if_self(state->periodic_threads, self->ident, (PyObject*)self);
                 }
 
-                // Inner scope ends here. GILGuard::~GILGuard releases the GIL and
-                // PyRef::~PyRef calls Py_DECREF(self). Both may interact with the
-                // Python VM; they must complete before stopped_event->set() below.
+                // Release the worker's Python reference before GILGuard
+                // clears the thread state so values added by its deallocator
+                // are included in that clear.
+                _ref.reset();
+
+                // Inner scope ends here. GILGuard::~GILGuard clears and deletes
+                // the worker's thread state, then releases the GIL.
             }
 
             // All Python VM interactions are done. Signal that the thread has fully
@@ -1086,10 +1114,10 @@ PeriodicThread_dealloc(PeriodicThread* self)
     // 2. The thread is always detached at creation, so destroying _thread
     //    (non-joinable std::thread) is a no-op regardless of which thread
     //    calls it.
-    // 3. After dealloc returns, the lambda only calls stopped_event->set()
-    //    via its captured shared_ptr — it never accesses self again.
+    // 3. After dealloc returns, the lambda only tears down its current thread
+    //    state and calls stopped_event->set(); it never accesses self again.
     // 4. GILGuard::~GILGuard (which runs after PyRef::~PyRef) only accesses
-    //    its own _mstate copy, not self.
+    //    its own _mstate copy and the current thread state, not self.
     //
     // Full cleanup is therefore correct in all cases;
 

--- a/releasenotes/notes/fix-periodic-thread-gilstate-cleanup-334c20fa91e3cd33.yaml
+++ b/releasenotes/notes/fix-periodic-thread-gilstate-cleanup-334c20fa91e3cd33.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    internal: Fixes an issue on Python 3.9 through 3.12.3 where applications can crash when
+    background worker threads clean up thread-local or context-local data.

--- a/tests/internal/test_periodic.py
+++ b/tests/internal/test_periodic.py
@@ -51,6 +51,48 @@ def test_periodic_double_start():
     t.join()
 
 
+@pytest.mark.subprocess(timeout=10)
+def test_periodic_thread_gilstate_reentry_during_thread_state_cleanup():
+    """Thread and context-local destructors may re-enter PyGILState during worker teardown."""
+    import contextvars
+    import ctypes
+    import threading
+
+    from ddtrace.internal._threads import PERIODIC_STOP
+    from ddtrace.internal._threads import PeriodicThread
+
+    ensure = ctypes.pythonapi.PyGILState_Ensure
+    ensure.argtypes = []
+    ensure.restype = ctypes.c_int
+    release = ctypes.pythonapi.PyGILState_Release
+    release.argtypes = [ctypes.c_int]
+    release.restype = None
+
+    local = threading.local()
+    context_value = contextvars.ContextVar("context_value")
+    finalized = []
+
+    class ReenterPyGILState:
+        def __init__(self, kind):
+            self.kind = kind
+
+        def __del__(self):
+            finalized.append(self.kind)
+            state = ensure()
+            release(state)
+
+    def target():
+        local.value = ReenterPyGILState("thread-local")
+        context_value.set(ReenterPyGILState("context-local"))
+        return PERIODIC_STOP
+
+    thread = PeriodicThread(0.001, target, name="SignalUploader", no_wait_at_start=True)
+    thread.start()
+    thread.join()
+
+    assert sorted(finalized) == ["context-local", "thread-local"]
+
+
 def test_periodic_join_positional_timeout_is_honored():
     """Regression: PeriodicThread.join(timeout) passed positionally was ignored.
 


### PR DESCRIPTION
## Description

Backports #19445 to the 4.10 release branch.

This prevents a native `PeriodicThread` worker from recursively deleting its Python thread state while thread-local or context-local values are being cleared on affected GIL-enabled Python versions. The backport preserves the 4.10 worker lifecycle and applies the corrected CPython cleanup sequence at its shared GIL guard.

## Testing

- `scripts/run-tests --venv 3c0f005 -- -- -vv -k test_periodic_thread_gilstate_reentry_during_thread_state_cleanup`, passed on Python 3.10.
- C and C++ formatting passed.
- Python formatting passed.
- Release-note spelling passed.
- `git diff --check` passed.
- Full `scripts/lint checks` reaches 86 existing mypy errors in unrelated bytecode wrapping files on the 4.10 branch.

## Risks

The workaround directly clears and deletes an auto-created worker thread state instead of calling the affected `PyGILState_Release()`. It only applies when `PyGILState_Ensure()` created the state and the counter is exactly 1. Pre-existing Python thread states continue through the normal release path.

## Additional Notes

- Source PR: #19445.
- Source merge commit: `368bc590e8dca9615c0e26e1e3f475a37ed53714`.
- Release note: `releasenotes/notes/fix-periodic-thread-gilstate-cleanup-334c20fa91e3cd33.yaml`.
- This does not change public APIs.
