### PR TITLE
ci: add job to push wheels to `adms`

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -206,6 +206,66 @@ variables:
   variables:
     UPLOAD_SUFFIX: "manylinux2014_x86_64"
 
+# Rewrites each wheel's version to major.minor.patch[rc].dev<pipeline_id>+<local>.<commit_sha>,
+# then uploads it to the private prerelease index.
+#
+# DEV: only manylinux2014 and macOS wheels get this treatment. musllinux, Windows and the
+# sdist are deliberately left out: the prerelease index exists to hand a custom build to a
+# customer or an internal service, and those all run manylinux or macOS.
+.patch_wheel_versions_base:
+  # DEV: the testrunner image is used for the adms binary it ships.
+  image: ${TESTRUNNER_IMAGE}
+  tags: [ "arch:amd64" ]
+  stage: package
+  script:
+    - |
+      set -euo pipefail
+      # Only run when the version has a local segment (e.g. 4.1.3rc3+memory-leak-fix).
+      # A plain semver or pre-release (4.1.3, 4.1.3rc3) skips this job.
+      if [[ "${PACKAGE_VERSION:-}" != *+* ]]; then
+        echo "Version '${PACKAGE_VERSION:-}' has no local segment (+...) -- nothing to patch, exiting."
+        exit 0
+      fi
+    - python3 .gitlab/scripts/patch-wheel-versions.py pywheels pywheels-patched
+    - |
+      set -euo pipefail
+      shopt -s nullglob
+      wheels=(pywheels-patched/*.whl)
+      if [ ${#wheels[@]} -eq 0 ]; then
+        echo "No patched wheels to upload."
+        exit 0
+      fi
+      # adms parseRepositoryURL accepts only host/org/repo (5 slash parts).
+      # GitLab sets CI_REPOSITORY_URL to DataDog/apm-reliability/dd-trace-py.
+      export CI_REPOSITORY_URL="https://github.com/DataDog/dd-trace-py"
+      for wheel in "${wheels[@]}"; do
+        adms first-party python upload --repository datadog/pypi-private-prereleases "${wheel}"
+      done
+
+"patch manylinux2014 wheel versions":
+  extends: .patch_wheel_versions_base
+  needs:
+    - job: "build linux"
+      artifacts: true
+      parallel:
+        matrix:
+          - ARCH_TAG: "amd64"
+            PYTHON_TAG: *PYTHON_TAGS
+            IMAGE_TAG: "v113741238-d2b8243-manylinux2014_x86_64"
+          - ARCH_TAG: "arm64"
+            PYTHON_TAG: *PYTHON_TAGS
+            IMAGE_TAG: "v113741357-d2b8243-manylinux2014_aarch64"
+    - job: "package version"
+
+"patch macos wheel versions":
+  extends: .patch_wheel_versions_base
+  needs:
+    - job: "build macos amd64"
+      artifacts: true
+    - job: "build macos arm64"
+      artifacts: true
+    - job: "package version"
+
 # All manylinux2014 wheels
 "upload manylinux2014":
   extends: .upload_wheels_base

--- a/.gitlab/scripts/patch-wheel-versions.py
+++ b/.gitlab/scripts/patch-wheel-versions.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Rewrite the version in built wheels.
+
+Usage: patch-wheel-versions.py <src_dir> <dest_dir>
+
+Reads CI_PIPELINE_ID, CI_COMMIT_SHA, and PACKAGE_VERSION from the environment.
+For each wheel found in <src_dir>, rewrites the version to
+major.minor.patch[rc].dev<pipeline_id>+<local>.<commit_sha>
+where local is the PEP 440 local segment from pyproject.toml, with '-' and '_'
+normalized to '.' so the filename and METADATA match.
+
+The distribution name and import package stay ddtrace.
+
+The following locations inside the wheel are updated:
+  - dist-info/ directory prefix in every arcname
+  - .data/ directory prefix in every arcname (if present)
+  - The "Version:" header in dist-info/METADATA
+  - dist-info/RECORD (arcnames and METADATA sha256/size)
+  - The output wheel filename
+"""
+
+import argparse
+import base64
+import csv
+import hashlib
+import io
+import os
+from pathlib import Path
+import re
+import sys
+import zipfile
+
+
+# Matches a dist-info directory name: <name>-<version>.dist-info
+_DIST_INFO_RE = re.compile(r"^([A-Za-z0-9_.-]+)-([^/]+)\.dist-info/")
+
+
+def _sha256_b64(data: bytes) -> str:
+    digest = hashlib.sha256(data).digest()
+    return "sha256=" + base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def _parse_dist_info_version(names: list[str]) -> tuple[str, str]:
+    """Return (pkg_name, version) discovered from the dist-info directory entries."""
+    for name in names:
+        m = _DIST_INFO_RE.match(name)
+        if m:
+            return m.group(1), m.group(2)
+    raise ValueError("No .dist-info/ directory found in wheel -- cannot determine version")
+
+
+def _build_patched_version(source_version: str, pipeline_id: str, commit_sha: str) -> str:
+    """Build major.minor.patch[rc].dev<pipeline_id>+<local>.<commit_sha>."""
+    public, plus, local = source_version.partition("+")
+    if not plus or not local:
+        raise ValueError(f"Version {source_version!r} has no local segment; cannot patch")
+    # Drop an existing .devN so the pipeline id becomes the only dev stamp.
+    public = re.sub(r"\.dev\d+$", "", public)
+    # PEP 440 local-version normal form uses '.'. Wheel filenames cannot contain
+    # '-' (field delimiter). '_' is allowed as a synonym of '-', but adms compares
+    # the filename to this dotted form, so use '.' in both filename and METADATA.
+    local = local.replace("-", ".").replace("_", ".")
+    commit_sha = commit_sha.replace("-", ".").replace("_", ".")
+    return f"{public}.dev{pipeline_id}+{local}.{commit_sha}"
+
+
+def _rewrite_arcname(arcname: str, old_prefix: str, new_prefix: str) -> str:
+    if arcname.startswith(old_prefix):
+        return new_prefix + arcname[len(old_prefix) :]
+    return arcname
+
+
+def _patch_wheel(src: Path, dest_dir: Path, new_version: str) -> Path:
+    """Patch src wheel version and write the result to dest_dir."""
+    with zipfile.ZipFile(src, "r") as zf:
+        names = zf.namelist()
+
+        pkg_name, old_version = _parse_dist_info_version(names)
+        old_dist_info = f"{pkg_name}-{old_version}.dist-info/"
+        new_dist_info = f"{pkg_name}-{new_version}.dist-info/"
+        old_data = f"{pkg_name}-{old_version}.data/"
+        new_data = f"{pkg_name}-{new_version}.data/"
+
+        record_arc = old_dist_info + "RECORD"
+        metadata_arc = old_dist_info + "METADATA"
+
+        if record_arc not in names:
+            raise ValueError(f"No RECORD found in {src.name}")
+        if metadata_arc not in names:
+            raise ValueError(f"No METADATA found in {src.name}")
+
+        # Patch METADATA: replace the "Version:" header value. old_version comes from the
+        # dist-info directory name, so a header that spells the same version differently
+        # (case, '-'/'_' instead of '.') would not match: fail instead of shipping a wheel
+        # whose filename and METADATA disagree.
+        raw_metadata = zf.read(metadata_arc)
+        new_metadata_bytes, count = re.subn(
+            rb"(?m)^(Version:[^\S\n]*)" + re.escape(old_version.encode()) + rb"(?=[^\S\n]*$)",
+            rb"\g<1>" + new_version.encode(),
+            raw_metadata,
+        )
+        if count != 1:
+            raise ValueError(f"Expected 1 'Version: {old_version}' header in METADATA, found {count}")
+
+        # Build new arcname mapping: old -> new (for dist-info and .data prefixes).
+        def _remap(arcname: str) -> str:
+            arcname = _rewrite_arcname(arcname, old_dist_info, new_dist_info)
+            arcname = _rewrite_arcname(arcname, old_data, new_data)
+            return arcname
+
+        # Collect all entries (except RECORD; we regenerate it).
+        new_record_arc = new_dist_info + "RECORD"
+
+        record_rows: list[list[str]] = []
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED, allowZip64=True) as out:
+            for info in zf.infolist():
+                new_arc = _remap(info.filename)
+
+                if info.filename == record_arc:
+                    # Skip; we write RECORD last.
+                    continue
+
+                new_info = zipfile.ZipInfo(new_arc, date_time=info.date_time)
+                new_info.compress_type = info.compress_type
+                new_info.external_attr = info.external_attr
+
+                if info.filename == metadata_arc:
+                    data = new_metadata_bytes
+                else:
+                    data = zf.read(info.filename)
+
+                out.writestr(new_info, data)
+                if not info.is_dir():
+                    record_rows.append([new_arc, _sha256_b64(data), str(len(data))])
+
+            # Write RECORD last (its own hash/size row is left empty per PEP 427).
+            record_rows.append([new_record_arc, "", ""])
+            record_buf = io.StringIO()
+            csv.writer(record_buf, lineterminator="\n").writerows(record_rows)
+            record_bytes = record_buf.getvalue().encode("utf-8")
+            record_info = zipfile.ZipInfo(new_record_arc)
+            record_info.compress_type = zipfile.ZIP_DEFLATED
+            out.writestr(record_info, record_bytes)
+
+        # Compute the new wheel filename from the old one.
+        # Wheel filename format: {name}-{version}-{python}-{abi}-{platform}.whl
+        stem = src.stem  # e.g. ddtrace-4.15.0rc1-cp311-cp311-manylinux2014_x86_64
+        # Replace only the first occurrence of old_version in the stem (the version segment).
+        # The stem starts with "<pkg_name>-<version>-"; replace that prefix.
+        old_stem_prefix = f"{pkg_name}-{old_version}-"
+        if not stem.startswith(old_stem_prefix):
+            raise ValueError(f"Wheel filename {src.name} does not start with expected prefix {old_stem_prefix!r}")
+        new_stem = f"{pkg_name}-{new_version}-" + stem[len(old_stem_prefix) :]
+        dest = dest_dir / (new_stem + ".whl")
+
+        dest.write_bytes(buf.getvalue())
+        return dest
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("src_dir", help="Directory containing the source wheels")
+    parser.add_argument("dest_dir", help="Directory to write the patched wheels to")
+    args = parser.parse_args()
+
+    pipeline_id = os.environ.get("CI_PIPELINE_ID", "")
+    commit_sha = os.environ.get("CI_COMMIT_SHA", "")
+    package_version = os.environ.get("PACKAGE_VERSION", "")
+    if not pipeline_id or not commit_sha:
+        print(
+            "[ERROR] CI_PIPELINE_ID and CI_COMMIT_SHA must be set in the environment",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if not package_version:
+        print("[ERROR] PACKAGE_VERSION must be set in the environment", file=sys.stderr)
+        sys.exit(1)
+    try:
+        new_version = _build_patched_version(package_version, pipeline_id, commit_sha)
+    except ValueError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        sys.exit(1)
+    print(f"Patched version: {new_version}")
+
+    src_dir = Path(args.src_dir)
+    dest_dir = Path(args.dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    wheels = sorted(src_dir.glob("*.whl"))
+    if not wheels:
+        print(f"[WARN] No .whl files found in {src_dir}", file=sys.stderr)
+        sys.exit(0)
+
+    errors: list[str] = []
+    for wheel in wheels:
+        try:
+            dest = _patch_wheel(wheel, dest_dir, new_version)
+            print(f"  {wheel.name}")
+            print(f"  -> {dest.name}")
+        except Exception as exc:
+            errors.append(f"{wheel.name}: {exc}")
+            print(f"[ERROR] {wheel.name}: {exc}", file=sys.stderr)
+
+    if errors:
+        print(f"\n[ERROR] {len(errors)} wheel(s) failed to patch", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"\nPatched {len(wheels)} wheel(s) -> {dest_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitlab/testrunner.yml
+++ b/.gitlab/testrunner.yml
@@ -1,5 +1,5 @@
 variables:
-  TESTRUNNER_IMAGE: registry.ddbuild.io/dd-trace-py:v115521171-bbc5877-testrunner@sha256:a3e99a5fab74078806d5507b9743370ca375e63dd36b0a0eace4d05cfd1ecda3
+  TESTRUNNER_IMAGE: registry.ddbuild.io/dd-trace-py:v131882734-d02e020-testrunner@sha256:90890eea305711baf275fcca5824f779708312fe1d9dc1436ee5a303f8d7674d
 
 .testrunner:
   image:

--- a/.gitlab/validate-ddtrace-package.py
+++ b/.gitlab/validate-ddtrace-package.py
@@ -23,6 +23,8 @@ import sys
 
 from packaging.utils import parse_sdist_filename
 from packaging.utils import parse_wheel_filename
+from packaging.version import InvalidVersion
+from packaging.version import Version
 
 
 # Configuration
@@ -146,9 +148,18 @@ def identify_version_mismatches(
 def main(args: argparse.Namespace) -> None:
     wheels_dir = args.wheels_dir
 
-    package_version: str | None = os.environ.get("PACKAGE_VERSION")
-    if not package_version:
+    raw_package_version: str | None = os.environ.get("PACKAGE_VERSION")
+    if not raw_package_version:
         print("[ERROR] PACKAGE_VERSION not set. Ensure 'package version' job ran.")
+        sys.exit(1)
+
+    # Filenames carry the PEP 440 canonical form of the version, so a local segment such as
+    # +memory-leak-fix reaches us as +memory.leak.fix. Compare against that form, not the raw
+    # pyproject.toml string.
+    try:
+        package_version: str = str(Version(raw_package_version))
+    except InvalidVersion as exc:
+        print(f"[ERROR] PACKAGE_VERSION is not a valid PEP 440 version: {raw_package_version} ({exc})")
         sys.exit(1)
 
     wheels_path = Path(wheels_dir)
@@ -159,7 +170,7 @@ def main(args: argparse.Namespace) -> None:
     print("=" * 70)
     print("DDTrace Package Validation")
     print("=" * 70)
-    print(f"Package version (from pyproject.toml): {package_version}")
+    print(f"Package version (from pyproject.toml): {raw_package_version}")
     print(f"Validating packages in: {wheels_dir}")
     print()
 
@@ -168,7 +179,9 @@ def main(args: argparse.Namespace) -> None:
 
     # Phase 1: Environment Check
     print("[Phase 1] Environment Check")
-    print(f"✓ PACKAGE_VERSION is set: {package_version}")
+    print(f"✓ PACKAGE_VERSION is set: {raw_package_version}")
+    if package_version != raw_package_version:
+        print(f"✓ Canonical form used for comparisons: {package_version}")
     print()
 
     # Phase 2: SDist Validation


### PR DESCRIPTION
## Description

More context on this change is available [in this document](https://docs.google.com/document/d/1NPQvC81luziY4SwiQUxXzgml5K78IurBp1jFXG3QZgE/edit?tab=t.0#heading=h.ty5eia46b19).

This PR updates our CI pipeline to have two new jobs (that do the same thing for `manylinux` builds and `macOS` builds, respectively). This new job edits the built wheels in order to modify their version, and change it from the one that is in `pyproject.toml` to an equivalent `major.minor.patch[rcX].dev<pipeline_id>+<local_segment_from_pyproject>.<commit_sha>.
The job only runs when the `pyproject` version has a local segment. 


Once all wheels have been patched, they are pushed to our internal Python wheel repository ADMS (operated by Dependency Management) and it is thus possible to "legally" use wheels not released to PyPI in internal services.

## Testing

This has been tested in CI and through `adms` tools. I also have PRs for `dogweb` and `dd-source` which make the necessary changes for them to use the special "unreleased `ddtrace` wheels" internal repository.  (I made some changes to the `pyproject` that are now reverted.)

For someone wanting to use an unreleased version of `ddtrace` internally, that setup will be transparent -- they will only need to set the right version in downstream `requirements` files.

## Alternatives considered

Currently the job runs automatically based on the `pyproject` version; it could have been a manual job instead. [Discussion here.](https://github.com/DataDog/dd-trace-py/pull/19727#discussion_r3821952212)