### PR TITLE
ci: make circular import job compare against merge base

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -422,9 +422,10 @@ detect_circular_imports:
       fi
       BASE_BRANCH=$(.gitlab/scripts/resolve-base-branch.sh)
       git fetch origin "${BASE_BRANCH}"
-      git checkout FETCH_HEAD
+      MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
+      git checkout "${MERGE_BASE}"
       cd ..
-    # Analyse the base branch ddtrace using the PR version of cycles.py (has uv metadata)
+    # Analyse the merge base ddtrace using the PR version of cycles.py (has uv metadata)
     - uv run --script cycles.py analyze --root dd-trace-py/ddtrace cycles-base.json
     - cat cycles-base.json
     - |
@@ -463,9 +464,10 @@ detect_layering_violations:
       fi
       BASE_BRANCH=$(.gitlab/scripts/resolve-base-branch.sh)
       git fetch origin "${BASE_BRANCH}"
-      git checkout FETCH_HEAD
+      MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
+      git checkout "${MERGE_BASE}"
       cd ..
-    # Analyse the base branch ddtrace using the PR version of layers.py/layers.json (has uv metadata)
+    # Analyse the merge base using the PR version of layers.py/layers.json (has uv metadata)
     - uv run --script layers.py analyze --root dd-trace-py/ddtrace layers-base.json
     - cat layers-base.json
     - |


### PR DESCRIPTION
## Description

As title says.  Currently, if a PR's merge base with `main` contains a cycle that the latest `main` doesn't have, then its circular imports job will fail because it'll see a circular import that `main` doesn't have.

This PR is based on a version of `main` that doesn't have a circular import fix that latest `main` does have, so if it passes CI, the fix does work.