### PR TITLE
chore(iast): make iast tests independent of execution order

### DIFF
--- a/tests/appsec/iast/conftest.py
+++ b/tests/appsec/iast/conftest.py
@@ -19,12 +19,15 @@ from ddtrace.appsec._iast._taint_tracking._context import debug_context_array_fr
 from ddtrace.appsec._iast._taint_tracking._context import debug_context_array_size
 from ddtrace.appsec._iast._taint_tracking._native import reset_source_truncation_cache
 from ddtrace.appsec._iast._taint_tracking._native import reset_taint_range_limit_cache
+from ddtrace.appsec._iast.sampling.vulnerability_detection import _reset_global_limit
+from ddtrace.appsec._iast.taint_sinks._base import VulnerabilityBase
 from ddtrace.appsec._iast.taint_sinks.code_injection import patch as code_injection_patch
 from ddtrace.appsec._iast.taint_sinks.header_injection import patch as header_injection_patch
 from ddtrace.appsec._iast.taint_sinks.untrusted_serialization import patch as unstrusted_serialization_patch
 from ddtrace.appsec._iast.taint_sinks.weak_cipher import patch as weak_cipher_patch
 from ddtrace.appsec._iast.taint_sinks.weak_hash import patch as weak_hash_patch
 from ddtrace.appsec._iast.taint_sinks.weak_hash import unpatch_iast as weak_hash_unpatch
+from ddtrace.internal import core
 from ddtrace.internal.utils.http import Response
 from ddtrace.internal.utils.http import get_connection
 from tests.appsec.iast.iast_utils import IAST_VALID_LOG
@@ -130,6 +133,26 @@ def iast_span_defaults(tracer):
     for _ in iast_context(dict(DD_IAST_ENABLED="true")):
         with tracer.trace("test") as span:
             yield span
+
+
+@pytest.fixture(autouse=True)
+def reset_iast_process_state():
+    """Restore the process-wide IAST state (patches, counters, native contexts) so that a test
+    that drives IAST directly, or fails before its own cleanup, cannot poison its neighbours.
+    """
+    yield
+    # testing_unpatch() is a no-op unless _iast_is_testing is set, and the test's own override
+    # is already gone by teardown time.
+    with override_global_config(dict(_iast_is_testing=True)):
+        _testing_unpatch_iast()
+    weak_hash_unpatch()
+    _reset_global_limit()
+    VulnerabilityBase._prepare_report._reset_cache()
+    core.discard_item(IAST.REQUEST_CONTEXT_KEY)
+    clear_all_request_context_slots()
+    IAST_CONTEXT.set(None)
+    reset_taint_range_limit_cache()
+    reset_source_truncation_cache()
 
 
 def pytest_configure(config):

--- a/tests/appsec/iast/test_fork_handler_regression.py
+++ b/tests/appsec/iast/test_fork_handler_regression.py
@@ -362,34 +362,41 @@ def test_early_fork_keeps_iast_enabled():
     remain enabled in the child and work normally.
     """
     from ddtrace.appsec._iast import _disable_iast_after_fork
+    from ddtrace.appsec._iast._iast_request_context_base import IAST_CONTEXT
     from ddtrace.appsec._iast._taint_tracking import initialize_native_state
     from ddtrace.appsec._iast._taint_tracking import is_tainted
+    from ddtrace.appsec._iast._taint_tracking._context import clear_all_request_context_slots
     from ddtrace.internal.settings.asm import config as asm_config
 
     # Ensure IAST is enabled but NO context is active (simulating early fork)
-    # Don't call _start_iast_context_and_oce() - this simulates pre-fork state
+    # Don't call _start_iast_context_and_oce() - this simulates pre-fork state.
+    # A leaked context would make the handler see a late fork and disable IAST, so drop any.
     initialize_native_state()
+    clear_all_request_context_slots()
+    IAST_CONTEXT.set(None)
     original_state = asm_config._iast_enabled
     asm_config._iast_enabled = True
 
-    # Call the fork handler - should detect no active context and keep IAST enabled
-    _disable_iast_after_fork()
+    try:
+        # Call the fork handler - should detect no active context and keep IAST enabled
+        _disable_iast_after_fork()
 
-    # IAST should still be enabled (early fork scenario)
-    assert asm_config._iast_enabled is True, "IAST should remain enabled for early forks"
+        # IAST should still be enabled (early fork scenario)
+        assert asm_config._iast_enabled is True, "IAST should remain enabled for early forks"
 
-    # Now we can initialize IAST fresh in this "worker"
-    _start_iast_context_and_oce()
+        # Now we can initialize IAST fresh in this "worker"
+        _start_iast_context_and_oce()
 
-    # IAST should work normally
-    tainted = taint_pyobject("worker_data", "source", "value", OriginType.PARAMETER)
-    assert is_tainted(tainted), "IAST should work in early fork (web worker)"
+        # IAST should work normally
+        tainted = taint_pyobject("worker_data", "source", "value", OriginType.PARAMETER)
+        assert is_tainted(tainted), "IAST should work in early fork (web worker)"
 
-    count = _num_objects_tainted_in_request()
-    assert count > 0, "Should have tainted objects in early fork"
+        count = _num_objects_tainted_in_request()
+        assert count > 0, "Should have tainted objects in early fork"
 
-    _end_iast_context_and_oce()
-    asm_config._iast_enabled = original_state
+        _end_iast_context_and_oce()
+    finally:
+        asm_config._iast_enabled = original_state
 
 
 if __name__ == "__main__":

--- a/tests/appsec/iast/test_patch_modules.py
+++ b/tests/appsec/iast/test_patch_modules.py
@@ -92,8 +92,11 @@ class TestWrapModulesForIAST:
     @pytest.fixture
     def wrap_modules(self):
         """Create a WrapFunctonsForIAST instance for testing."""
+        # MODULES_TO_UNPATCH is process-wide and these tests assert on its exact size.
+        MODULES_TO_UNPATCH.clear()
         wrap_modules = WrapFunctonsForIAST()
         yield wrap_modules
+        wrap_modules.testing = True
         wrap_modules.testing_unpatch()
 
     def test_init(self, wrap_modules):


### PR DESCRIPTION
APPSEC-69623

## Description

xdist `worksteal` (#19581) lets a worker steal chunks from other workers, so `tests/appsec/iast` files now share a process in arbitrary order. That exposed process-global IAST state leaking between tests: `MODULES_TO_UNPATCH`, leftover wrapt wrappers on `_md5`/`hashlib`, `GLOBAL_VULNERABILITIES_LIMIT`, and native context slots / `IAST_CONTEXT`.

Adds an autouse teardown resetting all of it, makes the `MODULES_TO_UNPATCH` size assertions hermetic, and gives `test_early_fork_keeps_iast_enabled` a clean pre-fork state.

Fixes the quarantined `test_metric_executed_sink`, `test_weak_hash_md5_builtin_py3_*`, `TestWrapModulesForIAST::test_patch_with_testing` / `test_testing_unpatch`, `test_early_fork_keeps_iast_enabled` and `test_oce_reset_vulnerabilities_report`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)