### PR TITLE
fix(llmobs): stop capturing LangGraph engine state in tool span metadata

### DIFF
--- a/ddtrace/llmobs/_integrations/langchain.py
+++ b/ddtrace/llmobs/_integrations/langchain.py
@@ -29,6 +29,7 @@ from ddtrace.llmobs._utils import _get_nearest_llmobs_ancestor
 from ddtrace.llmobs._utils import _validate_prompt
 from ddtrace.llmobs._utils import get_llmobs_span_links
 from ddtrace.llmobs._utils import get_tool_version_from_llm_span
+from ddtrace.llmobs._utils import load_data_value
 from ddtrace.llmobs._utils import safe_json
 from ddtrace.llmobs.types import Document
 from ddtrace.llmobs.types import Message
@@ -128,6 +129,25 @@ def _is_google_genai_backed(instance) -> bool:
     client = getattr(client, "client", client)
     module = type(client).__module__ if client is not None else ""
     return module == "google.genai" or module.startswith("google.genai.")
+
+
+def _format_tool_config(config: Any) -> Any:
+    """Strip framework internals from a tool's RunnableConfig before it is stored as metadata.
+
+    LangGraph namespaces its live execution state under dunder-prefixed configurable keys
+    (send/read closures, scratchpad counters, replay state, the checkpointer) and keeps callback
+    managers under callbacks. None of it is meaningful on a span, and holding it means
+    snapshotting the whole graph runtime into the payload. Filtering on the framework's own
+    private-key convention rather than an allowlist keeps genuinely new config keys flowing
+    through without upkeep here.
+    """
+    if not isinstance(config, dict):
+        return load_data_value(config)
+    formatted = {k: v for k, v in config.items() if k != "callbacks"}
+    configurable = formatted.get("configurable")
+    if isinstance(configurable, dict):
+        formatted["configurable"] = {k: v for k, v in configurable.items() if not k.startswith("__")}
+    return load_data_value(formatted)
 
 
 class LangChainIntegration(BaseLLMIntegration):
@@ -800,9 +820,9 @@ class LangChainIntegration(BaseLLMIntegration):
                 (tool_name, tool_args, "function", span, tool_id),
             )
             if tool_inputs.get("config"):
-                metadata["tool_config"] = tool_inputs.get("config")
+                metadata["tool_config"] = _format_tool_config(tool_inputs.get("config"))
             if tool_inputs.get("info"):
-                metadata["tool_info"] = tool_inputs.get("info")
+                metadata["tool_info"] = load_data_value(tool_inputs.get("info"))
             formatted_input = format_langchain_io(tool_inputs.get("input", {}))
         formatted_outputs = ""
         if not span.error and tool_output is not None:

--- a/releasenotes/notes/langchain-tool-config-framework-internals-655e1a16d03992b3.yaml
+++ b/releasenotes/notes/langchain-tool-config-framework-internals-655e1a16d03992b3.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    LLM Observability: Resolves a ``TypeError`` that dropped all spans in a trace when a LangGraph
+    agent invoked a tool. Tool span metadata no longer captures LangGraph's internal execution
+    state, which is not JSON serializable.

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -1476,3 +1476,91 @@ def test_shadow_tags_chat_when_llmobs_disabled(tracer):
     assert span.get_metric("_dd.llmobs.input_tokens") == 5
     assert span.get_metric("_dd.llmobs.output_tokens") == 3
     assert span.get_metric("_dd.llmobs.total_tokens") == 8
+
+
+def _pregel_style_config():
+    """A RunnableConfig shaped like the one LangGraph passes to a tool, including the
+    dunder-prefixed engine state that is not JSON serializable.
+    """
+    import dataclasses
+    import uuid
+
+    @dataclasses.dataclass
+    class PregelRuntime:
+        stream_writer: object
+        execution_info: dict
+
+    class LazyAtomicCounter:
+        pass
+
+    def stream_writer():
+        pass
+
+    return {
+        "callbacks": object(),
+        "tags": ["seq:step:1"],
+        "metadata": {"langgraph_node": "tools"},
+        "recursion_limit": 25,
+        "configurable": {
+            "thread_id": "3f2b1c",
+            "checkpoint_ns": "tools:abc",
+            "checkpoint_id": "1f0a",
+            "__pregel_runtime": PregelRuntime(stream_writer=stream_writer, execution_info={"thread_id": uuid.uuid4()}),
+            "__pregel_scratchpad": {"call_counter": LazyAtomicCounter()},
+            "__pregel_send": stream_writer,
+        },
+    }
+
+
+def test_format_tool_config_drops_framework_internals():
+    from ddtrace.llmobs._integrations.langchain import _format_tool_config
+
+    formatted = _format_tool_config(_pregel_style_config())
+
+    assert "callbacks" not in formatted
+    assert not [k for k in formatted["configurable"] if k.startswith("__")]
+    # the useful identifiers survive
+    assert formatted["configurable"] == {
+        "thread_id": "3f2b1c",
+        "checkpoint_ns": "tools:abc",
+        "checkpoint_id": "1f0a",
+    }
+    assert formatted["tags"] == ["seq:step:1"]
+    assert formatted["metadata"] == {"langgraph_node": "tools"}
+    assert formatted["recursion_limit"] == 25
+
+
+def test_format_tool_config_result_is_json_serializable():
+    """Regression test: without the filter the pregel runtime reaches the agentless JSON
+    encoder and drops every span in the trace.
+    """
+    from ddtrace.llmobs._integrations.langchain import _format_tool_config
+
+    json.dumps(_format_tool_config(_pregel_style_config()))
+
+
+def test_format_tool_config_passes_through_non_dict():
+    from ddtrace.llmobs._integrations.langchain import _format_tool_config
+
+    assert _format_tool_config("a string") == "a string"
+    assert _format_tool_config(None) is None
+
+
+def test_tool_span_metadata_is_json_serializable(tracer):
+    """A tool span's metadata must survive json.dumps, or the agentless JSON encoder drops
+    every span in the trace. Fails without the tool_config filter.
+    """
+    from unittest.mock import MagicMock
+
+    from ddtrace.llmobs._integrations.langchain import LangChainIntegration
+
+    integration = LangChainIntegration(MagicMock())
+    with tracer.trace("langchain.request") as span:
+        integration._llmobs_set_meta_tags_from_tool(
+            span,
+            tool_inputs={"input": "readme", "config": _pregel_style_config(), "info": {"name": "delete"}},
+            tool_output="Deleted.",
+        )
+        metadata = _get_llmobs_data_metastruct(span)["meta"]["metadata"]
+
+    json.dumps(metadata)


### PR DESCRIPTION
## Description

LangGraph packs live execution objects into the `RunnableConfig` it hands to a tool — closures, counters, a checkpointer, callback managers. The LangChain integration stored that config as-is in tool span metadata:

```python
metadata["tool_config"] = tool_inputs.get("config")
```

Those objects are not JSON serializable, so agentless trace encoding raised `TypeError` and **dropped every span in the trace** — silently, with the exception surfacing in the customer's application rather than in ddtrace.

This drops `callbacks` and LangGraph's private `configurable` keys before storing, and passes the rest through `load_data_value`. The useful identifiers stay: `thread_id`, `checkpoint_ns`, `checkpoint_map`, `recursion_limit`, and the `langgraph_*` node/step/trigger metadata.

Fixes MLOB-7962.

## Testing

A/B against a LangGraph `create_agent` reproduction, 8 runs per arm, trace encoder untouched in both. Only runs where the model actually invoked the tool counted as valid:

| | Valid runs | Reproduced | Fixed | Traces delivered |
|---|---|---|---|---|
| Before | 8 | 8/8 | 0 | 0 |
| After | 7 | 0 | 7/7 | 7 |

Verified in the UI that the delivered metadata is still a queryable nested object, with the LangGraph identifiers intact and no private keys present.

Tests in `tests/contrib/langchain/test_langchain_llmobs.py`:

- `test_tool_span_metadata_is_json_serializable` — the regression test. Drives `_llmobs_set_meta_tags_from_tool` and asserts the metadata survives `json.dumps`; fails without this change.
- `test_format_tool_config_drops_framework_internals`
- `test_format_tool_config_result_is_json_serializable`
- `test_format_tool_config_passes_through_non_dict`

Suite: same pre-existing failures before and after (VCR cassettes, API keys), +4 passing.

## Risks

Low — the change only removes keys from a metadata field. Traces that previously failed to encode now encode.

Known limitation: the tests use a fixture shaped like LangGraph's current config, so they would keep passing if LangGraph moved execution state out from behind its private-key prefix. A test in `tests/contrib/langgraph/` driving a real graph would assert the invariant instead. Happy to add here or as a follow-up.

## Additional Notes

`tool_info` is left alone — it is a `name`/`description` string pair and already serializable.