### PR TITLE
test(iast): stop test_metric_instrumented_propagation depending on flush timing

### DIFF
--- a/tests/appsec/iast/test_telemetry.py
+++ b/tests/appsec/iast/test_telemetry.py
@@ -185,18 +185,23 @@ def test_metric_instrumented_vulnerability(no_request_sampling, telemetry_writer
 
 
 def test_metric_instrumented_propagation(no_request_sampling, telemetry_writer, test_agent_session):
+    # Drain metrics emitted before this test so the session below holds only our own.
+    _get_iast_metrics(test_agent_session, telemetry_writer)
+    test_agent_session.clear()
+
     with override_global_config(dict(_iast_enabled=True, _iast_telemetry_report_lvl=TELEMETRY_INFORMATION_NAME)):
         _iast_patched_module("benchmarks.bm.iast_fixtures.str_methods")
 
     generate_metrics = _get_iast_metrics(test_agent_session, telemetry_writer)
-    # Remove potential sinks from internal usage of the lib (like http.client, used to communicate with
-    # the agent)
-    filtered_metrics = [
+    # A set, not a list: the native telemetry worker can flush mid-patching, splitting
+    # instrumented.propagation across series. executed.*/instrumented.sink come from the lib's own
+    # internal usage, not the module under test.
+    filtered_metrics = {
         metric["metric"]
         for metric in generate_metrics
-        if metric["metric"] not in ["executed.sink", "instrumented.sink"]
-    ]
-    assert filtered_metrics == ["instrumented.propagation"]
+        if metric["metric"] != "instrumented.sink" and not metric["metric"].startswith("executed.")
+    }
+    assert filtered_metrics == {"instrumented.propagation"}
 
 
 def test_metric_request_tainted(no_request_sampling, telemetry_writer, test_agent_session, tracer):


### PR DESCRIPTION
APPSEC-69623

`test_metric_instrumented_propagation` asserted on the raw series list of the shared telemetry session, so it failed two ways:

- The native telemetry worker can flush partway through patching the module, splitting one metric over several series. On py3.10-3.12 both metrics appear exactly twice — two payloads, not two emitters.
- Metrics emitted before the test (`executed.source`) were still in the session.

Fix: drain and clear the session before the action, then compare the set of metric names.

Flaky on py3.9-py3.13; all five keyed for attempt-to-fix. Split out of #19643 — different mechanism (flush timing, not state leaks), and it fails on `main` too.

Not reproduced locally; the attempt-to-fix run is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)