### PR TITLE
fix(snowflake): snowflake cursor now supports command keyword

### DIFF
--- a/ddtrace/contrib/internal/snowflake/patch.py
+++ b/ddtrace/contrib/internal/snowflake/patch.py
@@ -41,7 +41,6 @@ def _supported_versions() -> dict[str, str]:
 
 
 class _SFTracedCursor(TracedCursor):
-    # AIDEV-NOTE: This adapter keeps Snowflake's command keyword without changing TracedCursor's public API.
     def execute(self, command: str, *args: object, **kwargs: object) -> object:
         return super(_SFTracedCursor, self).execute(command, *args, **kwargs)
 

--- a/ddtrace/contrib/internal/snowflake/patch.py
+++ b/ddtrace/contrib/internal/snowflake/patch.py
@@ -41,6 +41,13 @@ def _supported_versions() -> dict[str, str]:
 
 
 class _SFTracedCursor(TracedCursor):
+    # AIDEV-NOTE: This adapter keeps Snowflake's command keyword without changing TracedCursor's public API.
+    def execute(self, command: str, *args: object, **kwargs: object) -> object:
+        return super(_SFTracedCursor, self).execute(command, *args, **kwargs)
+
+    def executemany(self, command: str, *args: object, **kwargs: object) -> object:
+        return super(_SFTracedCursor, self).executemany(command, *args, **kwargs)
+
     def _set_post_execute_tags(self, span):
         super(_SFTracedCursor, self)._set_post_execute_tags(span)
         span._set_attribute("sfqid", self.__wrapped__.sfqid)

--- a/releasenotes/notes/fix-snowflake-using-command-kwargs-ff1b5c0334e26297.yaml
+++ b/releasenotes/notes/fix-snowflake-using-command-kwargs-ff1b5c0334e26297.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    snowflake: Fixes an issue where traced cursor calls fail when ``command`` is passed as a
+    keyword argument to ``execute`` or ``executemany``.

--- a/tests/contrib/snowflake/test_snowflake.py
+++ b/tests/contrib/snowflake/test_snowflake.py
@@ -103,6 +103,18 @@ def test_snowflake_fetchone(client):
         assert cur.fetchone() == ("4.30.2",)
 
 
+@req_mock.activate
+def test_snowflake_execute_accepts_command_keyword(client):
+    add_snowflake_query_response(
+        rowtype=["TEXT"],
+        rows=[("4.30.2",)],
+    )
+    with client.cursor() as cur:
+        res = cur.execute(command="select current_version();")
+        assert res == cur
+        assert cur.fetchone() == ("4.30.2",)
+
+
 @snapshot()
 @req_mock.activate
 def test_snowflake_settings_override(client):
@@ -192,6 +204,25 @@ def test_snowflake_executemany_insert(client):
         res = cur.executemany(
             "insert into t (a, b) values (%s, %s);",
             [
+                ("1a", "1b"),
+                ("2a", "2b"),
+            ],
+        )
+        assert res == cur
+        assert res.rowcount == 2
+
+
+@req_mock.activate
+def test_snowflake_executemany_accepts_command_keyword(client):
+    add_snowflake_query_response(
+        rowtype=[],
+        rows=[],
+        total=2,
+    )
+    with client.cursor() as cur:
+        res = cur.executemany(
+            command="insert into t (a, b) values (%s, %s);",
+            seqparams=[
                 ("1a", "1b"),
                 ("2a", "2b"),
             ],


### PR DESCRIPTION
Superseeds https://github.com/DataDog/dd-trace-py/pull/19642

## Motivation 

The generic wrapper previously declared its first argument as `query`, even though wrapped drivers expose different names:

| library | first SQL parameter |
|---|---|
| `snowflake-connector-python` | `command` |
| ddtrace `TracedCursor` | `query` |

As a result, valid raw-driver calls such as `cursor.execute(command="SELECT 1")` raised `TypeError` after Snowflake tracing wrapped the cursor. This was reproduced in a customer FastAPI deployment with ddtrace 4.12.2 and snowflake-connector-python 4.5.0.

## Description

Adds a specific implementation of `execute` and `executemany` in the snowflake integration to make it compatible with the `command` keyword of snowflake
