### PR TITLE
ci(profiling): remove duplicate fast-copy profile runs

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -3734,15 +3734,6 @@ venv = Venv(
                                 "protobuf": latest,
                             },
                         ),
-                        # safe_memcpy fast-copy path (process_vm_readv is the default)
-                        Venv(
-                            env={
-                                "_DD_PROFILING_STACK_FAST_COPY": "1",
-                            },
-                            pkgs={
-                                "protobuf": latest,
-                            },
-                        ),
                     ],
                 ),
                 # Python 3.10
@@ -3790,15 +3781,6 @@ venv = Venv(
                                 "protobuf": latest,
                             },
                         ),
-                        # safe_memcpy fast-copy path (process_vm_readv is the default)
-                        Venv(
-                            env={
-                                "_DD_PROFILING_STACK_FAST_COPY": "1",
-                            },
-                            pkgs={
-                                "protobuf": latest,
-                            },
-                        ),
                     ],
                 ),
                 # Python >= 3.11 (excluding 3.14)
@@ -3829,15 +3811,6 @@ venv = Venv(
                             },
                             pkgs={
                                 "uvloop": latest,
-                                "protobuf": latest,
-                            },
-                        ),
-                        # safe_memcpy fast-copy path (process_vm_readv is the default)
-                        Venv(
-                            env={
-                                "_DD_PROFILING_STACK_FAST_COPY": "1",
-                            },
-                            pkgs={
                                 "protobuf": latest,
                             },
                         ),
@@ -3872,15 +3845,6 @@ venv = Venv(
                             },
                             pkgs={
                                 "uvloop": latest,
-                                "protobuf": latest,
-                            },
-                        ),
-                        # safe_memcpy fast-copy path (process_vm_readv is the default)
-                        Venv(
-                            env={
-                                "_DD_PROFILING_STACK_FAST_COPY": "1",
-                            },
-                            pkgs={
                                 "protobuf": latest,
                             },
                         ),


### PR DESCRIPTION
## Description

Removes six duplicate profiling runs that explicitly set `_DD_PROFILING_STACK_FAST_COPY=1`.

Fast copy has been enabled by default since #18329. The standard, gevent, and uvloop profiling environments already exercise the production default, `fast_copy=True`. The explicit environments repeat that same configuration with identical Python and package dependencies. Riot therefore assigns them the same hashes as the standard latest-protobuf environments and runs a second full profiling suite serially in those shards.

Removing the duplicates preserves fast-copy coverage, including gevent and uvloop coverage, while reducing the matrix from 30 executions sharing 24 hashes to 24 executions with 24 hashes. The disabled path remains covered by `test_fast_copy_memory_disabled`, which starts the profiler with `_DD_PROFILING_STACK_FAST_COPY=false` and verifies its state and telemetry.

This is prerequisite CI work for adding another full-suite profiling mode without increasing the existing timeout.

## Testing

- Verified the remaining profile matrix has 24 executions and 24 unique Riot hashes.
- Verified every remaining profile environment uses the default `fast_copy=True` configuration.
- Verified the active Riot hash set still matches the committed lockfile set, so no lockfile regeneration is needed.
- `scripts/lint fmt -- riotfile.py`
- `scripts/lint checks`
- `git diff --check`

## Risks

Low. This removes duplicate fast-copy-enabled executions. It does not remove fast-copy coverage or change the per-job timeout.

## Additional Notes

No release note is needed because this only changes internal CI scheduling.

#19686 removes the redundant Python 3.10 gevent environment independently.
