### PR TITLE
fix(tracing): republish the otel thread context when sampling decides

### DIFF
--- a/ddtrace/_trace/context.py
+++ b/ddtrace/_trace/context.py
@@ -8,6 +8,7 @@ from ddtrace._trace._span_link import SpanLink
 from ddtrace.constants import _ORIGIN_KEY
 from ddtrace.constants import _SAMPLING_PRIORITY_KEY
 from ddtrace.constants import _USER_ID_KEY
+from ddtrace.internal import core
 from ddtrace.internal.compat import NumericType
 from ddtrace.internal.constants import MAX_UINT_64BITS as _MAX_UINT_64BITS
 from ddtrace.internal.constants import W3C_TRACEPARENT_KEY
@@ -30,6 +31,18 @@ _ContextState = tuple[
 
 
 _DD_ORIGIN_INVALID_CHARS_REGEX = re.compile(r"[^\x20-\x7E]+")
+
+# For listeners that mirror the W3C trace-flags byte outside the tracer.
+SAMPLING_DECISION_EVENT = "ddtrace.trace.sampling_decision"
+# Nothing listens unless the OTel thread context is publishing, and dispatching into the
+# event hub costs half again as much as the setter below does otherwise.
+_sampling_decision_has_listeners = False
+
+
+def enable_sampling_decision_event() -> None:
+    global _sampling_decision_has_listeners
+    _sampling_decision_has_listeners = True
+
 
 log = get_logger(__name__)
 
@@ -136,8 +149,13 @@ class Context(object):
             if value is None:
                 if _SAMPLING_PRIORITY_KEY in self._metrics:
                     del self._metrics[_SAMPLING_PRIORITY_KEY]
-                return
-            self._metrics[_SAMPLING_PRIORITY_KEY] = value
+            else:
+                self._metrics[_SAMPLING_PRIORITY_KEY] = value
+        # A decision forced mid-trace (an outbound inject, a manual keep) leaves anything
+        # mirroring the trace-flags byte stale for the rest of the trace. Dispatched
+        # outside the lock because listeners run arbitrary code.
+        if _sampling_decision_has_listeners:
+            core.dispatch(SAMPLING_DECISION_EVENT)
 
     @property
     def _traceparent(self) -> str:

--- a/ddtrace/internal/opentelemetry/thread_context.py
+++ b/ddtrace/internal/opentelemetry/thread_context.py
@@ -4,7 +4,9 @@ from typing import Optional
 from typing import Protocol
 from typing import Union
 
+from ddtrace._trace.context import SAMPLING_DECISION_EVENT
 from ddtrace._trace.context import Context
+from ddtrace._trace.context import enable_sampling_decision_event
 from ddtrace._trace.provider import BaseContextProvider
 from ddtrace._trace.span import Span
 from ddtrace.internal import core
@@ -17,8 +19,9 @@ class TracerProtocol(Protocol):
 
 
 _ContextActivationListener = Callable[[BaseContextProvider, Optional[Union[Context, Span]]], None]
-_ContextSwitchListener = Callable[[], None]
-_ThreadContextListeners = tuple[_ContextActivationListener, _ContextSwitchListener]
+# Registered for every event that invalidates the record without carrying the new value.
+_ResyncListener = Callable[[], None]
+_ThreadContextListeners = tuple[_ContextActivationListener, _ResyncListener]
 
 
 if sys.platform == "linux":
@@ -46,6 +49,10 @@ if sys.platform == "linux":
 
         core.on("ddtrace.context_provider.activate", _on_context_provider_activate)
         core.on("python.context.switch", _sync_active_otel_thread_context)
+        # Sampling usually decides at trace-chunk finish, after the record was published
+        # with trace_flags=0.
+        core.on(SAMPLING_DECISION_EVENT, _sync_active_otel_thread_context)
+        enable_sampling_decision_event()
 
         if sys.implementation.name == "cpython" and sys.version_info >= (3, 14):
             from ddtrace.internal.native._native import register_context_watcher

--- a/releasenotes/notes/fix-otel-thread-context-sampling-flags-45663f57a84c9dea.yaml
+++ b/releasenotes/notes/fix-otel-thread-context-sampling-flags-45663f57a84c9dea.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    tracing: Fixes an issue where the OpenTelemetry thread context kept reporting a trace
+    as unsampled after its sampling decision was made, so compatible profiling and
+    security tools saw the wrong sampling flag for the rest of the trace.

--- a/tests/tracer/test_otel_thread_context.py
+++ b/tests/tracer/test_otel_thread_context.py
@@ -7,6 +7,7 @@ import threading
 
 import pytest
 
+from ddtrace._trace.context import SAMPLING_DECISION_EVENT
 from ddtrace._trace.provider import DefaultContextProvider
 from ddtrace._trace.tracer import Tracer
 from ddtrace.internal import core
@@ -57,10 +58,11 @@ def _published_trace_flags():
 def _register_otel_thread_context_listener(tracer):
     listeners = register_otel_thread_context_listener(tracer)
     assert listeners is not None
-    activation_listener, context_switch_listener = listeners
+    activation_listener, resync_listener = listeners
     yield
     core.reset_listeners("ddtrace.context_provider.activate", activation_listener)
-    core.reset_listeners("python.context.switch", context_switch_listener)
+    core.reset_listeners("python.context.switch", resync_listener)
+    core.reset_listeners(SAMPLING_DECISION_EVENT, resync_listener)
 
 
 def test_span_context_is_published_and_detached(tracer: Tracer):
@@ -78,6 +80,27 @@ def test_span_context_publishes_trace_flags(tracer: Tracer):
 
         span.context.sampling_priority = 0
         tracer.context_provider.activate(span)
+        assert _published_trace_flags() == 0
+
+
+def test_sampling_decision_republishes_trace_flags(tracer: Tracer):
+    """Nothing re-activates the span here: the decision alone has to republish.
+
+    A decision forced mid-trace -- an outbound inject, a manual keep -- would otherwise
+    leave the record marked unsampled for the rest of the trace.
+    """
+    with tracer.trace("test") as span:
+        assert _published_trace_flags() == 0
+
+        span.context.sampling_priority = 2
+        assert _published_trace_flags() == 1
+
+        span.context.sampling_priority = -1
+        assert _published_trace_flags() == 0
+
+        span.context.sampling_priority = 1
+        assert _published_trace_flags() == 1
+        span.context.sampling_priority = None
         assert _published_trace_flags() == 0
 
 
@@ -110,12 +133,14 @@ def test_thread_context_listeners_can_be_disabled():
 
     assert "ddtrace" not in sys.modules
 
+    from ddtrace._trace.context import SAMPLING_DECISION_EVENT
     from ddtrace.internal import core
     from ddtrace.internal.settings._config import config
 
     assert config._otel_thread_context_enabled is False
     assert core.has_listeners("ddtrace.context_provider.activate") is False
     assert core.has_listeners("python.context.switch") is False
+    assert core.has_listeners(SAMPLING_DECISION_EVENT) is False
 
     if sys.implementation.name == "cpython" and sys.version_info >= (3, 14):
         from ddtrace.internal.native._native import is_context_watcher_registered


### PR DESCRIPTION
## Description

The OTel thread-context record carries the W3C trace-flags byte, whose only input is the
trace's sampling priority. Sampling usually decides at trace-chunk finish — long after the
record was published — and nothing republished it. So a decision forced mid-trace, by an
outbound inject or a manual keep, left the record marked unsampled for the rest of the trace.

`Context.sampling_priority` now dispatches an event the publisher resyncs on.

Publishing `0` while the decision is still deferred is what W3C prescribes; not reflecting it
once it is definitive is the bug.

The dispatch is gated on the publisher having registered: it costs half again as much as the
setter does otherwise (88 → 131 ns ungated, 89.5 gated), and nothing else listens. Non-Linux
and disabled deployments never register, so they pay nothing.

## Testing

## Risks

## Additional Notes
