### PR TITLE
refactor: factor out import cycle in appsec

### DIFF
--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -1,5 +1,4 @@
 from collections.abc import Mapping
-import contextlib
 import json
 import re
 from types import TracebackType
@@ -784,11 +783,3 @@ def _set_headers(span: Span, headers: Any, kind: str, only_asm_enabled: bool = F
 def asm_listen() -> None:
     core.on("asm.set_blocked", set_blocked_dict)
     core.on("asm.get_blocked", get_blocked, "block_config")
-
-
-def iast_disabled_taint_sources() -> "contextlib.AbstractContextManager[None]":
-    if asm_config._iast_enabled:
-        from ddtrace.appsec._iast._iast_request_context_base import iast_suppress_context
-
-        return iast_suppress_context()
-    return contextlib.nullcontext()

--- a/ddtrace/appsec/_contrib/fastapi/__init__.py
+++ b/ddtrace/appsec/_contrib/fastapi/__init__.py
@@ -10,7 +10,7 @@ from ddtrace.appsec._asm_request_context import _call_waf_first
 from ddtrace.appsec._asm_request_context import _on_context_ended
 from ddtrace.appsec._asm_request_context import _set_headers_and_response
 from ddtrace.appsec._asm_request_context import get_blocked
-from ddtrace.appsec._asm_request_context import iast_disabled_taint_sources
+from ddtrace.appsec._iast._iast_request_context_base import iast_disabled_taint_sources
 from ddtrace.appsec._utils import Block_config
 from ddtrace.contrib.internal.trace_utils_base import _get_request_header_user_agent
 from ddtrace.contrib.internal.trace_utils_base import _set_url_tag

--- a/ddtrace/appsec/_contrib/flask/__init__.py
+++ b/ddtrace/appsec/_contrib/flask/__init__.py
@@ -12,11 +12,11 @@ from ddtrace.appsec._asm_request_context import _set_headers_and_response
 from ddtrace.appsec._asm_request_context import block_request
 from ddtrace.appsec._asm_request_context import call_waf_callback
 from ddtrace.appsec._asm_request_context import get_blocked
-from ddtrace.appsec._asm_request_context import iast_disabled_taint_sources
 from ddtrace.appsec._asm_request_context import in_asm_context
 from ddtrace.appsec._asm_request_context import is_blocked
 from ddtrace.appsec._asm_request_context import set_block_request_callable
 from ddtrace.appsec._asm_request_context import set_waf_address
+from ddtrace.appsec._iast._iast_request_context_base import iast_disabled_taint_sources
 from ddtrace.appsec._utils import Block_config
 from ddtrace.contrib import trace_utils
 from ddtrace.contrib.internal.trace_utils_base import _get_request_header_user_agent

--- a/ddtrace/appsec/_contrib/tornado/__init__.py
+++ b/ddtrace/appsec/_contrib/tornado/__init__.py
@@ -7,9 +7,9 @@ from ddtrace.appsec._asm_request_context import _use_html
 from ddtrace.appsec._asm_request_context import call_waf_callback
 from ddtrace.appsec._asm_request_context import get_blocked
 from ddtrace.appsec._asm_request_context import get_headers
-from ddtrace.appsec._asm_request_context import iast_disabled_taint_sources
 from ddtrace.appsec._asm_request_context import set_waf_address
 from ddtrace.appsec._constants import SPAN_DATA_NAMES
+from ddtrace.appsec._iast._iast_request_context_base import iast_disabled_taint_sources
 from ddtrace.appsec._utils import Block_config
 from ddtrace.internal import core
 from ddtrace.internal._exceptions import BlockingException

--- a/ddtrace/appsec/_iast/_evidence_redaction/_sensitive_handler.py
+++ b/ddtrace/appsec/_iast/_evidence_redaction/_sensitive_handler.py
@@ -5,7 +5,7 @@ from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings._config import config
 from ddtrace.internal.settings.asm import config as asm_config
 
-from .._taint_tracking import OriginType
+from .._taint_tracking._native.taint_tracking import OriginType
 from .._utils import _get_source_index
 from ..constants import VULN_CMDI
 from ..constants import VULN_CODE_INJECTION

--- a/ddtrace/appsec/_iast/_iast_request_context_base.py
+++ b/ddtrace/appsec/_iast/_iast_request_context_base.py
@@ -40,6 +40,12 @@ def iast_suppress_context():
         _IAST_TAINT_SOURCES_SUPPRESSED.reset(token)
 
 
+def iast_disabled_taint_sources() -> "contextlib.AbstractContextManager[None]":
+    if asm_config._iast_enabled:
+        return iast_suppress_context()
+    return contextlib.nullcontext()
+
+
 def _is_iast_taint_source_enabled() -> bool:
     return not _IAST_TAINT_SOURCES_SUPPRESSED.get()
 

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -21,7 +21,6 @@ from ddtrace.appsec._constants import WAF_DATA_NAMES
 from ddtrace.appsec._ddwaf import DDWaf
 from ddtrace.appsec._ddwaf import DDWafContext
 from ddtrace.appsec._exploit_prevention.stack_traces import report_stack
-from ddtrace.appsec._iast._iast_request_context_base import iast_disabled_taint_sources
 from ddtrace.appsec._metrics import set_waf_init_metric
 from ddtrace.appsec._metrics import set_waf_updates_metric
 from ddtrace.appsec._trace_utils import _asm_manual_keep
@@ -299,7 +298,7 @@ class AppSecSpanProcessor(SpanProcessor):
         # The address values gathered and serialized below only feed the WAF; suppress IAST taint source
         # generation so we don't create throwaway tainted objects (e.g. materializing lazy-tainted header /
         # query / body structures during serialization and WAF encoding). Customer reads re-taint independently.
-        with iast_disabled_taint_sources():
+        with _asm_request_context.iast_disabled_taint_sources():
             for key, waf_name in iter_data:
                 if key in data_already_sent and not force_sent:
                     continue

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -21,6 +21,7 @@ from ddtrace.appsec._constants import WAF_DATA_NAMES
 from ddtrace.appsec._ddwaf import DDWaf
 from ddtrace.appsec._ddwaf import DDWafContext
 from ddtrace.appsec._exploit_prevention.stack_traces import report_stack
+from ddtrace.appsec._iast._iast_request_context_base import iast_disabled_taint_sources
 from ddtrace.appsec._metrics import set_waf_init_metric
 from ddtrace.appsec._metrics import set_waf_updates_metric
 from ddtrace.appsec._trace_utils import _asm_manual_keep
@@ -298,7 +299,7 @@ class AppSecSpanProcessor(SpanProcessor):
         # The address values gathered and serialized below only feed the WAF; suppress IAST taint source
         # generation so we don't create throwaway tainted objects (e.g. materializing lazy-tainted header /
         # query / body structures during serialization and WAF encoding). Customer reads re-taint independently.
-        with _asm_request_context.iast_disabled_taint_sources():
+        with iast_disabled_taint_sources():
             for key, waf_name in iter_data:
                 if key in data_already_sent and not force_sent:
                     continue


### PR DESCRIPTION
Fixed by moving `iast_disabled_taint_sources` (Pattern 5 — move to the module that owns it) from `ddtrace/appsec/_asm_request_context.py` into `ddtrace/appsec/_iast/_iast_request_context_base.py`, which already defines the `iast_suppress_context` it wraps and already imports `asm_config`. This eliminates the `_asm_request_context -> _iast_request_context_base` edge, breaking the cycle.

Updated the four call sites (`_processor.py`, and the flask/tornado/fastapi appsec contrib `__init__.py` files) to import `iast_disabled_taint_sources` from its new home instead of via `_asm_request_context`.