### PR TITLE
refactor: implement SpanProtocol to decouple type hinting from ddtrace.trace

### DIFF
--- a/ddtrace/internal/_span_protocol.py
+++ b/ddtrace/internal/_span_protocol.py
@@ -1,0 +1,47 @@
+from typing import Any
+from typing import Mapping
+from typing import Optional
+from typing import Protocol
+from typing import Union
+from typing import runtime_checkable
+
+
+@runtime_checkable
+class SpanProtocol(Protocol):
+    """Structural contract for the span-like objects the encoders serialize.
+
+    Kept independent of ``ddtrace._trace.span.Span`` to avoid pulling the tracing
+    product into ``ddtrace.internal``; ``Span`` conforms to this shape.
+    """
+
+    parent_id: Optional[int]
+    span_id: int
+    service: Optional[str]
+    resource: str
+    name: str
+    error: int
+    start_ns: int
+    duration_ns: Optional[int]
+    span_type: Optional[str]
+
+    @property
+    def _trace_id_64bits(self) -> int: ...
+
+    @property
+    def _is_top_level(self) -> bool: ...
+
+    def _get_str_attributes(self) -> Mapping[str, str]: ...
+
+    def _get_numeric_attributes(self) -> Mapping[str, Union[int, float]]: ...
+
+    def _has_links(self) -> bool: ...
+
+    def _get_links(self) -> list[Any]: ...
+
+    def _has_events(self) -> bool: ...
+
+    def _get_events(self) -> list[Any]: ...
+
+    def _get_meta_structs(self) -> dict[str, Any]: ...
+
+    def _set_attribute(self, key: str, value: Union[str, int, float]) -> None: ...

--- a/ddtrace/internal/encoding.py
+++ b/ddtrace/internal/encoding.py
@@ -1,8 +1,8 @@
 import json
 import typing  # noqa:F401
-from typing import TYPE_CHECKING
 from typing import Any  # noqa:F401
 from typing import Optional
+from typing import Sequence
 
 from ddtrace.internal.settings._agent import config as agent_config  # noqa:F401
 from ddtrace.internal.threads import RLock
@@ -13,6 +13,7 @@ from ._encoding import BufferItemTooLarge
 from ._encoding import ListStringTable
 from ._encoding import MsgpackEncoderV04
 from ._encoding import MsgpackEncoderV05
+from ._span_protocol import SpanProtocol
 from .compat import ensure_text
 from .logger import get_logger
 
@@ -25,9 +26,6 @@ __all__ = [
     "MSGPACK_ENCODERS",
 ]
 
-
-if TYPE_CHECKING:  # pragma: no cover
-    from ddtrace._trace.span import Span  # noqa:F401
 
 log = get_logger(__name__)
 
@@ -43,14 +41,13 @@ class _EncoderBase(object):
     Encoder interface that provides the logic to encode traces and service.
     """
 
-    def encode_traces(self, traces: list[list["Span"]]) -> str:
+    def encode_traces(self, traces: Sequence[Sequence["SpanProtocol"]]) -> str:
         """
-        Encodes a list of traces, expecting a list of items where each items
-        is a list of spans. Before dumping the string in a serialized format all
-        traces are normalized according to the encoding format. The trace
-        nesting is not changed.
+        Encodes a list of traces. Before dumping the string in a serialized format all
+        traces are normalized according to the encoding format.
 
-        :param traces: A list of traces that should be serialized
+        :param traces: A list of traces that should be serialized.
+            Each list item is a list of Span-like objects
         """
         raise NotImplementedError()
 
@@ -63,7 +60,7 @@ class _EncoderBase(object):
         raise NotImplementedError()
 
     @staticmethod
-    def _span_to_dict(span: "Span") -> dict[str, Any]:
+    def _span_to_dict(span: "SpanProtocol") -> dict[str, Any]:
         d: dict[str, Any] = {
             "trace_id": span._trace_id_64bits,
             "parent_id": span.parent_id,
@@ -144,12 +141,12 @@ class JSONEncoderV2(JSONEncoder):
 
     content_type = "application/json"
 
-    def encode_traces(self, traces: list[list["Span"]]) -> str:
+    def encode_traces(self, traces: Sequence[Sequence["SpanProtocol"]]) -> str:
         normalized_traces = [[JSONEncoderV2._convert_span(span) for span in trace] for trace in traces]
         return self.encode({"traces": normalized_traces})[0]
 
     @staticmethod
-    def _convert_span(span: "Span") -> dict[str, Any]:
+    def _convert_span(span: "SpanProtocol") -> dict[str, Any]:
         sp = JSONEncoderV2._span_to_dict(span)
         sp = JSONEncoderV2._normalize_span(sp)
         sp["trace_id"] = JSONEncoderV2._encode_id_to_hex(sp.get("trace_id"))
@@ -211,7 +208,7 @@ class AgentlessTraceJSONEncoder(BufferedEncoder):
             return self._n_spans
 
     def put(self, item) -> None:
-        item = typing.cast(list["Span"], item)
+        item = typing.cast(Sequence["SpanProtocol"], item)
 
         if not item:
             return
@@ -246,7 +243,7 @@ class AgentlessTraceJSONEncoder(BufferedEncoder):
             self._reset()
         return [(payload, count)]
 
-    def _item_to_dict(self, item: "Span") -> dict[str, Any]:
+    def _item_to_dict(self, item: "SpanProtocol") -> dict[str, Any]:
         if not item.parent_id:
             item._set_attribute("_trace_root", 1)
         if item._is_top_level:


### PR DESCRIPTION
This change adds a `SpanProtocol` class that defines the "Span-like" interface expected by type-checking code in `ddtrace.internal`. This class can be imported by type-checkers instead of `Span` itself, eliminating a layering violation in which `internal` depends on a product (`trace`).

The `SpanProtocol` implementation is incomplete, currently only including the interface used by the classes in `encoding.py`. Future pull requests will augment the implementation to work with more internal modules.