### PR TITLE
chore: bump version to 4.11.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.11.5"
+version = "4.11.6"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }


### PR DESCRIPTION
## Description

Bumps the 4.11 release branch version to 4.11.6.

## Testing

- `scripts/lint checks` passed all available checks, then hit the release branch's existing missing `scripts/check_profiling_native_coverage.py` script.
- Parsed `pyproject.toml` with `tomllib` and verified the project version is `4.11.6`.

## Risks

None.

## Additional Notes

This prepares the 4.11.6 patch release.
