### PR TITLE
refactor: migrate Context to SpanData

### DIFF
--- a/ddtrace/_trace/sampling_rule.py
+++ b/ddtrace/_trace/sampling_rule.py
@@ -1,12 +1,12 @@
 from typing import Any
 from typing import Optional
 
-from ddtrace._trace.span import Span
 from ddtrace.internal.constants import MAX_UINT_64BITS
 from ddtrace.internal.constants import SAMPLING_HASH_MODULO
 from ddtrace.internal.constants import SAMPLING_KNUTH_FACTOR
 from ddtrace.internal.glob_matching import GlobMatcher
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.native._native import SpanData
 from ddtrace.internal.utils.cache import cachedmethod
 
 
@@ -84,7 +84,7 @@ class SamplingRule(object):
                 return False
         return True
 
-    def matches(self, span: Span) -> bool:
+    def matches(self, span: SpanData) -> bool:
         """
         Return if this span matches this rule
 
@@ -95,7 +95,7 @@ class SamplingRule(object):
         """
         return self.tags_match(span) and self.name_match((span.service, span.name, span.resource))
 
-    def tags_match(self, span: Span) -> bool:
+    def tags_match(self, span: SpanData) -> bool:
         if not self.tags:
             return True
 

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -7,7 +7,6 @@ from typing import Any
 from typing import Callable
 from typing import Mapping
 from typing import Optional
-from typing import Text
 from typing import Union
 from typing import cast
 
@@ -36,7 +35,6 @@ from ddtrace.internal.compat import NumericType
 from ddtrace.internal.constants import MAX_INT_64BITS as _MAX_INT_64BITS
 from ddtrace.internal.constants import MAX_UINT_64BITS as _MAX_UINT_64BITS
 from ddtrace.internal.constants import MIN_INT_64BITS as _MIN_INT_64BITS
-from ddtrace.internal.constants import SAMPLING_DECISION_TRACE_TAG_KEY
 from ddtrace.internal.constants import SPAN_API_DATADOG
 from ddtrace.internal.constants import SamplingMechanism
 from ddtrace.internal.logger import get_logger
@@ -61,7 +59,6 @@ def _get_64_highest_order_bits_as_hex(large_int: int) -> str:
 class Span(SpanData):
     __slots__ = [
         # Public span attributes
-        "_context",
         "_store",
         # Internal attributes
         "_local_root_value",
@@ -117,7 +114,7 @@ class Span(SpanData):
             # state — no lock required. Built inline (not via the `context` property) to
             # keep root-span creation off the property-getter call overhead on the hot
             # path; this mirrors the property's root branch below. Child spans stay lazy.
-            self._context: Optional[Context] = Context(trace_id=self.trace_id, span_id=self.span_id, is_remote=False)
+            self._context = Context(trace_id=self.trace_id, span_id=self.span_id, is_remote=False)
         else:
             self._context = None
 
@@ -130,33 +127,6 @@ class Span(SpanData):
         self._local_root_value: Optional["Span"] = None  # None means this is the root span.
         self._service_entry_span_value: Optional["Span"] = None  # None means this is the service entry span.
         self._store: Optional[dict[str, Any]] = None
-
-    @property
-    def context(self) -> Context:
-        """The trace context for this span.
-
-        For a child span this is a copy of the parent context that shares the
-        trace-level ``_meta``/``_metrics``/``_baggage``/lock while carrying this
-        span's own ``trace_id``/``span_id``; for a root span it is fresh
-        trace-level state. Child contexts are built lazily on first read; root
-        contexts are forced eagerly in ``__init__`` (before the span is published)
-        so the build cannot race across threads.
-        """
-        ctx = self._context
-        if ctx is None:
-            parent = self._parent_context
-            if parent is not None:
-                ctx = parent.copy(self.trace_id, self.span_id)
-            else:
-                # Root fallback (mirrors the eager inline build in __init__); reached
-                # only if a root's _context was cleared, e.g. via the setter.
-                ctx = Context(trace_id=self.trace_id, span_id=self.span_id, is_remote=False)
-            self._context = ctx
-        return ctx
-
-    @context.setter
-    def context(self, value: Context) -> None:
-        self._context = value
 
     def _context_for_child(self) -> Context:
         """Return the context a child span should inherit trace-level state from.
@@ -231,14 +201,6 @@ class Span(SpanData):
         if self._local_root:
             for key in (_SAMPLING_RULE_DECISION, _SAMPLING_AGENT_DECISION, _SAMPLING_LIMIT_DECISION):
                 self._local_root._remove_attribute(key)
-
-    def _set_sampling_decision_maker(
-        self,
-        sampling_mechanism: int,
-    ) -> Optional[Text]:
-        value = "-%d" % sampling_mechanism
-        self.context._meta[SAMPLING_DECISION_TRACE_TAG_KEY] = value
-        return value
 
     def set_tag(self, key: str, value: Optional[str] = None) -> None:
         """Set a tag key/value pair on the span."""

--- a/ddtrace/internal/native/_native.pyi
+++ b/ddtrace/internal/native/_native.pyi
@@ -1017,6 +1017,7 @@ class SpanData:
     _span_api: str
     _parent: Optional[Any]  # parent Span, or None for a root span
     _parent_context: Optional[Any]  # parent Context, or None
+    _context: Optional[Context]  # this span's own Context, lazily built; see `context` property
 
     def __new__(
         cls: type[_SpanDataT],
@@ -1037,6 +1038,11 @@ class SpanData:
     def finished(self) -> bool: ...  # Read-only, returns duration_ns != -1
     @property
     def _is_top_level(self) -> bool: ...  # Read-only: no parent, or service differs from parent's
+    @property
+    def context(self) -> Context: ...  # this span's own Context; lazily built/copied on first access
+    @context.setter
+    def context(self, value: Context) -> None: ...
+    def _set_sampling_decision_maker(self, sampling_mechanism: int) -> Optional[str]: ...
     def _set_struct_tag(self, key: str, value: dict[str, Any]) -> None: ...
     def _get_struct_tag(self, key: str) -> Optional[dict[str, Any]]: ...
     def _remove_struct_tag(self, key: str) -> Optional[dict[str, Any]]: ...

--- a/ddtrace/internal/sampling.py
+++ b/ddtrace/internal/sampling.py
@@ -5,7 +5,6 @@ from typing import Optional
 from typing import TypedDict
 
 from ddtrace._trace.sampling_rule import SamplingRule
-from ddtrace._trace.span import Span
 from ddtrace.constants import _SAMPLING_AGENT_DECISION
 from ddtrace.constants import _SAMPLING_RULE_DECISION
 from ddtrace.constants import _SINGLE_SPAN_SAMPLING_MAX_PER_SEC
@@ -26,6 +25,7 @@ from ddtrace.internal.constants import TRACE_SOURCE_PROPAGATION_KEY
 from ddtrace.internal.constants import SamplingMechanism
 from ddtrace.internal.glob_matching import GlobMatcher
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.native._native import SpanData
 from ddtrace.internal.settings._config import config
 
 from .rate_limiter import RateLimiter
@@ -120,14 +120,14 @@ class SpanSamplingRule:
         self._service_matcher = GlobMatcher(service) if service is not None else None
         self._name_matcher = GlobMatcher(name) if name is not None else None
 
-    def sample(self, span: Span) -> bool:
+    def sample(self, span: SpanData) -> bool:
         if self._sample(span):
             if self._limiter.is_allowed():
                 self.apply_span_sampling_tags(span)
                 return True
         return False
 
-    def _sample(self, span: Span) -> bool:
+    def _sample(self, span: SpanData) -> bool:
         if self._sample_rate == 1:
             return True
         elif self._sample_rate == 0:
@@ -135,7 +135,7 @@ class SpanSamplingRule:
 
         return ((span.span_id * SAMPLING_KNUTH_FACTOR) % SAMPLING_HASH_MODULO) <= self._sampling_id_threshold
 
-    def match(self, span: Span) -> bool:
+    def match(self, span: SpanData) -> bool:
         """Determines if the span's service and name match the configured patterns"""
         name = span.name
         service = span.service
@@ -160,7 +160,7 @@ class SpanSamplingRule:
                 name_match = self._name_matcher.match(name)
         return service_match and name_match
 
-    def apply_span_sampling_tags(self, span: Span) -> None:
+    def apply_span_sampling_tags(self, span: SpanData) -> None:
         span._set_attribute(_SINGLE_SPAN_SAMPLING_MECHANISM, SamplingMechanism.SPAN_SAMPLING_RULE)
         span._set_attribute(_SINGLE_SPAN_SAMPLING_RATE, self._sample_rate)
         # Only set this tag if it's not the default -1
@@ -250,7 +250,7 @@ def _check_unsupported_pattern(string: str) -> None:
             raise ValueError("Unsupported Glob pattern found, character:%r is not supported" % char)
 
 
-def _set_sampling_tags(span: Span, sampled: bool, sample_rate: float, mechanism: int) -> None:
+def _set_sampling_tags(span: SpanData, sampled: bool, sample_rate: float, mechanism: int) -> None:
     # Set the sampling mechanism once but never overwrite an existing tag
     if not span.context._meta.get(SAMPLING_DECISION_TRACE_TAG_KEY):
         span._set_sampling_decision_maker(mechanism)
@@ -273,7 +273,7 @@ def _set_sampling_tags(span: Span, sampled: bool, sample_rate: float, mechanism:
     span.context.sampling_priority = priorities[priority_index]
 
 
-def add_trace_source(span: Span, source: int) -> None:
+def add_trace_source(span: SpanData, source: int) -> None:
     """OR source (a TraceSource bit) into the span's _dd.p.ts trace-source mask.
 
     Marks that an enabled product originated or retained the trace so it is kept when APM
@@ -290,14 +290,14 @@ def add_trace_source(span: Span, source: int) -> None:
     meta[TRACE_SOURCE_PROPAGATION_KEY] = value
 
 
-def _inherit_sampling_tags(target: Span, source: Span):
+def _inherit_sampling_tags(target: SpanData, source: SpanData):
     """Set sampling tags from source span on target span."""
     target._set_attribute(SAMPLING_DECISION_MAKER_INHERITED, 1)
     target._set_attribute(SAMPLING_DECISION_MAKER_SERVICE, source.service)  # type: ignore[arg-type]
     target._set_attribute(SAMPLING_DECISION_MAKER_RESOURCE, source.resource)
 
 
-def _get_highest_precedence_rule_matching(span: Span, rules: list[SamplingRule]) -> Optional[SamplingRule]:
+def _get_highest_precedence_rule_matching(span: SpanData, rules: list[SamplingRule]) -> Optional[SamplingRule]:
     if not rules:
         return None
 

--- a/src/native/span/span_data.rs
+++ b/src/native/span/span_data.rs
@@ -1044,13 +1044,16 @@ impl SpanData {
         if let Some(d) = &self.meta_struct {
             visit.call(d)?;
         }
-        // `_parent` closes span -> parent span -> ... cycles; `_parent_context`
-        // can reach back to the span through the Context. Both must be visited
-        // so the cyclic GC can collect a finished trace.
+        // `_parent` closes span -> parent span -> ... cycles; `_context`/`_parent_context`
+        // can reach back to the span through the Context (e.g. via baggage). All must be
+        // visited so the cyclic GC can collect a finished trace.
         if let Some(p) = &self._parent {
             visit.call(p)?;
         }
         if let Some(c) = &self._parent_context {
+            visit.call(c)?;
+        }
+        if let Some(c) = &self._context {
             visit.call(c)?;
         }
         // PyBackedString fields hold `Py<PyAny>` storage for str/bytes/None.

--- a/src/native/span/span_data.rs
+++ b/src/native/span/span_data.rs
@@ -542,7 +542,11 @@ impl SpanData {
     #[setter(context)]
     #[inline(always)]
     fn set_context(&mut self, value: &Bound<'_, PyAny>) {
-        self._context = Some(value.clone().unbind());
+        self._context = if value.is_none() {
+            None
+        } else {
+            Some(value.clone().unbind())
+        };
     }
 
     // Records which sampling mechanism made the sampling decision, via the

--- a/src/native/span/span_data.rs
+++ b/src/native/span/span_data.rs
@@ -6,6 +6,25 @@ use pyo3::{
     },
     Bound, IntoPyObject as _, Py, PyAny, PyResult, Python,
 };
+use std::sync::OnceLock;
+
+// `Context` is still a pure-Python class (see context_provider.rs) — cached once so the
+// `context` property's root-span branch doesn't re-import/re-lookup the attribute on every call.
+static CONTEXT_CLASS: OnceLock<Py<PyAny>> = OnceLock::new();
+
+fn get_context_class(py: Python<'_>) -> PyResult<Py<PyAny>> {
+    if let Some(cls) = CONTEXT_CLASS.get() {
+        return Ok(cls.clone_ref(py));
+    }
+    let module = py.import("ddtrace._trace.context")?;
+    let cls = module.getattr("Context")?.unbind();
+    let _ = CONTEXT_CLASS.set(cls.clone_ref(py));
+    Ok(cls)
+}
+
+// Trace tag key that records which sampling mechanism made the sampling decision.
+// Mirrors `ddtrace.internal.constants.SAMPLING_DECISION_TRACE_TAG_KEY`.
+const SAMPLING_DECISION_TRACE_TAG_KEY: &str = "_dd.p.dm";
 
 use super::attributes::{AttrKey, AttributeMap, AttributeValue};
 use crate::ddtrace_utils::flatten_key_value_vec as flatten_key_value_vec_fn;
@@ -61,6 +80,10 @@ pub struct SpanData {
     /// The parent `Context` this span was created under, or `None`.
     /// Held as `Py<PyAny>` because `Context` is still a pure-Python class.
     pub _parent_context: Option<Py<PyAny>>,
+    /// This span's own `Context`, lazily built on first access by the `context`
+    /// getter: copied from `_parent_context` for a child span, or freshly
+    /// constructed for a root span. `None` until first accessed.
+    pub _context: Option<Py<PyAny>>,
 }
 
 impl SpanData {
@@ -473,6 +496,69 @@ impl SpanData {
         } else {
             Some(value.clone().unbind())
         };
+    }
+
+    // _context property — raw storage accessor for this span's own Context, or None.
+    #[getter(_context)]
+    #[inline(always)]
+    fn get_context_raw<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyAny>> {
+        self._context.as_ref().map(|c| c.bind(py).clone())
+    }
+
+    #[setter(_context)]
+    #[inline(always)]
+    fn set_context_raw(&mut self, value: &Bound<'_, PyAny>) {
+        self._context = if value.is_none() {
+            None
+        } else {
+            Some(value.clone().unbind())
+        };
+    }
+
+    // context property — lazily builds this span's own Context on first access:
+    // copied from `_parent_context` for a child span, or freshly constructed for a
+    // root span. Mirrors the logic previously on `Span.context` in Python.
+    #[getter(context)]
+    fn get_context<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        if let Some(ctx) = &self._context {
+            return Ok(ctx.bind(py).clone());
+        }
+        let trace_id = self.get_trace_id(py);
+        let span_id = self.span_id;
+        let ctx: Bound<'py, PyAny> = if let Some(parent) = self._parent_context.as_ref() {
+            parent.bind(py).call_method1("copy", (trace_id, span_id))?
+        } else {
+            let context_cls = get_context_class(py)?;
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("trace_id", trace_id)?;
+            kwargs.set_item("span_id", span_id)?;
+            kwargs.set_item("is_remote", false)?;
+            context_cls.bind(py).call((), Some(&kwargs))?
+        };
+        self._context = Some(ctx.clone().unbind());
+        Ok(ctx)
+    }
+
+    #[setter(context)]
+    #[inline(always)]
+    fn set_context(&mut self, value: &Bound<'_, PyAny>) {
+        self._context = Some(value.clone().unbind());
+    }
+
+    // Records which sampling mechanism made the sampling decision, via the
+    // `_dd.p.dm` trace tag. Mirrors the logic previously on `Span._set_sampling_decision_maker`.
+    #[pyo3(name = "_set_sampling_decision_maker")]
+    fn set_sampling_decision_maker(
+        &mut self,
+        py: Python<'_>,
+        sampling_mechanism: i64,
+    ) -> PyResult<Option<String>> {
+        let value = format!("-{}", sampling_mechanism);
+        let ctx = self.get_context(py)?;
+        let meta = ctx.getattr("_meta")?;
+        meta.cast::<PyDict>()?
+            .set_item(SAMPLING_DECISION_TRACE_TAG_KEY, &value)?;
+        Ok(Some(value))
     }
 
     // _is_top_level property (native for performance - avoids Python property hop).


### PR DESCRIPTION
This change removes the dependence of `ddtrace.internal.sampling` on `ddtrace._trace.span` and replaces it with dependence on `SpanData`. Because `sampling` accesses `Span.context`, this requires making that attribute accessible via `SpanData`.

  - `src/native/span/span_data.rs`: added a `_context: Option<Py<PyAny>>` field to `SpanData`, mirroring the existing `_parent_context` pattern. Context itself stays pure Python, called back into via PyO3, consistent with `context_provider.rs`'s documented architecture.
  - `ddtrace/_trace/span.py`: removed `_context` from `__slots__`; removed now-redundant methods
  - `ddtrace/_trace/sampling_rule.py`: retyped `SamplingRule.matches`/`tags_match` from `Span` to `SpanData` (they only touch native-only attributes)
  - `ddtrace/internal/sampling.py`: replaced the `Span` import/dependency with `SpanData`