### PR TITLE
feat(gevent): sync OpenTelemetry thread context across greenlet switches

### DIFF
--- a/ddtrace/contrib/internal/gevent/greenlet.py
+++ b/ddtrace/contrib/internal/gevent/greenlet.py
@@ -35,15 +35,17 @@ class _GreenletTrace:
             self.previous(event, args)
 
 
-def ensure_greenlet_context_switch() -> None:
+def ensure_greenlet_context_switch() -> bool:
     """Install the context-switch watcher in the current native thread."""
     if not _CONTEXT_SWITCH_ENABLED or not getattr(gevent, "__datadog_patch", False):
-        return
+        return False
 
     if getattr(_state, "trace", None) is None:
         trace = _GreenletTrace(gettrace())
         settrace(trace)
         _state.trace = trace
+
+    return True
 
 
 def disable_greenlet_context_switch() -> None:

--- a/ddtrace/contrib/internal/gevent/greenlet.py
+++ b/ddtrace/contrib/internal/gevent/greenlet.py
@@ -1,23 +1,71 @@
+import sys
+from typing import Any
+from typing import Callable
+from typing import Optional
+
 import gevent
+from gevent.monkey import get_original
+from greenlet import gettrace
+from greenlet import settrace
 
-from ddtrace._trace.provider import _DD_CONTEXTVAR
+from ddtrace.internal import core
+from ddtrace.internal.settings._config import config
+from ddtrace.trace import tracer
 
 
-GEVENT_VERSION = gevent.version_info[0:3]
+_state = get_original("threading", "local")()
+
+# The context-switch watcher only has a consumer on Linux (see
+# ddtrace.internal.opentelemetry.thread_context), so avoid the settrace overhead elsewhere.
+_CONTEXT_SWITCH_ENABLED = sys.platform == "linux" and config._otel_thread_context_enabled
+
+
+class _GreenletTrace:
+    def __init__(self, previous: Optional[Callable[[str, Any], None]]) -> None:
+        self.previous = previous
+
+    def __call__(self, event: str, args: Any) -> None:
+        if getattr(gevent, "__datadog_patch", False):
+            core.dispatch("python.context.switch")
+        elif gettrace() is self:
+            settrace(self.previous)
+            _state.trace = None
+
+        if self.previous is not None:
+            self.previous(event, args)
+
+
+def ensure_greenlet_context_switch() -> None:
+    """Install the context-switch watcher in the current native thread."""
+    if not _CONTEXT_SWITCH_ENABLED or not getattr(gevent, "__datadog_patch", False):
+        return
+
+    if getattr(_state, "trace", None) is None:
+        trace = _GreenletTrace(gettrace())
+        settrace(trace)
+        _state.trace = trace
+
+
+def disable_greenlet_context_switch() -> None:
+    trace = getattr(_state, "trace", None)
+    if trace is not None and gettrace() is trace:
+        settrace(trace.previous)
+        _state.trace = None
 
 
 class TracingMixin(object):
     def __init__(self, *args, **kwargs):
-        # Storse the current Datadog context.
+        ensure_greenlet_context_switch()
+        # Store the current Datadog context.
         # This is necessary to ensure tracing context is passed to greenlets.
         # Avoids setting Greenlet.gr_context, setting field could introduce
         # unintended side-effects in third party libraries.
-        self.trace_context = _DD_CONTEXTVAR.get()
+        self.trace_context = tracer.context_provider.active()
         super(TracingMixin, self).__init__(*args, **kwargs)
 
     def run(self):
         # Propagates Datadog context to spawned greenlets
-        _DD_CONTEXTVAR.set(self.trace_context)
+        tracer.context_provider.activate(self.trace_context)
         super(TracingMixin, self).run()
 
 

--- a/ddtrace/contrib/internal/gevent/greenlet.py
+++ b/ddtrace/contrib/internal/gevent/greenlet.py
@@ -26,7 +26,10 @@ class _GreenletTrace:
 
     def __call__(self, event: str, args: Any) -> None:
         if getattr(gevent, "__datadog_patch", False):
-            core.dispatch("python.context.switch")
+            # A displaced watcher can remain in another callback's chain, so only
+            # the current watcher publishes the context switch.
+            if getattr(_state, "trace", None) is self:
+                core.dispatch("python.context.switch")
         elif gettrace() is self:
             settrace(self.previous)
             _state.trace = None
@@ -40,8 +43,10 @@ def ensure_greenlet_context_switch() -> bool:
     if not _CONTEXT_SWITCH_ENABLED or not getattr(gevent, "__datadog_patch", False):
         return False
 
-    if getattr(_state, "trace", None) is None:
-        trace = _GreenletTrace(gettrace())
+    trace = getattr(_state, "trace", None)
+    current_trace = gettrace()
+    if trace is None or current_trace is not trace:
+        trace = _GreenletTrace(current_trace)
         settrace(trace)
         _state.trace = trace
 

--- a/ddtrace/contrib/internal/gevent/patch.py
+++ b/ddtrace/contrib/internal/gevent/patch.py
@@ -4,6 +4,8 @@ import gevent.pool
 from .greenlet import TracedGreenlet
 from .greenlet import TracedIMap
 from .greenlet import TracedIMapUnordered
+from .greenlet import disable_greenlet_context_switch
+from .greenlet import ensure_greenlet_context_switch
 
 
 __Greenlet = gevent.Greenlet
@@ -32,6 +34,7 @@ def patch():
         return
     gevent.__datadog_patch = True
 
+    ensure_greenlet_context_switch()
     _replace(TracedGreenlet, TracedIMap, TracedIMapUnordered)
 
 
@@ -46,6 +49,7 @@ def unpatch():
     gevent.__datadog_patch = False
 
     _replace(__Greenlet, __IMap, __IMapUnordered)
+    disable_greenlet_context_switch()
 
 
 def _replace(g_class, imap_class, imap_unordered_class):

--- a/ddtrace/contrib/internal/gevent/patch.py
+++ b/ddtrace/contrib/internal/gevent/patch.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import gevent
 import gevent.pool
 
@@ -9,8 +11,14 @@ from .greenlet import ensure_greenlet_context_switch
 
 
 __Greenlet = gevent.Greenlet
+__HubSwitch = gevent.hub.Hub.switch
 __IMap = gevent.pool.IMap
 __IMapUnordered = gevent.pool.IMapUnordered
+
+
+def _switch_hub(hub: gevent.hub.Hub) -> Any:
+    ensure_greenlet_context_switch()
+    return __HubSwitch(hub)
 
 
 def get_version() -> str:
@@ -34,7 +42,8 @@ def patch():
         return
     gevent.__datadog_patch = True
 
-    ensure_greenlet_context_switch()
+    if ensure_greenlet_context_switch():
+        gevent.hub.Hub.switch = _switch_hub
     _replace(TracedGreenlet, TracedIMap, TracedIMapUnordered)
 
 
@@ -49,6 +58,8 @@ def unpatch():
     gevent.__datadog_patch = False
 
     _replace(__Greenlet, __IMap, __IMapUnordered)
+    if gevent.hub.Hub.switch is _switch_hub:
+        gevent.hub.Hub.switch = __HubSwitch
     disable_greenlet_context_switch()
 
 

--- a/releasenotes/notes/fix-gevent-otel-context-propagation-00000e3c92c22b42.yaml
+++ b/releasenotes/notes/fix-gevent-otel-context-propagation-00000e3c92c22b42.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    gevent: Fixes an issue where context propagation bypasses a custom context provider configured on the tracer.
+features:
+  - |
+    gevent: Adds automatic synchronization of OpenTelemetry thread context when gevent switches between greenlets.

--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -1,19 +1,41 @@
 import subprocess  # noqa:I001
 import threading
+from typing import Optional
 
 import gevent
 import gevent.pool
+from greenlet import getcurrent
+import pytest
 
-
-from ddtrace.constants import ERROR_MSG
+from ddtrace._trace.provider import ActiveTrace
+from ddtrace._trace.provider import BaseContextProvider
 from ddtrace.constants import _SAMPLING_PRIORITY_KEY
+from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import USER_KEEP
-from ddtrace.trace import Context
 from ddtrace.contrib.internal.gevent.patch import patch
 from ddtrace.contrib.internal.gevent.patch import unpatch
+from ddtrace.trace import Context
 from tests.utils import TracerTestCase
 
 from .utils import silence_errors
+
+
+class _GreenletContextProvider(BaseContextProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self._contexts: dict[object, Optional[ActiveTrace]] = {}
+        self.activation_count = 0
+
+    def _has_active_context(self) -> bool:
+        return self.active() is not None
+
+    def activate(self, ctx: Optional[ActiveTrace]) -> None:
+        self.activation_count += 1
+        self._contexts[getcurrent()] = ctx
+        super().activate(ctx)
+
+    def active(self) -> Optional[ActiveTrace]:
+        return self._contexts.get(getcurrent())
 
 
 class TestGeventTracer(TracerTestCase):
@@ -260,6 +282,26 @@ class TestGeventTracer(TracerTestCase):
         assert traces[0][0].trace_id == 100
         assert traces[0][0].parent_id == 101
 
+    def test_greenlet_propagation_uses_configured_context_provider(self) -> None:
+        """Propagate context through the tracer's configured provider."""
+        original_provider = self.tracer.context_provider
+        configured_provider = _GreenletContextProvider()
+        parent_context = Context(trace_id=100, span_id=101)
+        self.tracer.configure(context_provider=configured_provider)
+        configured_provider.activate(parent_context)
+
+        try:
+            propagated_context = gevent.spawn(self.tracer.context_provider.active).get()
+
+            assert propagated_context is parent_context, "The greenlet did not receive the parent context"
+            assert configured_provider.activation_count == 2, (
+                "Expected one parent activation and one greenlet activation; "
+                "context switches must not activate the provider"
+            )
+        finally:
+            configured_provider.activate(None)
+            self.tracer.configure(context_provider=original_provider)
+
     def test_trace_concurrent_spawn_later_calls(self):
         # create multiple futures so that we expect multiple
         # traces instead of a single one, even if greenlets
@@ -390,3 +432,99 @@ class TestGeventTracer(TracerTestCase):
         assert p.returncode == 0, f"stdout: {stdout.decode()}\n\nstderr: {stderr.decode()}"
         assert b"Test success" in stdout, stdout.decode()
         assert b"RecursionError" not in stderr, stderr.decode()
+
+
+@pytest.mark.subprocess()
+def test_context_switches_publish_in_multiple_native_thread_hubs() -> None:
+    """Publish late-listener context from every native-thread hub."""
+    import concurrent.futures
+    import threading
+    from typing import Optional
+
+    import gevent
+
+    from ddtrace.internal import core
+    from ddtrace.trace import Context
+    from ddtrace.trace import tracer
+    from tests.contrib.gevent.utils import gevent_patched
+
+    workers_ready = threading.Barrier(2)
+    active_span_ids_by_thread: dict[int, Optional[int]] = {}
+
+    def record_active_span_on_context_switch() -> None:
+        active = tracer.context_provider.active()
+        active_span_ids_by_thread[threading.get_ident()] = active.span_id if active is not None else None
+
+    def switch_greenlet_in_native_thread(span_id: int) -> tuple[int, Optional[int]]:
+        native_thread_id = threading.get_ident()
+        tracer.context_provider.activate(Context(trace_id=span_id, span_id=span_id))
+        try:
+            hub_id = id(gevent.get_hub())
+            workers_ready.wait(timeout=10)
+            gevent.spawn(gevent.sleep, 0).get()
+            return hub_id, active_span_ids_by_thread.get(native_thread_id)
+        finally:
+            tracer.context_provider.activate(None)
+
+    with gevent_patched(force_context_switch=True):
+        core.on("python.context.switch", record_active_span_on_context_switch)
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                thread_results = list(executor.map(switch_greenlet_in_native_thread, (1, 2)))
+        finally:
+            core.reset_listeners("python.context.switch", record_active_span_on_context_switch)
+
+    hub_ids, observed_span_ids = zip(*thread_results)
+    assert len(set(hub_ids)) == 2, f"Expected two native-thread hubs, got {hub_ids}"
+    assert list(observed_span_ids) == [1, 2], (
+        f"Expected each hub to publish its thread's active span, got {observed_span_ids}"
+    )
+
+
+@pytest.mark.subprocess()
+def test_unpatch_restores_trace_callback_in_other_native_thread() -> None:
+    """Restore a native thread's previous callback after another thread unpatches."""
+    import concurrent.futures
+    import threading
+
+    import gevent
+    from greenlet import gettrace
+    from greenlet import greenlet
+    from greenlet import settrace
+
+    from ddtrace.contrib.internal.gevent.patch import unpatch
+    from tests.contrib.gevent.utils import gevent_patched
+
+    worker_watcher_ready = threading.Barrier(2)
+    unpatch_complete = threading.Event()
+    customer_trace_events: list[str] = []
+
+    def customer_trace(event: str, args: object) -> None:
+        customer_trace_events.append(event)
+
+    def run_watched_greenlet_in_native_thread() -> bool:
+        previous_trace = settrace(customer_trace)
+        try:
+            gevent.spawn(lambda: None).get()
+            worker_watcher_ready.wait(timeout=10)
+            assert unpatch_complete.wait(timeout=10), "The main thread did not complete gevent unpatching"
+
+            # The next switch lets the disabled watcher restore this thread's callback.
+            greenlet(lambda: None).switch()
+            return gettrace() is customer_trace
+        finally:
+            settrace(previous_trace)
+
+    try:
+        with gevent_patched(force_context_switch=True):
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                worker_future = executor.submit(run_watched_greenlet_in_native_thread)
+                worker_watcher_ready.wait(timeout=10)
+                unpatch()
+                unpatch_complete.set()
+                customer_trace_restored = worker_future.result(timeout=10)
+    finally:
+        unpatch_complete.set()
+
+    assert customer_trace_events, "The watcher did not chain the existing trace callback"
+    assert customer_trace_restored, "Unpatch left the Datadog watcher installed in the worker thread"

--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -435,8 +435,8 @@ class TestGeventTracer(TracerTestCase):
 
 
 @pytest.mark.subprocess()
-def test_context_switches_publish_in_multiple_native_thread_hubs() -> None:
-    """Publish late-listener context from every native-thread hub."""
+def test_context_switches_publish_for_raw_native_thread_hub_entries() -> None:
+    """Publish context when native threads enter gevent without a traced Greenlet."""
     import concurrent.futures
     import threading
     from typing import Optional
@@ -448,37 +448,54 @@ def test_context_switches_publish_in_multiple_native_thread_hubs() -> None:
     from ddtrace.trace import tracer
     from tests.contrib.gevent.utils import gevent_patched
 
-    workers_ready = threading.Barrier(2)
-    active_span_ids_by_thread: dict[int, Optional[int]] = {}
+    entrypoints = ("sleep", "hub.switch", "spawn_raw")
+    workers_ready = threading.Barrier(len(entrypoints))
+    active_span_ids_by_thread: dict[int, list[Optional[int]]] = {}
 
     def record_active_span_on_context_switch() -> None:
         active = tracer.context_provider.active()
-        active_span_ids_by_thread[threading.get_ident()] = active.span_id if active is not None else None
+        active_span_ids_by_thread[threading.get_ident()].append(active.span_id if active is not None else None)
 
-    def switch_greenlet_in_native_thread(span_id: int) -> tuple[int, Optional[int]]:
+    def enter_hub(entrypoint: str) -> None:
+        if entrypoint == "sleep":
+            gevent.sleep(0)
+        elif entrypoint == "hub.switch":
+            current = gevent.getcurrent()
+            hub = gevent.get_hub()
+            hub.loop.run_callback(current.switch)
+            hub.switch()
+        else:
+            completed = []
+            gevent.spawn_raw(lambda: completed.append(True))
+            gevent.sleep(0)
+            assert completed, "The raw greenlet did not run"
+
+    def switch_greenlet_in_native_thread(args: tuple[int, str]) -> tuple[str, int, int, list[Optional[int]]]:
+        span_id, entrypoint = args
         native_thread_id = threading.get_ident()
+        active_span_ids_by_thread[native_thread_id] = []
         tracer.context_provider.activate(Context(trace_id=span_id, span_id=span_id))
         try:
             hub_id = id(gevent.get_hub())
             workers_ready.wait(timeout=10)
-            gevent.spawn(gevent.sleep, 0).get()
-            return hub_id, active_span_ids_by_thread.get(native_thread_id)
+            enter_hub(entrypoint)
+            return entrypoint, span_id, hub_id, active_span_ids_by_thread[native_thread_id]
         finally:
             tracer.context_provider.activate(None)
 
     with gevent_patched(force_context_switch=True):
         core.on("python.context.switch", record_active_span_on_context_switch)
         try:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
-                thread_results = list(executor.map(switch_greenlet_in_native_thread, (1, 2)))
+            with concurrent.futures.ThreadPoolExecutor(max_workers=len(entrypoints)) as executor:
+                thread_results = list(executor.map(switch_greenlet_in_native_thread, enumerate(entrypoints, start=1)))
         finally:
             core.reset_listeners("python.context.switch", record_active_span_on_context_switch)
 
-    hub_ids, observed_span_ids = zip(*thread_results)
-    assert len(set(hub_ids)) == 2, f"Expected two native-thread hubs, got {hub_ids}"
-    assert list(observed_span_ids) == [1, 2], (
-        f"Expected each hub to publish its thread's active span, got {observed_span_ids}"
-    )
+    hub_ids = [hub_id for _, _, hub_id, _ in thread_results]
+    assert len(set(hub_ids)) == len(entrypoints), f"Expected one hub per native thread, got {hub_ids}"
+    for entrypoint, span_id, _, observed_span_ids in thread_results:
+        assert None in observed_span_ids, f"{entrypoint} did not publish the hub's empty context"
+        assert span_id in observed_span_ids, f"{entrypoint} did not restore the originating context"
 
 
 @pytest.mark.subprocess()

--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -502,6 +502,58 @@ def test_context_switches_publish_for_raw_native_thread_hub_entries() -> None:
 
 
 @pytest.mark.subprocess()
+def test_context_switch_watcher_recovers_after_trace_callback_replacement() -> None:
+    """Reinstall a displaced watcher without publishing duplicate switch events."""
+    import gevent
+    from greenlet import gettrace
+    from greenlet import settrace
+
+    from ddtrace.internal import core
+    from tests.contrib.gevent.utils import gevent_patched
+
+    switch_events: list[None] = []
+    chained_events: list[str] = []
+
+    def record_context_switch() -> None:
+        switch_events.append(None)
+
+    def early_trace(event: str, args: object) -> None:
+        pass
+
+    original_trace = settrace(early_trace)
+    try:
+        with gevent_patched(force_context_switch=True):
+            core.on("python.context.switch", record_context_switch)
+            try:
+                # Simulate a callback installed before the watcher restoring its
+                # original value and displacing the watcher when it is removed.
+                settrace(original_trace)
+                gevent.sleep(0)
+
+                assert switch_events, "The displaced watcher was not reinstalled"
+                watcher = gettrace()
+                assert watcher is not original_trace
+
+                # Simulate a callback installed after the watcher. Reinstalling
+                # around it must leave the older watcher inert in its callback chain.
+                def chained_trace(event: str, args: object) -> None:
+                    chained_events.append(event)
+                    assert watcher is not None
+                    watcher(event, args)
+
+                settrace(chained_trace)
+                switch_events.clear()
+                gevent.sleep(0)
+
+                assert chained_events, "The replacement trace callback was not preserved"
+                assert len(switch_events) == len(chained_events), "A stale watcher published duplicate switch events"
+            finally:
+                core.reset_listeners("python.context.switch", record_context_switch)
+    finally:
+        settrace(original_trace)
+
+
+@pytest.mark.subprocess()
 def test_unpatch_restores_trace_callback_in_other_native_thread() -> None:
     """Restore a native thread's previous callback after another thread unpatches."""
     import concurrent.futures

--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -603,7 +603,8 @@ def test_unpatch_restores_trace_callback_in_other_native_thread() -> None:
 
 
 @pytest.mark.subprocess()
-def test_context_switch_watcher_coexists_with_profiler_tracer() -> None:
+@pytest.mark.parametrize("profiler_first", [True, False], ids=["profiler_first", "contrib_first"])
+def test_context_switch_watcher_coexists_with_profiler_tracer(profiler_first: bool) -> None:
     """Both the contrib watcher and the profiler's greenlet tracer fire on switch."""
     import gevent
 
@@ -625,9 +626,11 @@ def test_context_switch_watcher_coexists_with_profiler_tracer() -> None:
         switch_events.append(None)
 
     profiler_gevent.greenlet_tracer = profiling_spy
-    with gevent_patched(force_context_switch=True):
-        # Install the profiler tracer on top of the contrib watcher.
+    if profiler_first:
         profiler_gevent.patch()
+    with gevent_patched(force_context_switch=True):
+        if not profiler_first:
+            profiler_gevent.patch()
         core.on("python.context.switch", record_context_switch)
         # Trigger a switch so the contrib watcher self-heals around the profiler.
         gevent.sleep(0)

--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -615,9 +615,11 @@ def test_context_switch_watcher_coexists_with_profiler_tracer() -> None:
     profiler_events: list[str] = []
 
     # Wrap the profiler tracer to record calls without changing behavior.
+    original_tracer = profiler_gevent.greenlet_tracer
+
     def profiling_spy(event, args):
         profiler_events.append(event)
-        profiler_gevent.greenlet_tracer(event, args)
+        original_tracer(event, args)
 
     def record_context_switch():
         switch_events.append(None)

--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -600,3 +600,35 @@ def test_unpatch_restores_trace_callback_in_other_native_thread() -> None:
 
     assert customer_trace_events, "The watcher did not chain the existing trace callback"
     assert customer_trace_restored, "Unpatch left the Datadog watcher installed in the worker thread"
+
+
+@pytest.mark.subprocess()
+def test_context_switch_watcher_coexists_with_profiler_tracer() -> None:
+    """Both the contrib watcher and the profiler's greenlet tracer fire on switch."""
+    import gevent
+
+    from ddtrace.internal import core
+    from ddtrace.profiling import _gevent as profiler_gevent
+    from tests.contrib.gevent.utils import gevent_patched
+
+    switch_events: list[None] = []
+    profiler_events: list[str] = []
+
+    # Wrap the profiler tracer to record calls without changing behavior.
+    def profiling_spy(event, args):
+        profiler_events.append(event)
+        profiler_gevent.greenlet_tracer(event, args)
+
+    def record_context_switch():
+        switch_events.append(None)
+
+    profiler_gevent.greenlet_tracer = profiling_spy
+    with gevent_patched(force_context_switch=True):
+        # Install the profiler tracer on top of the contrib watcher.
+        profiler_gevent.patch()
+        core.on("python.context.switch", record_context_switch)
+        # Trigger a switch so the contrib watcher self-heals around the profiler.
+        gevent.sleep(0)
+
+        assert switch_events, "Contrib watcher did not fire"
+        assert profiler_events, "Profiler tracer did not fire"

--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -453,8 +453,11 @@ def test_context_switches_publish_for_raw_native_thread_hub_entries() -> None:
     active_span_ids_by_thread: dict[int, list[Optional[int]]] = {}
 
     def record_active_span_on_context_switch() -> None:
+        observed_span_ids = active_span_ids_by_thread.get(threading.get_ident())
+        if observed_span_ids is None:
+            return
         active = tracer.context_provider.active()
-        active_span_ids_by_thread[threading.get_ident()].append(active.span_id if active is not None else None)
+        observed_span_ids.append(active.span_id if active is not None else None)
 
     def enter_hub(entrypoint: str) -> None:
         if entrypoint == "sleep":

--- a/tests/contrib/gevent/test_tracer.py
+++ b/tests/contrib/gevent/test_tracer.py
@@ -603,9 +603,8 @@ def test_unpatch_restores_trace_callback_in_other_native_thread() -> None:
 
 
 @pytest.mark.subprocess()
-@pytest.mark.parametrize("profiler_first", [True, False], ids=["profiler_first", "contrib_first"])
-def test_context_switch_watcher_coexists_with_profiler_tracer(profiler_first: bool) -> None:
-    """Both the contrib watcher and the profiler's greenlet tracer fire on switch."""
+def test_context_switch_watcher_coexists_with_profiler_tracer_profiler_first() -> None:
+    """Both tracers fire when the profiler patches before the contrib (default ddtrace-run order)."""
     import gevent
 
     from ddtrace.internal import core
@@ -615,7 +614,6 @@ def test_context_switch_watcher_coexists_with_profiler_tracer(profiler_first: bo
     switch_events: list[None] = []
     profiler_events: list[str] = []
 
-    # Wrap the profiler tracer to record calls without changing behavior.
     original_tracer = profiler_gevent.greenlet_tracer
 
     def profiling_spy(event, args):
@@ -626,13 +624,40 @@ def test_context_switch_watcher_coexists_with_profiler_tracer(profiler_first: bo
         switch_events.append(None)
 
     profiler_gevent.greenlet_tracer = profiling_spy
-    if profiler_first:
-        profiler_gevent.patch()
+    profiler_gevent.patch()
     with gevent_patched(force_context_switch=True):
-        if not profiler_first:
-            profiler_gevent.patch()
         core.on("python.context.switch", record_context_switch)
-        # Trigger a switch so the contrib watcher self-heals around the profiler.
+        gevent.sleep(0)
+
+        assert switch_events, "Contrib watcher did not fire"
+        assert profiler_events, "Profiler tracer did not fire"
+
+
+@pytest.mark.subprocess()
+def test_context_switch_watcher_coexists_with_profiler_tracer_contrib_first() -> None:
+    """Both tracers fire when the contrib patches before the profiler (self-healing path)."""
+    import gevent
+
+    from ddtrace.internal import core
+    from ddtrace.profiling import _gevent as profiler_gevent
+    from tests.contrib.gevent.utils import gevent_patched
+
+    switch_events: list[None] = []
+    profiler_events: list[str] = []
+
+    original_tracer = profiler_gevent.greenlet_tracer
+
+    def profiling_spy(event, args):
+        profiler_events.append(event)
+        original_tracer(event, args)
+
+    def record_context_switch():
+        switch_events.append(None)
+
+    profiler_gevent.greenlet_tracer = profiling_spy
+    with gevent_patched(force_context_switch=True):
+        profiler_gevent.patch()
+        core.on("python.context.switch", record_context_switch)
         gevent.sleep(0)
 
         assert switch_events, "Contrib watcher did not fire"

--- a/tests/contrib/gevent/utils.py
+++ b/tests/contrib/gevent/utils.py
@@ -1,9 +1,34 @@
+import contextlib
 from functools import wraps
 
 import gevent
 
 
 _NOT_ERROR = gevent.hub.Hub.NOT_ERROR
+
+
+@contextlib.contextmanager
+def gevent_patched(*, force_context_switch=False):
+    """Patch gevent for the duration of the block, always unpatching on exit.
+
+    force_context_switch overrides the platform/config gate on the greenlet context-switch
+    watcher, so tests can exercise it regardless of the host platform or DD_TRACE_OTEL_CTX_ENABLED.
+    """
+    import gevent.pool  # noqa:F401  greenlet.py's module-level class defs need this already imported
+
+    from ddtrace.contrib.internal.gevent import greenlet as greenlet_module
+    from ddtrace.contrib.internal.gevent.patch import patch
+    from ddtrace.contrib.internal.gevent.patch import unpatch
+
+    previous_enabled = greenlet_module._CONTEXT_SWITCH_ENABLED
+    if force_context_switch:
+        greenlet_module._CONTEXT_SWITCH_ENABLED = True
+    patch()
+    try:
+        yield
+    finally:
+        unpatch()
+        greenlet_module._CONTEXT_SWITCH_ENABLED = previous_enabled
 
 
 def silence_errors(f):


### PR DESCRIPTION
## Description

gevent greenlets switch within one OS thread, so OTel's thread-context sync (`ddtrace/internal/opentelemetry/thread_context.py`) never sees it. This adds a `greenlet.settrace()` watcher that publishes `python.context.switch` on every switch to keep it in sync.

Also fixes greenlet context propagation to go through `tracer.context_provider` instead of reading `_DD_CONTEXTVAR` directly (was bypassing custom context providers).


## Testing

Subprocess tests cover multi-thread patch/unpatch and watcher self-healing when displaced by another `settrace` caller (e.g. the profiler).

## Risks

Relatively low, additional instrumentation on a gevent relatively hot path. Local benchmarks did not show a meaningful impact.
