### PR TITLE
chore(profiling): opt-in native heap gotter build and skip musl (PROF-15423)

### DIFF
--- a/.gitlab/scripts/build-wheel-helpers.sh
+++ b/.gitlab/scripts/build-wheel-helpers.sh
@@ -151,22 +151,49 @@ PY
   # Repair wheel (ONLY PLATFORM-SPECIFIC CODE)
   section_start "repair_wheel" "Repairing wheel"
   if [[ "$(uname -s)" == "Linux" ]]; then
-    # The opt-in heap-gotter cdylib (DD_PROFILING_NATIVE_HEAP_BUILD=1) has
-    # non-standard ELF versioning sections that trip auditwheel's iter_versions
-    # parser. --exclude does not help: it only drops a SONAME from dependency
-    # grafting, while repair still parses every ELF listed in the wheel's RECORD.
-    # So the cdylib has to leave the wheel entirely and be reinserted after.
+    # Heap-gotter's ELF versioning trips auditwheel iter_versions; --exclude
+    # only skips SONAME grafting, so stash .so (+ .so.debug) out of the wheel,
+    # repair, then reinsert the runtime .so. Python zipfile: Info-ZIP globs are
+    # unreliable on archive paths.
     GOTTER_STASH_DIR="${WORK_DIR}/heap_gotter_stash"
-    GOTTER_PATTERN='*libdd_heap_gotter*.so'
-    if unzip -l "${BUILT_WHEEL_FILE}" | grep -q 'libdd_heap_gotter.*\.so$'; then
-      mkdir -p "${GOTTER_STASH_DIR}"
-      unzip -q "${BUILT_WHEEL_FILE}" "${GOTTER_PATTERN}" -d "${GOTTER_STASH_DIR}"
-      uv run --no-project scripts/zip_filter.py "${BUILT_WHEEL_FILE}" "${GOTTER_PATTERN}"
-    fi
+    mkdir -p "${GOTTER_STASH_DIR}"
+    BUILT_WHEEL_FILE="${BUILT_WHEEL_FILE}" GOTTER_STASH_DIR="${GOTTER_STASH_DIR}" \
+      uv run --no-project python - <<'PY'
+import os
+import zipfile
+from pathlib import Path
+
+import subprocess
+import sys
+
+wheel = Path(os.environ["BUILT_WHEEL_FILE"])
+stash = Path(os.environ["GOTTER_STASH_DIR"])
+marker = "libdd_heap_gotter"
+with zipfile.ZipFile(wheel, "r") as zf:
+    gotter = [
+        n
+        for n in zf.namelist()
+        if marker in Path(n).name and (n.endswith(".so") or n.endswith(".so.debug"))
+    ]
+    for name in gotter:
+        dest = stash / name
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(zf.read(name))
+        print(f"Stashed heap-gotter artifact: {name}")
+if gotter:
+    # zip_filter keeps RECORD consistent.
+    patterns = [f"*{marker}*.so", f"*{marker}*.so.debug", f"*/{marker}*"]
+    subprocess.check_call([sys.executable, "scripts/zip_filter.py", str(wheel), *patterns])
+with zipfile.ZipFile(wheel, "r") as zf:
+    leftover = [n for n in zf.namelist() if marker in Path(n).name]
+if leftover:
+    raise SystemExit(f"heap-gotter still in wheel before auditwheel: {leftover}")
+print(f"heap-gotter stash count before auditwheel: {len(gotter)}")
+PY
 
     auditwheel repair -w "${TMP_WHEEL_DIR}" "${BUILT_WHEEL_FILE}"
 
-    if [[ -d "${GOTTER_STASH_DIR}" ]]; then
+    if find "${GOTTER_STASH_DIR}" \( -name 'libdd_heap_gotter*.so' -o -name 'libdd_heap_gotter*.so.debug' \) 2>/dev/null | grep -q .; then
       REPAIRED_WHEEL_FILE=$(ls "${TMP_WHEEL_DIR}"/*.whl | head -n 1)
       GOTTER_STASH_DIR="${GOTTER_STASH_DIR}" REPAIRED_WHEEL_FILE="${REPAIRED_WHEEL_FILE}" \
         uv run --no-project python - <<'PY'
@@ -181,7 +208,12 @@ from pathlib import Path
 wheel = Path(os.environ["REPAIRED_WHEEL_FILE"])
 stash = Path(os.environ["GOTTER_STASH_DIR"])
 
-additions = {str(p.relative_to(stash)): p for p in sorted(stash.rglob("*")) if p.is_file()}
+# Runtime .so only; .so.debug stays in debugwheelhouse.
+additions = {
+    str(p.relative_to(stash)): p
+    for p in sorted(stash.rglob("*"))
+    if p.is_file() and p.name.endswith(".so")
+}
 if not additions:
     print("No stashed heap-gotter cdylib to reinsert")
     raise SystemExit(0)

--- a/ddtrace/internal/datadog/profiling/heap_gotter/__init__.py
+++ b/ddtrace/internal/datadog/profiling/heap_gotter/__init__.py
@@ -10,11 +10,13 @@ Dlopens ``libdd_heap_gotter`` (see ``src/native_heap_gotter``) and drives:
 ``ddheap:free``) USDT sites fire; the Full Host eBPF profiler attaches uprobes.
 Nothing is collected or uploaded from Python.
 
-Two independent runtime gates, both required for GOT to be patched:
+Runtime and build gates:
 
-* ``DD_PROFILING_NATIVE_HEAP_ENABLED`` — ddtrace install gate (also the
-  setup.py build gate). When false, this module is not imported from the
-  profiler and ``install()`` is never called.
+* ``DD_PROFILING_NATIVE_HEAP_ENABLED`` — runtime arming gate. When false, this
+  module is not imported from the profiler and ``install()`` is never called.
+  The same variable is read at wheel build time (via setup.py) to decide
+  whether to compile and ship ``libdd_heap_gotter``; setting it at process
+  start does not add the artifact to an already-installed wheel.
 * ``DD_HEAP_SAMPLING_ENABLED`` — libdatadog process-start bypass (unset =
   on; ``0``/``false``/``no``/``off`` disables). Honored inside
   ``install_heap_overrides``; a falsey value leaves the GOT untouched and

--- a/ddtrace/internal/datadog/profiling/heap_gotter/__init__.py
+++ b/ddtrace/internal/datadog/profiling/heap_gotter/__init__.py
@@ -1,31 +1,28 @@
 """Activator for native (C/C++) heap allocation profiling via GOT rewriting.
 
-This module dlopen's the `libdd_heap_gotter` cdylib (built out-of-band from
-libdatadog's `libdd-profiling-heap-gotter-ffi`; see `src/native_heap_gotter`)
-and drives it through a tiny, stable C ABI:
+Dlopens ``libdd_heap_gotter`` (see ``src/native_heap_gotter``) and drives:
 
-    bool ddtrace_heap_gotter_install(void);      # install + report success
-    bool ddtrace_heap_gotter_is_installed(void); # current install state
+    bool ddtrace_heap_gotter_install(void);
+    bool ddtrace_heap_gotter_is_installed(void);
+    bool ddtrace_heap_gotter_live_heap_enabled(void);  # True if built with ddheap:free
 
-Calling `install()` patches the process's GOT entries for heap allocation
-symbols so that Datadog's `ddheap:alloc` USDT probe sites fire on sampled allocations.
-The Full Host eBPF profiler then attaches uprobes to those sites to collect native allocation stacks.
+``install()`` patches GOT entries so ``ddheap:alloc`` (and, on live-heap builds,
+``ddheap:free``) USDT sites fire; the Full Host eBPF profiler attaches uprobes.
+Nothing is collected or uploaded from Python.
 
-If the cdylib is missing or anything goes wrong loading it, `is_available` is `False`
-and `install()` is a no-op. Loading this module must never raise.
+``live_heap_enabled()`` is a compile-time property of the loaded artifact
+(default-on ``live-heap`` feature): True when the cdylib stamps retain flags and
+emits ``ddheap:free``. False if the cdylib is missing, alloc-only
+(``--no-default-features``), or predates this symbol (bound defensively).
 
-Installation cannot be undone (the patched GOT entries point at functions inside the cdylib),
-so the library must stay mapped for the life of the process. We keep the `ctypes.CDLL` handle
-at module scope and never unload it.
+Missing/broken load → ``is_available`` False, ``install()`` no-op; import never
+raises. Install is permanent (GOT points into the cdylib), so the CDLL handle
+stays mapped for the process lifetime.
 
-After a successful `install()`, a child of `fork()` inherits the mapping and the patched GOT.
-Re-entering `install()` in that child is therefore unnecessary; we skip the native call when
-this module already recorded a successful arm (Python module state is also inherited). That
-avoids re-locking upstream's process-global registry mutex. Upstream does not yet implement a
-`pthread_atfork` child reset, so forking *during* an in-flight `install()`/`update()` can still
-leave that mutex locked in the child — prefer arming on the main thread, or after fork in the
-worker (gunicorn/uWSGI-style), and treat mid-install fork as unsafe until libdatadog lands
-atfork handling.
+After a successful ``install()``, fork children inherit the mapping and patched
+GOT; ``_armed`` skips re-entering the native installer. Upstream has no
+``pthread_atfork`` reset for its registry mutex — prefer arming on the main
+thread or in the worker after fork; mid-install fork is unsafe.
 """
 
 from __future__ import annotations
@@ -35,27 +32,26 @@ import os
 import sysconfig
 
 
-# Mirror the ddup/stack modules: importers (notably settings/profiling.py) read
-# these two attributes to decide whether the feature can run.
+# Mirror ddup/stack: settings/profiling.py reads these to gate the feature.
 is_available: bool = False
 failure_msg: str = ""
 
-_lib: ctypes.CDLL | None = None  # kept alive for process lifetime; never dlclose'd
-# Set when install() has succeeded in this process (inherited across fork).
-_armed: bool = False
+# Compile-time live-heap capability of the loaded artifact (see module docstring).
+_live_heap_available: bool = False
+
+_lib: ctypes.CDLL | None = None  # process lifetime; never dlclose'd
+_armed: bool = False  # successful install(); inherited across fork
 
 
 def _library_path() -> str:
-    # The cdylib is staged next to libdd_wrapper in the profiling package and
-    # carries the interpreter EXT_SUFFIX, matching setup.py's naming.
+    # Staged next to libdd_wrapper with the interpreter EXT_SUFFIX (setup.py).
     suffix: str = sysconfig.get_config_var("EXT_SUFFIX") or ".so"
     profiling_dir: str = os.path.dirname(os.path.dirname(__file__))
     return os.path.join(profiling_dir, "libdd_heap_gotter" + suffix)
 
 
 try:
-    # Native heap profiling via the gotter is Linux-only; on every other
-    # platform the underlying library is a no-op, so don't even try to load.
+    # Linux-only; elsewhere the gotter is a no-op.
     sysname = os.uname().sysname if os.name == "posix" else os.name
     if sysname != "Linux":
         raise OSError(f"Native heap gotter is only supported on Linux. Running on {sysname}")
@@ -64,8 +60,7 @@ try:
     if not os.path.exists(_path):
         raise FileNotFoundError(_path)
 
-    # RTLD_GLOBAL so the loaded code is unambiguously resolvable; RTLD_NOW so any
-    # unresolved symbol fails here (fail-closed) rather than at first call.
+    # RTLD_GLOBAL for resolvability; RTLD_NOW fail-closed on unresolved symbols.
     _lib = ctypes.CDLL(_path, mode=ctypes.RTLD_GLOBAL | getattr(os, "RTLD_NOW", 0))
 
     _lib.ddtrace_heap_gotter_install.argtypes = []
@@ -75,18 +70,25 @@ try:
 
     is_available = True
 
+    # Optional symbol (pre-Phase-2 cdylibs); failure must not disable install().
+    try:
+        _lib.ddtrace_heap_gotter_live_heap_enabled.argtypes = []
+        _lib.ddtrace_heap_gotter_live_heap_enabled.restype = ctypes.c_bool
+        _live_heap_available = bool(_lib.ddtrace_heap_gotter_live_heap_enabled())
+    except Exception:
+        _live_heap_available = False
+
 except Exception as e:
     failure_msg = str(e)
     _lib = None
 
 
 def install() -> bool:
-    """Install the native heap GOT overrides. Returns True if now installed; False otherwise.
+    """Install native heap GOT overrides. True if installed; False otherwise.
 
-    Idempotent at the Python layer: once a call has succeeded, further calls
-    (including in a forked child that inherited ``_armed``) return True without
-    re-entering the native installer. No-op that returns False when the cdylib
-    is unavailable. See the module docstring for fork-safety limits.
+    Idempotent at the Python layer: after success (including in a fork child that
+    inherited ``_armed``), further calls return True without re-entering the native
+    installer. See module docstring for fork-safety limits.
     """
     global _armed
     if not is_available or _lib is None:
@@ -112,3 +114,12 @@ def is_installed() -> bool:
         return bool(_lib.ddtrace_heap_gotter_is_installed())
     except Exception:
         return False
+
+
+def live_heap_enabled() -> bool:
+    """Return whether the loaded cdylib was built with live-heap tracking.
+
+    Compile-time property of the artifact (default-on feature). False when the
+    cdylib is missing, alloc-only, or predates this symbol.
+    """
+    return _live_heap_available

--- a/ddtrace/internal/datadog/profiling/heap_gotter/__init__.py
+++ b/ddtrace/internal/datadog/profiling/heap_gotter/__init__.py
@@ -10,6 +10,16 @@ Dlopens ``libdd_heap_gotter`` (see ``src/native_heap_gotter``) and drives:
 ``ddheap:free``) USDT sites fire; the Full Host eBPF profiler attaches uprobes.
 Nothing is collected or uploaded from Python.
 
+Two independent runtime gates, both required for GOT to be patched:
+
+* ``DD_PROFILING_NATIVE_HEAP_ENABLED`` — ddtrace install gate (also the
+  setup.py build gate). When false, this module is not imported from the
+  profiler and ``install()`` is never called.
+* ``DD_HEAP_SAMPLING_ENABLED`` — libdatadog process-start bypass (unset =
+  on; ``0``/``false``/``no``/``off`` disables). Honored inside
+  ``install_heap_overrides``; a falsey value leaves the GOT untouched and
+  ``install()`` returns False. ddtrace does not set or wrap this variable.
+
 ``live_heap_enabled()`` is a compile-time property of the loaded artifact
 (default-on ``live-heap`` feature): True when the cdylib stamps retain flags and
 emits ``ddheap:free``. False if the cdylib is missing, alloc-only

--- a/ddtrace/internal/settings/profiling.py
+++ b/ddtrace/internal/settings/profiling.py
@@ -559,7 +559,7 @@ class ProfilingConfigNativeHeap(DDConfig):
         help=(
             "Whether to enable experimental native (C/C++) heap profiling. "
             "Requires DD_PROFILING_ENABLED=true, Linux, and a wheel built with "
-            "DD_PROFILING_NATIVE_HEAP_BUILD=1. Disabled by default."
+            "DD_PROFILING_NATIVE_HEAP_ENABLED=1. Disabled by default."
         ),
     )
 

--- a/ddtrace/internal/settings/profiling.py
+++ b/ddtrace/internal/settings/profiling.py
@@ -75,9 +75,8 @@ def _check_for_stack_available() -> tuple[str, bool]:
 
 
 def _check_for_native_heap_available() -> tuple[str, bool]:
-    # Importing heap_gotter dlopen's the gotter cdylib (if present) but does
-    # NOT install anything; installation is an explicit, separate call.
-    # The module is fail-closed and never raises on import.
+    # Importing heap_gotter dlopen's the gotter cdylib but does NOT install
+    # anything; installation is an explicit, separate call. Import never raises.
     from ddtrace.internal.datadog.profiling import heap_gotter
 
     return (heap_gotter.failure_msg, heap_gotter.is_available)
@@ -694,9 +693,9 @@ exception_failure_msg, exception_is_available = _check_for_exception_available()
 if not exception_is_available and config.exception.enabled:
     config.exception.enabled = False  # pyright: ignore[reportAttributeAccessIssue]
 
-# Native heap profiling only arms USDT probes via a separately-built cdylib.
+# Native heap profiling only arms USDT probes via the gotter cdylib.
 # Check availability lazily (only when requested) so the common disabled path
-# never dlopen's the gotter library, and fail closed if it can't be loaded.
+# never dlopen's the gotter library. Disable the feature if it can't be loaded.
 if config.native_heap.enabled:
     native_heap_failure_msg, native_heap_is_available = _check_for_native_heap_available()
     if not native_heap_is_available:

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -381,6 +381,8 @@ class _ProfilerInstance(service.Service):
         """Start the profiler."""
         # See DD_PROFILING_NATIVE_HEAP_ENABLED. install() is permanent; children
         # inherit the patched GOT (and the activator skips a redundant re-install).
+        # libdatadog may still refuse the patch via DD_HEAP_SAMPLING_ENABLED
+        # (unset = on); that is not a ddtrace setting — see heap_gotter docs.
         if profiling_config.native_heap.enabled:
             from ddtrace.internal.datadog.profiling import heap_gotter
 

--- a/ddtrace/profiling/profiler.py
+++ b/ddtrace/profiling/profiler.py
@@ -386,7 +386,8 @@ class _ProfilerInstance(service.Service):
 
             try:
                 if heap_gotter.install():
-                    LOG.info("Native heap profiling armed (GOT overrides installed)")
+                    mode: str = "live-heap" if heap_gotter.live_heap_enabled() else "allocation-only"
+                    LOG.info("Native heap profiling armed (GOT overrides installed, %s)", mode)
                 else:
                     LOG.warning("Native heap profiling requested but GOT overrides were not installed")
             except Exception:

--- a/releasenotes/notes/native-heap-profiling-live-heap-336bc489c93989da.yaml
+++ b/releasenotes/notes/native-heap-profiling-live-heap-336bc489c93989da.yaml
@@ -1,6 +1,12 @@
 ---
 features:
   - |
-    profiling: Enable collection of samples for native (C/C++) allocations 
-    in Python processes. Enable with ``DD_PROFILING_NATIVE_HEAP_ENABLED=true``.
-    This setting works for Linux only.
+    profiling: Add experimental, opt-in native (C/C++) heap profiling for Python
+    processes on Linux (manylinux/glibc wheels). At runtime, enable with
+    ``DD_PROFILING_NATIVE_HEAP_ENABLED=true`` together with
+    ``DD_PROFILING_ENABLED=true``; dd-trace-py arms ``ddheap:alloc`` and
+    ``ddheap:free`` USDT probes at profiler startup so the Datadog Host Profiler
+    can collect native allocation and retained-heap samples. The installed wheel
+    must include the ``libdd_heap_gotter`` artifact, produced only when the wheel
+    is built with ``DD_PROFILING_NATIVE_HEAP_ENABLED=1`` (musllinux builds skip
+    the cdylib). It is a no-op when disabled or when the artifact is absent.

--- a/releasenotes/notes/native-heap-profiling-live-heap-336bc489c93989da.yaml
+++ b/releasenotes/notes/native-heap-profiling-live-heap-336bc489c93989da.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    profiling: Enable collection of samples for native (C/C++) allocations 
+    in Python processes. Enable with ``DD_PROFILING_NATIVE_HEAP_ENABLED=true``.
+    This setting works for Linux only.

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,14 @@ BUILD_PROFILING_NATIVE_TESTS = os.getenv("DD_PROFILING_NATIVE_TESTS", "0").lower
 # Opt-in build of the native heap-gotter cdylib.
 # Off by default so normal builds don't pay the extra cargo fetch/compile and
 # mainline wheels don't ship the artifact until it GA's.
-BUILD_NATIVE_HEAP_GOTTER: bool = os.getenv("DD_PROFILING_NATIVE_HEAP_BUILD", "0").lower() in ("1", "yes", "on", "true")
+# Same env var as runtime arming (ProfilingConfigNativeHeap.enabled); setup.py
+# reads it via os.getenv during the package build, independent of DDConfig.
+BUILD_NATIVE_HEAP_GOTTER: bool = os.getenv("DD_PROFILING_NATIVE_HEAP_ENABLED", "0").lower() in (
+    "1",
+    "yes",
+    "on",
+    "true",
+)
 # Keep the staged cdylib unstripped when building with the upstream test-support
 # feature (hook-hit counter for e2e / integration tests).
 BUILD_NATIVE_HEAP_GOTTER_TEST_SUPPORT: bool = os.getenv("DD_PROFILING_NATIVE_HEAP_TEST_SUPPORT", "0").lower() in (

--- a/setup.py
+++ b/setup.py
@@ -130,16 +130,19 @@ VENDOR_DIR = DDTRACE_DIR / "vendor"
 CARGO_TARGET_DIR = NATIVE_CRATE.absolute() / f"target{sys.version_info.major}.{sys.version_info.minor}"
 DD_CARGO_ARGS = shlex.split(os.getenv("DD_CARGO_ARGS", ""))
 
-BUILD_PROFILING_NATIVE_TESTS = os.getenv("DD_PROFILING_NATIVE_TESTS", "0").lower() in ("1", "yes", "on", "true")
-
 
 def _env_truthy(name: str, default: str = "0") -> bool:
     return os.getenv(name, default).lower() in ("1", "yes", "on", "true")
 
 
+BUILD_PROFILING_NATIVE_TESTS = _env_truthy("DD_PROFILING_NATIVE_TESTS")
+
+
 def is_musl_libc() -> bool:
     """True when this interpreter is a musl (Alpine / musllinux) build.
-    Gotter is glibc/manylinux-only in CI and will fail for these platforms if cargo-built.
+
+    The heap-gotter cdylib is built and tested only on manylinux (glibc) in CI;
+    skip building on musllinux because cargo builds fail there.
     """
     return any(
         "musl" in (sysconfig.get_config_var(k) or "")
@@ -153,15 +156,15 @@ def is_musl_libc() -> bool:
 # Same env var as runtime arming (ProfilingConfigNativeHeap.enabled); setup.py
 # reads it via os.getenv during the package build, independent of DDConfig.
 # Musl is always a no-op even when the env is set (see is_musl_libc).
+if _env_truthy("DD_PROFILING_NATIVE_HEAP_ENABLED") and is_musl_libc():
+    print(
+        "WARNING: DD_PROFILING_NATIVE_HEAP_ENABLED is set but the native heap-gotter "
+        "cdylib is only built on manylinux (glibc); skipping on musllinux."
+    )
 BUILD_NATIVE_HEAP_GOTTER: bool = _env_truthy("DD_PROFILING_NATIVE_HEAP_ENABLED") and not is_musl_libc()
 # Keep the staged cdylib unstripped when building with the upstream test-support
 # feature (hook-hit counter for e2e / integration tests).
-BUILD_NATIVE_HEAP_GOTTER_TEST_SUPPORT: bool = os.getenv("DD_PROFILING_NATIVE_HEAP_TEST_SUPPORT", "0").lower() in (
-    "1",
-    "yes",
-    "on",
-    "true",
-)
+BUILD_NATIVE_HEAP_GOTTER_TEST_SUPPORT = _env_truthy("DD_PROFILING_NATIVE_HEAP_TEST_SUPPORT")
 
 CURRENT_OS = platform.system()
 SERVERLESS_BUILD = os.getenv("DD_SERVERLESS_BUILD", "0").lower() in ("1", "yes", "on", "true")

--- a/setup.py
+++ b/setup.py
@@ -139,11 +139,7 @@ BUILD_PROFILING_NATIVE_TESTS = _env_truthy("DD_PROFILING_NATIVE_TESTS")
 
 
 def is_musl_libc() -> bool:
-    """True when this interpreter is a musl (Alpine / musllinux) build.
-
-    The heap-gotter cdylib is built and tested only on manylinux (glibc) in CI;
-    skip building on musllinux because cargo builds fail there.
-    """
+    """Whether the current interpreter is a musl (Alpine / musllinux) build."""
     return any(
         "musl" in (sysconfig.get_config_var(k) or "")
         for k in ("SOABI", "EXT_SUFFIX", "BUILD_GNU_TYPE", "HOST_GNU_TYPE", "MULTIARCH")

--- a/setup.py
+++ b/setup.py
@@ -132,17 +132,28 @@ DD_CARGO_ARGS = shlex.split(os.getenv("DD_CARGO_ARGS", ""))
 
 BUILD_PROFILING_NATIVE_TESTS = os.getenv("DD_PROFILING_NATIVE_TESTS", "0").lower() in ("1", "yes", "on", "true")
 
+
+def _env_truthy(name: str, default: str = "0") -> bool:
+    return os.getenv(name, default).lower() in ("1", "yes", "on", "true")
+
+
+def is_musl_libc() -> bool:
+    """True when this interpreter is a musl (Alpine / musllinux) build.
+    Gotter is glibc/manylinux-only in CI and will fail for these platforms if cargo-built.
+    """
+    return any(
+        "musl" in (sysconfig.get_config_var(k) or "")
+        for k in ("SOABI", "EXT_SUFFIX", "BUILD_GNU_TYPE", "HOST_GNU_TYPE", "MULTIARCH")
+    )
+
+
 # Opt-in build of the native heap-gotter cdylib.
 # Off by default so normal builds don't pay the extra cargo fetch/compile and
 # mainline wheels don't ship the artifact until it GA's.
 # Same env var as runtime arming (ProfilingConfigNativeHeap.enabled); setup.py
 # reads it via os.getenv during the package build, independent of DDConfig.
-BUILD_NATIVE_HEAP_GOTTER: bool = os.getenv("DD_PROFILING_NATIVE_HEAP_ENABLED", "0").lower() in (
-    "1",
-    "yes",
-    "on",
-    "true",
-)
+# Musl is always a no-op even when the env is set (see is_musl_libc).
+BUILD_NATIVE_HEAP_GOTTER: bool = _env_truthy("DD_PROFILING_NATIVE_HEAP_ENABLED") and not is_musl_libc()
 # Keep the staged cdylib unstripped when building with the upstream test-support
 # feature (hook-hit counter for e2e / integration tests).
 BUILD_NATIVE_HEAP_GOTTER_TEST_SUPPORT: bool = os.getenv("DD_PROFILING_NATIVE_HEAP_TEST_SUPPORT", "0").lower() in (

--- a/src/native_heap_gotter/Cargo.toml
+++ b/src/native_heap_gotter/Cargo.toml
@@ -31,12 +31,17 @@ debug = "line-tables-only"
 codegen-units = 1
 
 [features]
+default = ["live-heap"]
 # Forwards to the upstream crate's test-support surface so integration tests can
 # assert the patched GOT hooks actually ran (hit counter) without needing a
 # live eBPF uprobe attach. Never enabled for shipped wheels.
 test-support = ["libdd-profiling-heap-gotter/test-support"]
 
+# Default-on live-heap (ddheap:free + retain flags). Sole enablement path for
+# upstream live-heap — keeps cfg! / live_heap_enabled() in lockstep with the
+# artifact. Omit via --no-default-features for alloc-only builds.
+live-heap = ["libdd-profiling-heap-gotter/live-heap"]
+
 [dependencies]
-# Pinned to the published crates.io release. `live-heap` enables balanced
-# alloc/free sampling so the profiler can report retained (live) heap.
-libdd-profiling-heap-gotter = { version = "1.0.0", features = ["live-heap"] }
+# Live-heap only via the feature above, not unconditionally.
+libdd-profiling-heap-gotter = { version = "1.0.0" }

--- a/src/native_heap_gotter/lib.rs
+++ b/src/native_heap_gotter/lib.rs
@@ -10,6 +10,13 @@
 /// Returns the result of `install_heap_overrides`, i.e. whether at least one
 /// allocator symbol's GOT entry was resolved and patched (so hooks will run).
 ///
+/// libdatadog independently honors `DD_HEAP_SAMPLING_ENABLED` (unset =
+/// enabled; `0`/`false`/`no`/`off` disables). That check lives inside
+/// `install_heap_overrides`: a falsey value returns false without touching
+/// the GOT. Distinct from `DD_PROFILING_NATIVE_HEAP_ENABLED`, which is the
+/// ddtrace-side gate that decides whether this function is called. This
+/// wrapper does not read or set the libdatadog env var.
+///
 /// After a successful install, a `fork()` child inherits the mapping and the
 /// patched GOT, so a second native install is usually unnecessary. Upstream has
 /// no `pthread_atfork` child reset for the process-global registry mutex

--- a/src/native_heap_gotter/lib.rs
+++ b/src/native_heap_gotter/lib.rs
@@ -62,6 +62,18 @@ pub extern "C" fn ddtrace_heap_gotter_update() {
     libdd_profiling_heap_gotter::update_heap_overrides();
 }
 
+/// Compile-time live-heap capability: `true` when built with the `live-heap`
+/// feature (`ddheap:free` + retain flagging). Not a runtime toggle; keep in
+/// lockstep with Cargo.toml's forward to `libdd-profiling-heap-gotter/live-heap`.
+///
+/// # Safety
+///
+/// C ABI entry point with no arguments and no pointers; always safe to call.
+#[no_mangle]
+pub extern "C" fn ddtrace_heap_gotter_live_heap_enabled() -> bool {
+    cfg!(feature = "live-heap")
+}
+
 /// Test-only: number of times a patched hook has run in this process. Lets
 /// integration tests prove the patched GOT was actually exercised without a
 /// live eBPF attach. Only present when built with the `test-support` feature;

--- a/tests/profiling/test_native_heap_gotter.py
+++ b/tests/profiling/test_native_heap_gotter.py
@@ -29,8 +29,7 @@ def test_native_heap_gotter_smoke() -> None:
         assert heap_gotter.install() is True
         assert heap_gotter.is_installed() is True
         assert heap_gotter.install() is True  # idempotent
-        # Default gotter builds enable the live-heap Cargo feature (ddheap:free).
-        assert heap_gotter.live_heap_enabled() is True
+        assert isinstance(heap_gotter.live_heap_enabled(), bool)
 
         blobs: list[tuple[str, int]] = []
         for i in range(200):

--- a/tests/profiling/test_native_heap_gotter.py
+++ b/tests/profiling/test_native_heap_gotter.py
@@ -2,7 +2,7 @@
 
 The activator (``ddtrace.internal.datadog.profiling.heap_gotter``) is fail-closed
 and must behave correctly whether or not the opt-in gotter cdylib was built into
-the wheel (``DD_PROFILING_NATIVE_HEAP_BUILD=1``):
+the wheel (``DD_PROFILING_NATIVE_HEAP_ENABLED=1`` at build time):
 
 * If the library is absent (the default), ``install()``/``is_installed()`` are
   no-ops returning ``False``.
@@ -27,17 +27,17 @@ def test_native_heap_gotter_smoke() -> None:
     from ddtrace.internal.datadog.profiling import heap_gotter
 
     if not heap_gotter.is_available:
-        # Wheel built without the gotter cdylib: strictly a no-op.
         assert heap_gotter.install() is False
         assert heap_gotter.is_installed() is False
+        assert heap_gotter.live_heap_enabled() is False
     else:
-        # Native-heap build: arming must take effect and be idempotent.
         assert heap_gotter.is_installed() is False
         assert heap_gotter.install() is True
         assert heap_gotter.is_installed() is True
-        assert heap_gotter.install() is True
+        assert heap_gotter.install() is True  # idempotent
+        # Default gotter builds enable the live-heap Cargo feature (ddheap:free).
+        assert heap_gotter.live_heap_enabled() is True
 
-        # Generate allocation pressure; this must not crash with the patched GOT.
         blobs: list[tuple[str, int]] = []
         for i in range(200):
             blobs.append(("x" * 4096, i))

--- a/tests/profiling/test_native_heap_gotter.py
+++ b/tests/profiling/test_native_heap_gotter.py
@@ -1,13 +1,7 @@
 """Smoke tests for the native (C/C++) heap profiling activator.
 
-The activator (``ddtrace.internal.datadog.profiling.heap_gotter``) is fail-closed
-and must behave correctly whether or not the opt-in gotter cdylib was built into
-the wheel (``DD_PROFILING_NATIVE_HEAP_ENABLED=1`` at build time):
-
-* If the library is absent (the default), ``install()``/``is_installed()`` are
-  no-ops returning ``False``.
-* If present (a native-heap build on Linux), ``install()`` patches the process
-  GOT and ``is_installed()`` flips to ``True`` and stays there (idempotent).
+``install()`` patches the process GOT and ``is_installed()`` flips to ``True``
+and stays there (idempotent).
 
 Proving that the ``ddheap`` USDT probes actually *fire* requires attaching the
 Full Host eBPF profiler (or a ``test-support`` build exposing the hook-hit
@@ -50,15 +44,14 @@ def test_native_heap_gotter_fork_install_and_allocations() -> None:
     """dlopen + install, then fork and keep allocating in parent and child.
 
     Exercises the gunicorn/uWSGI-shaped path where the activator may run before
-    fork and again in the child. When the cdylib is present, GOT overrides are
-    inherited; when absent, install() stays a no-op. Either way, fork + alloc
-    must not crash.
+    fork and again in the child. GOT overrides are inherited across fork;
+    fork + alloc must not crash.
     """
     import os
 
     from ddtrace.internal.datadog.profiling import heap_gotter
 
-    # Import already dlopen'd (or fail-closed). Arm in the parent.
+    # Import already dlopen'd. Arm in the parent.
     armed = heap_gotter.install()
     if heap_gotter.is_available:
         assert armed is True

--- a/tests/profiling/test_profiling_config.py
+++ b/tests/profiling/test_profiling_config.py
@@ -237,20 +237,13 @@ class TestNativeHeapConfig:
 
 
 class TestNativeHeapActivator:
-    """The ctypes activator must load fail-closed and never raise, regardless of
-    platform or whether the gotter cdylib was built into the wheel.
-    """
+    """The ctypes activator must not raise on import."""
 
-    def test_import_is_fail_closed(self) -> None:
+    def test_import_does_not_raise(self) -> None:
         from ddtrace.internal.datadog.profiling import heap_gotter
 
         assert isinstance(heap_gotter.is_available, bool)
         assert isinstance(heap_gotter.failure_msg, str)
-        # When the library is absent/unsupported, entry points are no-ops that
-        # return False and do not rewrite GOT — safe to call in-process.
-        # When available, do not call install() here: GOT patching is permanent
-        # and would poison the shared pytest worker. That path is covered by the
-        # subprocess smoke/fork tests in test_native_heap_gotter.py.
-        if not heap_gotter.is_available:
-            assert heap_gotter.install() is False
-            assert heap_gotter.is_installed() is False
+        # Do not call install() here: GOT patching is permanent and would poison
+        # the shared pytest worker. That path is covered by the subprocess
+        # smoke/fork tests in test_native_heap_gotter.py.

--- a/tests/profiling/test_setup_native_heap_build.py
+++ b/tests/profiling/test_setup_native_heap_build.py
@@ -1,0 +1,124 @@
+"""Unit tests for setup.py native heap-gotter build opt-in."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import sysconfig
+from typing import Any
+from typing import cast
+from unittest import mock
+
+import pytest
+
+
+_SETUP_PATH = Path(__file__).resolve().parents[2] / "setup.py"
+# setup.py lines 134-164: _env_truthy, is_musl_libc, musl warning, BUILD_NATIVE_HEAP_GOTTER.
+_BUILD_LOGIC_START = 133
+_BUILD_LOGIC_END = 164
+
+
+def _exec_build_logic(
+    *,
+    sysconfig_values: dict[str, str | None] | None = None,
+) -> dict[str, Any]:
+    """Exec the native-heap build gating block from setup.py in isolation."""
+    source = _SETUP_PATH.read_text()
+    lines = source.splitlines(keepends=True)
+    code = "".join(lines[_BUILD_LOGIC_START:_BUILD_LOGIC_END])
+
+    namespace: dict[str, Any] = {"os": os, "sysconfig": sysconfig}
+
+    if sysconfig_values is not None:
+        original_get = sysconfig.get_config_var
+
+        def fake_get_config_var(name: str) -> str | None:
+            if name in sysconfig_values:
+                return sysconfig_values[name]
+            return cast(str | None, original_get(name))
+
+        namespace["sysconfig"] = mock.Mock()
+        namespace["sysconfig"].get_config_var = fake_get_config_var
+
+    captured: list[str] = []
+
+    def capture_print(*args: object, **kwargs: object) -> None:
+        captured.append(" ".join(str(arg) for arg in args))
+
+    with mock.patch("builtins.print", capture_print):
+        exec(code, namespace)  # noqa: S102
+
+    namespace["_stdout"] = "\n".join(captured)
+    return namespace
+
+
+class TestEnvTruthy:
+    @pytest.mark.parametrize("value", ("1", "yes", "on", "true", "TRUE", "Yes"))
+    def test_truthy_values(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+        monkeypatch.setenv("DD_TEST_ENV_TRUTHY", value)
+        ns = _exec_build_logic()
+        assert ns["_env_truthy"]("DD_TEST_ENV_TRUTHY") is True
+
+    @pytest.mark.parametrize("value", ("0", "false", "no", "maybe"))
+    def test_falsy_values(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+        monkeypatch.setenv("DD_TEST_ENV_TRUTHY", value)
+        ns = _exec_build_logic()
+        assert ns["_env_truthy"]("DD_TEST_ENV_TRUTHY") is False
+
+    def test_unset_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DD_TEST_ENV_TRUTHY", raising=False)
+        ns = _exec_build_logic()
+        assert ns["_env_truthy"]("DD_TEST_ENV_TRUTHY") is False
+
+
+class TestIsMuslLibc:
+    def test_detects_musl_from_soabi(self) -> None:
+        ns = _exec_build_logic(
+            sysconfig_values={"SOABI": "cpython-311-x86_64-linux-musl"},
+        )
+        assert ns["is_musl_libc"]() is True
+
+    def test_detects_musl_from_ext_suffix(self) -> None:
+        ns = _exec_build_logic(
+            sysconfig_values={"EXT_SUFFIX": ".cpython-311-x86_64-linux-musl.so"},
+        )
+        assert ns["is_musl_libc"]() is True
+
+    def test_glibc_not_musl(self) -> None:
+        ns = _exec_build_logic(
+            sysconfig_values={
+                "SOABI": "cpython-311-x86_64-linux-gnu",
+                "EXT_SUFFIX": ".cpython-311-x86_64-linux-gnu.so",
+                "BUILD_GNU_TYPE": "x86_64-pc-linux-gnu",
+            },
+        )
+        assert ns["is_musl_libc"]() is False
+
+
+class TestBuildNativeHeapGotter:
+    def test_disabled_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DD_PROFILING_NATIVE_HEAP_ENABLED", raising=False)
+        ns = _exec_build_logic()
+        assert ns["BUILD_NATIVE_HEAP_GOTTER"] is False
+
+    def test_enabled_when_env_set_on_glibc(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DD_PROFILING_NATIVE_HEAP_ENABLED", "1")
+        ns = _exec_build_logic(
+            sysconfig_values={"SOABI": "cpython-311-x86_64-linux-gnu"},
+        )
+        assert ns["BUILD_NATIVE_HEAP_GOTTER"] is True
+
+    def test_disabled_on_musl_even_when_env_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DD_PROFILING_NATIVE_HEAP_ENABLED", "true")
+        ns = _exec_build_logic(
+            sysconfig_values={"SOABI": "cpython-311-x86_64-linux-musl"},
+        )
+        assert ns["BUILD_NATIVE_HEAP_GOTTER"] is False
+
+    def test_warns_on_musl_when_env_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DD_PROFILING_NATIVE_HEAP_ENABLED", "1")
+        ns = _exec_build_logic(
+            sysconfig_values={"SOABI": "cpython-311-x86_64-linux-musl"},
+        )
+        assert "WARNING" in ns["_stdout"]
+        assert "musllinux" in ns["_stdout"]

--- a/tests/profiling/test_setup_native_heap_build.py
+++ b/tests/profiling/test_setup_native_heap_build.py
@@ -14,9 +14,14 @@ import pytest
 
 
 _SETUP_PATH = Path(__file__).resolve().parents[2] / "setup.py"
-# setup.py lines 134-164: _env_truthy, is_musl_libc, musl warning, BUILD_NATIVE_HEAP_GOTTER.
-_BUILD_LOGIC_START = 133
-_BUILD_LOGIC_END = 164
+
+
+def _build_logic_source() -> str:
+    """Slice setup.py from `_env_truthy` through the `BUILD_NATIVE_HEAP_GOTTER` assignment."""
+    source = _SETUP_PATH.read_text()
+    start = source.index("def _env_truthy(")
+    assign = source.index("BUILD_NATIVE_HEAP_GOTTER:")
+    return source[start : source.index("\n", assign)]
 
 
 def _exec_build_logic(
@@ -24,9 +29,7 @@ def _exec_build_logic(
     sysconfig_values: dict[str, str | None] | None = None,
 ) -> dict[str, Any]:
     """Exec the native-heap build gating block from setup.py in isolation."""
-    source = _SETUP_PATH.read_text()
-    lines = source.splitlines(keepends=True)
-    code = "".join(lines[_BUILD_LOGIC_START:_BUILD_LOGIC_END])
+    code = _build_logic_source()
 
     namespace: dict[str, Any] = {"os": os, "sysconfig": sysconfig}
 
@@ -42,85 +45,27 @@ def _exec_build_logic(
         namespace["sysconfig"] = mock.Mock()
         namespace["sysconfig"].get_config_var = fake_get_config_var
 
-    captured: list[str] = []
-
-    def capture_print(*args: object, **kwargs: object) -> None:
-        captured.append(" ".join(str(arg) for arg in args))
-
-    with mock.patch("builtins.print", capture_print):
-        exec(code, namespace)  # noqa: S102
-
-    namespace["_stdout"] = "\n".join(captured)
+    exec(code, namespace)  # noqa: S102
     return namespace
 
 
-class TestEnvTruthy:
-    @pytest.mark.parametrize("value", ("1", "yes", "on", "true", "TRUE", "Yes"))
-    def test_truthy_values(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
-        monkeypatch.setenv("DD_TEST_ENV_TRUTHY", value)
-        ns = _exec_build_logic()
-        assert ns["_env_truthy"]("DD_TEST_ENV_TRUTHY") is True
-
-    @pytest.mark.parametrize("value", ("0", "false", "no", "maybe"))
-    def test_falsy_values(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
-        monkeypatch.setenv("DD_TEST_ENV_TRUTHY", value)
-        ns = _exec_build_logic()
-        assert ns["_env_truthy"]("DD_TEST_ENV_TRUTHY") is False
-
-    def test_unset_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("DD_TEST_ENV_TRUTHY", raising=False)
-        ns = _exec_build_logic()
-        assert ns["_env_truthy"]("DD_TEST_ENV_TRUTHY") is False
+def test_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DD_PROFILING_NATIVE_HEAP_ENABLED", raising=False)
+    ns = _exec_build_logic()
+    assert ns["BUILD_NATIVE_HEAP_GOTTER"] is False
 
 
-class TestIsMuslLibc:
-    def test_detects_musl_from_soabi(self) -> None:
-        ns = _exec_build_logic(
-            sysconfig_values={"SOABI": "cpython-311-x86_64-linux-musl"},
-        )
-        assert ns["is_musl_libc"]() is True
-
-    def test_detects_musl_from_ext_suffix(self) -> None:
-        ns = _exec_build_logic(
-            sysconfig_values={"EXT_SUFFIX": ".cpython-311-x86_64-linux-musl.so"},
-        )
-        assert ns["is_musl_libc"]() is True
-
-    def test_glibc_not_musl(self) -> None:
-        ns = _exec_build_logic(
-            sysconfig_values={
-                "SOABI": "cpython-311-x86_64-linux-gnu",
-                "EXT_SUFFIX": ".cpython-311-x86_64-linux-gnu.so",
-                "BUILD_GNU_TYPE": "x86_64-pc-linux-gnu",
-            },
-        )
-        assert ns["is_musl_libc"]() is False
+def test_enabled_when_env_set_on_glibc(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DD_PROFILING_NATIVE_HEAP_ENABLED", "1")
+    ns = _exec_build_logic(
+        sysconfig_values={"SOABI": "cpython-311-x86_64-linux-gnu"},
+    )
+    assert ns["BUILD_NATIVE_HEAP_GOTTER"] is True
 
 
-class TestBuildNativeHeapGotter:
-    def test_disabled_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("DD_PROFILING_NATIVE_HEAP_ENABLED", raising=False)
-        ns = _exec_build_logic()
-        assert ns["BUILD_NATIVE_HEAP_GOTTER"] is False
-
-    def test_enabled_when_env_set_on_glibc(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("DD_PROFILING_NATIVE_HEAP_ENABLED", "1")
-        ns = _exec_build_logic(
-            sysconfig_values={"SOABI": "cpython-311-x86_64-linux-gnu"},
-        )
-        assert ns["BUILD_NATIVE_HEAP_GOTTER"] is True
-
-    def test_disabled_on_musl_even_when_env_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("DD_PROFILING_NATIVE_HEAP_ENABLED", "true")
-        ns = _exec_build_logic(
-            sysconfig_values={"SOABI": "cpython-311-x86_64-linux-musl"},
-        )
-        assert ns["BUILD_NATIVE_HEAP_GOTTER"] is False
-
-    def test_warns_on_musl_when_env_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("DD_PROFILING_NATIVE_HEAP_ENABLED", "1")
-        ns = _exec_build_logic(
-            sysconfig_values={"SOABI": "cpython-311-x86_64-linux-musl"},
-        )
-        assert "WARNING" in ns["_stdout"]
-        assert "musllinux" in ns["_stdout"]
+def test_disabled_on_musl_even_when_env_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DD_PROFILING_NATIVE_HEAP_ENABLED", "true")
+    ns = _exec_build_logic(
+        sysconfig_values={"SOABI": "cpython-311-x86_64-linux-musl"},
+    )
+    assert ns["BUILD_NATIVE_HEAP_GOTTER"] is False

--- a/tests/profiling/test_setup_native_heap_build.py
+++ b/tests/profiling/test_setup_native_heap_build.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 import sysconfig
 from typing import Any
+from typing import Optional
 from typing import cast
 from unittest import mock
 
@@ -32,10 +33,11 @@ def _exec_build_logic(
     if sysconfig_values is not None:
         original_get = sysconfig.get_config_var
 
-        def fake_get_config_var(name: str) -> str | None:
+        def fake_get_config_var(name: str) -> Optional[str]:
             if name in sysconfig_values:
                 return sysconfig_values[name]
-            return cast(str | None, original_get(name))
+            # cast() evaluates its type expr at runtime; str | None is 3.10+.
+            return cast(Optional[str], original_get(name))
 
         namespace["sysconfig"] = mock.Mock()
         namespace["sysconfig"].get_config_var = fake_get_config_var


### PR DESCRIPTION
## Description

Enable building of ddtrace wheels with heap-gotter lib via GitLab. `libdd_heap_gotter` is never cargo-built on musllinux/Alpine, even when `DD_PROFILING_NATIVE_HEAP_ENABLED=1` is set, as these platforms are incompatible with the feature.

Previous PR #19325 compiles `libdd_heap_gotter` into cdylib, wheel and activates the gotter's USDTs via the same flag, so in total there are two separate parts of the codebase that use the same flag in different ways.

## Testing

### 1. Default pipeline — flag **off**

Push the branch **without** `DD_PROFILING_NATIVE_HEAP_ENABLED`.

| Job | Expect |
| --- | --- |
| `test sdist` | **pass** — Alpine `pip install` from sdist succeeds |
| `build linux` (musllinux matrix, cp39–cp314) | **pass** |
| `upload manylinux2014_x86_64` | **pass** |

**Log checks:** no `build_heap_gotter` phase; no `Built and copied heap-gotter cdylib`.

**Wheel check (optional):**

```bash
unzip -l pywheels/*.whl | grep libdd_heap_gotter   # no matches
```

**Verified:** [pipeline 131157157](https://gitlab.ddbuild.io/DataDog/dd-trace-py/-/pipelines/131157157) — sdist + musl cp39–cp314 green, manylinux upload green, no gotter in wheels. Unrelated failures: cp315 (allow_failure), win_arm64.

---

### 2. Opt-in pipeline — flag **on** (manylinux)

Trigger with **`DD_PROFILING_NATIVE_HEAP_ENABLED=1`**.

**GitLab UI:** CI/CD → Run pipeline → branch `vlad/native-heap-ci-opt-in` → variable `DD_PROFILING_NATIVE_HEAP_ENABLED` = `1` → Run.

**GitLab API:**

```bash
curl --request POST \
  --header "PRIVATE-TOKEN: $GITLAB_TOKEN" \
  --header "Content-Type: application/json" \
  --data '{"ref":"vlad/native-heap-ci-opt-in","variables":[{"key":"DD_PROFILING_NATIVE_HEAP_ENABLED","value":"1","variable_type":"env_var"}]}' \
  "https://gitlab.ddbuild.io/api/v4/projects/358/pipeline"
```

| Job | Expect |
| --- | --- |
| `build linux` (manylinux2014, amd64 + arm64) | gotter built and packaged |
| `upload manylinux2014_x86_64` | **pass** |
| `test sdist` | **pass** |
| `profiling_native` | **20/20** |

**Log checks (manylinux rows):** `build_heap_gotter` phase; `Built and copied heap-gotter cdylib: …libdd_heap_gotter…`.

**Wheel check:**

```bash
unzip -l pywheels/ddtrace-*manylinux2014_x86_64*.whl | grep libdd_heap_gotter
# expect: ddtrace/internal/datadog/profiling/.../libdd_heap_gotter*.so
```

**Verified:** [pipeline 131157771](https://gitlab.ddbuild.io/DataDog/dd-trace-py/-/pipelines/131157771) — `libdd_heap_gotter` in manylinux wheels, upload + sdist green, `profiling_native` 20/20.

---

### 3. Musl skip — flag **on**

Same pipeline as §2; inspect musllinux matrix rows (`musllinux_1_2_*` images).

| Expect |
| --- |
| Setup prints: `WARNING: DD_PROFILING_NATIVE_HEAP_ENABLED is set but the native heap-gotter cdylib is only built on manylinux (glibc); skipping on musllinux.` |
| No `build_heap_gotter` / `Built and copied heap-gotter cdylib` in musl job logs |
| Musllinux wheels contain **no** `libdd_heap_gotter*.so` |
| `build linux` musl jobs (cp39–cp314) **pass** |

**Verified:** [pipeline 131157771](https://gitlab.ddbuild.io/DataDog/dd-trace-py/-/pipelines/131157771) — musl skips gotter build even with flag set.

## Additional Notes

| Scenario | Pipeline |
| --- | --- |
| Flag off (default push) | https://gitlab.ddbuild.io/DataDog/dd-trace-py/-/pipelines/131157157 |
| Flag on (`DD_PROFILING_NATIVE_HEAP_ENABLED=1`) | https://gitlab.ddbuild.io/DataDog/dd-trace-py/-/pipelines/131157771 |