### PR TITLE
feat(aiobotocore): trace Bedrock LLM calls

### DIFF
--- a/ddtrace/contrib/internal/aiobotocore/bedrock.py
+++ b/ddtrace/contrib/internal/aiobotocore/bedrock.py
@@ -1,0 +1,614 @@
+import asyncio
+import inspect
+import json
+import sys
+from typing import Any
+from typing import AsyncIterator
+from typing import Awaitable
+from typing import Callable
+from typing import Optional
+
+import wrapt
+
+from ddtrace import config
+from ddtrace._trace.utils_botocore.span_tags import _derive_peer_hostname
+from ddtrace.constants import _SPAN_MEASURED_KEY
+from ddtrace.constants import SPAN_KIND
+from ddtrace.contrib.internal.botocore.services.bedrock import _extract_streamed_response
+from ddtrace.contrib.internal.botocore.services.bedrock import _extract_streamed_response_metadata
+from ddtrace.contrib.internal.botocore.services.bedrock import _extract_text_and_response_reason
+from ddtrace.contrib.internal.botocore.services.bedrock import _resolve_application_inference_profile
+from ddtrace.contrib.internal.botocore.services.bedrock import _set_llmobs_usage
+from ddtrace.contrib.internal.botocore.services.bedrock import handle_bedrock_request
+from ddtrace.contrib.internal.botocore.services.bedrock import parse_model_id
+from ddtrace.contrib.internal.botocore.services.bedrock import safe_token_count
+from ddtrace.contrib.internal.trace_utils import set_service_and_source
+from ddtrace.ext import SpanKind
+from ddtrace.ext import SpanTypes
+from ddtrace.ext import aws
+from ddtrace.ext import http
+from ddtrace.internal import core
+from ddtrace.internal.constants import COMPONENT
+from ddtrace.internal.serverless import in_aws_lambda
+from ddtrace.internal.span_bus import span_from_context
+from ddtrace.llmobs._integrations.base_stream_handler import AsyncStreamHandler
+from ddtrace.llmobs._integrations.base_stream_handler import TracedAsyncStream
+
+
+class AiobotocoreStreamingBodyStreamHandler(AsyncStreamHandler):
+    async def process_chunk(self, chunk: dict[str, Any], iterator: Optional[Any] = None) -> None:
+        self.chunks.append(json.loads(chunk["chunk"]["bytes"]))
+
+    def handle_exception(self, exception: BaseException) -> None:
+        core.dispatch(
+            "botocore.patched_bedrock_api_call.exception", (self.options.get("execution_ctx", {}), sys.exc_info())
+        )
+
+    def finalize_stream(self, exception: Optional[BaseException] = None) -> None:
+        if exception:
+            return
+        execution_ctx = self.options.get("execution_ctx", {})
+        _extract_streamed_response_metadata(execution_ctx, self.chunks)
+        formatted_response = _extract_streamed_response(execution_ctx, self.chunks)
+        core.dispatch("botocore.bedrock.process_response", (execution_ctx, formatted_response))
+
+
+class AiobotocoreConverseStreamHandler(AsyncStreamHandler):
+    async def process_chunk(self, chunk: dict[str, Any], iterator: Optional[Any] = None) -> None:
+        stream_processor = self.options.get("stream_processor")
+        if stream_processor:
+            stream_processor.send(chunk)
+
+    def handle_exception(self, exception: BaseException) -> None:
+        execution_ctx = self.options.get("execution_ctx", {})
+        core.dispatch("botocore.patched_bedrock_api_call.exception", (execution_ctx, sys.exc_info()))
+
+    def finalize_stream(self, exception: Optional[BaseException] = None) -> None:
+        if exception:
+            return
+        stream_processor = self.options.get("stream_processor")
+        execution_ctx = self.options.get("execution_ctx", {})
+        core.dispatch("botocore.bedrock.process_response_converse", (execution_ctx, stream_processor))
+
+
+class AiobotocoreTracedAsyncStream(TracedAsyncStream):
+    """Traced async stream that owns cancellation and close finalization."""
+
+    def __init__(self, stream: Any, handler: AsyncStreamHandler) -> None:
+        super().__init__(stream, handler)
+        self._self_finalized = False
+
+    def _finalize(self, exception: Optional[BaseException] = None) -> None:
+        if self._self_finalized:
+            return
+        self._self_finalized = True
+        if exception is not None:
+            self._self_handler.handle_exception(exception)
+        self._self_handler.finalize_stream(exception)
+
+    async def __aiter__(self) -> AsyncIterator[Any]:
+        self._ensure_started()
+        exception: Optional[BaseException] = None
+        try:
+            async for chunk in self._self_async_stream_iter:
+                await self._self_handler.process_chunk(chunk, self._self_async_stream_iter)
+                # Both Bedrock event-stream handlers are transparent: every SDK event must be
+                # returned to the caller after instrumentation has observed it.
+                yield chunk
+        except asyncio.CancelledError as exc:
+            exception = exc
+            raise
+        except Exception as exc:
+            exception = exc
+            raise
+        finally:
+            self._finalize(exception)
+
+    async def __anext__(self) -> Any:
+        self._ensure_started()
+        try:
+            chunk = await self._self_async_stream_iter.__anext__()
+            await self._self_handler.process_chunk(chunk, self._self_async_stream_iter)
+        except StopAsyncIteration:
+            self._finalize()
+            raise
+        except asyncio.CancelledError as exc:
+            self._finalize(exc)
+            raise
+        except Exception as exc:
+            self._finalize(exc)
+            raise
+        return chunk
+
+    def close(self) -> Any:
+        try:
+            result = self.__wrapped__.close()
+        except asyncio.CancelledError as exc:
+            self._finalize(exc)
+            raise
+        except Exception as exc:
+            self._finalize(exc)
+            raise
+
+        if inspect.isawaitable(result):
+
+            async def await_close() -> Any:
+                try:
+                    value = await result
+                except asyncio.CancelledError as exc:
+                    self._finalize(exc)
+                    raise
+                except Exception as exc:
+                    self._finalize(exc)
+                    raise
+                else:
+                    self._finalize()
+                    return value
+
+            return await_close()
+
+        self._finalize()
+        return result
+
+    async def aclose(self) -> None:
+        aclose = getattr(self.__wrapped__, "aclose", None)
+        try:
+            if callable(aclose):
+                result = aclose()
+            else:
+                result = self.__wrapped__.close()
+            if inspect.isawaitable(result):
+                await result
+        except asyncio.CancelledError as exc:
+            self._finalize(exc)
+            raise
+        except Exception as exc:
+            self._finalize(exc)
+            raise
+        else:
+            self._finalize()
+
+
+def make_aiobotocore_streaming_body_traced_event_stream(stream: Any, execution_ctx: core.ExecutionContext) -> Any:
+    return AiobotocoreTracedAsyncStream(
+        stream,
+        AiobotocoreStreamingBodyStreamHandler(None, None, None, None, execution_ctx=execution_ctx),
+    )
+
+
+def make_aiobotocore_converse_traced_stream(stream: Any, execution_ctx: core.ExecutionContext) -> Any:
+    stream_processor = execution_ctx["bedrock_integration"]._converse_output_stream_processor()
+    next(stream_processor)
+    return AiobotocoreTracedAsyncStream(
+        stream,
+        AiobotocoreConverseStreamHandler(
+            None, None, None, None, execution_ctx=execution_ctx, stream_processor=stream_processor
+        ),
+    )
+
+
+class AiobotocoreStreamingBody(wrapt.ObjectProxy):
+    """Collect an async Bedrock response body and finalize its tracing span exactly once."""
+
+    def __init__(self, body: Any, execution_ctx: core.ExecutionContext) -> None:
+        super().__init__(body)
+        self._self_execution_ctx = execution_ctx
+        self._self_chunks: list[bytes] = []
+        self._self_finished = False
+
+    def _dispatch_exception(self, exc_info: Optional[Any] = None) -> None:
+        if self._self_finished:
+            return
+        self._self_finished = True
+        core.dispatch(
+            "botocore.patched_bedrock_api_call.exception",
+            (self._self_execution_ctx, exc_info or sys.exc_info()),
+        )
+
+    def _finish(self, allow_partial: bool = False) -> None:
+        if self._self_finished:
+            return
+        self._self_finished = True
+        try:
+            raw_body = b"".join(self._self_chunks)
+            if raw_body:
+                try:
+                    response = json.loads(raw_body)
+                except (UnicodeDecodeError, ValueError):
+                    if not allow_partial:
+                        raise
+                    response = {}
+            else:
+                response = {}
+            formatted_response = _extract_text_and_response_reason(self._self_execution_ctx, response)
+            core.dispatch("botocore.bedrock.process_response", (self._self_execution_ctx, formatted_response))
+        except Exception:
+            # `_self_finished` is already set so dispatch directly instead of using
+            # `_dispatch_exception`, whose guard intentionally prevents double finalization.
+            core.dispatch(
+                "botocore.patched_bedrock_api_call.exception", (self._self_execution_ctx, sys.exc_info())
+            )
+            if not allow_partial:
+                raise
+
+    def _fully_consumed(self) -> bool:
+        body = self.__wrapped__
+        # Current aiobotocore inherits botocore's `_amount_read` / `_content_length`.
+        # Older wrappers have also exposed `_self_*` variants, so accept both shapes.
+        for amount_name, length_name in (
+            ("_amount_read", "_content_length"),
+            ("_self_amount_read", "_self_content_length"),
+        ):
+            amount_read = getattr(body, amount_name, None)
+            content_length = getattr(body, length_name, None)
+            if amount_read is not None and content_length is not None:
+                try:
+                    return int(amount_read) >= int(content_length)
+                except (TypeError, ValueError):
+                    pass
+
+        tell = getattr(body, "tell", None)
+        content_length = getattr(body, "_content_length", None)
+        if callable(tell) and content_length is not None:
+            try:
+                return int(tell()) >= int(content_length)
+            except (TypeError, ValueError):
+                return False
+        return False
+
+    async def read(self, amt: Optional[int] = None) -> bytes:
+        try:
+            body = await self.__wrapped__.read() if amt is None else await self.__wrapped__.read(amt)
+            self._self_chunks.append(body)
+            if amt is None or amt < 0 or (amt > 0 and not body) or self._fully_consumed():
+                self._finish()
+            return body
+        except asyncio.CancelledError:
+            self._dispatch_exception()
+            raise
+        except Exception:
+            self._dispatch_exception()
+            raise
+
+    async def readinto(self, buffer: bytearray) -> int:
+        try:
+            amount_read = await self.__wrapped__.readinto(buffer)
+            self._self_chunks.append(bytes(buffer[:amount_read]))
+            if (len(buffer) > 0 and amount_read == 0) or self._fully_consumed():
+                self._finish()
+            return amount_read
+        except asyncio.CancelledError:
+            self._dispatch_exception()
+            raise
+        except Exception:
+            self._dispatch_exception()
+            raise
+
+    async def readlines(self) -> list[bytes]:
+        try:
+            lines = await self.__wrapped__.readlines()
+            self._self_chunks.extend(lines)
+            self._finish()
+            return lines
+        except asyncio.CancelledError:
+            self._dispatch_exception()
+            raise
+        except Exception:
+            self._dispatch_exception()
+            raise
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        completed = False
+        try:
+            async for body in self.__wrapped__:
+                self._self_chunks.append(body)
+                yield body
+            completed = True
+        except asyncio.CancelledError:
+            self._dispatch_exception()
+            raise
+        except Exception:
+            self._dispatch_exception()
+            raise
+        finally:
+            if not self._self_finished:
+                self._finish(allow_partial=not completed)
+
+    async def __anext__(self) -> bytes:
+        try:
+            body = await self.__wrapped__.__anext__()
+            self._self_chunks.append(body)
+            if self._fully_consumed():
+                self._finish()
+            return body
+        except StopAsyncIteration:
+            self._finish()
+            raise
+        except asyncio.CancelledError:
+            self._dispatch_exception()
+            raise
+        except Exception:
+            self._dispatch_exception()
+            raise
+
+    anext = __anext__
+
+    async def iter_chunks(self, chunk_size: int = 1024) -> AsyncIterator[bytes]:
+        while True:
+            chunk = await self.read(chunk_size)
+            if chunk == b"":
+                break
+            yield chunk
+
+    async def iter_lines(self, chunk_size: int = 1024, keepends: bool = False) -> AsyncIterator[bytes]:
+        pending = b""
+        async for chunk in self.iter_chunks(chunk_size):
+            lines = (pending + chunk).splitlines(True)
+            for line in lines[:-1]:
+                yield line.splitlines(keepends)[0]
+            pending = lines[-1]
+        if pending:
+            yield pending.splitlines(keepends)[0]
+
+    def close(self) -> Any:
+        try:
+            result = self.__wrapped__.close()
+        except asyncio.CancelledError:
+            self._dispatch_exception()
+            raise
+        except Exception:
+            self._dispatch_exception()
+            raise
+
+        if inspect.isawaitable(result):
+
+            async def await_close() -> Any:
+                try:
+                    value = await result
+                except asyncio.CancelledError:
+                    self._dispatch_exception()
+                    raise
+                except Exception:
+                    self._dispatch_exception()
+                    raise
+                else:
+                    self._finish(allow_partial=True)
+                    return value
+
+            return await_close()
+
+        self._finish(allow_partial=True)
+        return result
+
+    async def aclose(self) -> None:
+        aclose = getattr(self.__wrapped__, "aclose", None)
+        try:
+            if callable(aclose):
+                result = aclose()
+            else:
+                result = self.__wrapped__.close()
+            if inspect.isawaitable(result):
+                await result
+        except asyncio.CancelledError:
+            self._dispatch_exception()
+            raise
+        except Exception:
+            self._dispatch_exception()
+            raise
+        else:
+            self._finish(allow_partial=True)
+
+    async def __aenter__(self) -> "AiobotocoreStreamingBody":
+        await self.__wrapped__.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback) -> Any:
+        try:
+            return await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
+        except asyncio.CancelledError:
+            self._dispatch_exception()
+            raise
+        except Exception:
+            self._dispatch_exception()
+            raise
+        finally:
+            if not self._self_finished:
+                if exc_type is not None and exc_value is not None:
+                    self._dispatch_exception((exc_type, exc_value, traceback))
+                else:
+                    self._finish(allow_partial=True)
+
+
+def make_aiobotocore_streaming_body_traced_stream(
+    streaming_body: Any, execution_ctx: core.ExecutionContext
+) -> AiobotocoreStreamingBody:
+    return AiobotocoreStreamingBody(streaming_body, execution_ctx)
+
+
+def _record_bedrock_response_metadata(ctx: core.ExecutionContext, result: dict[str, Any]) -> None:
+    metadata = result["ResponseMetadata"]
+    http_headers = metadata["HTTPHeaders"]
+
+    total_tokens = None
+    input_tokens = http_headers.get("x-amzn-bedrock-input-token-count", "")
+    output_tokens = http_headers.get("x-amzn-bedrock-output-token-count", "")
+    cache_read_tokens = None
+    cache_write_tokens = None
+
+    if ctx["resource"] == "Converse":
+        usage = result.get("usage", {})
+        if usage:
+            input_tokens = usage.get("inputTokens", input_tokens)
+            output_tokens = usage.get("outputTokens", output_tokens)
+            total_tokens = usage.get("totalTokens", total_tokens)
+            cache_read_tokens = usage.get("cacheReadInputTokenCount", None) or usage.get("cacheReadInputTokens", None)
+            cache_write_tokens = usage.get("cacheWriteInputTokenCount", None) or usage.get(
+                "cacheWriteInputTokens", None
+            )
+        if "stopReason" in result:
+            ctx.set_item("llmobs.stop_reason", result.get("stopReason"))
+
+    _set_llmobs_usage(
+        ctx,
+        safe_token_count(input_tokens),
+        safe_token_count(output_tokens),
+        safe_token_count(total_tokens),
+        safe_token_count(cache_read_tokens),
+        safe_token_count(cache_write_tokens),
+    )
+
+
+def _set_apm_request_tags(ctx: core.ExecutionContext, function_vars: dict[str, Any]) -> None:
+    span = span_from_context(ctx)
+    if span is None:
+        return
+
+    instance = function_vars["instance"]
+    endpoint_name = function_vars["endpoint_name"]
+    operation = function_vars["operation"]
+    params = function_vars.get("params")
+    service = function_vars["service"]
+
+    set_service_and_source(span, service, config.aiobotocore)
+    span._set_attribute(COMPONENT, config.aiobotocore.integration_name)
+    span._set_attribute(SPAN_KIND, SpanKind.CLIENT)
+    span._set_attribute(_SPAN_MEASURED_KEY, 1)
+    span.resource = "{}.{}".format(endpoint_name, operation.lower())
+
+    if params and not config.aiobotocore["tag_no_params"]:
+        aws._add_api_param_span_tags(span, endpoint_name, params)
+
+    region_name = getattr(getattr(instance, "meta", None), "region_name", None)
+    if in_aws_lambda():
+        hostname = _derive_peer_hostname(endpoint_name, region_name, params)
+        if hostname:
+            span._set_attribute("peer.service", hostname)
+
+    meta = {
+        "aws.agent": "aiobotocore",
+        "aws.operation": operation,
+        "aws.region": region_name,
+        "region": region_name,
+    }
+    if region_name:
+        meta["aws.partition"] = aws.get_aws_partition(region_name)
+    span.set_tags(meta)
+
+
+def _set_apm_response_tags(ctx: core.ExecutionContext, result: dict[str, Any]) -> None:
+    span = span_from_context(ctx)
+    if span is None:
+        return
+    response_meta = result.get("ResponseMetadata", {})
+    status_code = response_meta.get("HTTPStatusCode")
+    if status_code is not None:
+        span._set_attribute(http.STATUS_CODE, status_code)
+        if 500 <= status_code < 600:
+            span.error = 1
+    if "RetryAttempts" in response_meta:
+        span.set_tag("retry_attempts", response_meta["RetryAttempts"])
+    request_id = response_meta.get("RequestId")
+    if request_id:
+        span._set_attribute("aws.requestid", request_id)
+    response_headers = response_meta.get("HTTPHeaders", {})
+    request_id2 = response_headers.get("x-amz-id-2")
+    if request_id2:
+        span._set_attribute("aws.requestid2", request_id2)
+
+
+def handle_aiobotocore_bedrock_response(
+    ctx: core.ExecutionContext,
+    result: dict[str, Any],
+) -> dict[str, Any]:
+    _record_bedrock_response_metadata(ctx, result)
+    _set_apm_response_tags(ctx, result)
+
+    if ctx["resource"] == "Converse":
+        core.dispatch("botocore.bedrock.process_response_converse", (ctx, result))
+        return result
+    if ctx["resource"] == "ConverseStream":
+        if "stream" in result:
+            result["stream"] = make_aiobotocore_converse_traced_stream(result["stream"], ctx)
+        return result
+    if ctx["resource"] == "InvokeModelWithResponseStream":
+        result["body"] = make_aiobotocore_streaming_body_traced_event_stream(result["body"], ctx)
+        return result
+
+    result["body"] = make_aiobotocore_streaming_body_traced_stream(result["body"], ctx)
+    return result
+
+
+def _handle_aiobotocore_bedrock_request(ctx: core.ExecutionContext) -> None:
+    """Extract Bedrock request metadata without consuming file-like InvokeModel bodies."""
+    if ctx["resource"] in ("Converse", "ConverseStream"):
+        handle_bedrock_request(ctx)
+        return
+
+    body = ctx["params"].get("body")
+    if isinstance(body, (str, bytes, bytearray)):
+        handle_bedrock_request(ctx)
+        return
+
+    # Botocore accepts seekable/file-like blobs for InvokeModel. Reading them here would both
+    # block the event loop and risk advancing the SDK payload before it is sent. Keep tracing
+    # active but omit prompt-specific request metadata for payloads we cannot safely inspect.
+    request_params: dict[str, Any] = {}
+    core.dispatch("botocore.patched_bedrock_api_call.started", (ctx, request_params))
+    if ctx["bedrock_integration"].llmobs_enabled:
+        ctx.set_item("llmobs.request_params", request_params)
+
+
+async def patched_aiobotocore_bedrock_api_call(
+    original_func: Callable[..., Awaitable[Any]],
+    instance: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    function_vars: dict[str, Any],
+) -> Any:
+    params = function_vars.get("params") or {}
+    integration = function_vars["integration"]
+    model_id = params.get("modelId", "")
+    model_provider, model_name = parse_model_id(model_id)
+    # Cache hits are safe to share with the synchronous integration. Do not perform
+    # the synchronous GetInferenceProfile control-plane lookup on the event loop.
+    model_id, model_provider, model_name = _resolve_application_inference_profile(
+        model_id, model_provider, model_name, llmobs_enabled=integration.llmobs_enabled
+    )
+    submit_to_llmobs = integration.llmobs_enabled and "embed" not in model_name
+
+    context_vars = {
+        **function_vars,
+        "span_type": SpanTypes.LLM if submit_to_llmobs else SpanTypes.HTTP,
+        "resource": function_vars["operation"],
+        "bedrock_integration": integration,
+        "model_provider": model_provider,
+        "model_name": model_name,
+        "model_id": model_id,
+    }
+    with core.context_with_data(
+        "botocore.patched_bedrock_api_call",
+        pin=function_vars["pin"],
+        span_name=function_vars["trace_operation"],
+        service=function_vars["service"],
+        resource=context_vars["resource"],
+        span_type=context_vars["span_type"],
+        call_trace=True,
+        bedrock_integration=integration,
+        params=params,
+        model_provider=model_provider,
+        model_name=model_name,
+        model_id=model_id,
+        instance=instance,
+    ) as ctx:
+        function_vars = {**function_vars, "instance": instance}
+        _set_apm_request_tags(ctx, function_vars)
+        try:
+            _handle_aiobotocore_bedrock_request(ctx)
+            result = await original_func(*args, **kwargs)
+            return handle_aiobotocore_bedrock_response(ctx, result)
+        except asyncio.CancelledError:
+            core.dispatch("botocore.patched_bedrock_api_call.exception", (ctx, sys.exc_info()))
+            raise
+        except Exception:
+            core.dispatch("botocore.patched_bedrock_api_call.exception", (ctx, sys.exc_info()))
+            raise

--- a/ddtrace/contrib/internal/aiobotocore/bedrock.py
+++ b/ddtrace/contrib/internal/aiobotocore/bedrock.py
@@ -37,6 +37,9 @@ from ddtrace.llmobs._integrations.base_stream_handler import TracedAsyncStream
 
 class AiobotocoreStreamingBodyStreamHandler(AsyncStreamHandler):
     async def process_chunk(self, chunk: dict[str, Any], iterator: Optional[Any] = None) -> None:
+        execution_ctx = self.options.get("execution_ctx", {})
+        if not execution_ctx["bedrock_integration"].llmobs_enabled:
+            return
         self.chunks.append(json.loads(chunk["chunk"]["bytes"]))
 
     def handle_exception(self, exception: BaseException) -> None:
@@ -48,8 +51,16 @@ class AiobotocoreStreamingBodyStreamHandler(AsyncStreamHandler):
         if exception:
             return
         execution_ctx = self.options.get("execution_ctx", {})
-        _extract_streamed_response_metadata(execution_ctx, self.chunks)
-        formatted_response = _extract_streamed_response(execution_ctx, self.chunks)
+        if not execution_ctx["bedrock_integration"].llmobs_enabled:
+            core.dispatch("botocore.bedrock.process_response", (execution_ctx, {}))
+            return
+        try:
+            _extract_streamed_response_metadata(execution_ctx, self.chunks)
+            formatted_response = _extract_streamed_response(execution_ctx, self.chunks)
+        except (KeyError, IndexError, TypeError, ValueError):
+            if not self.options.get("allow_partial", False):
+                raise
+            formatted_response = {}
         core.dispatch("botocore.bedrock.process_response", (execution_ctx, formatted_response))
 
 
@@ -78,10 +89,12 @@ class AiobotocoreTracedAsyncStream(TracedAsyncStream):
         super().__init__(stream, handler)
         self._self_finalized = False
 
-    def _finalize(self, exception: Optional[BaseException] = None) -> None:
+    def _finalize(self, exception: Optional[BaseException] = None, allow_partial: bool = False) -> None:
         if self._self_finalized:
             return
         self._self_finalized = True
+        if allow_partial:
+            self._self_handler.options["allow_partial"] = True
         if exception is not None:
             self._self_handler.handle_exception(exception)
         self._self_handler.finalize_stream(exception)
@@ -142,12 +155,12 @@ class AiobotocoreTracedAsyncStream(TracedAsyncStream):
                     self._finalize(exc)
                     raise
                 else:
-                    self._finalize()
+                    self._finalize(allow_partial=True)
                     return value
 
             return await_close()
 
-        self._finalize()
+        self._finalize(allow_partial=True)
         return result
 
     async def aclose(self) -> None:
@@ -166,7 +179,7 @@ class AiobotocoreTracedAsyncStream(TracedAsyncStream):
             self._finalize(exc)
             raise
         else:
-            self._finalize()
+            self._finalize(allow_partial=True)
 
 
 def make_aiobotocore_streaming_body_traced_event_stream(stream: Any, execution_ctx: core.ExecutionContext) -> Any:
@@ -195,6 +208,15 @@ class AiobotocoreStreamingBody(wrapt.ObjectProxy):
         self._self_execution_ctx = execution_ctx
         self._self_chunks: list[bytes] = []
         self._self_finished = False
+        self._self_collect_response = execution_ctx["bedrock_integration"].llmobs_enabled
+
+    def _append_chunk(self, chunk: bytes) -> None:
+        if self._self_collect_response:
+            self._self_chunks.append(chunk)
+
+    def _extend_chunks(self, chunks: list[bytes]) -> None:
+        if self._self_collect_response:
+            self._self_chunks.extend(chunks)
 
     def _dispatch_exception(self, exc_info: Optional[Any] = None) -> None:
         if self._self_finished:
@@ -209,6 +231,9 @@ class AiobotocoreStreamingBody(wrapt.ObjectProxy):
         if self._self_finished:
             return
         self._self_finished = True
+        if not self._self_collect_response:
+            core.dispatch("botocore.bedrock.process_response", (self._self_execution_ctx, {}))
+            return
         try:
             raw_body = b"".join(self._self_chunks)
             if raw_body:
@@ -259,7 +284,7 @@ class AiobotocoreStreamingBody(wrapt.ObjectProxy):
     async def read(self, amt: Optional[int] = None) -> bytes:
         try:
             body = await self.__wrapped__.read() if amt is None else await self.__wrapped__.read(amt)
-            self._self_chunks.append(body)
+            self._append_chunk(body)
             if amt is None or amt < 0 or (amt > 0 and not body) or self._fully_consumed():
                 self._finish()
             return body
@@ -273,7 +298,7 @@ class AiobotocoreStreamingBody(wrapt.ObjectProxy):
     async def readinto(self, buffer: bytearray) -> int:
         try:
             amount_read = await self.__wrapped__.readinto(buffer)
-            self._self_chunks.append(bytes(buffer[:amount_read]))
+            self._append_chunk(bytes(buffer[:amount_read]))
             if (len(buffer) > 0 and amount_read == 0) or self._fully_consumed():
                 self._finish()
             return amount_read
@@ -287,7 +312,7 @@ class AiobotocoreStreamingBody(wrapt.ObjectProxy):
     async def readlines(self) -> list[bytes]:
         try:
             lines = await self.__wrapped__.readlines()
-            self._self_chunks.extend(lines)
+            self._extend_chunks(lines)
             self._finish()
             return lines
         except asyncio.CancelledError:
@@ -301,7 +326,7 @@ class AiobotocoreStreamingBody(wrapt.ObjectProxy):
         completed = False
         try:
             async for body in self.__wrapped__:
-                self._self_chunks.append(body)
+                self._append_chunk(body)
                 yield body
             completed = True
         except asyncio.CancelledError:
@@ -317,7 +342,7 @@ class AiobotocoreStreamingBody(wrapt.ObjectProxy):
     async def __anext__(self) -> bytes:
         try:
             body = await self.__wrapped__.__anext__()
-            self._self_chunks.append(body)
+            self._append_chunk(body)
             if self._fully_consumed():
                 self._finish()
             return body

--- a/ddtrace/contrib/internal/aiobotocore/patch.py
+++ b/ddtrace/contrib/internal/aiobotocore/patch.py
@@ -12,12 +12,12 @@ from ddtrace._trace.subscribers.http_client import _http_propagation_suppressed
 from ddtrace._trace.utils_botocore.span_tags import _derive_peer_hostname
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
+from ddtrace.contrib.internal.aiobotocore.bedrock import patched_aiobotocore_bedrock_api_call
 
 # AIDEV-NOTE: Shared with botocore; this integration registers its own owner-gated
 # wrapper via _ensure_before_sign_handler. See botocore/patch.py for the contract.
 from ddtrace.contrib.internal.botocore.patch import _ensure_before_sign_handler
 from ddtrace.contrib.internal.botocore.patch import _inject_trace_headers_handler
-from ddtrace.contrib.internal.botocore.services.bedrock import patched_aiobotocore_bedrock_api_call
 from ddtrace.contrib.internal.trace_utils import ext_service
 from ddtrace.contrib.internal.trace_utils import set_service_and_source
 from ddtrace.contrib.internal.trace_utils import unwrap
@@ -148,9 +148,9 @@ async def _wrapped_api_call(original_func, instance, args, kwargs):
         operation = None
         params = None
 
-    # AIDEV-NOTE: Bedrock is the one aiobotocore endpoint whose span must
-    # outlive this coroutine. Its async body/stream wrapper owns finalization;
-    # keep the supported operation set aligned with botocore/patch.py.
+    # Bedrock spans must outlive this coroutine while the async body/stream is consumed.
+    # The Bedrock helper preserves the same APM tags as this generic path and owns
+    # finalization for every supported async consumption path.
     if endpoint_name == "bedrock-runtime" and operation in BEDROCK_RUNTIME_OPERATIONS:
         trace_operation = schematize_cloud_api_operation(
             "{}.command".format(endpoint_name), cloud_provider="aws", cloud_service=endpoint_name

--- a/ddtrace/contrib/internal/aiobotocore/patch.py
+++ b/ddtrace/contrib/internal/aiobotocore/patch.py
@@ -17,6 +17,7 @@ from ddtrace.constants import SPAN_KIND
 # wrapper via _ensure_before_sign_handler. See botocore/patch.py for the contract.
 from ddtrace.contrib.internal.botocore.patch import _ensure_before_sign_handler
 from ddtrace.contrib.internal.botocore.patch import _inject_trace_headers_handler
+from ddtrace.contrib.internal.botocore.services.bedrock import patched_aiobotocore_bedrock_api_call
 from ddtrace.contrib.internal.trace_utils import ext_service
 from ddtrace.contrib.internal.trace_utils import set_service_and_source
 from ddtrace.contrib.internal.trace_utils import unwrap
@@ -34,6 +35,7 @@ from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.formats import deep_getattr
 from ddtrace.internal.utils.version import parse_version
+from ddtrace.llmobs._integrations import BedrockIntegration
 from ddtrace.trace import tracer
 
 
@@ -48,6 +50,7 @@ elif AIOBOTOCORE_VERSION >= (0, 11, 0) and AIOBOTOCORE_VERSION < (2, 3, 0):
 
 ARGS_NAME = ("action", "params", "path", "verb")
 TRACED_ARGS = {"params", "path", "verb"}
+BEDROCK_RUNTIME_OPERATIONS = frozenset(("Converse", "ConverseStream", "InvokeModel", "InvokeModelWithResponseStream"))
 
 config._add(
     "aiobotocore",
@@ -79,6 +82,7 @@ def patch():
         return
     aiobotocore.client._datadog_patch = True
 
+    aiobotocore._datadog_integration = BedrockIntegration(integration_config=config.botocore)
     wrapt.wrap_function_wrapper("aiobotocore.client", "AioBaseClient._make_api_call", _wrapped_api_call)
     Pin().onto(aiobotocore.client.AioBaseClient)
 
@@ -135,8 +139,43 @@ async def _wrapped_api_call(original_func, instance, args, kwargs):
         return result
 
     endpoint_name = deep_getattr(instance, "_endpoint._endpoint_prefix")
-
     fallback_service = config._get_service(default="aws.{}".format(endpoint_name))
+
+    try:
+        operation = get_argument_value(args, kwargs, 0, "operation_name")
+        params = get_argument_value(args, kwargs, 1, "api_params")
+    except ArgumentError:
+        operation = None
+        params = None
+
+    # AIDEV-NOTE: Bedrock is the one aiobotocore endpoint whose span must
+    # outlive this coroutine. Its async body/stream wrapper owns finalization;
+    # keep the supported operation set aligned with botocore/patch.py.
+    if endpoint_name == "bedrock-runtime" and operation in BEDROCK_RUNTIME_OPERATIONS:
+        trace_operation = schematize_cloud_api_operation(
+            "{}.command".format(endpoint_name), cloud_provider="aws", cloud_service=endpoint_name
+        )
+        function_vars = {
+            "endpoint_name": endpoint_name,
+            "operation": operation,
+            "params": params,
+            "pin": pin,
+            "trace_operation": trace_operation,
+            "integration": aiobotocore._datadog_integration,
+            "service": ext_service(pin, config.aiobotocore, default=schematize_service_name(fallback_service)),
+        }
+
+        token = None
+        if not config.botocore["distributed_tracing"]:
+            token = _http_propagation_suppressed.set(True)
+        elif _ensure_before_sign_handler(instance, _aiobotocore_before_sign_handler):
+            token = _http_propagation_suppressed.set(True)
+        try:
+            return await patched_aiobotocore_bedrock_api_call(original_func, instance, args, kwargs, function_vars)
+        finally:
+            if token is not None:
+                _http_propagation_suppressed.reset(token)
+
     with tracer.trace(
         schematize_cloud_api_operation(
             "{}.command".format(endpoint_name), cloud_provider="aws", cloud_service=endpoint_name
@@ -155,16 +194,12 @@ async def _wrapped_api_call(original_func, instance, args, kwargs):
 
         span._set_attribute(_SPAN_MEASURED_KEY, 1)
 
-        try:
-            operation = get_argument_value(args, kwargs, 0, "operation_name")
-            params = get_argument_value(args, kwargs, 1, "api_params")
-
+        if operation is not None:
             span.resource = "{}.{}".format(endpoint_name, operation.lower())
 
             if params and not config.aiobotocore["tag_no_params"]:
                 aws._add_api_param_span_tags(span, endpoint_name, params)
-        except ArgumentError:
-            operation = None
+        else:
             span.resource = endpoint_name
 
         region_name = deep_getattr(instance, "meta.region_name")

--- a/ddtrace/contrib/internal/aiobotocore/patch.py
+++ b/ddtrace/contrib/internal/aiobotocore/patch.py
@@ -16,6 +16,7 @@ from ddtrace.contrib.internal.aiobotocore.bedrock import patched_aiobotocore_bed
 
 # AIDEV-NOTE: Shared with botocore; this integration registers its own owner-gated
 # wrapper via _ensure_before_sign_handler. See botocore/patch.py for the contract.
+from ddtrace.contrib.internal.botocore.patch import _PATCHED_SUBMODULES as _BOTOCORE_PATCHED_SUBMODULES
 from ddtrace.contrib.internal.botocore.patch import _ensure_before_sign_handler
 from ddtrace.contrib.internal.botocore.patch import _inject_trace_headers_handler
 from ddtrace.contrib.internal.trace_utils import ext_service
@@ -51,6 +52,7 @@ elif AIOBOTOCORE_VERSION >= (0, 11, 0) and AIOBOTOCORE_VERSION < (2, 3, 0):
 ARGS_NAME = ("action", "params", "path", "verb")
 TRACED_ARGS = {"params", "path", "verb"}
 BEDROCK_RUNTIME_OPERATIONS = frozenset(("Converse", "ConverseStream", "InvokeModel", "InvokeModelWithResponseStream"))
+_PATCHED_SUBMODULES = set()
 
 config._add(
     "aiobotocore",
@@ -85,9 +87,27 @@ def patch():
     aiobotocore._datadog_integration = BedrockIntegration(integration_config=config.botocore)
     wrapt.wrap_function_wrapper("aiobotocore.client", "AioBaseClient._make_api_call", _wrapped_api_call)
     Pin().onto(aiobotocore.client.AioBaseClient)
+    _PATCHED_SUBMODULES.clear()
+
+
+def patch_submodules(submodules):
+    """Restrict tracing to selected AWS services when a caller supplies a service list.
+
+    LLMObs patches botocore with a Bedrock-only service list but currently reaches
+    aiobotocore with a boolean patch indicator. Mirror botocore's active service
+    restriction in that case so enabling LLMObs does not start tracing unrelated
+    async S3/SQS/DynamoDB traffic. An ordinary ``patch(aiobotocore=True)`` keeps
+    the historical all-services behavior because botocore has no active filter.
+    """
+    _PATCHED_SUBMODULES.clear()
+    if isinstance(submodules, list):
+        _PATCHED_SUBMODULES.update(submodule.lower() for submodule in submodules)
+    elif isinstance(submodules, bool) and submodules and _BOTOCORE_PATCHED_SUBMODULES:
+        _PATCHED_SUBMODULES.update(_BOTOCORE_PATCHED_SUBMODULES)
 
 
 def unpatch():
+    _PATCHED_SUBMODULES.clear()
     if getattr(aiobotocore.client, "_datadog_patch", False):
         aiobotocore.client._datadog_patch = False
         unwrap(aiobotocore.client.AioBaseClient, "_make_api_call")
@@ -139,6 +159,9 @@ async def _wrapped_api_call(original_func, instance, args, kwargs):
         return result
 
     endpoint_name = deep_getattr(instance, "_endpoint._endpoint_prefix")
+    if _PATCHED_SUBMODULES and endpoint_name not in _PATCHED_SUBMODULES:
+        return await original_func(*args, **kwargs)
+
     fallback_service = config._get_service(default="aws.{}".format(endpoint_name))
 
     try:

--- a/ddtrace/contrib/internal/botocore/services/bedrock.py
+++ b/ddtrace/contrib/internal/botocore/services/bedrock.py
@@ -2,12 +2,7 @@ from contextvars import ContextVar
 import json
 import sys
 from typing import Any
-from typing import AsyncIterator
-from typing import Awaitable
-from typing import Callable
 from typing import Optional
-
-import wrapt
 
 from ddtrace import config
 from ddtrace.contrib.internal.trace_utils import ext_service
@@ -21,7 +16,6 @@ from ddtrace.llmobs._integrations._bedrock_inference_profiles import begin_resol
 from ddtrace.llmobs._integrations._bedrock_inference_profiles import lookup_inference_profile
 from ddtrace.llmobs._integrations._bedrock_inference_profiles import record_inference_profile
 from ddtrace.llmobs._integrations._bedrock_inference_profiles import record_resolve_failure
-from ddtrace.llmobs._integrations.base_stream_handler import AsyncStreamHandler
 from ddtrace.llmobs._integrations.base_stream_handler import StreamHandler
 from ddtrace.llmobs._integrations.base_stream_handler import make_traced_stream
 from ddtrace.llmobs._integrations.bedrock_utils import _AI21
@@ -114,42 +108,6 @@ class BotocoreConverseStreamHandler(StreamHandler):
         core.dispatch("botocore.bedrock.process_response_converse", (execution_ctx, stream_processor))
 
 
-class AiobotocoreStreamingBodyStreamHandler(AsyncStreamHandler):
-    async def process_chunk(self, chunk: dict[str, Any], iterator: Optional[Any] = None) -> None:
-        self.chunks.append(json.loads(chunk["chunk"]["bytes"]))
-
-    def handle_exception(self, exception: BaseException) -> None:
-        core.dispatch(
-            "botocore.patched_bedrock_api_call.exception", (self.options.get("execution_ctx", {}), sys.exc_info())
-        )
-
-    def finalize_stream(self, exception: Optional[BaseException] = None) -> None:
-        if exception:
-            return
-        execution_ctx = self.options.get("execution_ctx", {})
-        _extract_streamed_response_metadata(execution_ctx, self.chunks)
-        formatted_response = _extract_streamed_response(execution_ctx, self.chunks)
-        core.dispatch("botocore.bedrock.process_response", (execution_ctx, formatted_response))
-
-
-class AiobotocoreConverseStreamHandler(AsyncStreamHandler):
-    async def process_chunk(self, chunk: dict[str, Any], iterator: Optional[Any] = None) -> None:
-        stream_processor = self.options.get("stream_processor")
-        if stream_processor:
-            stream_processor.send(chunk)
-
-    def handle_exception(self, exception: BaseException) -> None:
-        execution_ctx = self.options.get("execution_ctx", {})
-        core.dispatch("botocore.patched_bedrock_api_call.exception", (execution_ctx, sys.exc_info()))
-
-    def finalize_stream(self, exception: Optional[BaseException] = None) -> None:
-        if exception:
-            return
-        stream_processor = self.options.get("stream_processor")
-        execution_ctx = self.options.get("execution_ctx", {})
-        core.dispatch("botocore.bedrock.process_response_converse", (execution_ctx, stream_processor))
-
-
 def make_botocore_streaming_body_traced_stream(streaming_body, execution_ctx):
     original_read = getattr(streaming_body, "read", None)
     original_readlines = getattr(streaming_body, "readlines", None)
@@ -174,146 +132,6 @@ def make_botocore_converse_traced_stream(stream, execution_ctx):
             None, None, None, None, execution_ctx=execution_ctx, stream_processor=stream_processor
         ),
     )
-
-
-def make_aiobotocore_streaming_body_traced_event_stream(stream: Any, execution_ctx: core.ExecutionContext) -> Any:
-    return make_traced_stream(
-        stream,
-        AiobotocoreStreamingBodyStreamHandler(None, None, None, None, execution_ctx=execution_ctx),
-    )
-
-
-def make_aiobotocore_converse_traced_stream(stream: Any, execution_ctx: core.ExecutionContext) -> Any:
-    stream_processor = execution_ctx["bedrock_integration"]._converse_output_stream_processor()
-    next(stream_processor)
-    return make_traced_stream(
-        stream,
-        AiobotocoreConverseStreamHandler(
-            None, None, None, None, execution_ctx=execution_ctx, stream_processor=stream_processor
-        ),
-    )
-
-
-class AiobotocoreStreamingBody(wrapt.ObjectProxy):
-    """Collect an async Bedrock response body and finish its LLM span at EOF."""
-
-    def __init__(self, body: Any, execution_ctx: core.ExecutionContext) -> None:
-        super().__init__(body)
-        self._self_execution_ctx = execution_ctx
-        self._self_chunks = []
-        self._self_finished = False
-
-    def _finish(self) -> None:
-        if self._self_finished:
-            return
-        self._self_finished = True
-        try:
-            response = json.loads(b"".join(self._self_chunks))
-            formatted_response = _extract_text_and_response_reason(self._self_execution_ctx, response)
-            core.dispatch("botocore.bedrock.process_response", (self._self_execution_ctx, formatted_response))
-        except Exception:
-            core.dispatch("botocore.patched_bedrock_api_call.exception", (self._self_execution_ctx, sys.exc_info()))
-            raise
-
-    def _fully_consumed(self) -> bool:
-        tell = getattr(self.__wrapped__, "tell", None)
-        content_length = getattr(self.__wrapped__, "_content_length", None)
-        if not callable(tell) or content_length is None:
-            return False
-        return tell() == int(content_length)
-
-    async def read(self, amt: Optional[int] = None) -> bytes:
-        try:
-            body = await self.__wrapped__.read() if amt is None else await self.__wrapped__.read(amt)
-            self._self_chunks.append(body)
-            # aiobotocore's read() without an amount consumes the remainder.
-            # Sized reads signal EOF with an empty chunk.
-            if amt is None or amt < 0 or (amt > 0 and not body) or self._fully_consumed():
-                self._finish()
-            return body
-        except Exception:
-            if not self._self_finished:
-                core.dispatch("botocore.patched_bedrock_api_call.exception", (self._self_execution_ctx, sys.exc_info()))
-            raise
-
-    async def readinto(self, buffer: bytearray) -> int:
-        try:
-            amount_read = await self.__wrapped__.readinto(buffer)
-            self._self_chunks.append(bytes(buffer[:amount_read]))
-            if (len(buffer) > 0 and amount_read == 0) or self._fully_consumed():
-                self._finish()
-            return amount_read
-        except Exception:
-            if not self._self_finished:
-                core.dispatch("botocore.patched_bedrock_api_call.exception", (self._self_execution_ctx, sys.exc_info()))
-            raise
-
-    async def readlines(self) -> list[bytes]:
-        try:
-            lines = await self.__wrapped__.readlines()
-            self._self_chunks.extend(lines)
-            self._finish()
-            return lines
-        except Exception:
-            if not self._self_finished:
-                core.dispatch("botocore.patched_bedrock_api_call.exception", (self._self_execution_ctx, sys.exc_info()))
-            raise
-
-    async def __aiter__(self) -> AsyncIterator[bytes]:
-        try:
-            async for body in self.__wrapped__:
-                self._self_chunks.append(body)
-                yield body
-            self._finish()
-        except Exception:
-            if not self._self_finished:
-                core.dispatch("botocore.patched_bedrock_api_call.exception", (self._self_execution_ctx, sys.exc_info()))
-            raise
-
-    async def __anext__(self) -> bytes:
-        try:
-            body = await self.__wrapped__.__anext__()
-            self._self_chunks.append(body)
-            return body
-        except StopAsyncIteration:
-            self._finish()
-            raise
-        except Exception:
-            if not self._self_finished:
-                core.dispatch("botocore.patched_bedrock_api_call.exception", (self._self_execution_ctx, sys.exc_info()))
-            raise
-
-    anext = __anext__
-
-    async def iter_chunks(self, chunk_size: int = 1024) -> AsyncIterator[bytes]:
-        while True:
-            chunk = await self.read(chunk_size)
-            if chunk == b"":
-                break
-            yield chunk
-
-    async def iter_lines(self, chunk_size: int = 1024, keepends: bool = False) -> AsyncIterator[bytes]:
-        pending = b""
-        async for chunk in self.iter_chunks(chunk_size):
-            lines = (pending + chunk).splitlines(True)
-            for line in lines[:-1]:
-                yield line.splitlines(keepends)[0]
-            pending = lines[-1]
-        if pending:
-            yield pending.splitlines(keepends)[0]
-
-    async def __aenter__(self) -> "AiobotocoreStreamingBody":
-        await self.__wrapped__.__aenter__()
-        return self
-
-    async def __aexit__(self, *args: Any, **kwargs: Any) -> Any:
-        return await self.__wrapped__.__aexit__(*args, **kwargs)
-
-
-def make_aiobotocore_streaming_body_traced_stream(
-    streaming_body: Any, execution_ctx: core.ExecutionContext
-) -> AiobotocoreStreamingBody:
-    return AiobotocoreStreamingBody(streaming_body, execution_ctx)
 
 
 def safe_token_count(token_count) -> Optional[int]:
@@ -584,7 +402,10 @@ def handle_bedrock_request(ctx: core.ExecutionContext) -> None:
         ctx.set_item("llmobs.request_params", request_params)
 
 
-def _record_bedrock_response_metadata(ctx: core.ExecutionContext, result: dict[str, Any]) -> None:
+def handle_bedrock_response(
+    ctx: core.ExecutionContext,
+    result: dict[str, Any],
+) -> dict[str, Any]:
     metadata = result["ResponseMetadata"]
     http_headers = metadata["HTTPHeaders"]
 
@@ -625,13 +446,6 @@ def _record_bedrock_response_metadata(ctx: core.ExecutionContext, result: dict[s
         safe_token_count(cache_write_tokens),
     )
 
-
-def handle_bedrock_response(
-    ctx: core.ExecutionContext,
-    result: dict[str, Any],
-) -> dict[str, Any]:
-    _record_bedrock_response_metadata(ctx, result)
-
     if ctx["resource"] == "Converse":
         core.dispatch("botocore.bedrock.process_response_converse", (ctx, result))
         return result
@@ -642,31 +456,6 @@ def handle_bedrock_response(
 
     body = result["body"]
     result["body"] = make_botocore_streaming_body_traced_stream(body, ctx)
-    return result
-
-
-def handle_aiobotocore_bedrock_response(
-    ctx: core.ExecutionContext,
-    result: dict[str, Any],
-) -> dict[str, Any]:
-    """Apply Bedrock response semantics without changing aiobotocore's async contract."""
-    _record_bedrock_response_metadata(ctx, result)
-
-    if ctx["resource"] == "Converse":
-        core.dispatch("botocore.bedrock.process_response_converse", (ctx, result))
-        return result
-
-    if ctx["resource"] == "ConverseStream":
-        if "stream" in result:
-            result["stream"] = make_aiobotocore_converse_traced_stream(result["stream"], ctx)
-        return result
-
-    if ctx["resource"] == "InvokeModelWithResponseStream":
-        result["body"] = make_aiobotocore_streaming_body_traced_event_stream(result["body"], ctx)
-        return result
-
-    body = result["body"]
-    result["body"] = make_aiobotocore_streaming_body_traced_stream(body, ctx)
     return result
 
 
@@ -833,49 +622,6 @@ def patched_bedrock_api_call(original_func, instance, args, kwargs, function_var
             result = original_func(*args, **kwargs)
             result = handle_bedrock_response(ctx, result)
             return result
-        except Exception:
-            core.dispatch("botocore.patched_bedrock_api_call.exception", (ctx, sys.exc_info()))
-            raise
-
-
-async def patched_aiobotocore_bedrock_api_call(
-    original_func: Callable[..., Awaitable[Any]],
-    instance: Any,
-    args: tuple[Any, ...],
-    kwargs: dict[str, Any],
-    function_vars: dict[str, Any],
-) -> Any:
-    """Async counterpart to patched_bedrock_api_call for aiobotocore clients."""
-    params = function_vars.get("params")
-    pin = function_vars.get("pin")
-    integration = function_vars.get("integration")
-    model_id = params.get("modelId")
-    model_provider, model_name = parse_model_id(model_id)
-    # Cache hits are safe to share with the synchronous integration. A cache miss
-    # intentionally avoids botocore's blocking control-plane lookup on the event loop.
-    model_id, model_provider, model_name = _resolve_application_inference_profile(
-        model_id, model_provider, model_name, llmobs_enabled=integration.llmobs_enabled
-    )
-    submit_to_llmobs = integration.llmobs_enabled and "embed" not in model_name
-    with core.context_with_data(
-        "botocore.patched_bedrock_api_call",
-        pin=pin,
-        span_name=function_vars.get("trace_operation"),
-        service=function_vars.get("service"),
-        resource=function_vars.get("operation"),
-        span_type=SpanTypes.LLM if submit_to_llmobs else None,
-        call_trace=True,
-        bedrock_integration=integration,
-        params=params,
-        model_provider=model_provider,
-        model_name=model_name,
-        model_id=model_id,
-        instance=instance,
-    ) as ctx:
-        try:
-            handle_bedrock_request(ctx)
-            result = await original_func(*args, **kwargs)
-            return handle_aiobotocore_bedrock_response(ctx, result)
         except Exception:
             core.dispatch("botocore.patched_bedrock_api_call.exception", (ctx, sys.exc_info()))
             raise

--- a/ddtrace/contrib/internal/botocore/services/bedrock.py
+++ b/ddtrace/contrib/internal/botocore/services/bedrock.py
@@ -2,7 +2,12 @@ from contextvars import ContextVar
 import json
 import sys
 from typing import Any
+from typing import AsyncIterator
+from typing import Awaitable
+from typing import Callable
 from typing import Optional
+
+import wrapt
 
 from ddtrace import config
 from ddtrace.contrib.internal.trace_utils import ext_service
@@ -16,6 +21,7 @@ from ddtrace.llmobs._integrations._bedrock_inference_profiles import begin_resol
 from ddtrace.llmobs._integrations._bedrock_inference_profiles import lookup_inference_profile
 from ddtrace.llmobs._integrations._bedrock_inference_profiles import record_inference_profile
 from ddtrace.llmobs._integrations._bedrock_inference_profiles import record_resolve_failure
+from ddtrace.llmobs._integrations.base_stream_handler import AsyncStreamHandler
 from ddtrace.llmobs._integrations.base_stream_handler import StreamHandler
 from ddtrace.llmobs._integrations.base_stream_handler import make_traced_stream
 from ddtrace.llmobs._integrations.bedrock_utils import _AI21
@@ -108,6 +114,42 @@ class BotocoreConverseStreamHandler(StreamHandler):
         core.dispatch("botocore.bedrock.process_response_converse", (execution_ctx, stream_processor))
 
 
+class AiobotocoreStreamingBodyStreamHandler(AsyncStreamHandler):
+    async def process_chunk(self, chunk: dict[str, Any], iterator: Optional[Any] = None) -> None:
+        self.chunks.append(json.loads(chunk["chunk"]["bytes"]))
+
+    def handle_exception(self, exception: BaseException) -> None:
+        core.dispatch(
+            "botocore.patched_bedrock_api_call.exception", (self.options.get("execution_ctx", {}), sys.exc_info())
+        )
+
+    def finalize_stream(self, exception: Optional[BaseException] = None) -> None:
+        if exception:
+            return
+        execution_ctx = self.options.get("execution_ctx", {})
+        _extract_streamed_response_metadata(execution_ctx, self.chunks)
+        formatted_response = _extract_streamed_response(execution_ctx, self.chunks)
+        core.dispatch("botocore.bedrock.process_response", (execution_ctx, formatted_response))
+
+
+class AiobotocoreConverseStreamHandler(AsyncStreamHandler):
+    async def process_chunk(self, chunk: dict[str, Any], iterator: Optional[Any] = None) -> None:
+        stream_processor = self.options.get("stream_processor")
+        if stream_processor:
+            stream_processor.send(chunk)
+
+    def handle_exception(self, exception: BaseException) -> None:
+        execution_ctx = self.options.get("execution_ctx", {})
+        core.dispatch("botocore.patched_bedrock_api_call.exception", (execution_ctx, sys.exc_info()))
+
+    def finalize_stream(self, exception: Optional[BaseException] = None) -> None:
+        if exception:
+            return
+        stream_processor = self.options.get("stream_processor")
+        execution_ctx = self.options.get("execution_ctx", {})
+        core.dispatch("botocore.bedrock.process_response_converse", (execution_ctx, stream_processor))
+
+
 def make_botocore_streaming_body_traced_stream(streaming_body, execution_ctx):
     original_read = getattr(streaming_body, "read", None)
     original_readlines = getattr(streaming_body, "readlines", None)
@@ -132,6 +174,144 @@ def make_botocore_converse_traced_stream(stream, execution_ctx):
             None, None, None, None, execution_ctx=execution_ctx, stream_processor=stream_processor
         ),
     )
+
+
+def make_aiobotocore_streaming_body_traced_event_stream(stream: Any, execution_ctx: core.ExecutionContext) -> Any:
+    return make_traced_stream(
+        stream,
+        AiobotocoreStreamingBodyStreamHandler(None, None, None, None, execution_ctx=execution_ctx),
+    )
+
+
+def make_aiobotocore_converse_traced_stream(stream: Any, execution_ctx: core.ExecutionContext) -> Any:
+    stream_processor = execution_ctx["bedrock_integration"]._converse_output_stream_processor()
+    next(stream_processor)
+    return make_traced_stream(
+        stream,
+        AiobotocoreConverseStreamHandler(
+            None, None, None, None, execution_ctx=execution_ctx, stream_processor=stream_processor
+        ),
+    )
+
+
+class AiobotocoreStreamingBody(wrapt.ObjectProxy):
+    """Collect an async Bedrock response body and finish its LLM span at EOF."""
+
+    def __init__(self, body: Any, execution_ctx: core.ExecutionContext) -> None:
+        super().__init__(body)
+        self._self_execution_ctx = execution_ctx
+        self._self_chunks = []
+        self._self_finished = False
+
+    def _finish(self) -> None:
+        if self._self_finished:
+            return
+        self._self_finished = True
+        try:
+            response = json.loads(b"".join(self._self_chunks))
+            formatted_response = _extract_text_and_response_reason(self._self_execution_ctx, response)
+            core.dispatch("botocore.bedrock.process_response", (self._self_execution_ctx, formatted_response))
+        except Exception:
+            core.dispatch("botocore.patched_bedrock_api_call.exception", (self._self_execution_ctx, sys.exc_info()))
+            raise
+
+    def _fully_consumed(self) -> bool:
+        tell = getattr(self.__wrapped__, "tell", None)
+        content_length = getattr(self.__wrapped__, "_content_length", None)
+        if not callable(tell) or content_length is None:
+            return False
+        return tell() == int(content_length)
+
+    async def read(self, amt: Optional[int] = None) -> bytes:
+        try:
+            body = await self.__wrapped__.read() if amt is None else await self.__wrapped__.read(amt)
+            self._self_chunks.append(body)
+            # aiobotocore's read() without an amount consumes the remainder.
+            # Sized reads signal EOF with an empty chunk.
+            if amt is None or amt < 0 or (amt > 0 and not body) or self._fully_consumed():
+                self._finish()
+            return body
+        except Exception:
+            if not self._self_finished:
+                core.dispatch("botocore.patched_bedrock_api_call.exception", (self._self_execution_ctx, sys.exc_info()))
+            raise
+
+    async def readinto(self, buffer: bytearray) -> int:
+        try:
+            amount_read = await self.__wrapped__.readinto(buffer)
+            self._self_chunks.append(bytes(buffer[:amount_read]))
+            if (len(buffer) > 0 and amount_read == 0) or self._fully_consumed():
+                self._finish()
+            return amount_read
+        except Exception:
+            if not self._self_finished:
+                core.dispatch("botocore.patched_bedrock_api_call.exception", (self._self_execution_ctx, sys.exc_info()))
+            raise
+
+    async def readlines(self) -> list[bytes]:
+        try:
+            lines = await self.__wrapped__.readlines()
+            self._self_chunks.extend(lines)
+            self._finish()
+            return lines
+        except Exception:
+            if not self._self_finished:
+                core.dispatch("botocore.patched_bedrock_api_call.exception", (self._self_execution_ctx, sys.exc_info()))
+            raise
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        try:
+            async for body in self.__wrapped__:
+                self._self_chunks.append(body)
+                yield body
+            self._finish()
+        except Exception:
+            if not self._self_finished:
+                core.dispatch("botocore.patched_bedrock_api_call.exception", (self._self_execution_ctx, sys.exc_info()))
+            raise
+
+    async def __anext__(self) -> bytes:
+        try:
+            body = await self.__wrapped__.__anext__()
+            self._self_chunks.append(body)
+            return body
+        except StopAsyncIteration:
+            self._finish()
+            raise
+        except Exception:
+            if not self._self_finished:
+                core.dispatch("botocore.patched_bedrock_api_call.exception", (self._self_execution_ctx, sys.exc_info()))
+            raise
+
+    async def iter_chunks(self, chunk_size: int = 1024) -> AsyncIterator[bytes]:
+        while True:
+            chunk = await self.read(chunk_size)
+            if chunk == b"":
+                break
+            yield chunk
+
+    async def iter_lines(self, chunk_size: int = 1024, keepends: bool = False) -> AsyncIterator[bytes]:
+        pending = b""
+        async for chunk in self.iter_chunks(chunk_size):
+            lines = (pending + chunk).splitlines(True)
+            for line in lines[:-1]:
+                yield line.splitlines(keepends)[0]
+            pending = lines[-1]
+        if pending:
+            yield pending.splitlines(keepends)[0]
+
+    async def __aenter__(self) -> "AiobotocoreStreamingBody":
+        await self.__wrapped__.__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> Any:
+        return await self.__wrapped__.__aexit__(*args, **kwargs)
+
+
+def make_aiobotocore_streaming_body_traced_stream(
+    streaming_body: Any, execution_ctx: core.ExecutionContext
+) -> AiobotocoreStreamingBody:
+    return AiobotocoreStreamingBody(streaming_body, execution_ctx)
 
 
 def safe_token_count(token_count) -> Optional[int]:
@@ -402,10 +582,7 @@ def handle_bedrock_request(ctx: core.ExecutionContext) -> None:
         ctx.set_item("llmobs.request_params", request_params)
 
 
-def handle_bedrock_response(
-    ctx: core.ExecutionContext,
-    result: dict[str, Any],
-) -> dict[str, Any]:
+def _record_bedrock_response_metadata(ctx: core.ExecutionContext, result: dict[str, Any]) -> None:
     metadata = result["ResponseMetadata"]
     http_headers = metadata["HTTPHeaders"]
 
@@ -446,6 +623,13 @@ def handle_bedrock_response(
         safe_token_count(cache_write_tokens),
     )
 
+
+def handle_bedrock_response(
+    ctx: core.ExecutionContext,
+    result: dict[str, Any],
+) -> dict[str, Any]:
+    _record_bedrock_response_metadata(ctx, result)
+
     if ctx["resource"] == "Converse":
         core.dispatch("botocore.bedrock.process_response_converse", (ctx, result))
         return result
@@ -456,6 +640,31 @@ def handle_bedrock_response(
 
     body = result["body"]
     result["body"] = make_botocore_streaming_body_traced_stream(body, ctx)
+    return result
+
+
+def handle_aiobotocore_bedrock_response(
+    ctx: core.ExecutionContext,
+    result: dict[str, Any],
+) -> dict[str, Any]:
+    """Apply Bedrock response semantics without changing aiobotocore's async contract."""
+    _record_bedrock_response_metadata(ctx, result)
+
+    if ctx["resource"] == "Converse":
+        core.dispatch("botocore.bedrock.process_response_converse", (ctx, result))
+        return result
+
+    if ctx["resource"] == "ConverseStream":
+        if "stream" in result:
+            result["stream"] = make_aiobotocore_converse_traced_stream(result["stream"], ctx)
+        return result
+
+    if ctx["resource"] == "InvokeModelWithResponseStream":
+        result["body"] = make_aiobotocore_streaming_body_traced_event_stream(result["body"], ctx)
+        return result
+
+    body = result["body"]
+    result["body"] = make_aiobotocore_streaming_body_traced_stream(body, ctx)
     return result
 
 
@@ -622,6 +831,49 @@ def patched_bedrock_api_call(original_func, instance, args, kwargs, function_var
             result = original_func(*args, **kwargs)
             result = handle_bedrock_response(ctx, result)
             return result
+        except Exception:
+            core.dispatch("botocore.patched_bedrock_api_call.exception", (ctx, sys.exc_info()))
+            raise
+
+
+async def patched_aiobotocore_bedrock_api_call(
+    original_func: Callable[..., Awaitable[Any]],
+    instance: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    function_vars: dict[str, Any],
+) -> Any:
+    """Async counterpart to patched_bedrock_api_call for aiobotocore clients."""
+    params = function_vars.get("params")
+    pin = function_vars.get("pin")
+    integration = function_vars.get("integration")
+    model_id = params.get("modelId")
+    model_provider, model_name = parse_model_id(model_id)
+    # Cache hits are safe to share with the synchronous integration. A cache miss
+    # intentionally avoids botocore's blocking control-plane lookup on the event loop.
+    model_id, model_provider, model_name = _resolve_application_inference_profile(
+        model_id, model_provider, model_name, llmobs_enabled=integration.llmobs_enabled
+    )
+    submit_to_llmobs = integration.llmobs_enabled and "embed" not in model_name
+    with core.context_with_data(
+        "botocore.patched_bedrock_api_call",
+        pin=pin,
+        span_name=function_vars.get("trace_operation"),
+        service=function_vars.get("service"),
+        resource=function_vars.get("operation"),
+        span_type=SpanTypes.LLM if submit_to_llmobs else None,
+        call_trace=True,
+        bedrock_integration=integration,
+        params=params,
+        model_provider=model_provider,
+        model_name=model_name,
+        model_id=model_id,
+        instance=instance,
+    ) as ctx:
+        try:
+            handle_bedrock_request(ctx)
+            result = await original_func(*args, **kwargs)
+            return handle_aiobotocore_bedrock_response(ctx, result)
         except Exception:
             core.dispatch("botocore.patched_bedrock_api_call.exception", (ctx, sys.exc_info()))
             raise

--- a/ddtrace/contrib/internal/botocore/services/bedrock.py
+++ b/ddtrace/contrib/internal/botocore/services/bedrock.py
@@ -283,6 +283,8 @@ class AiobotocoreStreamingBody(wrapt.ObjectProxy):
                 core.dispatch("botocore.patched_bedrock_api_call.exception", (self._self_execution_ctx, sys.exc_info()))
             raise
 
+    anext = __anext__
+
     async def iter_chunks(self, chunk_size: int = 1024) -> AsyncIterator[bytes]:
         while True:
             chunk = await self.read(chunk_size)

--- a/ddtrace/llmobs/_constants.py
+++ b/ddtrace/llmobs/_constants.py
@@ -238,6 +238,7 @@ class LLMOBS_STRUCT:
 SUPPORTED_LLMOBS_INTEGRATIONS: dict[str, str] = {
     "anthropic": "anthropic",
     "bedrock": "botocore",
+    "aiobotocore": "aiobotocore",
     "openai": "openai",
     "langchain": "langchain",
     "google_adk": "google_adk",

--- a/releasenotes/notes/aiobotocore-bedrock-llmobs-0589c1241d2b2149.yaml
+++ b/releasenotes/notes/aiobotocore-bedrock-llmobs-0589c1241d2b2149.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    aiobotocore: Adds LLM Observability tracing for Amazon Bedrock Runtime model calls,
+    including streaming and Converse operations.

--- a/tests/contrib/aiobotocore/test_bedrock_lifecycle.py
+++ b/tests/contrib/aiobotocore/test_bedrock_lifecycle.py
@@ -1,0 +1,323 @@
+import asyncio
+import contextlib
+import io
+import json
+
+import mock
+import pytest
+
+from ddtrace.constants import _SPAN_MEASURED_KEY
+from ddtrace.constants import SPAN_KIND
+from ddtrace.contrib.internal.aiobotocore import bedrock as aiobotocore_bedrock
+from ddtrace.ext import SpanKind
+from ddtrace.ext import http
+from ddtrace.internal import core
+from ddtrace.internal.constants import COMPONENT
+from ddtrace.llmobs._llmobs import LLMObs
+
+
+MODEL_ID = "meta.llama2-13b-chat-v1"
+RESPONSE_BODY = json.dumps({"generation": "partial response", "stop_reason": "max_tokens"}).encode()
+STREAM_EVENT = {"chunk": {"bytes": RESPONSE_BODY}}
+
+
+class _CounterStreamingBody:
+    def __init__(self, body=RESPONSE_BODY):
+        self._body = body
+        self._amount_read = 0
+        self._content_length = len(body)
+        self.closed = False
+
+    async def read(self, amt=None):
+        end = len(self._body) if amt is None else self._amount_read + amt
+        chunk = self._body[self._amount_read : end]
+        self._amount_read += len(chunk)
+        return chunk
+
+    async def readinto(self, buffer):
+        chunk = await self.read(len(buffer))
+        buffer[: len(chunk)] = chunk
+        return len(chunk)
+
+    async def readlines(self):
+        return [await self.read()]
+
+    def close(self):
+        self.closed = True
+
+    async def aclose(self):
+        self.close()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await self.aclose()
+        return False
+
+
+class _SelfCounterStreamingBody(_CounterStreamingBody):
+    def __init__(self, body=RESPONSE_BODY):
+        super().__init__(body)
+        self._self_amount_read = 0
+        self._self_content_length = len(body)
+        del self._amount_read
+        del self._content_length
+
+    async def read(self, amt=None):
+        end = len(self._body) if amt is None else self._self_amount_read + amt
+        chunk = self._body[self._self_amount_read : end]
+        self._self_amount_read += len(chunk)
+        return chunk
+
+
+class _CancelledStreamingBody(_CounterStreamingBody):
+    async def read(self, amt=None):
+        raise asyncio.CancelledError()
+
+
+class _CancelledEventStream:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise asyncio.CancelledError()
+
+
+class _ClosableEventStream:
+    def __init__(self):
+        self.closed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration()
+
+    def close(self):
+        self.closed = True
+
+
+class _SingleEventStream(_ClosableEventStream):
+    def __init__(self):
+        super().__init__()
+        self._event = STREAM_EVENT
+
+    async def __anext__(self):
+        if self._event is None:
+            raise StopAsyncIteration()
+        event = self._event
+        self._event = None
+        return event
+
+
+def _execution_ctx():
+    return core.ExecutionContext(
+        "test.aiobotocore.bedrock",
+        model_name=MODEL_ID,
+        model_provider="meta",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("body_cls", [_CounterStreamingBody, _SelfCounterStreamingBody])
+async def test_sized_read_finishes_when_content_length_is_consumed(body_cls):
+    body = body_cls()
+    wrapped = aiobotocore_bedrock.AiobotocoreStreamingBody(body, _execution_ctx())
+
+    with mock.patch.object(aiobotocore_bedrock.core, "dispatch") as dispatch:
+        assert await wrapped.read(len(RESPONSE_BODY)) == RESPONSE_BODY
+
+    assert dispatch.call_count == 1
+    assert dispatch.call_args.args[0] == "botocore.bedrock.process_response"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_body_read_dispatches_exception_and_finishes_once():
+    wrapped = aiobotocore_bedrock.AiobotocoreStreamingBody(_CancelledStreamingBody(), _execution_ctx())
+
+    with mock.patch.object(aiobotocore_bedrock.core, "dispatch") as dispatch:
+        with pytest.raises(asyncio.CancelledError):
+            await wrapped.read()
+        wrapped._finish(allow_partial=True)
+
+    assert dispatch.call_count == 1
+    assert dispatch.call_args.args[0] == "botocore.patched_bedrock_api_call.exception"
+    assert dispatch.call_args.args[1][1][0] is asyncio.CancelledError
+
+
+@pytest.mark.asyncio
+async def test_cancelled_event_stream_dispatches_exception_instead_of_success():
+    stream = aiobotocore_bedrock.make_aiobotocore_streaming_body_traced_event_stream(
+        _CancelledEventStream(), _execution_ctx()
+    )
+
+    with mock.patch.object(aiobotocore_bedrock.core, "dispatch") as dispatch:
+        with pytest.raises(asyncio.CancelledError):
+            await stream.__anext__()
+
+    assert dispatch.call_count == 1
+    assert dispatch.call_args.args[0] == "botocore.patched_bedrock_api_call.exception"
+    assert dispatch.call_args.args[1][1][0] is asyncio.CancelledError
+
+
+@pytest.mark.asyncio
+async def test_event_stream_yields_processed_chunk():
+    body = _SingleEventStream()
+    stream = aiobotocore_bedrock.make_aiobotocore_streaming_body_traced_event_stream(body, _execution_ctx())
+
+    with mock.patch.object(aiobotocore_bedrock.core, "dispatch") as dispatch:
+        assert await stream.__anext__() == STREAM_EVENT
+        stream.close()
+
+    assert dispatch.call_count == 1
+    assert dispatch.call_args.args[0] == "botocore.bedrock.process_response"
+
+
+def test_early_event_stream_close_finalizes_once():
+    body = _ClosableEventStream()
+    stream = aiobotocore_bedrock.make_aiobotocore_streaming_body_traced_event_stream(body, _execution_ctx())
+
+    with mock.patch.object(aiobotocore_bedrock.core, "dispatch") as dispatch:
+        stream.close()
+        stream.close()
+
+    assert body.closed
+    assert dispatch.call_count == 1
+    assert dispatch.call_args.args[0] == "botocore.bedrock.process_response"
+
+
+@pytest.mark.asyncio
+async def test_early_aclose_finishes_partial_body_without_waiting_for_eof():
+    body = _CounterStreamingBody()
+    wrapped = aiobotocore_bedrock.AiobotocoreStreamingBody(body, _execution_ctx())
+
+    with mock.patch.object(aiobotocore_bedrock.core, "dispatch") as dispatch:
+        assert await wrapped.read(4) == RESPONSE_BODY[:4]
+        await wrapped.aclose()
+
+    assert body.closed
+    assert dispatch.call_count == 1
+    assert dispatch.call_args.args[0] == "botocore.bedrock.process_response"
+
+
+@pytest.mark.asyncio
+async def test_early_context_exit_finishes_partial_body():
+    body = _CounterStreamingBody()
+    wrapped = aiobotocore_bedrock.AiobotocoreStreamingBody(body, _execution_ctx())
+
+    with mock.patch.object(aiobotocore_bedrock.core, "dispatch") as dispatch:
+        async with wrapped:
+            pass
+
+    assert body.closed
+    assert dispatch.call_count == 1
+    assert dispatch.call_args.args[0] == "botocore.bedrock.process_response"
+
+
+def test_file_like_invoke_body_is_not_consumed_during_request_tagging():
+    body = io.BytesIO(b'{"prompt":"hello"}')
+    integration = mock.MagicMock(llmobs_enabled=True)
+    ctx = core.ExecutionContext(
+        "test.aiobotocore.bedrock.request",
+        resource="InvokeModel",
+        params={"modelId": MODEL_ID, "body": body},
+        model_provider="meta",
+        bedrock_integration=integration,
+    )
+
+    with mock.patch.object(aiobotocore_bedrock.core, "dispatch") as dispatch:
+        aiobotocore_bedrock._handle_aiobotocore_bedrock_request(ctx)
+
+    assert body.tell() == 0
+    assert body.read() == b'{"prompt":"hello"}'
+    dispatch.assert_called_once_with("botocore.patched_bedrock_api_call.started", (ctx, {}))
+    assert ctx["llmobs.request_params"] == {}
+
+
+@pytest.mark.asyncio
+async def test_initial_request_cancellation_dispatches_bedrock_exception():
+    integration = mock.MagicMock(llmobs_enabled=True)
+    ctx = mock.MagicMock()
+    original = mock.AsyncMock(side_effect=asyncio.CancelledError())
+    function_vars = {
+        "pin": mock.MagicMock(),
+        "trace_operation": "bedrock-runtime.command",
+        "service": "aws.bedrock-runtime",
+        "operation": "InvokeModel",
+        "endpoint_name": "bedrock-runtime",
+        "params": {"modelId": MODEL_ID, "body": "{}"},
+        "integration": integration,
+    }
+
+    with (
+        mock.patch.object(aiobotocore_bedrock.core, "context_with_data", return_value=contextlib.nullcontext(ctx)),
+        mock.patch.object(aiobotocore_bedrock, "_set_apm_request_tags"),
+        mock.patch.object(aiobotocore_bedrock, "_handle_aiobotocore_bedrock_request"),
+        mock.patch.object(aiobotocore_bedrock.core, "dispatch") as dispatch,
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await aiobotocore_bedrock.patched_aiobotocore_bedrock_api_call(
+                original,
+                mock.MagicMock(),
+                (),
+                {},
+                function_vars,
+            )
+
+    assert dispatch.call_count == 1
+    assert dispatch.call_args.args[0] == "botocore.patched_bedrock_api_call.exception"
+    assert dispatch.call_args.args[1][1][0] is asyncio.CancelledError
+
+
+def test_bedrock_specialized_path_preserves_aiobotocore_apm_tags():
+    span = mock.MagicMock()
+    instance = mock.MagicMock()
+    instance.meta.region_name = "us-east-1"
+    integration_config = mock.MagicMock()
+    integration_config.integration_name = "aiobotocore"
+    integration_config.__getitem__.return_value = False
+    config = mock.MagicMock()
+    config.aiobotocore = integration_config
+    function_vars = {
+        "instance": instance,
+        "endpoint_name": "bedrock-runtime",
+        "operation": "InvokeModel",
+        "params": {"modelId": MODEL_ID},
+        "service": "aws.bedrock-runtime",
+    }
+    result = {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {"x-amz-id-2": "secondary-request-id"},
+            "RetryAttempts": 1,
+            "RequestId": "request-id",
+        }
+    }
+
+    with (
+        mock.patch.object(aiobotocore_bedrock, "span_from_context", return_value=span),
+        mock.patch.object(aiobotocore_bedrock, "config", config),
+        mock.patch.object(aiobotocore_bedrock, "set_service_and_source") as set_service,
+        mock.patch.object(aiobotocore_bedrock, "in_aws_lambda", return_value=False),
+    ):
+        aiobotocore_bedrock._set_apm_request_tags(mock.MagicMock(), function_vars)
+        aiobotocore_bedrock._set_apm_response_tags(mock.MagicMock(), result)
+
+    set_service.assert_called_once_with(span, "aws.bedrock-runtime", integration_config)
+    span._set_attribute.assert_any_call(COMPONENT, "aiobotocore")
+    span._set_attribute.assert_any_call(SPAN_KIND, SpanKind.CLIENT)
+    span._set_attribute.assert_any_call(_SPAN_MEASURED_KEY, 1)
+    span._set_attribute.assert_any_call(http.STATUS_CODE, 200)
+    span._set_attribute.assert_any_call("aws.requestid", "request-id")
+    span._set_attribute.assert_any_call("aws.requestid2", "secondary-request-id")
+    span.set_tag.assert_called_with("retry_attempts", 1)
+    assert span.resource == "bedrock-runtime.invokemodel"
+
+
+def test_llmobs_auto_patch_includes_aiobotocore():
+    with mock.patch("ddtrace.llmobs._llmobs.patch") as patch:
+        LLMObs._patch_integrations()
+
+    assert patch.call_count == 1
+    assert patch.call_args.kwargs["aiobotocore"] is True

--- a/tests/contrib/aiobotocore/test_bedrock_llmobs.py
+++ b/tests/contrib/aiobotocore/test_bedrock_llmobs.py
@@ -1,0 +1,488 @@
+import json
+
+import botocore.session
+import mock
+import pytest
+
+from ddtrace.contrib.internal.aiobotocore.patch import patch
+from ddtrace.contrib.internal.aiobotocore.patch import unpatch
+from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
+from tests.contrib.aiobotocore.utils import aiobotocore_client
+from tests.llmobs._processors import install_mock_llmobs_writer
+from tests.llmobs._utils import assert_llmobs_span_data
+from tests.utils import override_global_config
+
+
+MODEL_ID = "meta.llama2-13b-chat-v1"
+REQUEST_BODY = {
+    "prompt": "What does 'lorem ipsum' mean?",
+    "temperature": 0.9,
+    "top_p": 1.0,
+    "max_gen_len": 60,
+}
+RESPONSE_BODY = json.dumps(
+    {
+        "generation": "Lorem ipsum is placeholder text used in publishing and design.",
+        "stop_reason": "max_tokens",
+    }
+).encode()
+CONVERSE_REQUEST = {
+    "modelId": "anthropic.claude-3-sonnet-20240229-v1:0",
+    "messages": [{"role": "user", "content": [{"text": "Explain distributed tracing."}]}],
+    "inferenceConfig": {"temperature": 0.7, "maxTokens": 100},
+}
+
+_botocore_session = botocore.session.get_session()
+_available_services = _botocore_session.get_available_services()
+HAS_BEDROCK_RUNTIME = "bedrock-runtime" in _available_services
+if HAS_BEDROCK_RUNTIME:
+    _bedrock_operations = set(_botocore_session.get_service_model("bedrock-runtime").operation_names)
+else:
+    _bedrock_operations = set()
+HAS_CONVERSE = {"Converse", "ConverseStream"}.issubset(_bedrock_operations)
+
+pytestmark = pytest.mark.skipif(not HAS_BEDROCK_RUNTIME, reason="Bedrock Runtime is unavailable in this botocore")
+
+
+class AsyncStreamingBody:
+    def __init__(self, body):
+        self._body = body
+        self._content_length = len(body)
+        self._position = 0
+
+    async def read(self, amt=None):
+        end = len(self._body) if amt is None else self._position + amt
+        chunk = self._body[self._position : end]
+        self._position += len(chunk)
+        return chunk
+
+    def tell(self):
+        return self._position
+
+    async def readinto(self, buffer):
+        chunk = await self.read(len(buffer))
+        buffer[: len(chunk)] = chunk
+        return len(chunk)
+
+    async def readlines(self):
+        return [line async for line in self.iter_lines()]
+
+    async def iter_chunks(self, chunk_size=1024):
+        while True:
+            chunk = await self.read(chunk_size)
+            if not chunk:
+                break
+            yield chunk
+
+    async def iter_lines(self, chunk_size=1024, keepends=False):
+        pending = b""
+        async for chunk in self.iter_chunks(chunk_size):
+            lines = (pending + chunk).splitlines(True)
+            for line in lines[:-1]:
+                yield line.splitlines(keepends)[0]
+            pending = lines[-1]
+        if pending:
+            yield pending.splitlines(keepends)[0]
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        chunk = await self.read(16)
+        if chunk:
+            return chunk
+        raise StopAsyncIteration
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return False
+
+
+class AsyncEventStream:
+    def __init__(self, chunks):
+        self._chunks = iter(chunks)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._chunks)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+@pytest.fixture(autouse=True)
+def patch_aiobotocore():
+    patch()
+    yield
+    unpatch()
+
+
+@pytest.fixture
+def bedrock_llmobs(tracer):
+    LLMObs.disable()
+    with override_global_config(
+        {
+            "_llmobs_ml_app": "<ml-app-name>",
+            "_dd_api_key": "<not-a-real-key>",
+        }
+    ):
+        LLMObs.enable(_tracer=tracer, integrations_enabled=False, agentless_enabled=False)
+        install_mock_llmobs_writer(tracer)
+        yield LLMObs
+    LLMObs.disable()
+
+
+@pytest.mark.asyncio
+async def test_llmobs_invoke_model_finishes_after_async_body_read(bedrock_llmobs, tracer, test_spans):
+    response_body = AsyncStreamingBody(RESPONSE_BODY)
+    parsed_response = {
+        "ResponseMetadata": {
+            "RequestId": "fddf10b3-c895-4e5d-9b21-3ca963708b03",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-bedrock-invocation-latency": "2823",
+                "x-amzn-bedrock-output-token-count": "91",
+                "x-amzn-bedrock-input-token-count": "10",
+            },
+            "RetryAttempts": 0,
+        },
+        "contentType": "application/json",
+        "body": response_body,
+    }
+    http_response = mock.MagicMock(status_code=200)
+
+    async with aiobotocore_client("bedrock-runtime", tracer) as client:
+        with mock.patch.object(client, "_make_request", new_callable=mock.AsyncMock) as make_request:
+            make_request.return_value = http_response, parsed_response
+            response = await client.invoke_model(body=json.dumps(REQUEST_BODY), modelId=MODEL_ID)
+
+        assert test_spans.pop_traces() == []
+        assert await response["body"].read() == RESPONSE_BODY
+
+    spans = [span for trace in test_spans.pop_traces() for span in trace]
+    assert len(spans) == 1
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        span_kind="llm",
+        model_name=MODEL_ID,
+        model_provider="amazon_bedrock",
+        input_messages=[{"content": REQUEST_BODY["prompt"]}],
+        output_messages=[{"content": "Lorem ipsum is placeholder text used in publishing and design."}],
+        metadata={"temperature": 0.9, "max_tokens": 60},
+        metrics={"input_tokens": 10, "output_tokens": 91, "total_tokens": 101},
+        tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_llmobs_invoke_model_read_zero_does_not_finish_body(bedrock_llmobs, tracer, test_spans):
+    parsed_response = {
+        "ResponseMetadata": {
+            "RequestId": "fddf10b3-c895-4e5d-9b21-3ca963708b03",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-bedrock-output-token-count": "91",
+                "x-amzn-bedrock-input-token-count": "10",
+            },
+            "RetryAttempts": 0,
+        },
+        "contentType": "application/json",
+        "body": AsyncStreamingBody(RESPONSE_BODY),
+    }
+    http_response = mock.MagicMock(status_code=200)
+
+    async with aiobotocore_client("bedrock-runtime", tracer) as client:
+        with mock.patch.object(client, "_make_request", new_callable=mock.AsyncMock) as make_request:
+            make_request.return_value = http_response, parsed_response
+            response = await client.invoke_model(body=json.dumps(REQUEST_BODY), modelId=MODEL_ID)
+
+        assert await response["body"].read(0) == b""
+        assert test_spans.pop_traces() == []
+        assert await response["body"].read() == RESPONSE_BODY
+
+    spans = [span for trace in test_spans.pop_traces() for span in trace]
+    assert len(spans) == 1
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        span_kind="llm",
+        model_name=MODEL_ID,
+        model_provider="amazon_bedrock",
+        output_messages=[{"content": "Lorem ipsum is placeholder text used in publishing and design."}],
+        metrics={"input_tokens": 10, "output_tokens": 91, "total_tokens": 101},
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("consumer", ["readinto", "readlines", "iter_chunks", "iter_lines", "anext", "context"])
+async def test_llmobs_invoke_model_preserves_async_body_consumers(consumer, bedrock_llmobs, tracer, test_spans):
+    parsed_response = {
+        "ResponseMetadata": {
+            "RequestId": "fddf10b3-c895-4e5d-9b21-3ca963708b03",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-bedrock-output-token-count": "91",
+                "x-amzn-bedrock-input-token-count": "10",
+            },
+            "RetryAttempts": 0,
+        },
+        "contentType": "application/json",
+        "body": AsyncStreamingBody(RESPONSE_BODY),
+    }
+    http_response = mock.MagicMock(status_code=200)
+
+    async with aiobotocore_client("bedrock-runtime", tracer) as client:
+        with mock.patch.object(client, "_make_request", new_callable=mock.AsyncMock) as make_request:
+            make_request.return_value = http_response, parsed_response
+            response = await client.invoke_model(body=json.dumps(REQUEST_BODY), modelId=MODEL_ID)
+
+        body = response["body"]
+        if consumer == "readinto":
+            chunks = []
+            while True:
+                buffer = bytearray(17)
+                amount_read = await body.readinto(buffer)
+                if amount_read == 0:
+                    break
+                chunks.append(bytes(buffer[:amount_read]))
+            consumed = b"".join(chunks)
+        elif consumer == "readlines":
+            consumed = b"".join(await body.readlines())
+        elif consumer == "iter_chunks":
+            consumed = b"".join([chunk async for chunk in body.iter_chunks(17)])
+        elif consumer == "iter_lines":
+            consumed = b"\n".join([line async for line in body.iter_lines(17)])
+        elif consumer == "anext":
+            chunks = []
+            while True:
+                try:
+                    chunks.append(await body.__anext__())
+                except StopAsyncIteration:
+                    break
+            consumed = b"".join(chunks)
+        else:
+            async with body as entered_body:
+                assert entered_body is body
+                consumed = await entered_body.read()
+
+    assert consumed == RESPONSE_BODY
+    spans = [span for trace in test_spans.pop_traces() for span in trace]
+    assert len(spans) == 1
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        span_kind="llm",
+        model_name=MODEL_ID,
+        model_provider="amazon_bedrock",
+        output_messages=[{"content": "Lorem ipsum is placeholder text used in publishing and design."}],
+        metrics={"input_tokens": 10, "output_tokens": 91, "total_tokens": 101},
+    )
+
+
+@pytest.mark.asyncio
+async def test_llmobs_invoke_model_supports_async_body_iteration(bedrock_llmobs, tracer, test_spans):
+    parsed_response = {
+        "ResponseMetadata": {
+            "RequestId": "fddf10b3-c895-4e5d-9b21-3ca963708b03",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-bedrock-output-token-count": "91",
+                "x-amzn-bedrock-input-token-count": "10",
+            },
+            "RetryAttempts": 0,
+        },
+        "contentType": "application/json",
+        "body": AsyncStreamingBody(RESPONSE_BODY),
+    }
+    http_response = mock.MagicMock(status_code=200)
+
+    async with aiobotocore_client("bedrock-runtime", tracer) as client:
+        with mock.patch.object(client, "_make_request", new_callable=mock.AsyncMock) as make_request:
+            make_request.return_value = http_response, parsed_response
+            response = await client.invoke_model(body=json.dumps(REQUEST_BODY), modelId=MODEL_ID)
+
+        assert b"".join([chunk async for chunk in response["body"]]) == RESPONSE_BODY
+
+    spans = [span for trace in test_spans.pop_traces() for span in trace]
+    assert len(spans) == 1
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        span_kind="llm",
+        model_name=MODEL_ID,
+        model_provider="amazon_bedrock",
+        output_messages=[{"content": "Lorem ipsum is placeholder text used in publishing and design."}],
+        metrics={"input_tokens": 10, "output_tokens": 91, "total_tokens": 101},
+    )
+
+
+@pytest.mark.asyncio
+async def test_llmobs_invoke_model_stream_finishes_after_async_iteration(bedrock_llmobs, tracer, test_spans):
+    event = {
+        "chunk": {
+            "bytes": json.dumps(
+                {
+                    "generation": "Lorem ipsum is placeholder text used in publishing and design.",
+                    "stop_reason": "max_tokens",
+                    "amazon-bedrock-invocationMetrics": {
+                        "inputTokenCount": 10,
+                        "outputTokenCount": 91,
+                        "invocationLatency": 2823,
+                    },
+                }
+            ).encode()
+        }
+    }
+    parsed_response = {
+        "ResponseMetadata": {
+            "RequestId": "fddf10b3-c895-4e5d-9b21-3ca963708b03",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {},
+            "RetryAttempts": 0,
+        },
+        "contentType": "application/json",
+        "body": AsyncEventStream([event]),
+    }
+    http_response = mock.MagicMock(status_code=200)
+
+    async with aiobotocore_client("bedrock-runtime", tracer) as client:
+        with mock.patch.object(client, "_make_request", new_callable=mock.AsyncMock) as make_request:
+            make_request.return_value = http_response, parsed_response
+            response = await client.invoke_model_with_response_stream(body=json.dumps(REQUEST_BODY), modelId=MODEL_ID)
+
+        assert test_spans.pop_traces() == []
+        assert [chunk async for chunk in response["body"]] == [event]
+
+    spans = [span for trace in test_spans.pop_traces() for span in trace]
+    assert len(spans) == 1
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        span_kind="llm",
+        model_name=MODEL_ID,
+        model_provider="amazon_bedrock",
+        input_messages=[{"content": REQUEST_BODY["prompt"]}],
+        output_messages=[{"content": "Lorem ipsum is placeholder text used in publishing and design."}],
+        metadata={"temperature": 0.9, "max_tokens": 60},
+        metrics={"input_tokens": 10, "output_tokens": 91, "total_tokens": 101},
+        tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"},
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_CONVERSE, reason="Converse APIs are unavailable in this botocore")
+async def test_llmobs_converse_records_async_response(bedrock_llmobs, tracer, test_spans):
+    parsed_response = {
+        "ResponseMetadata": {
+            "RequestId": "fddf10b3-c895-4e5d-9b21-3ca963708b03",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {},
+            "RetryAttempts": 0,
+        },
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "Distributed tracing follows a request across services."}],
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 8, "outputTokens": 9, "totalTokens": 17},
+        "metrics": {"latencyMs": 125},
+    }
+    http_response = mock.MagicMock(status_code=200)
+
+    async with aiobotocore_client("bedrock-runtime", tracer) as client:
+        with mock.patch.object(client, "_make_request", new_callable=mock.AsyncMock) as make_request:
+            make_request.return_value = http_response, parsed_response
+            response = await client.converse(**CONVERSE_REQUEST)
+
+    assert response is parsed_response
+    spans = [span for trace in test_spans.pop_traces() for span in trace]
+    assert len(spans) == 1
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        span_kind="llm",
+        model_name=CONVERSE_REQUEST["modelId"],
+        model_provider="amazon_bedrock",
+        input_messages=[{"role": "user", "content": "Explain distributed tracing."}],
+        output_messages=[{"role": "assistant", "content": "Distributed tracing follows a request across services."}],
+        metadata={"temperature": 0.7, "max_tokens": 100, "stop_reason": "end_turn"},
+        metrics={"input_tokens": 8, "output_tokens": 9, "total_tokens": 17},
+        tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"},
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not HAS_CONVERSE, reason="Converse APIs are unavailable in this botocore")
+async def test_llmobs_converse_stream_finishes_after_async_iteration(bedrock_llmobs, tracer, test_spans):
+    events = [
+        {"messageStart": {"role": "assistant"}},
+        {
+            "contentBlockDelta": {
+                "contentBlockIndex": 0,
+                "delta": {"text": "Distributed tracing follows a request across services."},
+            }
+        },
+        {"messageStop": {"stopReason": "end_turn"}},
+        {"metadata": {"usage": {"inputTokens": 8, "outputTokens": 9, "totalTokens": 17}}},
+    ]
+    parsed_response = {
+        "ResponseMetadata": {
+            "RequestId": "fddf10b3-c895-4e5d-9b21-3ca963708b03",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {},
+            "RetryAttempts": 0,
+        },
+        "stream": AsyncEventStream(events),
+    }
+    http_response = mock.MagicMock(status_code=200)
+
+    async with aiobotocore_client("bedrock-runtime", tracer) as client:
+        with mock.patch.object(client, "_make_request", new_callable=mock.AsyncMock) as make_request:
+            make_request.return_value = http_response, parsed_response
+            response = await client.converse_stream(**CONVERSE_REQUEST)
+
+        assert test_spans.pop_traces() == []
+        assert [event async for event in response["stream"]] == events
+
+    spans = [span for trace in test_spans.pop_traces() for span in trace]
+    assert len(spans) == 1
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(spans[0]),
+        span_kind="llm",
+        model_name=CONVERSE_REQUEST["modelId"],
+        model_provider="amazon_bedrock",
+        input_messages=[{"role": "user", "content": "Explain distributed tracing."}],
+        output_messages=[{"role": "assistant", "content": "Distributed tracing follows a request across services."}],
+        metadata={"temperature": 0.7, "max_tokens": 100},
+        metrics={"input_tokens": 8, "output_tokens": 9, "total_tokens": 17},
+        tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_llmobs_async_request_error_finishes_span(bedrock_llmobs, tracer, test_spans):
+    async with aiobotocore_client("bedrock-runtime", tracer) as client:
+        with mock.patch.object(client, "_make_request", new_callable=mock.AsyncMock) as make_request:
+            make_request.side_effect = RuntimeError("request failed")
+            with pytest.raises(RuntimeError, match="request failed"):
+                await client.invoke_model(body=json.dumps(REQUEST_BODY), modelId=MODEL_ID)
+
+    spans = [span for trace in test_spans.pop_traces() for span in trace]
+    assert len(spans) == 1
+    span = spans[0]
+    assert_llmobs_span_data(
+        _get_llmobs_data_metastruct(span),
+        span_kind="llm",
+        model_name=MODEL_ID,
+        model_provider="amazon_bedrock",
+        input_messages=[{"content": REQUEST_BODY["prompt"]}],
+        output_messages=[{"content": ""}],
+        error={
+            "type": span.get_tag("error.type"),
+            "message": span.get_tag("error.message"),
+            "stack": span.get_tag("error.stack"),
+        },
+        tags={"service": "aws.bedrock-runtime", "ml_app": "<ml-app-name>", "integration": "bedrock"},
+    )

--- a/tests/contrib/aiobotocore/test_bedrock_llmobs.py
+++ b/tests/contrib/aiobotocore/test_bedrock_llmobs.py
@@ -94,6 +94,8 @@ class AsyncStreamingBody:
             return chunk
         raise StopAsyncIteration
 
+    anext = __anext__
+
     async def __aenter__(self):
         return self
 
@@ -218,7 +220,9 @@ async def test_llmobs_invoke_model_read_zero_does_not_finish_body(bedrock_llmobs
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("consumer", ["readinto", "readlines", "iter_chunks", "iter_lines", "anext", "context"])
+@pytest.mark.parametrize(
+    "consumer", ["readinto", "readlines", "iter_chunks", "iter_lines", "anext", "anext_alias", "context"]
+)
 async def test_llmobs_invoke_model_preserves_async_body_consumers(consumer, bedrock_llmobs, tracer, test_spans):
     parsed_response = {
         "ResponseMetadata": {
@@ -261,6 +265,14 @@ async def test_llmobs_invoke_model_preserves_async_body_consumers(consumer, bedr
             while True:
                 try:
                     chunks.append(await body.__anext__())
+                except StopAsyncIteration:
+                    break
+            consumed = b"".join(chunks)
+        elif consumer == "anext_alias":
+            chunks = []
+            while True:
+                try:
+                    chunks.append(await body.anext())
                 except StopAsyncIteration:
                     break
             consumed = b"".join(chunks)


### PR DESCRIPTION
## Description

Adds Bedrock Runtime LLM Observability support to the aiobotocore integration. `InvokeModel`, `InvokeModelWithResponseStream`, `Converse`, and `ConverseStream` reuse the existing Bedrock request/response semantics while preserving aiobotocore's existing APM behavior.

The async-specific implementation now lives in `ddtrace/contrib/internal/aiobotocore/bedrock.py`; the shared synchronous botocore Bedrock module is left unchanged.

Closes #18346.

## Changes

- Auto-patch `aiobotocore` from the standard `LLMObs.enable(integrations_enabled=True)` path.
- Preserve existing aiobotocore APM attributes on specialized Bedrock calls: component/span kind/measured, AWS operation and region tags, generic resource shape, HTTP status, retries and request IDs. APM-only calls retain `SpanTypes.HTTP`; LLMObs-submitted calls use the expected LLM span type.
- Keep InvokeModel spans open until their async body is consumed or explicitly closed.
- Detect complete sized reads from both current aiobotocore `_amount_read` / `_content_length` counters and older `_self_*` shapes.
- Finalize cancelled reads and cancelled initial requests through the Bedrock exception path instead of leaking an active span.
- Treat `CancelledError` as a terminal error for `InvokeModelWithResponseStream` and `ConverseStream`.
- Finalize early `close` / `aclose` on event streams exactly once, so the underlying stream cannot be closed while its Bedrock span remains active.
- Keep event-stream instrumentation transparent: processed SDK events are returned unchanged to callers.
- Finalize early `close` / `aclose` / async-context exits on InvokeModel bodies with partial or empty output rather than leaving the span open; failed/cancelled closes use the exception path.
- Preserve seekable/file-like `InvokeModel` request bodies without reading or advancing them during tracing. Prompt extraction is skipped for payload types that cannot be inspected safely on the event loop.
- Share application inference-profile cache hits with the synchronous integration without performing the synchronous control-plane lookup on the event loop.

## Testing

Original validation before review follow-up:

- `scripts/run-tests --venv 13c0fff -- -s -- -vv`: 69 passed.
- `scripts/run-tests --venv 1ada48c -- -- -vv -k bedrock`: 90 passed, 246 deselected, 1 expected xfailed, 1 xpassed.
- `scripts/run-tests --venv 113966a -- -- -vv -k 'TestAiobotocorePatch or test_traced_client'`: 23 passed, 46 deselected on Python 3.9 / aiobotocore 1.0.
- `scripts/run-tests --venv 17b66d6 -- -s`: global-lock detector passed.
- `scripts/lint checks`, `scripts/check-releasenotes`, and `git diff --check` passed.

Review follow-up adds focused regression coverage for:

- exact-size reads completing the span for both counter layouts;
- cancellation during body reads and async event streams;
- event streams yielding their original SDK chunks;
- early event-stream close finalizing exactly once;
- early async body close and context exit;
- file-like InvokeModel bodies remaining unconsumed during request tagging;
- cancellation during the initial Bedrock request;
- preservation of aiobotocore APM request/response tags;
- automatic LLMObs patching of aiobotocore.

The review-follow-up commit has not been re-run locally in the current environment. A fresh Codex review has been requested and upstream CI still requires maintainer approval.

## Risks

Moderate. This adds lifecycle ownership around async response bodies and event streams, but completion/error paths are explicit and both wrappers guard finalization against duplicate dispatch. Non-Bedrock aiobotocore endpoints remain on the existing generic tracing path, and the synchronous botocore Bedrock implementation is no longer modified by this PR.

## AI assistance

I used ChatGPT/Codex to inspect the issue and review feedback, trace async body and span ownership, implement the follow-up fixes, and write regression tests. I reviewed the resulting diff and kept the async-specific changes isolated to the aiobotocore integration.
