### PR TITLE
test(iast): stop splitting the ASMConfig singleton

### DIFF
--- a/tests/appsec/iast/test_product_inspect_regression.py
+++ b/tests/appsec/iast/test_product_inspect_regression.py
@@ -17,7 +17,7 @@ This happens because:
 
 import sys
 
-from tests.utils import override_env
+from tests.utils import override_global_config
 
 
 def sample_function_with_many_params(
@@ -84,16 +84,9 @@ class TestInspectModuleDropRegression:
         inspect_id_before = id(sys.modules.get("inspect"))
         inspect_module_before = sys.modules.get("inspect")
 
-        # Call post_preload directly (this is what happens in production)
-        # We need to ensure IAST is enabled for post_preload to run its logic
-        with override_env({"DD_IAST_ENABLED": "true"}):
-            # Force reload of asm_config to pick up the environment variable
-            import importlib
-
-            from ddtrace.internal.settings import asm
-
-            importlib.reload(asm)
-
+        # Enabled in place: reloading the asm module would rebind its config to a new object,
+        # leaving every module that already imported the old one reading stale settings.
+        with override_global_config(dict(_iast_enabled=True)):
             from ddtrace.internal.iast import product
 
             # Call post_preload - this should NOT drop inspect


### PR DESCRIPTION
APPSEC-69623

`test_iast_post_preload_does_not_drop_inspect` called `importlib.reload` on `ddtrace.internal.settings.asm`, re-running `config = ASMConfig()` and leaving a second config object. Modules that already imported the first one — the IAST fork handler, `tests.utils`, the IAST product — kept reading it, while later function-local imports got the second.

The fork handler then set `_iast_enabled=False` on the stale object while assertions read the fresh one, so fork tests scheduled after this file failed with `assert True is False` (and the forked child exited 1). `--dist=worksteal` makes that order arbitrary, hence the flakiness.

Enabling IAST in place with `override_global_config` keeps a single config object.

Verified locally: with collection forced into the poisoning order, all 5 active tests in `test_fork_handler_regression.py` fail before this change and pass after; full `appsec_iast_default` suite green.

DD_OH6MKE DD_N1QYZK DD_UCVTES DD_WK8CRJ DD_GFK4LG DD_6C3WMP DD_4XCT5L DD_DMHHUA DD_K4OKPY
