### PR TITLE
fix(profiling): query Python task sources independently

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -518,12 +518,11 @@ ThreadInfo::get_all_tasks(EchionSampler& echion, PyThreadState* tstate)
     // CPython iterates over both:
     // 1. Per-thread list: tstate->asyncio_tasks_head (active tasks)
     // 2. Per-interpreter list: interp->asyncio_tasks_head (lingering tasks)
-    // First, get tasks from this thread's linked-list (if tstate_addr is set)
-    // Note: We continue processing even if one source fails to maximize partial results
-    if (tstate != nullptr && this->tstate_addr != 0) {
+    // Query each source independently and continue if either one is unavailable.
+    if (this->tstate_addr != 0) {
         (void)get_tasks_from_thread_linked_list(echion, tasks);
-
-        // Second, get tasks from interpreter's linked-list (lingering tasks)
+    }
+    if (tstate != nullptr) {
         (void)get_tasks_from_interpreter_linked_list(echion, tstate, tasks);
     }
 


### PR DESCRIPTION
## Description

Queries the two native Python 3.14 asyncio task sources independently.

CPython keeps active tasks in a per-thread linked list and lingering tasks in a per-interpreter linked list. The current implementation queries both only when it has both a copied thread-state address and a `PyThreadState` snapshot. Those inputs are independent:

- the per-thread list needs the saved thread-state address;
- the per-interpreter list needs `tstate->interp`.

This change uses whichever source is available and preserves the existing best-effort behavior when either lookup fails. Normal wall sampling generally provides both inputs, but keeping the sources independent makes task discovery correct for other sampling paths that can have only one.

This is the first prerequisite for separating lightweight task-address discovery from full `TaskInfo` construction.

## Testing

- Compiled the native stack extension against CPython 3.14.5 in release mode with warnings treated as errors.
- `scripts/lint cformat`
- `scripts/lint profiling-native-check`
- `scripts/lint checks`
- `git diff --check`

## Risks

Low. The change only broadens best-effort task discovery when one of the two independent inputs is unavailable. Existing source failures remain non-fatal.

## Additional Notes

No release note is needed because this changes internal task discovery and has no public API impact.
