### PR TITLE
test(iast): assert SCA reachability on the event that recorded the call

### DIFF
--- a/tests/appsec/integrations/flask_tests/test_sca_flask_testagent.py
+++ b/tests/appsec/integrations/flask_tests/test_sca_flask_testagent.py
@@ -212,19 +212,20 @@ class TestSCAFlaskTelemetry:
         events = _get_dependency_events(iast_test_token)
         assert len(events) > 0, "No app-dependencies-loaded events found"
 
-        # Look for GHSA-652x-xj99-gmcc in the requests dependency metadata
-        dep, cve_value = _find_dep_with_cve(events, "requests", "GHSA-652x-xj99-gmcc")
+        # Every heartbeat re-reports the dependency, so an event emitted before the vulnerable
+        # call carries reached=[]. Take the entry that recorded the call, not the first one.
+        cve_values = _find_all_cve_metadata(events, "requests", "GHSA-652x-xj99-gmcc")
 
-        assert dep is not None, (
+        assert cve_values, (
             "GHSA-652x-xj99-gmcc not found in requests dependency metadata. "
             f"Events: {json.dumps(events, indent=2)[:2000]}"
         )
-        assert dep["name"] == "requests"
-        assert cve_value["id"] == "GHSA-652x-xj99-gmcc"
+        assert all(value["id"] == "GHSA-652x-xj99-gmcc" for value in cve_values)
         # AIDEV-NOTE: RFC v3 — reached is now an array of {path, method, line} objects.
-        assert isinstance(cve_value["reached"], list)
-        assert len(cve_value["reached"]) >= 1
-        hit = cve_value["reached"][0]
+        assert all(isinstance(value["reached"], list) for value in cve_values)
+        reported = [value for value in cve_values if value["reached"]]
+        assert reported, f"No reached entry reported for the CVE after the vulnerable call: {cve_values}"
+        hit = reported[0]["reached"][0]
         # AIDEV-NOTE: path/method/line report the *caller* (user code that
         # invoked the vulnerable function), not the target function itself.
         assert "app.py" in hit["path"], f"Expected caller path containing 'app.py', got: {hit['path']}"


### PR DESCRIPTION
APPSEC-69623

`_find_dep_with_cve()` returns the *first* matching dependency across all events, but with `DD_TELEMETRY_HEARTBEAT_INTERVAL=2` the dependency is re-reported on every heartbeat. The test warms the server up, then hits the vulnerable endpoint, so the stream can hold the `requests` dependency twice: once from before the call with `reached=[]`, once after with the caller recorded.

Picking the first gave `assert 0 >= 1 where 0 = len([])` whenever the earlier event already carried the reachability metadata — a 4.9% failure rate, not a product break.

Fix: collect every entry for the CVE with the existing `_find_all_cve_metadata()` helper (already used by `test_sca_same_cve_first_hit_wins`) and assert on the one that recorded the call, failing loudly if none did.

The sibling `test_sca_cve_registered_at_load_time_has_empty_reached` also uses `_find_dep_with_cve`, but it never calls the vulnerable endpoint and asserts `reached == []`, so first-match is correct there — left unchanged.

This does not remove the `sleep(4)` versus 2s heartbeat race, only the reading of the wrong event. If it still flakes, the next step is polling until a reached entry appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)