### PR TITLE
fix(llmobs): emit a single error log when payload send retries are exhausted

### DIFF
--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -313,13 +313,13 @@ class BaseLLMObsWriter(PeriodicService):
             else:
                 logger.debug("sent %d LLMObs %s events to %s", num_events, self.EVENT_TYPE, self._url)
             return Response.from_http_response(resp)
-        except Exception:
-            logger.error(
-                "failed to send %d LLMObs %s events to %s",
+        except Exception as e:
+            logger.debug(
+                "attempt to send %d LLMObs %s events to %s failed, will retry if attempts remain: %r",
                 num_events,
                 self.EVENT_TYPE,
                 self._intake,
-                exc_info=True,
+                e,
                 extra={"send_to_telemetry": False},
             )
             raise

--- a/releasenotes/notes/fix-llmobs-retry-logs-df273a85d28d0972.yaml
+++ b/releasenotes/notes/fix-llmobs-retry-logs-df273a85d28d0972.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    LLM Observability: Fixes an issue where transient connection failures during event delivery produce
+    misleading error logs even when a retry succeeds. Error logs are now emitted only when all delivery
+    attempts fail and the payload is dropped.

--- a/tests/llmobs/test_llmobs_span_agent_writer.py
+++ b/tests/llmobs/test_llmobs_span_agent_writer.py
@@ -104,6 +104,71 @@ def test_send_chat_completion_event(mock_send_payload, mock_writer_logs):
     mock_writer_logs.debug.assert_has_calls([mock.call("encoded %d LLMObs %s events to be sent", 1, "span")])
 
 
+@mock.patch("ddtrace.internal.utils.retry.sleep")
+@mock.patch("ddtrace.llmobs._writer.telemetry.record_dropped_payload")
+@mock.patch("ddtrace.llmobs._writer.get_connection")
+def test_connection_error_logs_debug_before_retry_and_no_error_after_success(
+    mock_get_connection, mock_record_dropped_payload, mock_sleep, mock_writer_logs
+):
+    connection_error = ConnectionError("temporary connection failure")
+    failed_connection = mock.Mock()
+    failed_connection.request.side_effect = connection_error
+    successful_connection = mock.Mock()
+    successful_connection.getresponse.return_value.status = 200
+    successful_connection.getresponse.return_value.read.return_value = b"OK"
+    mock_get_connection.side_effect = [failed_connection, successful_connection]
+
+    llmobs_span_writer = LLMObsSpanWriter(1, 1, is_agentless=False)
+    llmobs_span_writer.enqueue(_completion_event())
+    llmobs_span_writer.periodic()
+
+    retry_log = mock.call(
+        "attempt to send %d LLMObs %s events to %s failed, will retry if attempts remain: %r",
+        1,
+        "span",
+        llmobs_span_writer._intake,
+        connection_error,
+        extra={"send_to_telemetry": False},
+    )
+    assert mock_writer_logs.debug.call_args_list.count(retry_log) == 1
+    assert mock_get_connection.call_count == 2
+    mock_writer_logs.error.assert_not_called()
+    mock_record_dropped_payload.assert_not_called()
+
+
+@mock.patch("ddtrace.internal.utils.retry.sleep")
+@mock.patch("ddtrace.llmobs._writer.telemetry.record_dropped_payload")
+@mock.patch("ddtrace.llmobs._writer.get_connection")
+def test_connection_error_logs_one_error_after_retries_exhausted(
+    mock_get_connection, mock_record_dropped_payload, mock_sleep, mock_writer_logs
+):
+    connection_error = ConnectionError("persistent connection failure")
+    mock_get_connection.return_value.request.side_effect = connection_error
+
+    llmobs_span_writer = LLMObsSpanWriter(1, 1, is_agentless=False)
+    llmobs_span_writer.enqueue(_completion_event())
+    llmobs_span_writer.periodic()
+
+    retry_log = mock.call(
+        "attempt to send %d LLMObs %s events to %s failed, will retry if attempts remain: %r",
+        1,
+        "span",
+        llmobs_span_writer._intake,
+        connection_error,
+        extra={"send_to_telemetry": False},
+    )
+    assert mock_writer_logs.debug.call_args_list.count(retry_log) == llmobs_span_writer.RETRY_ATTEMPTS
+    mock_writer_logs.error.assert_called_once_with(
+        "failed to send %d LLMObs %s events to %s",
+        1,
+        "span",
+        llmobs_span_writer._intake,
+        exc_info=True,
+        extra={"send_to_telemetry": False},
+    )
+    mock_record_dropped_payload.assert_called_once_with(1, event_type="span", error="connection_error")
+
+
 @mock.patch("ddtrace.llmobs._writer.BaseLLMObsWriter._send_payload")
 def test_send_timed_events(mock_send_payload, mock_writer_logs):
     llmobs_span_writer = LLMObsSpanWriter(0.01, 1, is_agentless=False)


### PR DESCRIPTION
## Description

<!-- Provide an overview of the change and motivation for the change.
     Implementation detail and rationale belong here, not in the release note -
     release notes are customer-facing (see docs/releasenotes.rst). -->

Fixes #17476.

LLMObs retries payload delivery up to three times after connection failures. Previously,
every failed attempt emitted an `ERROR` log with a traceback. If all attempts failed,
`periodic()` emitted the same `ERROR` again when the payload was finally dropped.
As a result:
- A transient failure still produced an `ERROR`, even when a later retry succeeded.
- An exhausted retry sequence could invoke the same `ERROR` log four times for one batch.
- The logs did not distinguish a failed attempt from a definitively dropped payload.
This change logs individual connection failures at `DEBUG` level and describes them as
retry attempts. The exception is included using `%r`, which preserves its type and message
without repeating the full traceback.
The existing `ERROR` in `periodic()` remains the final failure signal. It is emitted only
after all retry attempts fail and retains `exc_info=True`, so one traceback is available
for the dropped payload.
Retry behavior and dropped-payload telemetry are unchanged.

## Testing
Added regression tests covering both connection-failure outcomes:
- A transient failure followed by a successful retry emits one retry `DEBUG`, no `ERROR`,
  and no dropped-payload telemetry.
- Three failed attempts emit three retry `DEBUG` logs, one final `ERROR`, and one
  dropped-payload telemetry record.

<!-- Describe your testing strategy or note what tests are included -->

## Risks
This intentionally reduces `ERROR` volume for connection failures. Monitors that rely on
each failed attempt being logged at `ERROR` will no longer observe transient failures;
per-attempt details now require `DEBUG` logging.
The final `failed to send ... LLMObs ... events` error message is unchanged, so queries
matching that message will continue to detect payloads dropped after retries are exhausted.

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

HTTP error responses (`resp.status >= 300`) retain their existing `ERROR` logging and
dropped-payload telemetry behavior. This change only affects connection exceptions handled
by the retry path.
<!-- Any other information that would be helpful for reviewers -->
