### PR TITLE
fix(dbapi): support driver-specific SQL keyword arguments

### DIFF
--- a/ddtrace/appsec/_iast/taint_sinks/sql_injection.py
+++ b/ddtrace/appsec/_iast/taint_sinks/sql_injection.py
@@ -12,6 +12,9 @@ from ddtrace.appsec._iast.taint_sinks._base import VulnerabilityBase
 from ddtrace.internal.settings.asm import config as asm_config
 
 
+_SQL_KEYWORD_ARGUMENT_NAMES = ("query", "command", "sql", "operation", "statement")
+
+
 class SqlInjection(VulnerabilityBase):
     vulnerability_type = VULN_SQL_INJECTION
     secure_mark = VulnerabilityType.SQL_INJECTION
@@ -36,14 +39,13 @@ def _on_report_sqli(*args, **kwargs) -> bool:
             query_args, kwargs, integration_name, method = args
 
             if supported_dbapi_integration(integration_name) and method.__name__ == "execute":
-                if (
-                    len(query_args)
-                    and query_args[0]
-                    and isinstance(query_args[0], IAST.TEXT_TYPES)
-                    and is_iast_request_enabled()
-                ):
-                    if SqlInjection.has_quota() and SqlInjection.is_tainted_pyobject(query_args[0]):
-                        SqlInjection.report(evidence_value=query_args[0], dialect=integration_name)
+                query = next(
+                    (kwargs[name] for name in _SQL_KEYWORD_ARGUMENT_NAMES if kwargs and name in kwargs),
+                    query_args[0] if query_args else None,
+                )
+                if query and isinstance(query, IAST.TEXT_TYPES) and is_iast_request_enabled():
+                    if SqlInjection.has_quota() and SqlInjection.is_tainted_pyobject(query):
+                        SqlInjection.report(evidence_value=query, dialect=integration_name)
                         reported = True
 
                     # Reports Span Metrics

--- a/ddtrace/contrib/dbapi.py
+++ b/ddtrace/contrib/dbapi.py
@@ -2,6 +2,7 @@
 Generic dbapi tracing code.
 """
 
+import inspect
 from typing import Mapping
 from typing import Optional
 
@@ -32,6 +33,19 @@ from .internal.trace_utils import iswrapped
 log = get_logger(__name__)
 
 _SQL_KEYWORD_ARGUMENT_NAMES = ("query", "command", "sql", "operation", "statement")
+_CURSOR_EXECUTE_SIGNATURE = inspect.Signature(
+    parameters=(
+        inspect.Parameter("self", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        inspect.Parameter("query", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        inspect.Parameter("args", inspect.Parameter.VAR_POSITIONAL),
+        inspect.Parameter("kwargs", inspect.Parameter.VAR_KEYWORD),
+    )
+)
+
+
+def _preserve_cursor_execute_signature(method):
+    setattr(method, "__signature__", _CURSOR_EXECUTE_SIGNATURE)
+    return method
 
 
 config._add(
@@ -147,6 +161,7 @@ class TracedCursor(wrapt.ObjectProxy):
                 # Try to fetch custom properties that were passed by the specific Database implementation
                 self._set_post_execute_tags(s)
 
+    @_preserve_cursor_execute_signature
     def executemany(self, *args, **kwargs):
         """Wraps the cursor.executemany method"""
         query = self._get_sql_statement(args, kwargs)
@@ -165,6 +180,7 @@ class TracedCursor(wrapt.ObjectProxy):
             **kwargs,
         )
 
+    @_preserve_cursor_execute_signature
     def execute(self, *args, **kwargs):
         """Wraps the cursor.execute method"""
         query = self._get_sql_statement(args, kwargs)

--- a/ddtrace/contrib/dbapi.py
+++ b/ddtrace/contrib/dbapi.py
@@ -31,6 +31,8 @@ from .internal.trace_utils import iswrapped
 
 log = get_logger(__name__)
 
+_SQL_KEYWORD_ARGUMENT_NAMES = ("query", "command", "sql", "operation", "statement")
+
 
 config._add(
     "dbapi2",
@@ -90,6 +92,13 @@ class TracedCursor(wrapt.ObjectProxy):
     def __next__(self):
         return self.__wrapped__.__next__()
 
+    @staticmethod
+    def _get_sql_statement(args, kwargs):
+        for name in _SQL_KEYWORD_ARGUMENT_NAMES:
+            if name in kwargs:
+                return get_argument_value(args, kwargs, 0, name, optional=True)
+        return get_argument_value(args, kwargs, 0, "query", optional=True)
+
     def _trace_method(self, method, name, resource, extra_tags, dbm_propagator, *args, **kwargs):
         """
         Internal function to trace the call to the underlying cursor method
@@ -138,14 +147,13 @@ class TracedCursor(wrapt.ObjectProxy):
                 # Try to fetch custom properties that were passed by the specific Database implementation
                 self._set_post_execute_tags(s)
 
-    def executemany(self, query, *args, **kwargs):
+    def executemany(self, *args, **kwargs):
         """Wraps the cursor.executemany method"""
+        query = self._get_sql_statement(args, kwargs)
         self._self_last_execute_operation = query
         # Always return the result as-is
         # DEV: Some libraries return `None`, others `int`, and others the cursor objects
         #      These differences should be overridden at the integration specific layer (e.g. in `sqlite3/patch.py`)
-        # FIXME[matt] properly handle kwargs here. arg names can be different
-        # with different libs.
         core.dispatch("asm.block.dbapi.execute", (self, query, args, kwargs))
         return self._trace_method(
             self.__wrapped__.executemany,
@@ -153,13 +161,13 @@ class TracedCursor(wrapt.ObjectProxy):
             query,
             {"sql.executemany": "true"},
             self._self_dbm_propagator,
-            query,
             *args,
             **kwargs,
         )
 
-    def execute(self, query, *args, **kwargs):
+    def execute(self, *args, **kwargs):
         """Wraps the cursor.execute method"""
+        query = self._get_sql_statement(args, kwargs)
         self._self_last_execute_operation = query
 
         # Always return the result as-is
@@ -172,7 +180,6 @@ class TracedCursor(wrapt.ObjectProxy):
             query,
             {},
             self._self_dbm_propagator,
-            query,
             *args,
             **kwargs,
         )

--- a/ddtrace/propagation/_database_monitoring.py
+++ b/ddtrace/propagation/_database_monitoring.py
@@ -35,6 +35,7 @@ DBM_TRACE_PARENT_KEY: Literal["traceparent"] = "traceparent"
 DBM_TRACE_INJECTED_TAG: Literal["_dd.dbm_trace_injected"] = "_dd.dbm_trace_injected"
 DBM_PROPAGATION_MODE_DYNAMIC_SERVICE: Literal["dynamic_service"] = "dynamic_service"
 _DBM_INJECTION_MODES = ("full", "service", DBM_PROPAGATION_MODE_DYNAMIC_SERVICE)
+_SQL_KEYWORD_ARGUMENT_NAMES = ("query", "command", "sql", "operation", "statement")
 
 log = get_logger(__name__)
 
@@ -95,11 +96,15 @@ class _DBM_Propagator(object):
         if _should_inject_sql_basehash() and (base_hash := process_tags.base_hash):
             dbspan._set_attribute(PROPAGATED_HASH, str(base_hash))
 
-        original_sql_statement = get_argument_value(args, kwargs, self.sql_pos, self.sql_kw)
+        sql_kw = self.sql_kw
+        if sql_kw not in kwargs and sql_kw in _SQL_KEYWORD_ARGUMENT_NAMES:
+            sql_kw = next((name for name in _SQL_KEYWORD_ARGUMENT_NAMES if name in kwargs), sql_kw)
+
+        original_sql_statement = get_argument_value(args, kwargs, self.sql_pos, sql_kw)
         # add dbm comment to original_sql_statement
         sql_with_dbm_tags = self.comment_injector(dbm_comment, original_sql_statement)
         # replace the original query or procedure with sql_with_dbm_tags
-        args, kwargs = set_argument_value(args, kwargs, self.sql_pos, self.sql_kw, sql_with_dbm_tags)
+        args, kwargs = set_argument_value(args, kwargs, self.sql_pos, sql_kw, sql_with_dbm_tags)
         return args, kwargs
 
     def _get_dbm_comment(self, db_span):

--- a/releasenotes/notes/dbapi-keyword-sql-arguments-2e7d936de71569df.yaml
+++ b/releasenotes/notes/dbapi-keyword-sql-arguments-2e7d936de71569df.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    dbapi: Fixes an issue where traced ``execute`` and ``executemany`` calls fail when the SQL statement is passed
+    with a driver-specific keyword argument, such as Snowflake's ``command`` argument.

--- a/tests/appsec/iast/taint_sinks/test_sql_injection_dbapi.py
+++ b/tests/appsec/iast/taint_sinks/test_sql_injection_dbapi.py
@@ -61,6 +61,33 @@ class TestTracedCursor(TracerTestCase):
 
             mock_sql_injection_report.assert_called_once_with(evidence_value=query, dialect="sqlite")
 
+    @pytest.mark.parametrize("query_keyword", ["query", "command", "sql", "operation", "statement"])
+    @pytest.mark.skipif(not asm_config._iast_supported, reason="IAST compatible versions")
+    def test_tainted_query_keyword(self, query_keyword):
+        from ddtrace.appsec._iast._taint_tracking import OriginType
+        from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
+
+        with (
+            override_global_config(
+                dict(
+                    _iast_enabled=True,
+                )
+            ),
+            mock.patch(
+                "ddtrace.appsec._iast.taint_sinks.sql_injection.SqlInjection.report"
+            ) as mock_sql_injection_report,
+        ):
+            query = "SELECT * FROM db;"
+            query = taint_pyobject(query, source_name="query", source_value=query, source_origin=OriginType.PARAMETER)
+
+            cursor = self.cursor
+            cfg = IntegrationConfig(Config(), "sqlite", service="dbapi_service")
+            traced_cursor = TracedCursor(cursor, cfg=cfg)
+            traced_cursor.execute(**{query_keyword: query})
+            cursor.execute.assert_called_once_with(**{query_keyword: query})
+
+            mock_sql_injection_report.assert_called_once_with(evidence_value=query, dialect="sqlite")
+
     @pytest.mark.skipif(not asm_config._iast_supported, reason="IAST compatible versions")
     def test_tainted_query_args(self):
         from ddtrace.appsec._iast._taint_tracking import OriginType

--- a/tests/appsec/iast/taint_sinks/test_sql_injection_dbapi.py
+++ b/tests/appsec/iast/taint_sinks/test_sql_injection_dbapi.py
@@ -61,32 +61,36 @@ class TestTracedCursor(TracerTestCase):
 
             mock_sql_injection_report.assert_called_once_with(evidence_value=query, dialect="sqlite")
 
-    @pytest.mark.parametrize("query_keyword", ["query", "command", "sql", "operation", "statement"])
     @pytest.mark.skipif(not asm_config._iast_supported, reason="IAST compatible versions")
-    def test_tainted_query_keyword(self, query_keyword):
+    def test_tainted_query_keyword(self):
         from ddtrace.appsec._iast._taint_tracking import OriginType
         from ddtrace.appsec._iast._taint_tracking._taint_objects import taint_pyobject
 
-        with (
-            override_global_config(
-                dict(
-                    _iast_enabled=True,
+        for query_keyword in ("query", "command", "sql", "operation", "statement"):
+            with (
+                self.subTest(query_keyword=query_keyword),
+                override_global_config(
+                    dict(
+                        _iast_enabled=True,
+                    )
+                ),
+                mock.patch(
+                    "ddtrace.appsec._iast.taint_sinks.sql_injection.SqlInjection.report"
+                ) as mock_sql_injection_report,
+            ):
+                query = "SELECT * FROM db;"
+                query = taint_pyobject(
+                    query, source_name="query", source_value=query, source_origin=OriginType.PARAMETER
                 )
-            ),
-            mock.patch(
-                "ddtrace.appsec._iast.taint_sinks.sql_injection.SqlInjection.report"
-            ) as mock_sql_injection_report,
-        ):
-            query = "SELECT * FROM db;"
-            query = taint_pyobject(query, source_name="query", source_value=query, source_origin=OriginType.PARAMETER)
 
-            cursor = self.cursor
-            cfg = IntegrationConfig(Config(), "sqlite", service="dbapi_service")
-            traced_cursor = TracedCursor(cursor, cfg=cfg)
-            traced_cursor.execute(**{query_keyword: query})
-            cursor.execute.assert_called_once_with(**{query_keyword: query})
+                cursor = mock.Mock()
+                cursor.execute.__name__ = "execute"
+                cfg = IntegrationConfig(Config(), "sqlite", service="dbapi_service")
+                traced_cursor = TracedCursor(cursor, cfg=cfg)
+                traced_cursor.execute(**{query_keyword: query})
+                cursor.execute.assert_called_once_with(**{query_keyword: query})
 
-            mock_sql_injection_report.assert_called_once_with(evidence_value=query, dialect="sqlite")
+                mock_sql_injection_report.assert_called_once_with(evidence_value=query, dialect="sqlite")
 
     @pytest.mark.skipif(not asm_config._iast_supported, reason="IAST compatible versions")
     def test_tainted_query_args(self):

--- a/tests/contrib/dbapi/test_dbapi.py
+++ b/tests/contrib/dbapi/test_dbapi.py
@@ -20,11 +20,12 @@ class TestTracedCursor(TracerTestCase):
         super(TestTracedCursor, self).setUp()
         self.cursor = mock.Mock()
 
-    @pytest.mark.parametrize("method_name", ["execute", "executemany"])
-    def test_execute_signature(self, method_name):
-        method = getattr(TracedCursor, method_name)
-        assert str(inspect.signature(method)) == "(self, query, *args, **kwargs)"
-        assert str(inspect.signature(method.__get__(self.cursor))) == "(query, *args, **kwargs)"
+    def test_execute_signature(self):
+        for method_name in ("execute", "executemany"):
+            with self.subTest(method_name=method_name):
+                method = getattr(TracedCursor, method_name)
+                assert str(inspect.signature(method)) == "(self, query, *args, **kwargs)"
+                assert str(inspect.signature(method.__get__(self.cursor))) == "(query, *args, **kwargs)"
 
     def test_execute_wrapped_is_called_and_returned(self):
         cursor = self.cursor

--- a/tests/contrib/dbapi/test_dbapi.py
+++ b/tests/contrib/dbapi/test_dbapi.py
@@ -27,6 +27,26 @@ class TestTracedCursor(TracerTestCase):
         # DEV: We always pass through the result
         assert "__result__" == traced_cursor.execute("__query__", "arg_1", kwarg1="kwarg1")
         cursor.execute.assert_called_once_with("__query__", "arg_1", kwarg1="kwarg1")
+        assert self.pop_spans()[0].resource == "__query__"
+
+    def test_execute_with_keyword_query(self):
+        cursor = self.cursor
+        cursor.rowcount = 0
+        cursor.execute.return_value = "__result__"
+
+        traced_cursor = TracedCursor(cursor, {})
+        assert "__result__" == traced_cursor.execute(command="__query__")
+        cursor.execute.assert_called_once_with(command="__query__")
+        assert self.pop_spans()[0].resource == "__query__"
+
+    def test_execute_without_query(self):
+        cursor = self.cursor
+        cursor.rowcount = 0
+
+        traced_cursor = TracedCursor(cursor, {})
+        traced_cursor.execute()
+
+        cursor.execute.assert_called_once_with()
 
     @TracerTestCase.run_in_subprocess(env_overrides=dict(DD_DBM_PROPAGATION_MODE="full"))
     def test_dbm_propagation_not_supported(self):
@@ -66,6 +86,24 @@ class TestTracedCursor(TracerTestCase):
         # DBM comment should not be added procedure names
         cursor.callproc.assert_called_once_with("procedure_named_moon")
 
+    @TracerTestCase.run_in_subprocess(
+        env_overrides=dict(
+            DD_DBM_PROPAGATION_MODE="service",
+            DD_SERVICE="orders-app",
+            DD_ENV="staging",
+            DD_VERSION="v7343437-d7ac743",
+        )
+    )
+    def test_cursor_execute_with_keyword_and_dbm_injection(self):
+        cursor = self.cursor
+        cfg = IntegrationConfig(Config(), "dbapi", service="orders-db", _dbm_propagator=_DBM_Propagator(0, "command"))
+        traced_cursor = TracedCursor(cursor, cfg=cfg)
+
+        traced_cursor.execute(command="SELECT * FROM db;")
+
+        dbm_comment = "/*dddbs='orders-db',dde='staging',ddps='orders-app',ddpv='v7343437-d7ac743'*/ "
+        cursor.execute.assert_called_once_with(command=dbm_comment + "SELECT * FROM db;")
+
     def test_executemany_wrapped_is_called_and_returned(self):
         cursor = self.cursor
         cursor.rowcount = 0
@@ -75,6 +113,17 @@ class TestTracedCursor(TracerTestCase):
         # DEV: We always pass through the result
         assert "__result__" == traced_cursor.executemany("__query__", "arg_1", kwarg1="kwarg1")
         cursor.executemany.assert_called_once_with("__query__", "arg_1", kwarg1="kwarg1")
+        assert self.pop_spans()[0].resource == "__query__"
+
+    def test_executemany_with_keyword_query(self):
+        cursor = self.cursor
+        cursor.rowcount = 0
+        cursor.executemany.return_value = "__result__"
+
+        traced_cursor = TracedCursor(cursor, {})
+        assert "__result__" == traced_cursor.executemany(command="__query__", seqparams=((),))
+        cursor.executemany.assert_called_once_with(command="__query__", seqparams=((),))
+        assert self.pop_spans()[0].resource == "__query__"
 
     def test_fetchone_wrapped_is_called_and_returned(self):
         cursor = self.cursor

--- a/tests/contrib/dbapi/test_dbapi.py
+++ b/tests/contrib/dbapi/test_dbapi.py
@@ -104,13 +104,15 @@ class TestTracedCursor(TracerTestCase):
     )
     def test_cursor_execute_with_keyword_and_dbm_injection(self):
         cursor = self.cursor
-        cfg = IntegrationConfig(Config(), "dbapi", service="orders-db", _dbm_propagator=_DBM_Propagator(0, "command"))
+        cfg = IntegrationConfig(Config(), "dbapi", service="orders-db", _dbm_propagator=_DBM_Propagator(0, "query"))
         traced_cursor = TracedCursor(cursor, cfg=cfg)
 
-        traced_cursor.execute(command="SELECT * FROM db;")
+        traced_cursor.execute(operation="SELECT * FROM db;")
+        traced_cursor.executemany(command="SELECT * FROM db;", seqparams=((),))
 
         dbm_comment = "/*dddbs='orders-db',dde='staging',ddps='orders-app',ddpv='v7343437-d7ac743'*/ "
-        cursor.execute.assert_called_once_with(command=dbm_comment + "SELECT * FROM db;")
+        cursor.execute.assert_called_once_with(operation=dbm_comment + "SELECT * FROM db;")
+        cursor.executemany.assert_called_once_with(command=dbm_comment + "SELECT * FROM db;", seqparams=((),))
 
     def test_executemany_wrapped_is_called_and_returned(self):
         cursor = self.cursor

--- a/tests/contrib/dbapi/test_dbapi.py
+++ b/tests/contrib/dbapi/test_dbapi.py
@@ -1,3 +1,5 @@
+import inspect
+
 import mock
 import pytest
 
@@ -17,6 +19,12 @@ class TestTracedCursor(TracerTestCase):
     def setUp(self):
         super(TestTracedCursor, self).setUp()
         self.cursor = mock.Mock()
+
+    @pytest.mark.parametrize("method_name", ["execute", "executemany"])
+    def test_execute_signature(self, method_name):
+        method = getattr(TracedCursor, method_name)
+        assert str(inspect.signature(method)) == "(self, query, *args, **kwargs)"
+        assert str(inspect.signature(method.__get__(self.cursor))) == "(query, *args, **kwargs)"
 
     def test_execute_wrapped_is_called_and_returned(self):
         cursor = self.cursor


### PR DESCRIPTION
## Description

Allow `TracedCursor.execute()` and `TracedCursor.executemany()` to resolve SQL statements passed either positionally or through driver-specific keyword arguments while forwarding the caller's original `args` and `kwargs` unchanged.

The generic wrapper previously declared its first argument as `query`, even though wrapped drivers expose different names:

| library | first SQL parameter |
|---|---|
| `snowflake-connector-python` | `command` |
| `sqlite3` | `sql` |
| ddtrace `TracedCursor` | `query` |

As a result, valid raw-driver calls such as `cursor.execute(command="SELECT 1")` raised `TypeError` after Snowflake tracing wrapped the cursor. This was reproduced in a customer FastAPI deployment with ddtrace 4.12.2 and snowflake-connector-python 4.5.0.

The implementation resolves the SQL statement separately for the last-operation state, AppSec dispatch, and span resource. It leaves the original packed arguments intact for the wrapped cursor and for Database Monitoring propagation rewrites. This resolves the long-standing `FIXME` in `ddtrace/contrib/dbapi.py` noting that keyword names differ between libraries (introduced in `f9c132d65f` in 2017), and applies the same correction to `execute()`.

## Testing

- `python -m ruff format --check ddtrace/contrib/dbapi.py tests/contrib/dbapi/test_dbapi.py`
- `python -m ruff check ddtrace/contrib/dbapi.py tests/contrib/dbapi/test_dbapi.py`
- `reno lint`
- Built ddtrace 4.14.0rc1 locally as an editable install with its native extension.
- `python -m pytest tests/contrib/dbapi/test_dbapi.py -x -q`: 32 passed.
- Live Snowflake 4.5.0 reproduction app: all four positional, chained, keyword-`command`, and cursor-chained patterns returned real results with the consumer shim inactive.
- Snowflake integration tests: 22 passed locally; the remainder require the repository test-agent/Docker snapshot infrastructure, which was unavailable on this host. The full suite was started and those tests failed only on test-agent connection or isolated subprocess environment setup, not assertions in this change.

## Risks

Low. The public positional call shape is unchanged and has explicit regression coverage. Driver arguments remain in their original positional/keyword containers. Database Monitoring rewriting is covered for both positional and keyword SQL calls. Cursor subclasses were reviewed; none depend on `query` as a named wrapper parameter.

## Additional Notes

Reproduction app: https://github.com/marwan-zibaoui_ddog/snowflake-ddtrace-repro

Reviewed synchronous `TracedCursor` subclasses: `FetchTracedCursor`, `_SFTracedCursor`, `TracedSQLiteCursor`/`TracedSQLiteFetchCursor`, `PyODBCTracedCursor`, and Psycopg 2/3 traced/fetch cursor variants. SQLite overrides `execute`/`executemany` only for return-value semantics; Snowflake, PyODBC, and Psycopg inherit the generic methods. Existing internal `query=` calls in Psycopg tests remain supported.
