### PR TITLE
fix(profiling): use file/function names to cache async boundary frame

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
@@ -17,6 +17,16 @@
 // Forward declaration
 class Frame;
 
+// Identity of the frame that separates the asyncio machinery from the pure Python stack.
+// We memoize the interned name and filename rather than a Frame cache key: the cache key
+// mixes in the bytecode offset, so it only matches the boundary frame while it sits on the
+// very instruction it happened to be on when we first identified it.
+struct BoundaryFrame
+{
+    StringTable::Key name = 0;
+    StringTable::Key filename = 0;
+};
+
 class EchionSampler
 {
     // Thread Info map (Thread ID -> ThreadInfo)
@@ -39,8 +49,8 @@ class EchionSampler
     PyObject* asyncio_eager_tasks_ = nullptr;
 
     // Task unwinding state
-    std::optional<Frame::Key> asyncio_frame_cache_key_;
-    std::optional<Frame::Key> uvloop_frame_cache_key_;
+    std::optional<BoundaryFrame> asyncio_boundary_frame_;
+    std::optional<BoundaryFrame> uvloop_boundary_frame_;
     std::unordered_set<PyObject*> previous_task_objects_;
 
     // Sampling-thread scratch buffer. Only the single sampling thread
@@ -99,8 +109,8 @@ class EchionSampler
         asyncio_eager_tasks_ = (eager_tasks != Py_None) ? eager_tasks : nullptr;
     }
 
-    std::optional<Frame::Key>& asyncio_frame_cache_key() { return asyncio_frame_cache_key_; }
-    std::optional<Frame::Key>& uvloop_frame_cache_key() { return uvloop_frame_cache_key_; }
+    std::optional<BoundaryFrame>& asyncio_boundary_frame() { return asyncio_boundary_frame_; }
+    std::optional<BoundaryFrame>& uvloop_boundary_frame() { return uvloop_boundary_frame_; }
     std::unordered_set<PyObject*>& previous_task_objects() { return previous_task_objects_; }
 
     std::unordered_set<PyObject*>& seen_frames_scratch() { return seen_frames_scratch_; }
@@ -149,8 +159,8 @@ class EchionSampler
         new (&greenlet_thread_map_) std::unordered_map<uintptr_t, GreenletInfo::ID>();
         new (&previous_task_objects_) std::unordered_set<PyObject*>();
 
-        asyncio_frame_cache_key_.reset();
-        uvloop_frame_cache_key_.reset();
+        asyncio_boundary_frame_.reset();
+        uvloop_boundary_frame_.reset();
         asyncio_task_count_ = 0;
         rng_ = std::minstd_rand{ std::random_device{}() };
 

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/threads.h
@@ -63,6 +63,11 @@ class ThreadInfo
     [[nodiscard]] Result<void> sample(EchionSampler&, PyThreadState*, microsecond_t);
     void unwind(EchionSampler&, PyThreadState*, microsecond_t wall_time_us);
 
+    // Number of frames in python_stack from the asyncio boundary frame (inclusive) up to the root,
+    // that is to say the asyncio machinery plus the synchronous entry point. Returns the size of the
+    // whole stack when the boundary frame is not there.
+    [[nodiscard]] size_t find_upper_python_stack_size(EchionSampler&) const;
+
     // ------------------------------------------------------------------------
 #if defined PL_LINUX
     ThreadInfo(uintptr_t thread_id, unsigned long native_id, const char* name, clockid_t cpu_clock_id)

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -39,36 +39,37 @@ ThreadInfo::unwind(EchionSampler& echion, PyThreadState* tstate, microsecond_t w
 }
 
 // ----------------------------------------------------------------------------
-Result<void>
-ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate, microsecond_t wall_time_us)
+size_t
+ThreadInfo::find_upper_python_stack_size(EchionSampler& echion) const
 {
-    // The size of the "pure Python" stack (before asyncio Frames).
     // Defaults to the full Python stack size (and updated if we find the boundary frame)
     size_t upper_python_stack_size = python_stack.size();
 
     // Check if the Python stack contains the asyncio boundary frame.
     // For regular asyncio, this is "Handle._run" from asyncio/events.py.
     // For uvloop, this is "Runner.run" from asyncio/runners.py (uvloop uses asyncio.Runner internally).
-    // To avoid having to do string comparisons every time we unwind Tasks, we keep track
-    // of the cache key of the boundary frame.
-
-    // Note: We use separate cache keys for asyncio and uvloop because switching between them
+    // To avoid having to do string comparisons every time we unwind Tasks, we memoize the interned
+    // name and filename of the boundary Frame the first time we identify it.
+    // Note: We memoize asyncio and uvloop separately because switching between them
     // (though unlikely at runtime) would cause incorrect boundary detection otherwise.
-    auto& asyncio_frame_cache_key = echion.asyncio_frame_cache_key();
-    auto& uvloop_frame_cache_key = echion.uvloop_frame_cache_key();
+    auto& asyncio_boundary_frame = echion.asyncio_boundary_frame();
+    auto& uvloop_boundary_frame = echion.uvloop_boundary_frame();
 
-    auto& frame_cache_key = using_uvloop ? uvloop_frame_cache_key : asyncio_frame_cache_key;
+    auto& boundary_frame = using_uvloop ? uvloop_boundary_frame : asyncio_boundary_frame;
 
-    if (!frame_cache_key) {
-        for (size_t i = 0; i < python_stack.size(); i++) {
-            const auto& frame = python_stack[i];
+    for (size_t i = 0; i < python_stack.size(); i++) {
+        const auto& frame = python_stack[i];
+
+        bool is_boundary_frame = false;
+
+        if (boundary_frame) {
+            is_boundary_frame = frame.name == boundary_frame->name && frame.filename == boundary_frame->filename;
+        } else {
             auto maybe_frame_name = echion.string_table().lookup(frame.name);
             if (!maybe_frame_name) {
                 continue;
             }
             const auto& frame_name = maybe_frame_name->get();
-
-            bool is_boundary_frame = false;
 
             if (using_uvloop) {
                 // For uvloop, the boundary frame depends on the Python version:
@@ -113,24 +114,25 @@ ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate, microseco
             }
 
             if (is_boundary_frame) {
-                // Although Frames are stored in an LRUCache, the cache key is ALWAYS the same
-                // even if the Frame gets evicted from the cache.
-                // This means we can keep the cache key and reuse it to determine
-                // whether we see the boundary Frame in the Python stack.
-                frame_cache_key = frame.cache_key;
-                upper_python_stack_size = python_stack.size() - i;
-                break;
+                boundary_frame = BoundaryFrame{ frame.name, frame.filename };
             }
         }
-    } else {
-        for (size_t i = 0; i < python_stack.size(); i++) {
-            const auto& frame = python_stack[i];
-            if (frame.cache_key == *frame_cache_key) {
-                upper_python_stack_size = python_stack.size() - i;
-                break;
-            }
+
+        if (is_boundary_frame) {
+            upper_python_stack_size = python_stack.size() - i;
+            break;
         }
     }
+
+    return upper_python_stack_size;
+}
+
+// ----------------------------------------------------------------------------
+Result<void>
+ThreadInfo::unwind_tasks(EchionSampler& echion, PyThreadState* tstate, microsecond_t wall_time_us)
+{
+    // The size of the "pure Python" stack (before asyncio Frames).
+    const size_t upper_python_stack_size = find_upper_python_stack_size(echion);
 
     std::vector<TaskInfo::Ref> leaf_tasks;
     std::unordered_set<PyObject*> parent_tasks;

--- a/releasenotes/notes/fix-profiling-asyncio-boundary-frame-8f3b41c07d2a95e6.yaml
+++ b/releasenotes/notes/fix-profiling-asyncio-boundary-frame-8f3b41c07d2a95e6.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    profiling: Fixes an issue where asyncio task samples could be reported with the coroutine
+    frames at the top of the stack and the calling frames duplicated underneath them.


### PR DESCRIPTION
## Description

This PR fixes a bug we currently have in the task unwinding logic and that is caused by how we keep track of the "async boundary frame". As a reminder, the boundary frame is the frame at which we cut the thread stack of a running asyncio task in two, with one part being the sync entrypoint and asynchronous machinery, and the other being the asynchronous execution task itself.

Prior to this PR, we would always cache (for `asyncio` and `uvloop`) the `Frame::Key` for the boundary frame. This, however, was not correct, as `Frame::key` maps to a "code location" (bytecode offset) and not a whole function. As a result, if the unwound thread stack contained the boundary function but not currently at the known code location, we would assume the boundary frame was not there and thus not apply the correct stack splitting and stacking logic. 

In order to simplify the code a bit, I decided to split the logic to find the boundary frame and determine the size of the "upper Python stack" from the code that really does task unwinding and stack sampling. 

## Testing

This PR has been validated mostly by unit testing/CI.  
The changes, as far as I can tell, are not risky correctness-wise: the logic is effectively still the same, only the means by which we compare the boundary frame have been updated (made more correct/flexible). 

<!--

Fixes flaky DD_BRWKNM DD_41Q1FD DD_ZCP6W8 DD_VM7CWP DD_WZ45ZL DD_58R9II DD_721ZVA

-->

## Risks

As far as I can tell, the main risk would be to break asynchronous unwinding (it already was broken, but only in rare cases). This is mitigated by running the async unwinding unit tests _many times_ and making sure they are not flaky. If no run on several hundreds flakes, then it means the logic is very probably correct. 

## Additional Notes

One thing that used to "just work" but now doesn't is post-fork behaviour. `Frame::Key` was a hash of code address + bytecode offset + firstlineno, whereas `StringTable::Key` (which we now cache) is (in our case) the address of the Python string for the file name / function name. As far as I know, the `StringTable::Key` themselves wouldn't change, but for fork-safety reasons we have to reset the string tables post-fork, meaning the `StringTable::Key` aren't valid string table keys anymore. We thus reset those values post-fork and re-discover them. 

## Pre-review checklist

- ✅   The changes have been tested in real services in staging (HTTP Smoke Tests)
- ✅   The PR does not result in new crashes
