### PR TITLE
chore(test): add Podman compatibility for Bits Code

### DIFF
--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -1,0 +1,83 @@
+# Use with `DD_TEST_PODMAN_COMPAT=1` and the test scripts, or pass this file
+# after docker-compose.yml to podman-compose. Host networking avoids Podman's
+# CNI port-forwarding requirement. Start only the services needed by a suite
+# because alternatives share their default ports.
+x-podman-host-network: &podman-host-network
+    network_mode: host
+
+services:
+    elasticsearch:
+        <<: *podman-host-network
+    opensearch:
+        <<: *podman-host-network
+    cassandra:
+        <<: *podman-host-network
+    consul:
+        <<: *podman-host-network
+    postgres:
+        <<: *podman-host-network
+    mariadb:
+        <<: *podman-host-network
+    mysql:
+        <<: *podman-host-network
+    redis:
+        <<: *podman-host-network
+    kafka:
+        <<: *podman-host-network
+        platform: ${PODMAN_PLATFORM:-linux/amd64}
+        environment:
+            KAFKA_LISTENERS: PLAINTEXT://:19092,CONTROLLER://:19093,EXTERNAL://:29092
+            KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:19092,EXTERNAL://localhost:29092
+            KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:19093
+    rediscluster:
+        <<: *podman-host-network
+        environment:
+            LC_ALL: C
+            LANG: C
+    mongo:
+        <<: *podman-host-network
+    memcached:
+        <<: *podman-host-network
+    moto:
+        <<: *podman-host-network
+    rabbitmq:
+        <<: *podman-host-network
+    ddagent:
+        <<: *podman-host-network
+    testagent:
+        <<: *podman-host-network
+        command: ["ddapm-test-agent", "--port=9126"]
+    vertica:
+        <<: *podman-host-network
+    azurecosmosemulator:
+        <<: *podman-host-network
+        environment:
+            BLOB_SERVER: 127.0.0.1
+            METADATA_SERVER: 127.0.0.1
+    azureeventhubsemulator:
+        <<: *podman-host-network
+        environment:
+            BLOB_SERVER: 127.0.0.1
+            METADATA_SERVER: 127.0.0.1
+    azureservicebusemulator:
+        <<: *podman-host-network
+        environment:
+            SQL_SERVER: 127.0.0.1
+    azuresqledge:
+        <<: *podman-host-network
+    azurite:
+        <<: *podman-host-network
+    localstack:
+        <<: *podman-host-network
+    httpbin:
+        <<: *podman-host-network
+        command: ["gunicorn", "-b", "127.0.0.1:8001", "httpbin:app", "-k", "gevent"]
+    valkey:
+        <<: *podman-host-network
+    pubsub:
+        <<: *podman-host-network
+    valkeycluster:
+        <<: *podman-host-network
+        environment:
+            LC_ALL: C
+            LANG: C

--- a/docs/contributing-testing.rst
+++ b/docs/contributing-testing.rst
@@ -62,6 +62,17 @@ You can access it by running
 
     $ scripts/ddtest
 
+**Podman compatibility**
+
+When Podman cannot configure CNI port forwarding, set
+``DD_TEST_PODMAN_COMPAT=1``. The test scripts then apply
+``docker-compose.podman.yml``, which uses host networking while preserving the
+service endpoints expected by the suites.
+
+.. code-block:: bash
+
+    $ DD_TEST_PODMAN_COMPAT=1 scripts/run-tests tests/contrib/redis/
+
 Some of our test suites are managed with Riot.
 
 You can run riot commands and lint checks in the test runner container with commands like these:

--- a/scripts/ddtest
+++ b/scripts/ddtest
@@ -65,13 +65,29 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ]; then
 fi
 
 COMPOSE_FILES=("-f" "$PROJECT_ROOT/docker-compose.yml")
+if [ "${DD_TEST_PODMAN_COMPAT:-0}" = "1" ]; then
+    COMPOSE_FILES+=("-f" "$PROJECT_ROOT/docker-compose.podman.yml")
+fi
 if command -v nvidia-smi >/dev/null 2>&1; then
     COMPOSE_FILES+=("-f" "$PROJECT_ROOT/docker-compose.gpu.yml")
 fi
 
-docker compose ${COMPOSE_FILES[@]} run $BUILD_FLAG \
-       -e DD_TRACE_AGENT_URL \
-       --rm \
-       -i \
-       testrunner \
-       bash -c "(git config --global --add safe.directory /home/bits/project || true) && $CMD"
+if [ "${DD_TEST_PODMAN_COMPAT:-0}" = "1" ]; then
+    if [ "$BUILD_FLAG" = "--build" ]; then
+        docker compose ${COMPOSE_FILES[@]} build testrunner
+    fi
+    RUN_ARGS=(--rm)
+    if [ -n "${DD_TRACE_AGENT_URL+x}" ]; then
+        RUN_ARGS+=(-e "DD_TRACE_AGENT_URL=$DD_TRACE_AGENT_URL")
+    fi
+    docker compose ${COMPOSE_FILES[@]} run "${RUN_ARGS[@]}" \
+           testrunner \
+           bash -c "(git config --global --add safe.directory /home/bits/project || true) && $CMD"
+else
+    docker compose ${COMPOSE_FILES[@]} run $BUILD_FLAG \
+           -e DD_TRACE_AGENT_URL \
+           --rm \
+           -i \
+           testrunner \
+           bash -c "(git config --global --add safe.directory /home/bits/project || true) && $CMD"
+fi

--- a/scripts/ddtest
+++ b/scripts/ddtest
@@ -77,9 +77,23 @@ if [ "${DD_TEST_PODMAN_COMPAT:-0}" = "1" ]; then
         docker compose ${COMPOSE_FILES[@]} build testrunner
     fi
     RUN_ARGS=(--rm)
+    RUN_AS_USER="${DD_TEST_USER-$(id -u):$(id -g)}"
+    if [ -n "$RUN_AS_USER" ]; then
+        RUN_ARGS+=(--user "$RUN_AS_USER")
+        RUN_ARGS+=(
+            -e "PATH=/home/bits/.cargo/bin:/home/bits/.local/bin:/home/bits/.pyenv/shims:/home/bits/.pyenv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            -e "CARGO_HOME=/home/bits/.cargo"
+            -e "RUSTUP_HOME=/home/bits/.rustup"
+        )
+    fi
     if [ -n "${DD_TRACE_AGENT_URL+x}" ]; then
         RUN_ARGS+=(-e "DD_TRACE_AGENT_URL=$DD_TRACE_AGENT_URL")
     fi
+    for variable in $(compgen -e); do
+        case "$variable" in
+            TEST_*) RUN_ARGS+=(-e "${variable}=${!variable}") ;;
+        esac
+    done
     docker compose ${COMPOSE_FILES[@]} run "${RUN_ARGS[@]}" \
            testrunner \
            bash -c "(git config --global --add safe.directory /home/bits/project || true) && $CMD"

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -55,6 +55,9 @@ from tests.suitespec import get_suites  # noqa: E402
 
 # Constants
 TESTAGENT_PORT_DEFAULT = 9126
+PODMAN_COMPAT_ENV_VAR = "DD_TEST_PODMAN_COMPAT"
+DOCKER_COMPOSE_FILE = ROOT / "docker-compose.yml"
+PODMAN_COMPOSE_FILE = ROOT / "docker-compose.podman.yml"
 
 
 class RiotVenv(NamedTuple):
@@ -144,6 +147,14 @@ class TestRunner:
         self.changed_files: set[str] = set()
         self.matching_suites: dict[str, dict] = {}
         self.required_services: set[str] = set()
+        self.podman_compat = os.environ.get(PODMAN_COMPAT_ENV_VAR, "0") == "1"
+
+    def _compose_command(self, *args: str) -> list[str]:
+        cmd = ["docker", "compose", "-f", str(DOCKER_COMPOSE_FILE)]
+        if self.podman_compat:
+            cmd.extend(["-f", str(PODMAN_COMPOSE_FILE)])
+        cmd.extend(args)
+        return cmd
 
     def _run_git_command(self, cmd: list[str]) -> set[str]:
         """Helper to run a git command and return set of file paths."""
@@ -297,11 +308,11 @@ class TestRunner:
 
         print(f"\n🐳 Starting required services: {', '.join(sorted(services))}")
         try:
-            cmd = ["docker", "compose", "up", "-d"] + list(services)
+            cmd = self._compose_command("up", "-d", *services)
             subprocess.run(cmd, cwd=self.root, check=True)
             return True
         except subprocess.CalledProcessError:
-            if "testagent" in services:
+            if "testagent" in services and not self.podman_compat:
                 # NOTE: When falling back to a random port, snapshot tests that
                 # hardcode localhost:9126 in their URLs (e.g., in test code or
                 # snapshot files) may fail. This only happens for the second+
@@ -309,7 +320,7 @@ class TestRunner:
                 print("⚠️  Port conflict detected, retrying testagent with a random port...")
                 os.environ["TESTAGENT_HOST_PORT"] = "0"
                 try:
-                    cmd = ["docker", "compose", "up", "-d"] + list(services)
+                    cmd = self._compose_command("up", "-d", *services)
                     subprocess.run(cmd, cwd=self.root, check=True)
                     return True
                 except subprocess.CalledProcessError as e:
@@ -321,9 +332,14 @@ class TestRunner:
 
     def get_testagent_url(self) -> str:
         """Discover the testagent URL by querying its dynamically assigned host port."""
+        if self.podman_compat:
+            url = f"http://localhost:{TESTAGENT_PORT_DEFAULT}"
+            print(f"🔍 Using host-networked Podman testagent at {url}")
+            return url
+
         try:
             result = subprocess.run(
-                ["docker", "compose", "port", "testagent", "8126"],
+                self._compose_command("port", "testagent", "8126"),
                 capture_output=True,
                 text=True,
                 cwd=self.root,
@@ -349,7 +365,10 @@ class TestRunner:
 
         print(f"\n🛑 Stopping services: {', '.join(sorted(services))}")
         try:
-            cmd = ["docker", "compose", "down"] + list(services)
+            if self.podman_compat:
+                cmd = self._compose_command("down")
+            else:
+                cmd = self._compose_command("down", *services)
             subprocess.run(cmd, cwd=self.root, check=True)
             return True
         except subprocess.CalledProcessError as e:
@@ -555,7 +574,10 @@ class TestRunner:
             suite_env = suite_config.get("env", {})
             if suite_env:
                 for key, value in suite_env.items():
-                    env[key] = str(value)
+                    value = str(value)
+                    if self.podman_compat and key.endswith("_HOST") and value in suite_services:
+                        value = "localhost"
+                    env[key] = value
                     print(f"🔧 Setting {key}={value}")
 
             # Override with testagent URL if needed

--- a/tests/meta/test_docker_compose.py
+++ b/tests/meta/test_docker_compose.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+DOCKER_COMPOSE = ROOT / "docker-compose.yml"
+PODMAN_COMPOSE = ROOT / "docker-compose.podman.yml"
+
+
+def _services(path):
+    services = {}
+    service = None
+    in_services = False
+
+    for line in path.read_text().splitlines():
+        if line == "services:":
+            in_services = True
+        elif in_services and line and not line.startswith((" ", "#")):
+            break
+        elif in_services and len(line) - len(line.lstrip()) == 4 and line.rstrip().endswith(":"):
+            service = line.strip()[:-1]
+            services[service] = set()
+        elif in_services and service is not None and len(line) - len(line.lstrip()) > 4 and ":" in line:
+            services[service].add(line.strip().split(":", 1)[0])
+
+    return services
+
+
+def test_podman_compose_inherits_every_required_service_image():
+    docker_services = _services(DOCKER_COMPOSE)
+    podman_services = _services(PODMAN_COMPOSE)
+
+    assert all("image" in fields for fields in docker_services.values())
+    assert podman_services.keys() <= docker_services.keys()
+
+    services_requiring_host_network = {
+        service for service, fields in docker_services.items() if "ports" in fields and "network_mode" not in fields
+    }
+
+    assert services_requiring_host_network <= podman_services.keys()
+    assert all("image" not in fields for fields in podman_services.values())

--- a/tests/suitespec.yml
+++ b/tests/suitespec.yml
@@ -162,6 +162,14 @@ suites:
       - '**/conftest.py'
     pattern: meta-testing
     snapshot: false
+  docker_compose:
+    parallelism: 1
+    paths:
+      - docker-compose.yml
+      - docker-compose.podman.yml
+      - tests/meta/test_docker_compose.py
+    pattern: meta-testing
+    snapshot: false
   ddtracerun:
     parallelism: 3
     paths:


### PR DESCRIPTION
<!-- dd-meta {"pullId":"5fd273fb-e3fb-4f4a-a4d7-f9a5ec7cdc89","source":"chat","resourceId":"4f218e7f-25a1-4539-9bc1-eeb26af7c007","workflowId":"ddb7801e-7017-4ed6-8179-e9f16be9d5c0","codeChangeId":"ddb7801e-7017-4ed6-8179-e9f16be9d5c0","sourceType":"chat"} -->
## Description

Motivation: enable the repository test environment to run under Podman where CNI port forwarding cannot update `route_localnet`, while preventing Docker and Podman service definitions from drifting.

Changes:
- add the Podman host-network Compose override and select it with `DD_TEST_PODMAN_COMPAT=1`;
- run the Podman testrunner as the invoking user and forward test service environment variables;
- add a CI-selected meta test verifying that all Podman services inherit images from Docker Compose and that every port-publishing Docker service has a Podman override.

## Testing

- Ran the Kafka integration `test_message` with the Podman Kafka and test-agent containers: 2 passed.
- Ran the Compose parity meta test through Riot: 1 passed.
- Ran `scripts/lint fmt` for the new test and `scripts/lint suitespec-check`.
- Validated Compose configuration and whitespace.

## Risks

Podman compatibility uses host networking, so mutually exclusive services sharing a port must not run together. The existing Vertica image remains unavailable from Docker Hub.

## Additional Notes

The parity test is assigned to the `meta-testing` Riot pattern through `tests/suitespec.yml`, so Compose or parity-test changes select it in CI.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/4f218e7f-25a1-4539-9bc1-eeb26af7c007)

Comment @datadog to request changes