### PR TITLE
test(appsec): isolate filesystem and browser side effects

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -376,6 +376,7 @@ venv = Venv(
                 "pip": "<25",
             },
             env={
+                "BROWSER": "true",  # Prevent webbrowser tests from launching the host browser.
                 "_DD_IAST_PATCH_MODULES": "benchmarks.,tests.appsec.",
                 "DD_IAST_REQUEST_SAMPLING": "100",
                 "DD_IAST_DEDUPLICATION_ENABLED": "false",

--- a/tests/appsec/contrib_appsec/test_django.py
+++ b/tests/appsec/contrib_appsec/test_django.py
@@ -1,5 +1,7 @@
 import importlib
 import os
+from pathlib import Path
+import shutil
 
 import django
 from django.conf import settings
@@ -15,6 +17,25 @@ from tests.utils import scoped_tracer
 
 _FLAT_URLCONF = "tests.appsec.contrib_appsec.django_app.urls"
 _SUBAPP_URLCONF = "tests.appsec.contrib_appsec.django_app.urls_subapps"
+_DATABASE_TEMPLATE = Path(__file__).with_name("db.sqlite3")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def isolated_database(tmp_path_factory):
+    """Use a worker-local copy of the Django database template."""
+    database_path = tmp_path_factory.mktemp("appsec-django") / "db.sqlite3"
+    shutil.copyfile(_DATABASE_TEMPLATE, database_path)
+
+    os.environ["DJANGO_SETTINGS_MODULE"] = "tests.appsec.contrib_appsec.django_app.settings"
+    original_database_name = settings.DATABASES["default"]["NAME"]
+    settings.DATABASES["default"]["NAME"] = str(database_path)
+    try:
+        yield
+    finally:
+        from django.db import connections
+
+        connections.close_all()
+        settings.DATABASES["default"]["NAME"] = original_database_name
 
 
 class _Test_Django_Base:

--- a/tests/appsec/iast/fixtures/taint_sinks/path_traversal.py
+++ b/tests/appsec/iast/fixtures/taint_sinks/path_traversal.py
@@ -8,6 +8,7 @@ import os
 import pickle
 import shutil
 import tarfile
+import tempfile
 from zipfile import ZipFile
 
 
@@ -58,8 +59,9 @@ def path_os_remove(origin_string):
 
 def path_os_rename(origin_string):
     try:
-        # label path_os_rename
-        os.rename(origin_string, "test.txt")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # label path_os_rename
+            os.rename(origin_string, os.path.join(tmp_dir, "test.txt"))
     except Exception:
         pass
 
@@ -90,24 +92,27 @@ def path_os_listdir(origin_string):
 
 def path_shutil_copy(origin_string):
     try:
-        # label path_shutil_copy
-        shutil.copy(origin_string, "not_exists.txt2")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # label path_shutil_copy
+            shutil.copy(origin_string, os.path.join(tmp_dir, "copied.txt"))
     except Exception:
         pass
 
 
 def path_shutil_copytree(origin_string):
     try:
-        # label path_shutil_copytree
-        shutil.copytree(origin_string, "not_exists.txt2")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # label path_shutil_copytree
+            shutil.copytree(origin_string, os.path.join(tmp_dir, "copied"))
     except Exception:
         pass
 
 
 def path_shutil_move(origin_string):
     try:
-        # label path_shutil_move
-        shutil.move(origin_string, "not_exists.txt2")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # label path_shutil_move
+            shutil.move(origin_string, os.path.join(tmp_dir, "moved.txt"))
     except Exception:
         pass
 


### PR DESCRIPTION
## Description

IAST and AppSec test runs could leave filesystem artifacts in the checkout and launch the host browser.

- Run path-traversal rename, copy, and move destinations in automatically cleaned temporary directories.
- Run Django AppSec tests against a worker-local temporary copy of the checked-in SQLite template.
- Configure the default browser for the IAST Riot environment as the no-op `true` command.

This keeps the checkout clean while preserving the sink calls exercised by IAST.

## Testing

- `scripts/lint checks`
- `scripts/lint riot`
- Focused IAST path-traversal and browser tests: 34 passed
- IAST webbrowser tests under the rebuilt Riot environment: 2 passed
- Django automatic user-event tests: 72 passed
- Verified `tests/appsec/contrib_appsec/db.sqlite3` still matches its `HEAD` blob after the ORM tests

## Risks

Low. The changes are limited to test fixtures and test-environment configuration.

## Additional Notes

No release note is needed because this is a test-only change.