### PR TITLE
chore(profiling): fix fuzz link errors

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/fuzz/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/CMakeLists.txt
@@ -18,6 +18,7 @@ set(FUZZ_ECHION_SOURCES
     ../src/echion/strings.cc
     ../src/echion/tasks.cc
     ../src/echion/threads.cc
+    ../src/origin_task_links.cpp
     ../src/stack_renderer.cpp
     ../src/sampler.cpp
     ../src/thread_span_links.cpp)


### PR DESCRIPTION
## Description

The `fuzzer_infra` CI job failed to link all `stack` fuzz targets -- this PR fixes it.

```
undefined reference to `Datadog::OriginTaskLinks::get_origin_task(unsigned long)'
undefined reference to `Datadog::OriginTaskLinks::enable()'
undefined reference to `Datadog::OriginTaskLinks::postfork_child()'
```

Root cause was #19082  introducing a new file but not linking it for fuzzing.