### PR TITLE
refactor(appsec): compose lifecycle dependencies explicitly

### DIFF
--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -42,7 +42,6 @@ def _patch_subprocess(module):
 
 def patch_common_modules():
     global _is_patched
-
     if _is_patched:
         return
 
@@ -108,10 +107,9 @@ def _get_rasp_capability(capability: str) -> bool:
 
         try:
             from ddtrace.appsec._processor import AppSecSpanProcessor
-        except Exception as e:
-            from ddtrace.appsec._listeners import _abort_appsec
-
-            _abort_appsec(str(e))
+        except Exception:
+            # load_appsec owns fatal processor load failures; wrappers only need to
+            # report the capability as unavailable while imports are in progress.
             return False
 
         return AppSecSpanProcessor._instance is not None and getattr(

--- a/ddtrace/appsec/_listeners.py
+++ b/ddtrace/appsec/_listeners.py
@@ -36,8 +36,6 @@ def _abort_appsec(failure_msg: str) -> None:
 
     This is called in case of non-recoverable AppSec load-time failure, such as a libddwaf loading error.
     """
-    from ddtrace.trace import tracer
-
     log.warning("Disabling AppSec: libddwaf failed to load (%s)", failure_msg or "unknown error")
 
     if asm_config._asm_enabled:

--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 import os
-from typing import Any
 from typing import Callable
 from typing import Optional
 from typing import Sequence
+from typing import TypedDict
+from typing import cast
 
 from ddtrace.appsec._capabilities import _ALL_ASM_CAPABILITIES
 from ddtrace.appsec._capabilities import _asm_feature_is_required
@@ -28,6 +29,23 @@ APPSEC_PRODUCTS = {
     RemoteConfigProduct.AsmData,
     RemoteConfigProduct.AsmDd,
 }
+
+
+class _AsmFeatureState(TypedDict, total=False):
+    enabled: bool
+
+
+class _AutoUserInstrumState(TypedDict, total=False):
+    mode: Optional[str]
+
+
+class AsmFeaturesResult(TypedDict, total=False):
+    """Shape of an ASM_FEATURES RC payload's content, and of the dict _update_asm_features
+    derives from a batch of such payloads.
+    """
+
+    asm: _AsmFeatureState
+    auto_user_instrum: _AutoUserInstrumState
 
 
 def enable_appsec_rc(callback: "AppSecCallback") -> None:
@@ -76,8 +94,7 @@ class AppSecCallback(RCCallback):
 
     def __init__(self, enable_asm: Callable[[], None], disable_asm: Callable[[], None]) -> None:
         """Initialize the AppSec callback."""
-        self._cache: dict[str, dict[str, Any]] = {}
-        self._asm_features_cache: dict[str, dict[str, Any]] = {}
+        self._cache: dict[str, AsmFeaturesResult] = {}
         self._enable_asm = enable_asm
         self._disable_asm = disable_asm
 
@@ -89,6 +106,11 @@ class AppSecCallback(RCCallback):
         """
         if not payloads:
             return
+        # ASM_FEATURES payloads are folded into `result` here, once, and reused below for both
+        # the immediate product (de)registration and the enable_asm/disable_asm decision. Calling
+        # _update_asm_features a second time on the same payloads against the same cache would
+        # consume the pop-on-removal transition it just recorded and silently drop the second
+        # decision (e.g. missing a disable_asm() call on an ASM_FEATURES removal payload).
         result = _update_asm_features(payloads, self._cache)
         if "asm" in result:
             if asm_config._asm_static_rule_file is None:
@@ -110,33 +132,27 @@ class AppSecCallback(RCCallback):
                     remoteconfig_poller.unregister_callback(RemoteConfigProduct.AsmDd)
                     remoteconfig_poller.disable_product(RemoteConfigProduct.AsmDd)
         debug_info = (
-            f"appsec._remoteconfiguration.deb::_appsec_callback::payload"
+            f"appsec._remoteconfiguration.deb::AppSecCallback::payload"
             f"{tuple(p.path for p in payloads)}[{os.getpid()}][P: {os.getppid()}]"
         )
         log.debug(debug_info)
 
         for_the_waf_updates: list[tuple[str, str, PayloadType]] = []
         for_the_waf_removals: list[tuple[str, str]] = []
-        for_the_tracer: list[Payload] = []
         for payload in payloads:
             if payload.metadata.product_name == "ASM_FEATURES":
-                for_the_tracer.append(payload)
+                continue  # already folded into `result` above
             elif payload.content is None:
                 for_the_waf_removals.append((payload.metadata.product_name, payload.path))
             else:
                 for_the_waf_updates.append((payload.metadata.product_name, payload.path, payload.content))
-        _process_asm_features(
-            for_the_tracer,
-            self._asm_features_cache,
-            enable_asm=self._enable_asm,
-            disable_asm=self._disable_asm,
-        )
+        _process_asm_features(result, enable_asm=self._enable_asm, disable_asm=self._disable_asm)
         if (for_the_waf_removals or for_the_waf_updates) and asm_config._asm_enabled:
             core.dispatch("waf.update", (for_the_waf_removals, for_the_waf_updates))
 
 
-def _update_asm_features(payload_list: Sequence[Payload], cache: dict[str, dict[str, Any]]) -> dict[str, Any]:
-    res: dict[str, dict[str, Optional[bool]]] = {}
+def _update_asm_features(payload_list: Sequence[Payload], cache: dict[str, AsmFeaturesResult]) -> AsmFeaturesResult:
+    res: AsmFeaturesResult = {}
     for payload in payload_list:
         if payload.metadata.product_name == "ASM_FEATURES":
             payload_content = payload.content
@@ -148,14 +164,14 @@ def _update_asm_features(payload_list: Sequence[Payload], cache: dict[str, dict[
                         res["auto_user_instrum"] = {"mode": None}
                 cache.pop(payload.path, None)
             else:
-                res.update(payload_content)
-                cache[payload.path] = payload_content
+                asm_features_content = cast(AsmFeaturesResult, payload_content)
+                res.update(asm_features_content)
+                cache[payload.path] = asm_features_content
     return res
 
 
 def _process_asm_features(
-    payload_list: list[Payload],
-    cache: dict[str, dict[str, Any]],
+    result: AsmFeaturesResult,
     enable_asm: Callable[[], None],
     disable_asm: Callable[[], None],
 ) -> None:
@@ -171,8 +187,11 @@ def _process_asm_features(
     | false             | true       | Disabled |
     | true              | true       | Enabled  |
     ```
+
+    `result` is the dict already produced by _update_asm_features for the current payload batch;
+    callers must not call _update_asm_features again for the same batch (it pops the cache entry
+    on a removal payload, so a second call would silently miss the enable/disable decision).
     """
-    result = _update_asm_features(payload_list, cache)
     if "asm" in result and asm_config._asm_can_be_enabled:
         if result["asm"].get("enabled", False):
             enable_asm()

--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 import os
 from typing import Any
+from typing import Callable
 from typing import Optional
 from typing import Sequence
 
 from ddtrace.appsec._capabilities import _ALL_ASM_CAPABILITIES
 from ddtrace.appsec._capabilities import _asm_feature_is_required
 from ddtrace.appsec._capabilities import _rc_capabilities
-from ddtrace.appsec._constants import APPSEC
 from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.native import RemoteConfigProduct
@@ -30,7 +30,7 @@ APPSEC_PRODUCTS = {
 }
 
 
-def enable_appsec_rc() -> None:
+def enable_appsec_rc(callback: "AppSecCallback") -> None:
     """Remote config will be used by ASM libraries to receive four different updates from the backend.
     Each update has it's own product:
     - ASM_FEATURES product - To allow users enable or disable ASM remotely
@@ -46,27 +46,19 @@ def enable_appsec_rc() -> None:
     if _asm_feature_is_required():
         remoteconfig_poller.register_callback(
             RemoteConfigProduct.AsmFeatures,
-            _appsec_callback,
+            callback,
             capabilities=_rc_capabilities(),
         )
         remoteconfig_poller.enable_product(RemoteConfigProduct.AsmFeatures)
 
     # Register other ASM products if AppSec is enabled
     if asm_config._asm_enabled and asm_config._asm_static_rule_file is None:
-        remoteconfig_poller.register_callback(RemoteConfigProduct.AsmData, _appsec_callback)  # IP Blocking
+        remoteconfig_poller.register_callback(RemoteConfigProduct.AsmData, callback)  # IP Blocking
         remoteconfig_poller.enable_product(RemoteConfigProduct.AsmData)
-        remoteconfig_poller.register_callback(
-            RemoteConfigProduct.Asm, _appsec_callback
-        )  # Exclusion Filters & Custom Rules
+        remoteconfig_poller.register_callback(RemoteConfigProduct.Asm, callback)  # Exclusion Filters & Custom Rules
         remoteconfig_poller.enable_product(RemoteConfigProduct.Asm)
-        remoteconfig_poller.register_callback(RemoteConfigProduct.AsmDd, _appsec_callback)  # DD Rules
+        remoteconfig_poller.register_callback(RemoteConfigProduct.AsmDd, callback)  # DD Rules
         remoteconfig_poller.enable_product(RemoteConfigProduct.AsmDd)
-
-    # ensure exploit prevention patches are loaded by one-click activation
-    if asm_config._asm_enabled:
-        from ddtrace.appsec._listeners import load_common_appsec_modules
-
-        load_common_appsec_modules()
 
     if asm_config._asm_enabled:
         telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, True)
@@ -82,9 +74,12 @@ def disable_appsec_rc() -> None:
 class AppSecCallback(RCCallback):
     """Remote config callback for AppSec products."""
 
-    def __init__(self) -> None:
+    def __init__(self, enable_asm: Callable[[], None], disable_asm: Callable[[], None]) -> None:
         """Initialize the AppSec callback."""
         self._cache: dict[str, dict[str, Any]] = {}
+        self._asm_features_cache: dict[str, dict[str, Any]] = {}
+        self._enable_asm = enable_asm
+        self._disable_asm = disable_asm
 
     def __call__(self, payloads: Sequence[Payload]) -> None:
         """Process AppSec configuration payloads.
@@ -130,13 +125,14 @@ class AppSecCallback(RCCallback):
                 for_the_waf_removals.append((payload.metadata.product_name, payload.path))
             else:
                 for_the_waf_updates.append((payload.metadata.product_name, payload.path, payload.content))
-        _process_asm_features(for_the_tracer)
+        _process_asm_features(
+            for_the_tracer,
+            self._asm_features_cache,
+            enable_asm=self._enable_asm,
+            disable_asm=self._disable_asm,
+        )
         if (for_the_waf_removals or for_the_waf_updates) and asm_config._asm_enabled:
             core.dispatch("waf.update", (for_the_waf_removals, for_the_waf_updates))
-
-
-# Create singleton instance for global usage
-_appsec_callback = AppSecCallback()
 
 
 def _update_asm_features(payload_list: Sequence[Payload], cache: dict[str, dict[str, Any]]) -> dict[str, Any]:
@@ -157,7 +153,12 @@ def _update_asm_features(payload_list: Sequence[Payload], cache: dict[str, dict[
     return res
 
 
-def _process_asm_features(payload_list: list[Payload], cache: dict[str, dict[str, Any]] = {}) -> None:
+def _process_asm_features(
+    payload_list: list[Payload],
+    cache: dict[str, dict[str, Any]],
+    enable_asm: Callable[[], None],
+    disable_asm: Callable[[], None],
+) -> None:
     """This callback updates appsec enabled in tracer and config instances following this logic:
     ```
     | DD_APPSEC_ENABLED | RC Enabled | Result   |
@@ -182,20 +183,3 @@ def _process_asm_features(payload_list: list[Payload], cache: dict[str, dict[str
     if "asm" in result or "auto_user_instrum" in result:
         # Re-advertise capabilities so blocking/RASP follow one-click activation/deactivation.
         remoteconfig_poller.update_capabilities(_ALL_ASM_CAPABILITIES, _rc_capabilities())
-
-
-def disable_asm() -> None:
-    if asm_config._asm_enabled:
-        from ddtrace.appsec._listeners import disable_appsec
-
-        disable_appsec(reconfigure_tracer=True)
-        if not asm_config._asm_enabled:
-            telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, False)
-
-
-def enable_asm() -> None:
-    if asm_config._asm_can_be_enabled and not asm_config._asm_enabled:
-        from ddtrace.appsec._listeners import load_appsec
-
-        if load_appsec(reconfigure_tracer=True, origin=APPSEC.ENABLED_ORIGIN_RC):
-            telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, True)

--- a/ddtrace/internal/appsec/product.py
+++ b/ddtrace/internal/appsec/product.py
@@ -14,14 +14,16 @@ def enabled():
 
 def start():
     if config._asm_enabled or config._asm_can_be_enabled:
+        # The product owns common-patch setup for both static and remote activation.
         from ddtrace.appsec._listeners import load_common_appsec_modules
 
         load_common_appsec_modules()
 
     if config._asm_rc_enabled:
+        from ddtrace.appsec._remoteconfiguration import AppSecCallback
         from ddtrace.appsec._remoteconfiguration import enable_appsec_rc
 
-        enable_appsec_rc()
+        enable_appsec_rc(AppSecCallback(_enable_asm, _disable_asm))
 
     if config._asm_enabled:
         from ddtrace.appsec._listeners import load_appsec
@@ -35,3 +37,25 @@ def restart(join=False):
 
 def stop(join=False):
     pass
+
+
+def _disable_asm() -> None:
+    if config._asm_enabled:
+        from ddtrace.appsec._listeners import disable_appsec
+        from ddtrace.internal.telemetry import telemetry_writer
+        from ddtrace.internal.telemetry.constants import TELEMETRY_APM_PRODUCT
+
+        disable_appsec(reconfigure_tracer=True)
+        if not config._asm_enabled:
+            telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, False)
+
+
+def _enable_asm() -> None:
+    if config._asm_can_be_enabled and not config._asm_enabled:
+        from ddtrace.appsec._constants import APPSEC
+        from ddtrace.appsec._listeners import load_appsec
+        from ddtrace.internal.telemetry import telemetry_writer
+        from ddtrace.internal.telemetry.constants import TELEMETRY_APM_PRODUCT
+
+        if load_appsec(reconfigure_tracer=True, origin=APPSEC.ENABLED_ORIGIN_RC):
+            telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, True)

--- a/tests/appsec/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/appsec/test_remoteconfiguration.py
@@ -18,7 +18,6 @@ from ddtrace.internal.appsec.product import _enable_asm
 from ddtrace.internal.native import RemoteConfigProduct
 from ddtrace.internal.service import ServiceStatus
 from ddtrace.internal.settings.asm import config as asm_config
-from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_APM_PRODUCT
 from ddtrace.internal.utils.formats import asbool
 import tests.appsec.rules as rules
@@ -465,25 +464,29 @@ def test_rc_activation_reports_appsec_product_when_enabled(tracer, rc_poller, ap
     disable_appsec_rc()
 
 
-def test_rc_enable_then_disable_asm_reports_telemetry(tracer, rc_poller, appsec_callback):
-    """When AppSec is enabled/disabled via RC, telemetry should reflect the changes."""
-    with override_global_config(dict(_asm_enabled=False, _asm_can_be_enabled=True, _remote_config_enabled=True)):
-        with mock.patch.object(telemetry_writer, "product_activated") as product_activated:
-            enable_appsec_rc(appsec_callback)
+def test_enable_asm_reports_telemetry():
+    with (
+        mock.patch.object(asm_config, "_asm_enabled", False),
+        mock.patch.object(asm_config, "_asm_can_be_enabled", True),
+        mock.patch("ddtrace.appsec._listeners.load_appsec", return_value=True) as load_appsec,
+        mock.patch("ddtrace.internal.telemetry.telemetry_writer.product_activated") as product_activated,
+    ):
+        _enable_asm()
 
-            # Initially not activated
-            product_activated.assert_not_called()
+    load_appsec.assert_called_once_with(reconfigure_tracer=True, origin=APPSEC.ENABLED_ORIGIN_RC)
+    product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, True)
 
-            # Simulate RC enabling AppSec
-            enable_config = [build_payload("ASM_FEATURES", {"asm": {"enabled": True}}, "config")]
-            appsec_callback(enable_config)
-            product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, True)
 
-            product_activated.reset_mock()
+def test_disable_asm_reports_telemetry():
+    def disable_appsec(*, reconfigure_tracer):
+        assert reconfigure_tracer is True
+        asm_config._asm_enabled = False
 
-            # Simulate RC disabling AppSec
-            disable_config = [build_payload("ASM_FEATURES", {"asm": {}}, "config")]
-            appsec_callback(disable_config)
-            product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, False)
+    with (
+        mock.patch.object(asm_config, "_asm_enabled", True),
+        mock.patch("ddtrace.appsec._listeners.disable_appsec", side_effect=disable_appsec),
+        mock.patch("ddtrace.internal.telemetry.telemetry_writer.product_activated") as product_activated,
+    ):
+        _disable_asm()
 
-    disable_appsec_rc()
+    product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, False)

--- a/tests/appsec/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/appsec/test_remoteconfiguration.py
@@ -8,14 +8,17 @@ from ddtrace.appsec._capabilities import _appsec_rc_capabilities
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import DEFAULT
 from ddtrace.appsec._processor import AppSecSpanProcessor
-from ddtrace.appsec._remoteconfiguration import _appsec_callback
+from ddtrace.appsec._remoteconfiguration import AppSecCallback
 from ddtrace.appsec._remoteconfiguration import disable_appsec_rc
 from ddtrace.appsec._remoteconfiguration import enable_appsec_rc
 from ddtrace.appsec._utils import get_triggers
 from ddtrace.contrib.internal.trace_utils import set_http_meta
+from ddtrace.internal.appsec.product import _disable_asm
+from ddtrace.internal.appsec.product import _enable_asm
 from ddtrace.internal.native import RemoteConfigProduct
 from ddtrace.internal.service import ServiceStatus
 from ddtrace.internal.settings.asm import config as asm_config
+from ddtrace.internal.telemetry import telemetry_writer
 from ddtrace.internal.telemetry.constants import TELEMETRY_APM_PRODUCT
 from ddtrace.internal.utils.formats import asbool
 import tests.appsec.rules as rules
@@ -24,6 +27,11 @@ from tests.appsec.utils import build_payload
 from tests.appsec.utils import get_waf_addresses
 from tests.utils import override_env
 from tests.utils import override_global_config
+
+
+@pytest.fixture
+def appsec_callback():
+    return AppSecCallback(_enable_asm, _disable_asm)
 
 
 @pytest.fixture(autouse=True)
@@ -47,6 +55,35 @@ def _set_and_get_appsec_tags(tracer, check_client_id=False):
     return get_triggers(span)
 
 
+def test_appsec_callback_uses_injected_lifecycle(rc_poller):
+    enable_asm = mock.Mock()
+    disable_asm = mock.Mock()
+    callback = AppSecCallback(enable_asm, disable_asm)
+
+    with mock.patch("ddtrace.appsec._remoteconfiguration._process_asm_features") as process_asm_features:
+        callback([build_payload("ASM_FEATURES", {"asm": {"enabled": True}}, "config")])
+
+    process_asm_features.assert_called_once()
+    assert process_asm_features.call_args.kwargs["enable_asm"] is enable_asm
+    assert process_asm_features.call_args.kwargs["disable_asm"] is disable_asm
+
+
+def test_appsec_product_wires_remote_configuration():
+    from ddtrace.internal.appsec import product
+
+    with (
+        mock.patch.object(product.config, "_asm_enabled", False),
+        mock.patch.object(product.config, "_asm_can_be_enabled", False),
+        mock.patch.object(product.config, "_asm_rc_enabled", True),
+        mock.patch("ddtrace.appsec._remoteconfiguration.enable_appsec_rc") as enable_rc,
+    ):
+        product.start()
+
+        callback = enable_rc.call_args.args[0]
+        assert callback._enable_asm is product._enable_asm
+        assert callback._disable_asm is product._disable_asm
+
+
 @pytest.mark.xfail(
     reason="DD_REMOTE_CONFIGURATION_ENABLED is set to false for all riot venvs, "
     "this is not the default behavior for users"
@@ -58,19 +95,19 @@ def test_rc_enabled_by_default(tracer):
     assert asm_config._asm_can_be_enabled
 
 
-def test_rc_activate_is_active_and_get_processor_tags(tracer, rc_poller):
+def test_rc_activate_is_active_and_get_processor_tags(tracer, rc_poller, appsec_callback):
     with override_global_config(dict(_remote_config_enabled=True)):
         rc_config = build_payload("ASM_FEATURES", {"asm": {"enabled": True}}, "config")
-        _appsec_callback([rc_config])
+        appsec_callback([rc_config])
         assert AppSecSpanProcessor._instance
         assert _set_and_get_appsec_tags(tracer)
         rc_config = build_payload("ASM_FEATURES", None, "config")
-        _appsec_callback([rc_config])
+        appsec_callback([rc_config])
         result = _set_and_get_appsec_tags(tracer)
         assert result is None
         assert AppSecSpanProcessor._instance is None
         rc_config = build_payload("ASM_FEATURES", {"asm": {"enabled": True}}, "config")
-        _appsec_callback([rc_config])
+        appsec_callback([rc_config])
         assert AppSecSpanProcessor._instance
         assert _set_and_get_appsec_tags(tracer)
 
@@ -83,7 +120,7 @@ def test_rc_activate_is_active_and_get_processor_tags(tracer, rc_poller):
         ("true", False),
     ],
 )
-def test_rc_activation_states_on(tracer, appsec_enabled, rc_value, rc_poller):
+def test_rc_activation_states_on(tracer, appsec_enabled, rc_value, rc_poller, appsec_callback):
     with (
         override_env({APPSEC.ENV: appsec_enabled} if appsec_enabled else {}),
         override_global_config(dict(_asm_enabled=asbool(appsec_enabled), _remote_config_enabled=True)),
@@ -91,7 +128,7 @@ def test_rc_activation_states_on(tracer, appsec_enabled, rc_value, rc_poller):
         if appsec_enabled:
             tracer.configure(appsec_enabled=asbool(appsec_enabled))
         rc_config = build_payload("ASM_FEATURES", {"asm": {"enabled": rc_value}}, "config")
-        _appsec_callback([rc_config])
+        appsec_callback([rc_config])
         result = _set_and_get_appsec_tags(tracer)
         assert result
 
@@ -104,7 +141,7 @@ def test_rc_activation_states_on(tracer, appsec_enabled, rc_value, rc_poller):
         ("false", True),
     ],
 )
-def test_rc_activation_states_off(tracer, appsec_enabled, rc_value, rc_poller):
+def test_rc_activation_states_off(tracer, appsec_enabled, rc_value, rc_poller, appsec_callback):
     with override_env({APPSEC.ENV: appsec_enabled}):
         if appsec_enabled == "":
             del os.environ[APPSEC.ENV]
@@ -115,7 +152,7 @@ def test_rc_activation_states_off(tracer, appsec_enabled, rc_value, rc_poller):
             if rc_value is False:
                 rc_configs = []
 
-            _appsec_callback(rc_configs)
+            appsec_callback(rc_configs)
             result = _set_and_get_appsec_tags(tracer)
             assert result is None
 
@@ -151,7 +188,7 @@ def test_rc_capabilities(rc_enabled, appsec_enabled, capability, tracer):
         ({"_asm_static_rule_file": DEFAULT.RULES}, "gAAAAg=="),  # Only ASM_FEATURES
     ],
 )
-def test_rc_activation_capabilities(tracer, rc_poller, env_rules, expected):
+def test_rc_activation_capabilities(tracer, rc_poller, env_rules, expected, appsec_callback):
     global_config = dict(_asm_enabled=False, _remote_config_enabled=True)
     global_config.update(env_rules)
     with override_global_config(global_config):
@@ -159,19 +196,19 @@ def test_rc_activation_capabilities(tracer, rc_poller, env_rules, expected):
         # flaky test
         # assert not rc_poller._worker
 
-        _appsec_callback(rc_configs)
+        appsec_callback(rc_configs)
 
         assert _appsec_rc_capabilities() == expected
 
 
-def test_rc_capabilities_updated_after_one_click_activation(tracer, rc_poller):
+def test_rc_capabilities_updated_after_one_click_activation(tracer, rc_poller, appsec_callback):
     """Regression test: advertised capabilities must follow one-click ASM activation/deactivation.
 
     Capabilities are registered once (while AppSec is still disabled for a remotely-activated
-    service). The client must *re-advertise* blocking/RASP once ASM is turned on and *drop*
+    service). The client must re-advertise blocking/RASP once ASM is turned on and drop
     them again when it is turned off, otherwise the backend reports "UPDATE REQUIRED" for
     blocking even though it is functional. This exercises the appsec wiring
-    (``_appsec_callback`` -> ``update_capabilities(_ALL_ASM_CAPABILITIES, _rc_capabilities())``);
+    (AppSecCallback -> update_capabilities(_ALL_ASM_CAPABILITIES, _rc_capabilities()));
     the replace-within-mask mechanics themselves are covered by the native RC tests.
     """
     from ddtrace.appsec._capabilities import _ALL_ASM_BLOCKING
@@ -187,20 +224,20 @@ def test_rc_capabilities_updated_after_one_click_activation(tracer, rc_poller):
     disable_config = [build_payload("ASM_FEATURES", {"asm": {}}, "config")]
 
     with override_global_config(dict(_remote_config_enabled=True, _asm_enabled=False, _asm_can_be_enabled=True)):
-        enable_appsec_rc()
+        enable_appsec_rc(appsec_callback)
 
         # AppSec is not enabled yet (remote activation pending): activation only, no blocking.
         assert Cap.AsmActivation in advertised()
         assert advertised().isdisjoint(_ALL_ASM_BLOCKING)
 
         # One-click activation: blocking (and RASP) capabilities must now be advertised.
-        _appsec_callback(enable_config)
+        appsec_callback(enable_config)
         assert asm_config._asm_enabled
         assert set(_ALL_ASM_BLOCKING) <= advertised()
         assert advertised() == set(_rc_capabilities())
 
         # One-click deactivation: blocking capabilities must be dropped again.
-        _appsec_callback(disable_config)
+        appsec_callback(disable_config)
         assert not asm_config._asm_enabled
         assert Cap.AsmActivation in advertised()
         assert advertised().isdisjoint(_ALL_ASM_BLOCKING)
@@ -209,20 +246,20 @@ def test_rc_capabilities_updated_after_one_click_activation(tracer, rc_poller):
     disable_appsec_rc()
 
 
-def test_rc_activation_validate_products(tracer, rc_poller):
+def test_rc_activation_validate_products(tracer, rc_poller, appsec_callback):
     with override_global_config(dict(_asm_enabled=False, _remote_config_enabled=True, api_version="v0.4")):
         assert not rc_poller._worker
 
-        enable_appsec_rc()
+        enable_appsec_rc(appsec_callback)
 
         assert rc_poller._client._product_callbacks[RemoteConfigProduct.AsmFeatures]
     disable_appsec_rc()
 
 
-def test_rc_activation_validate_client_id(tracer, rc_poller):
+def test_rc_activation_validate_client_id(tracer, rc_poller, appsec_callback):
     with override_global_config(dict(_asm_enabled=True, _remote_config_enabled=True, api_version="v0.4")):
         tracer.configure(appsec_enabled=True)
-        enable_appsec_rc()
+        enable_appsec_rc(appsec_callback)
         _set_and_get_appsec_tags(tracer, True)
     disable_appsec_rc()
 
@@ -249,7 +286,7 @@ def test_rc_activation_validate_client_id(tracer, rc_poller):
     ],
 )
 def test_rc_activation_check_asm_features_product_disables_rest_of_products(
-    tracer, rc_poller, env_rules, expected, enable_config_content, disable_config_content
+    tracer, rc_poller, env_rules, expected, enable_config_content, disable_config_content, appsec_callback
 ):
     global_config = dict(_remote_config_enabled=True, _asm_enabled=True)
     global_config.update(env_rules)
@@ -261,33 +298,33 @@ def test_rc_activation_check_asm_features_product_disables_rest_of_products(
     disable_config = [build_payload("ASM_FEATURES", disable_config_content, "config")]
     with override_global_config(global_config):
         tracer.configure(appsec_enabled=True)
-        enable_appsec_rc()
+        enable_appsec_rc(appsec_callback)
         assert bool(rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmData)) is expected
         assert bool(rc_poller._client._product_callbacks.get(RemoteConfigProduct.Asm)) is expected
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmFeatures)
 
         # sending nothing should not change anything (configuration is the same)
-        _appsec_callback(empty_config)
+        appsec_callback(empty_config)
 
         assert bool(rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmData)) is expected
         assert bool(rc_poller._client._product_callbacks.get(RemoteConfigProduct.Asm)) is expected
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmFeatures)
 
         # sending empty config for asm should disable asm (meaning asm was deleted)
-        _appsec_callback(disable_config)
+        appsec_callback(disable_config)
 
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmData) is None
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.Asm) is None
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmFeatures)
 
         # sending nothing should not change anything (configuration is the same)
-        _appsec_callback(empty_config)
+        appsec_callback(empty_config)
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmData) is None
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.Asm) is None
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmFeatures)
 
         # sending config should enable asm again
-        _appsec_callback(enable_config)
+        appsec_callback(enable_config)
         assert bool(rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmData)) is expected
         assert bool(rc_poller._client._product_callbacks.get(RemoteConfigProduct.Asm)) is expected
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmFeatures)
@@ -296,7 +333,7 @@ def test_rc_activation_check_asm_features_product_disables_rest_of_products(
 
 
 @pytest.mark.parametrize("auto_user", [True, False])
-def test_rc_activation_with_auto_user_appsec_fixed(tracer, rc_poller, auto_user):
+def test_rc_activation_with_auto_user_appsec_fixed(tracer, rc_poller, auto_user, appsec_callback):
     with (
         override_env({APPSEC.ENV: "true"}),
         override_global_config(
@@ -309,7 +346,7 @@ def test_rc_activation_with_auto_user_appsec_fixed(tracer, rc_poller, auto_user)
         ),
     ):
         tracer.configure(appsec_enabled=True)
-        enable_appsec_rc()
+        enable_appsec_rc(appsec_callback)
 
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmData)
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.Asm)
@@ -318,7 +355,7 @@ def test_rc_activation_with_auto_user_appsec_fixed(tracer, rc_poller, auto_user)
     disable_appsec_rc()
 
 
-def test_rc_activation_ip_blocking_data(tracer, rc_poller):
+def test_rc_activation_ip_blocking_data(tracer, rc_poller, appsec_callback):
     with override_global_config({"_asm_enabled": True}):
         rc_config = {
             "rules_data": [
@@ -338,7 +375,7 @@ def test_rc_activation_ip_blocking_data(tracer, rc_poller):
         }
         assert rc_poller.status == ServiceStatus.STOPPED
 
-        _appsec_callback([build_payload("ASM_DATA", rc_config, "data")])
+        appsec_callback([build_payload("ASM_DATA", rc_config, "data")])
         with asm_context(tracer, ip_addr="8.8.4.4") as span:
             set_http_meta(
                 span,
@@ -348,7 +385,7 @@ def test_rc_activation_ip_blocking_data(tracer, rc_poller):
         assert get_waf_addresses("http.request.remote_ip") == "8.8.4.4"
 
 
-def test_rc_activation_ip_blocking_data_expired(tracer, rc_poller):
+def test_rc_activation_ip_blocking_data_expired(tracer, rc_poller, appsec_callback):
     with override_env({APPSEC.ENV: "true"}), override_global_config({}):
         tracer.configure(appsec_enabled=True)
         rc_config = {
@@ -365,7 +402,7 @@ def test_rc_activation_ip_blocking_data_expired(tracer, rc_poller):
 
         assert rc_poller.status == ServiceStatus.STOPPED
 
-        _appsec_callback([build_payload("ASM_DATA", rc_config, "data")])
+        appsec_callback([build_payload("ASM_DATA", rc_config, "data")])
 
         with asm_context(tracer, ip_addr="8.8.4.4") as span:
             set_http_meta(
@@ -375,7 +412,7 @@ def test_rc_activation_ip_blocking_data_expired(tracer, rc_poller):
         assert get_triggers(span) is None
 
 
-def test_rc_activation_ip_blocking_data_not_expired(tracer, rc_poller):
+def test_rc_activation_ip_blocking_data_not_expired(tracer, rc_poller, appsec_callback):
     with override_global_config({"_asm_enabled": True}):
         rc_config = {
             "rules_data": [
@@ -391,7 +428,7 @@ def test_rc_activation_ip_blocking_data_not_expired(tracer, rc_poller):
 
         assert rc_poller.status == ServiceStatus.STOPPED
 
-        _appsec_callback([build_payload("ASM_DATA", rc_config, "data")])
+        appsec_callback([build_payload("ASM_DATA", rc_config, "data")])
 
         with asm_context(tracer, ip_addr="8.8.4.4") as span:
             set_http_meta(
@@ -402,11 +439,11 @@ def test_rc_activation_ip_blocking_data_not_expired(tracer, rc_poller):
         assert get_waf_addresses("http.request.remote_ip") == "8.8.4.4"
 
 
-def test_rc_activation_does_not_report_appsec_product_when_only_rc_enabled(tracer, rc_poller):
+def test_rc_activation_does_not_report_appsec_product_when_only_rc_enabled(tracer, rc_poller, appsec_callback):
     """Regression test: registering RC listeners should not report AppSec as an enabled product in telemetry."""
     with override_global_config(dict(_asm_enabled=False, _asm_can_be_enabled=True, _remote_config_enabled=True)):
         with mock.patch("ddtrace.appsec._remoteconfiguration.telemetry_writer") as mock_tw:
-            enable_appsec_rc()
+            enable_appsec_rc(appsec_callback)
 
             # RC listeners are registered but AppSec is not enabled
             assert rc_poller._client._product_callbacks[RemoteConfigProduct.AsmFeatures]
@@ -416,37 +453,37 @@ def test_rc_activation_does_not_report_appsec_product_when_only_rc_enabled(trace
     disable_appsec_rc()
 
 
-def test_rc_activation_reports_appsec_product_when_enabled(tracer, rc_poller):
+def test_rc_activation_reports_appsec_product_when_enabled(tracer, rc_poller, appsec_callback):
     """When AppSec is explicitly enabled, enable_appsec_rc should report the product as activated."""
     with override_global_config(dict(_asm_enabled=True, _remote_config_enabled=True)):
         tracer.configure(appsec_enabled=True)
         with mock.patch("ddtrace.appsec._remoteconfiguration.telemetry_writer") as mock_tw:
-            enable_appsec_rc()
+            enable_appsec_rc(appsec_callback)
 
             mock_tw.product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, True)
 
     disable_appsec_rc()
 
 
-def test_rc_enable_then_disable_asm_reports_telemetry(tracer, rc_poller):
+def test_rc_enable_then_disable_asm_reports_telemetry(tracer, rc_poller, appsec_callback):
     """When AppSec is enabled/disabled via RC, telemetry should reflect the changes."""
     with override_global_config(dict(_asm_enabled=False, _asm_can_be_enabled=True, _remote_config_enabled=True)):
-        with mock.patch("ddtrace.appsec._remoteconfiguration.telemetry_writer") as mock_tw:
-            enable_appsec_rc()
+        with mock.patch.object(telemetry_writer, "product_activated") as product_activated:
+            enable_appsec_rc(appsec_callback)
 
             # Initially not activated
-            mock_tw.product_activated.assert_not_called()
+            product_activated.assert_not_called()
 
             # Simulate RC enabling AppSec
             enable_config = [build_payload("ASM_FEATURES", {"asm": {"enabled": True}}, "config")]
-            _appsec_callback(enable_config)
-            mock_tw.product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, True)
+            appsec_callback(enable_config)
+            product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, True)
 
-            mock_tw.product_activated.reset_mock()
+            product_activated.reset_mock()
 
             # Simulate RC disabling AppSec
             disable_config = [build_payload("ASM_FEATURES", {"asm": {}}, "config")]
-            _appsec_callback(disable_config)
-            mock_tw.product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, False)
+            appsec_callback(disable_config)
+            product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, False)
 
     disable_appsec_rc()

--- a/tests/appsec/appsec/test_telemetry.py
+++ b/tests/appsec/appsec/test_telemetry.py
@@ -13,12 +13,14 @@ import ddtrace.appsec._ddwaf.ddwaf_types
 import ddtrace.appsec._ddwaf.waf
 from ddtrace.appsec._deduplications import deduplication
 from ddtrace.appsec._processor import AppSecSpanProcessor
-from ddtrace.appsec._remoteconfiguration import enable_asm
+from ddtrace.appsec._remoteconfiguration import AppSecCallback
 from ddtrace.appsec._utils import DDWaf_result
 from ddtrace.appsec._utils import _observator
 from ddtrace.constants import APPSEC_ENV
 from ddtrace.contrib.internal.trace_utils import set_http_meta
 from ddtrace.ext import SpanTypes
+from ddtrace.internal.appsec.product import _disable_asm
+from ddtrace.internal.appsec.product import _enable_asm
 from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.trace import tracer
@@ -218,13 +220,12 @@ def test_metrics_when_appsec_block(telemetry_writer, test_agent_session, tracer)
 
 
 def test_metrics_when_appsec_block_custom(telemetry_writer, test_agent_session, tracer):
+    appsec_callback = AppSecCallback(_enable_asm, _disable_asm)
     with asm_context(tracer=tracer, ip_addr=rules._IP.BLOCKED, span_name="test", config=config_asm) as span:
-        from ddtrace.appsec._remoteconfiguration import _appsec_callback
-
         actions = {
             "actions": [{"id": "block", "type": "block_request", "parameters": {"status_code": 429, "type": "json"}}]
         }
-        _appsec_callback(
+        appsec_callback(
             [
                 build_payload("ASM", actions, "actions"),
             ],
@@ -502,7 +503,7 @@ def test_appsec_enabled_metric(
     ):
         tracer.configure(appsec_enabled=appsec_enabled, appsec_enabled_origin=APPSEC.ENABLED_ORIGIN_DEFAULT)
         if rc_enabled:
-            enable_asm()
+            _enable_asm()
 
         # Drain telemetry queued while configuring, then capture only the change-driven
         # DD_APPSEC_ENABLED report for the final state.


### PR DESCRIPTION
## Description

Model AppSec remote activation through the AppSec product instead of relying on implicit global state or core-context dispatch.

- construct the remote-configuration callback in `ddtrace.internal.appsec.product` and inject the product-owned enable/disable operations
- keep RC registration and unregistration together in `_remoteconfiguration.py`
- let the RC poller retain the callback, avoiding an AppSec callback singleton
- keep fatal processor load handling in `_listeners`; common RASP wrappers treat the capability as unavailable while processor imports are in progress
- remove the redundant common-module load from RC registration because the product performs that setup for both static and remote activation before registering RC

This removes the `_common_module_patches` / `_listeners` circular import without adding a new cycle or dependency-direction violation.

## Testing

## Risks

Low. The main risk is changing one-click activation ordering or fatal processor-load handling. Existing RC coverage and the subprocess regression for libddwaf load failure pass, and the product preserves common-module setup before RC registration.

## Additional Notes

No release note: this is an internal dependency-ownership refactor with no intended customer-visible behavior change.
