### PR TITLE
test(appsec): poll for snapshot traces instead of sleeping

### DIFF
--- a/tests/contrib/flask/test_appsec_flask_snapshot.py
+++ b/tests/contrib/flask/test_appsec_flask_snapshot.py
@@ -2,7 +2,6 @@ import os
 import signal
 import subprocess
 import sys
-import time
 from typing import Callable  # noqa:F401
 from typing import Generator  # noqa:F401
 
@@ -89,11 +88,8 @@ def flask_client(
             client.get_ignored("/shutdown")
         except Exception:
             pass
-        # At this point the traces have been sent to the test agent
-        # but the test agent hasn't necessarily finished processing
-        # the traces (race condition) so wait just a bit for that
-        # processing to complete.
-        time.sleep(0.2)
+        # The test agent may not have finished processing the traces yet. Each test declares
+        # wait_for_num_traces so the snapshot polls for them rather than racing a fixed sleep.
     finally:
         os.killpg(proc.pid, signal.SIGKILL)
         stdout, stderr = proc.communicate()
@@ -103,6 +99,7 @@ def flask_client(
 
 
 @pytest.mark.snapshot(
+    wait_for_num_traces=1,
     ignores=[
         "error",
         "type",
@@ -135,6 +132,7 @@ def test_flask_ipblock_match_403(flask_client):
 
 
 @pytest.mark.snapshot(
+    wait_for_num_traces=1,
     ignores=[
         "error",
         "type",
@@ -167,6 +165,7 @@ def test_flask_ipblock_match_403_json(flask_client):
 
 
 @pytest.mark.snapshot(
+    wait_for_num_traces=1,
     ignores=[
         "error",
         "type",
@@ -198,6 +197,7 @@ def test_flask_userblock_match_403_json(flask_client):
 
 
 @pytest.mark.snapshot(
+    wait_for_num_traces=1,
     ignores=[
         "error",
         "type",
@@ -229,6 +229,7 @@ def test_flask_userblock_match_200_json(flask_client):
 
 
 @pytest.mark.snapshot(
+    wait_for_num_traces=1,
     ignores=[
         "error",
         "type",
@@ -261,6 +262,7 @@ def test_flask_processexec_ossystem(flask_client):
 
 
 @pytest.mark.snapshot(
+    wait_for_num_traces=1,
     ignores=[
         "error",
         "type",
@@ -294,6 +296,7 @@ def test_flask_processexec_osspawn(flask_client):
 
 
 @pytest.mark.snapshot(
+    wait_for_num_traces=1,
     ignores=[
         "error",
         "type",
@@ -326,6 +329,7 @@ def test_flask_processexec_subprocesscommunicateshell(flask_client):
 
 
 @pytest.mark.snapshot(
+    wait_for_num_traces=1,
     ignores=[
         "error",
         "type",


### PR DESCRIPTION
APPSEC-69623

Every flaky record in this suite that carries an error message shows the same failure — the trace never arrived, rather than arriving wrong:

```
At compare of 1 expected trace(s) to 0 received trace(s):
Did not receive expected traces: 'flask.request'
```

The fixture bet a fixed 200ms on the agent finishing, and said so:

```python
# the test agent hasn't necessarily finished processing
# the traces (race condition) so wait just a bit for that
time.sleep(0.2)
```

Use `wait_for_num_traces` instead, which polls `/test/session/traces` for up to 5s and fails with the traces it did see. It is already the idiom in `tests/opentelemetry/test_trace.py`. All 8 tests here issue exactly one request, so each declares 1, and the sleep goes away with the import that only it used.

Scope: 2 quarantined records (`25Y3YM`, and `Z4FYLH` which last flaked on an mq branch so it is missing from main-scoped views) plus 8 still active — the whole file shares the one racy fixture. Three further records here are already marked fixed. All 10 unresolved are keyed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)