### PR TITLE
fix(grpc): finish aio client spans on abandoned calls

### DIFF
--- a/ddtrace/contrib/internal/grpc/aio_client_interceptor.py
+++ b/ddtrace/contrib/internal/grpc/aio_client_interceptor.py
@@ -224,7 +224,6 @@ class _ClientInterceptor:
         span: Span,
     ) -> ResponseIterableType:
         try:
-            _handle_add_callback(call, _done_callback_stream(span))
             async for response in call:
                 yield response
         except StopAsyncIteration:
@@ -264,6 +263,9 @@ class _ClientInterceptor:
             # So we can't handle the error in done callbacks.
             _handle_rpc_error(span, rpc_error)
             raise
+        except asyncio.CancelledError:
+            span.finish()
+            raise
 
 
 class _UnaryUnaryClientInterceptor(aio.UnaryUnaryClientInterceptor, _ClientInterceptor):
@@ -293,6 +295,7 @@ class _UnaryStreamClientInterceptor(aio.UnaryStreamClientInterceptor, _ClientInt
             client_call_details,
         )
         call = await continuation(client_call_details, request)
+        _handle_add_callback(call, _done_callback_stream(span))
         return self._wrap_stream_response(call, span)
 
 
@@ -323,4 +326,5 @@ class _StreamStreamClientInterceptor(aio.StreamStreamClientInterceptor, _ClientI
             client_call_details,
         )
         call = await continuation(client_call_details, request_iterator)
+        _handle_add_callback(call, _done_callback_stream(span))
         return self._wrap_stream_response(call, span)

--- a/ddtrace/contrib/internal/grpc/aio_client_interceptor.py
+++ b/ddtrace/contrib/internal/grpc/aio_client_interceptor.py
@@ -69,17 +69,34 @@ def _done_callback_unary(span: Span, code: grpc.StatusCode, details: str) -> Cal
 _GRPC_AIO_ERROR_HANDLED = "_dd.grpc_aio.error_handled"
 
 
+def _claim_stream_error(span: Span) -> bool:
+    if span._get_ctx_item(_GRPC_AIO_ERROR_HANDLED):
+        return False
+    span._set_ctx_item(_GRPC_AIO_ERROR_HANDLED, True)
+    return True
+
+
+async def _finish_stream_terminal_state(call: aio.Call, span: Span) -> None:
+    if not _claim_stream_error(span):
+        return
+    try:
+        code = await call.code()
+        details = await call.details()
+        if isinstance(details, bytes):
+            details = details.decode("utf-8", errors="ignore")
+        else:
+            details = str(details)
+
+        if code == grpc.StatusCode.OK:
+            span._set_attribute(constants.GRPC_STATUS_CODE_KEY, str(code))
+        else:
+            _set_error_attrs(span, str(code), details)
+    finally:
+        span.finish()
+
+
 def _done_callback_stream(span: Span) -> Callable[[aio.Call], None]:
     def func(call: aio.Call) -> None:
-        # AIDEV-NOTE: gRPC can mark the call done and invoke this callback while
-        # the stream iterator's `_raise_for_status()` is still building the
-        # `AioRpcError` — i.e. before control reaches our `except aio.AioRpcError`
-        # handler and `_handle_stream_rpc_error` has had a chance to set the ctx
-        # flag. So the flag check alone is not sufficient: on any non-OK terminal
-        # state we must also defer to the awaited handler, because parsing
-        # `call.__repr__()` here returns the transport-level placeholder
-        # ("Internal error from Core") and finishing flushes the span before the
-        # handler can apply the authoritative `await call.code()` / `details()`.
         if span._get_ctx_item(_GRPC_AIO_ERROR_HANDLED):
             return
         if not call.done():
@@ -87,22 +104,27 @@ def _done_callback_stream(span: Span) -> Callable[[aio.Call], None]:
             span.finish()
             return
         try:
-            # we need to call __repr__ as we cannot call code() or details() since they are both async
+            # Fast-path successful calls without scheduling another task. For non-OK calls,
+            # use the async accessors below because repr details can still be transport placeholders.
             code, _details = utils._parse_rpc_repr_string(call.__repr__(), grpc)
         except ValueError:
-            # ValueError is thrown from _parse_rpc_repr_string
-            log.warning("Unable to parse async grpc string for status code and details.")
+            code = None
+        if code == grpc.StatusCode.OK:
+            span._set_attribute(constants.GRPC_STATUS_CODE_KEY, str(code))
             span.finish()
             return
-        if code != grpc.StatusCode.OK:
-            # Non-OK terminal state: gRPC will surface an AioRpcError (or
-            # CancelledError) to the consumer of `_wrap_stream_response`, so an
-            # awaited error handler will run and own finishing the span with
-            # authoritative values. Bail before writing repr-derived tags or
-            # calling span.finish().
+
+        # A stream may never be consumed, so there may be no iterator-side error handler to own
+        # finalization. Schedule an async finalizer that can read authoritative code/details.
+        # `_claim_stream_error` makes this race-safe with `_wrap_stream_response`: whichever path
+        # starts handling the terminal state first owns tagging and finishing the span.
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            log.warning("Unable to schedule async grpc terminal-state handling; finishing span without status tags.")
+            span.finish()
             return
-        span._set_attribute(constants.GRPC_STATUS_CODE_KEY, str(code))
-        span.finish()
+        loop.create_task(_finish_stream_terminal_state(call, span))
 
     return func
 
@@ -135,12 +157,8 @@ def _handle_rpc_error(span: Span, rpc_error: aio.AioRpcError) -> None:
 
 
 async def _handle_cancelled_error(call: aio.Call, span: Span) -> None:
-    # Mark synchronously before awaiting so `_done_callback_stream` bails out if it
-    # fires while we're suspended on `await call.code()` / `await call.details()`.
-    # The done callback also defers on any non-OK terminal state, so this handler
-    # is the sole owner of `span.finish()` for the cancelled path — wrap the body
-    # in try/finally so the span is still finished if an await raises.
-    span._set_ctx_item(_GRPC_AIO_ERROR_HANDLED, True)
+    if not _claim_stream_error(span):
+        return
     try:
         _set_error_attrs(span, str(await call.code()), await call.details())
     finally:
@@ -148,13 +166,8 @@ async def _handle_cancelled_error(call: aio.Call, span: Span) -> None:
 
 
 async def _handle_stream_rpc_error(span: Span, call: aio.Call, rpc_error: aio.AioRpcError) -> None:
-    # AIDEV-NOTE: rpc_error.details() can return the transport placeholder
-    # "Internal error from Core" if trailers haven't been processed yet; awaiting
-    # call.code()/details() blocks until the call is fully terminated and returns
-    # the authoritative final state. Set the ctx flag synchronously before
-    # awaiting so `_done_callback_stream` bails out if it fires while we're
-    # suspended, instead of flushing the span with repr-derived tags.
-    span._set_ctx_item(_GRPC_AIO_ERROR_HANDLED, True)
+    if not _claim_stream_error(span):
+        return
     try:
         try:
             code = await call.code()
@@ -231,14 +244,12 @@ class _ClientInterceptor:
             _handle_cancelled_error()
             raise
         except aio.AioRpcError as rpc_error:
-            # NOTE: We can also handle the error in done callbacks, but capturing
-            # error tags here means we hold onto the call object and can read its
-            # authoritative final state instead of rpc_error's racy snapshot.
+            # NOTE: The callback and iterator can observe termination concurrently.
+            # `_handle_stream_rpc_error` claims ownership synchronously before awaiting,
+            # so exactly one path writes terminal tags and finishes the span.
             await _handle_stream_rpc_error(span, call, rpc_error)
             raise
         except asyncio.CancelledError:
-            # NOTE: We can't handle the cancelled error in done callbacks
-            # because they cannot handle awaitable functions.
             await _handle_cancelled_error(call, span)
             raise
 
@@ -248,6 +259,7 @@ class _ClientInterceptor:
         continuation: Callable[[], Union[aio.StreamUnaryCall, aio.UnaryUnaryCall]],
         span: Span,
     ) -> Union[aio.StreamUnaryCall, aio.UnaryUnaryCall]:
+        call = None
         try:
             call = await continuation()
             code = await call.code()
@@ -264,7 +276,11 @@ class _ClientInterceptor:
             _handle_rpc_error(span, rpc_error)
             raise
         except asyncio.CancelledError:
-            span.finish()
+            if call is not None:
+                await _handle_cancelled_error(call, span)
+            else:
+                _set_error_attrs(span, str(grpc.StatusCode.CANCELLED), "Locally cancelled by application!")
+                span.finish()
             raise
 
 

--- a/ddtrace/contrib/internal/grpc/aio_client_interceptor.py
+++ b/ddtrace/contrib/internal/grpc/aio_client_interceptor.py
@@ -97,6 +97,10 @@ async def _finish_stream_terminal_state(call: aio.Call, span: Span) -> None:
 
 def _done_callback_stream(span: Span) -> Callable[[aio.Call], None]:
     def func(call: aio.Call) -> None:
+        # AIDEV-NOTE: gRPC can invoke this done callback while the stream iterator is still
+        # surfacing its terminal exception. Successful calls can be finalized synchronously,
+        # but non-OK calls need the authoritative async code/details accessors. The shared
+        # `_claim_stream_error` gate makes callback-side and iterator-side finalization mutually exclusive.
         if span._get_ctx_item(_GRPC_AIO_ERROR_HANDLED):
             return
         if not call.done():
@@ -166,6 +170,9 @@ async def _handle_cancelled_error(call: aio.Call, span: Span) -> None:
 
 
 async def _handle_stream_rpc_error(span: Span, call: aio.Call, rpc_error: aio.AioRpcError) -> None:
+    # AIDEV-NOTE: `rpc_error.details()` may still contain a transport placeholder while gRPC is
+    # completing trailers. Await the call's code/details for the authoritative terminal state,
+    # and claim ownership before awaiting so the done callback cannot flush the span concurrently.
     if not _claim_stream_error(span):
         return
     try:

--- a/releasenotes/notes/fix-grpc-aio-span-lifecycle-e9fd5a013b6f3d6f.yaml
+++ b/releasenotes/notes/fix-grpc-aio-span-lifecycle-e9fd5a013b6f3d6f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    grpc: Fixes an issue where cancelled or unconsumed asynchronous client calls retain unfinished tracing spans.

--- a/tests/contrib/grpc_aio/test_client_interceptor_lifecycle.py
+++ b/tests/contrib/grpc_aio/test_client_interceptor_lifecycle.py
@@ -1,0 +1,75 @@
+import asyncio
+
+import grpc
+from grpc import aio
+import pytest
+
+from ddtrace.constants import ERROR_MSG
+from ddtrace.constants import ERROR_TYPE
+from ddtrace.contrib.internal.grpc import constants
+from ddtrace.contrib.internal.grpc.aio_client_interceptor import _UnaryUnaryClientInterceptor
+from ddtrace.contrib.internal.grpc.aio_client_interceptor import _done_callback_stream
+
+
+class _CancelledDuringCodeCall:
+    def __init__(self):
+        self._code_calls = 0
+
+    async def code(self):
+        self._code_calls += 1
+        if self._code_calls == 1:
+            raise asyncio.CancelledError()
+        return grpc.StatusCode.CANCELLED
+
+    async def details(self):
+        return "Locally cancelled by application!"
+
+
+class _CompletedErrorStreamCall:
+    def done(self):
+        return True
+
+    def __repr__(self):
+        return 'status = StatusCode.INVALID_ARGUMENT, details = "stream failed"'
+
+    async def code(self):
+        return grpc.StatusCode.INVALID_ARGUMENT
+
+    async def details(self):
+        return "stream failed"
+
+
+def _written_spans(tracer):
+    return tracer._span_aggregator.writer.spans
+
+
+async def test_unary_cancellation_sets_error_metadata_before_finishing(tracer):
+    interceptor = _UnaryUnaryClientInterceptor("localhost", 50051)
+    span = tracer.trace("grpc")
+    call = _CancelledDuringCodeCall()
+
+    async def continuation():
+        return call
+
+    with pytest.raises(asyncio.CancelledError):
+        await interceptor._wrap_unary_response(continuation, span)
+
+    assert span.error == 1
+    assert span.get_tag(constants.GRPC_STATUS_CODE_KEY) == "StatusCode.CANCELLED"
+    assert span.get_tag(ERROR_TYPE) == "StatusCode.CANCELLED"
+    assert span.get_tag(ERROR_MSG) == "Locally cancelled by application!"
+    assert span in _written_spans(tracer)
+
+
+async def test_unconsumed_non_ok_stream_callback_finishes_with_error_metadata(tracer):
+    span = tracer.trace("grpc")
+    call = _CompletedErrorStreamCall()
+
+    _done_callback_stream(span)(call)
+    await asyncio.sleep(0)
+
+    assert span.error == 1
+    assert span.get_tag(constants.GRPC_STATUS_CODE_KEY) == "StatusCode.INVALID_ARGUMENT"
+    assert span.get_tag(ERROR_TYPE) == "StatusCode.INVALID_ARGUMENT"
+    assert span.get_tag(ERROR_MSG) == "stream failed"
+    assert span in _written_spans(tracer)

--- a/tests/contrib/grpc_aio/test_grpc_aio.py
+++ b/tests/contrib/grpc_aio/test_grpc_aio.py
@@ -10,6 +10,8 @@ import pytest
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
+from ddtrace.contrib.internal.grpc.aio_client_interceptor import _StreamStreamClientInterceptor
+from ddtrace.contrib.internal.grpc.aio_client_interceptor import _UnaryStreamClientInterceptor
 from ddtrace.contrib.internal.grpc.patch import patch
 from ddtrace.contrib.internal.grpc.patch import unpatch
 from ddtrace.contrib.internal.grpc.utils import _parse_rpc_repr_string
@@ -37,6 +39,9 @@ class _CoroHelloServicer(HelloServicer):
             context.set_code(grpc.StatusCode.OK)
             message = ";".join(w.key + "=" + w.value for w in metadata if w.key.startswith("x-datadog"))
             return HelloReply(message=message)
+
+        if request.name == "slow":
+            await asyncio.sleep(1)
 
         if request.name == "exception":
             await context.abort(grpc.StatusCode.INVALID_ARGUMENT, "abort_details")
@@ -162,6 +167,17 @@ class DummyClientInterceptor(aio.UnaryUnaryClientInterceptor):
 
     def add_done_callback(self, unused_callback):
         pass
+
+
+class _CompletedStreamCall:
+    def add_done_callback(self, callback):
+        callback(self)
+
+    def done(self):
+        return True
+
+    def __repr__(self):
+        return 'status = StatusCode.OK, details = "complete"'
 
 
 @pytest.fixture(autouse=True)
@@ -401,6 +417,18 @@ async def test_unary_cancellation(server_info, tracer):
     assert len(spans) == 0
 
 
+@pytest.mark.parametrize("server_info", [_CoroHelloServicer()], indirect=True)
+async def test_unary_timeout_finishes_client_span(server_info, tracer):
+    async with aio.insecure_channel(server_info.target) as channel:
+        stub = HelloStub(channel)
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(stub.SayHello(HelloRequest(name="slow")), timeout=0.01)
+
+    await asyncio.sleep(0.1)
+    client_spans = [span for span in _get_spans(tracer) if span.service == "grpc-aio-client"]
+    assert len(client_spans) == 1
+
+
 @pytest.mark.parametrize(
     "server_info", [_CoroHelloServicer(), _AsyncGenHelloServicer(), _SyncHelloServicer()], indirect=True
 )
@@ -428,6 +456,37 @@ async def test_server_streaming(server_info, tracer):
         expected_port=server_info.target.rsplit(":", 1)[-1],
     )
     _check_server_span(server_span, "grpc-aio-server", "SayHelloTwice", "server_streaming")
+
+
+@pytest.mark.parametrize(
+    "interceptor,intercept_method,request_arg",
+    [
+        (_UnaryStreamClientInterceptor("localhost", 50051), "intercept_unary_stream", HelloRequest(name="test")),
+        (
+            _StreamStreamClientInterceptor("localhost", 50051),
+            "intercept_stream_stream",
+            iter([HelloRequest(name="test")]),
+        ),
+    ],
+    ids=["server_streaming", "bidi_streaming"],
+)
+async def test_streaming_uniterated_finishes_client_span(tracer, interceptor, intercept_method, request_arg):
+    call = _CompletedStreamCall()
+
+    async def continuation(client_call_details, request):
+        return call
+
+    client_call_details = aio.ClientCallDetails(
+        b"/helloworld.Hello/SayHelloTwice",
+        None,
+        None,
+        None,
+        None,
+    )
+    await getattr(interceptor, intercept_method)(continuation, client_call_details, request_arg)
+
+    client_spans = [span for span in _get_spans(tracer) if span.service == "grpc-aio-client"]
+    assert len(client_spans) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Fixes #19600.

gRPC asyncio client spans could remain unfinished along two paths: a unary call cancelled before its done callback was registered, and a streaming call whose lazy response wrapper was never iterated.

This change makes completion ownership explicit once an interceptor creates a span:

- unary cancellation records `grpc.status.code`, error type/details, and finishes the span before re-raising `CancelledError`;
- unary-stream and stream-stream calls register their done callbacks as soon as `continuation` returns the call, before returning the lazy wrapper;
- non-OK abandoned streams schedule an async terminal-state finalizer so authoritative `call.code()` / `call.details()` are captured even when no consumer ever iterates the stream;
- iterator-side cancellation/RPC errors and callback-side finalization share a small ownership flag so only one path writes terminal tags and finishes the span.

## Testing

Original validation before the review follow-up:

- Python 3.11, `grpcio~=1.59.0`: 58 passed, 13 skipped.
- Python 3.9, `grpcio~=1.59.0`: 67 passed, 4 skipped.
- `scripts/lint checks`
- `git diff --check`

Review follow-up adds focused regressions for:

- unary cancellation preserving CANCELLED error metadata;
- a completed non-OK stream that is never consumed still finishing with its final status/details.

The updated branch has not been re-run locally in the current environment; a fresh Codex review has been requested and upstream CI still requires maintainer approval.

## Risks

Low to moderate. The callback path now schedules a small async finalizer for non-OK terminal streams. The ownership flag prevents that task from racing the iterator-side error handler into a double finish. Successful stream callbacks remain synchronous.

## Additional Notes

A local attempt to run the oldest Python 3.9 / `grpcio==1.34.1` environment did not reach pytest because grpcio's isolated source build failed while importing `pkg_resources`. No project configuration was changed to bypass that build failure.
