### PR TITLE
chore: bump version to 4.10.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.10.11"
+version = "4.10.12"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }


### PR DESCRIPTION
## Description

Bumps the 4.10 release branch version to 4.10.12.

## Testing

- Parsed `pyproject.toml` with `tomllib` and verified the project version is `4.10.12`.

## Risks

None.

## Additional Notes

This prepares the 4.10.12 patch release.
