### PR TITLE
test(appsec): bound the django test app flush and fix its suitespec gap

### DIFF
--- a/tests/appsec/integrations/django_tests/django_app/urls.py
+++ b/tests/appsec/integrations/django_tests/django_app/urls.py
@@ -15,7 +15,9 @@ else:
 
 def shutdown(request):
     # Endpoint used to flush traces to the agent when doing snapshots.
-    tracer.shutdown()
+    # Bounded because the default never gives up, and gevent can park an untimed wait forever.
+    # Stays under the caller's 10s read timeout in appsec_utils.
+    tracer.shutdown(timeout=5)
     return HttpResponse(status=200)
 
 

--- a/tests/appsec/suitespec.yml
+++ b/tests/appsec/suitespec.yml
@@ -74,6 +74,7 @@ suites:
     paths:
       - '@appsec_iast'
       - tests/appsec/iast_packages/*
+      - tests/appsec/app.py
       - tests/appsec/appsec_utils.py
     timeout: 50m
   iast_tdd_propagation:
@@ -85,6 +86,7 @@ suites:
       - '@appsec_iast'
       - '@remoteconfig'
       - tests/appsec/iast_tdd_propagation/*
+      - tests/appsec/app.py
       - tests/appsec/appsec_utils.py
     retry: 2
     snapshot: true
@@ -150,6 +152,7 @@ suites:
       - '@appsec_iast'
       - tests/appsec/integrations/flask_tests/test_iast_flask.py
       - tests/appsec/integrations/flask_tests/test_appsec_flask_telemetry.py
+      - tests/appsec/app.py
       - tests/appsec/appsec_utils.py
     retry: 2
     # test_appsec_flask_telemetry.py asserts on payloads received by the test agent.
@@ -165,6 +168,7 @@ suites:
       - '@appsec_iast'
       - '@remoteconfig'
       - tests/appsec/integrations/flask_tests/*
+      - tests/appsec/app.py
       - tests/appsec/appsec_utils.py
     retry: 2
     services:


### PR DESCRIPTION
APPSEC-69623

Two independent changes. **Neither is the fix for the gevent shutdown hang**, so this PR deliberately carries no attempt-to-fix keys — the fix is gevent 26.8.0 ([gevent/gevent#2199](https://github.com/gevent/gevent/pull/2199)), coming as a lockfile refresh.

**Bounds the django test app's trace flush.** `/shutdown` called `tracer.shutdown()` with no timeout, documented as "block until flushing has successfully completed". An unbounded wait in a fixture teardown holds the job to the suite timeout rather than failing one test, and a lost gevent notification can only park an *untimed* wait forever — a timed one still wakes on its hub timer. `tests/appsec/app.py` already passed a timeout, so django was the outlier.

**Adds `tests/appsec/app.py` to the four suites that serve it.** It matched only the threats suites, so changes to it ran none of the integration tests that use it. Same gap #19674 closed for `appsec_utils.py`.

Thanks @florentinl for both catches. The flask `10 → 5` change is reverted, and `DD_U55XLN` is removed: at a 0.07% failure rate, 21 attempt-to-fix retries would pass ~98% of the time regardless, so keeping the key here would have marked the test fixed without fixing it. It moves to the gevent PR, alongside `DD_EZS58U` — a second record with the identical `port_still_bound=True … exit_code=None` signature that showed up on `tests.appsec.app:app` under `-k gevent`, confirming this was never django-only.
