### PR TITLE
fix(crashtracking): isolate receiver from bootstrap instrumentation

### DIFF
--- a/ddtrace/internal/core/crashtracking.py
+++ b/ddtrace/internal/core/crashtracking.py
@@ -1,5 +1,6 @@
 # pyright: reportPossiblyUnboundVariable=false
 import importlib.util
+import os
 import platform
 import sys
 import traceback
@@ -157,6 +158,9 @@ def _get_args(additional_tags: Optional[dict[str, str]]):
     for env_var in inherited_env_vars:
         env_value = env.get(env_var)
         if env_value is not None:
+            if env_var == "PYTHONPATH":
+                bootstrap_dir = os.path.join(os.path.dirname(os.path.dirname(receiver_script_path)), "bootstrap")
+                env_value = os.pathsep.join(entry for entry in env_value.split(os.pathsep) if entry != bootstrap_dir)
             receiver_env[env_var] = env_value
 
     # This is equivalent to: python /path/to/_dd_crashtracker_receiver.py

--- a/releasenotes/notes/fix-crashtracker-receiver-recursion-7cf2518c488864c1.yaml
+++ b/releasenotes/notes/fix-crashtracker-receiver-recursion-7cf2518c488864c1.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    crashtracking: Fixes an issue where crashtracker receiver processes are automatically
+    instrumented when applications are started with Single Step Instrumentation or ``ddtrace-run``.

--- a/tests/crashtracker/test_crashtracker.py
+++ b/tests/crashtracker/test_crashtracker.py
@@ -1,5 +1,7 @@
+import importlib.util
 import os
 import shutil
+import subprocess
 import sys
 import warnings
 
@@ -984,6 +986,46 @@ def test_crashtracker_no_zombies():
                     time.sleep(0.01)  # Avoid busy-wait when no child exited
             except ChildProcessError:
                 break
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")
+def test_crashtracker_receiver_pythonpath_isolation(monkeypatch):
+    from ddtrace.internal.core import crashtracking
+
+    receiver_spec = importlib.util.find_spec("ddtrace.commands._dd_crashtracker_receiver")
+    assert receiver_spec is not None
+    assert receiver_spec.origin is not None
+    ddtrace_package_dir = os.path.dirname(os.path.dirname(receiver_spec.origin))
+    bootstrap_dir = os.path.join(ddtrace_package_dir, "bootstrap")
+    injected_site_packages = os.path.dirname(ddtrace_package_dir)
+    pythonpath = [bootstrap_dir, injected_site_packages]
+    pythonpath.extend(os.environ.get("PYTHONPATH", "").split(os.pathsep))
+    monkeypatch.setenv("PYTHONPATH", os.pathsep.join(pythonpath))
+
+    receiver_args = None
+    receiver_env = None
+
+    def capture_receiver_config(args, env, *_args):
+        nonlocal receiver_args, receiver_env
+        receiver_args = args
+        receiver_env = env
+
+    monkeypatch.setattr(crashtracking, "CrashtrackerReceiverConfig", capture_receiver_config)
+    crashtracking._get_args(None)
+
+    assert receiver_args is not None
+    assert receiver_env is not None
+    result = subprocess.run(
+        [
+            receiver_args[0],
+            "-c",
+            "import sys; import ddtrace.internal.native._native; assert 'ddtrace.bootstrap.preload' not in sys.modules",
+        ],
+        env=receiver_env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Linux only")


### PR DESCRIPTION
## Description

Prevents the Python crashtracker receiver from auto-instrumenting itself when the parent process was started through Single Step Instrumentation or `ddtrace-run`.

Receiver construction now removes only the exact `<ddtrace package>/bootstrap` entry derived from the receiver script path while preserving the rest of `PYTHONPATH`, including the selected ddtrace package location. `LD_LIBRARY_PATH` and `DYLD_LIBRARY_PATH` inheritance are unchanged.

The regression captures the generated receiver environment and starts its configured Python interpreter. It verifies both that `ddtrace.internal.native._native` remains importable and that `ddtrace.bootstrap.preload` is not loaded.

This fixes receiver self-instrumentation, not the separate libdatadog receiver segfault in remote libunwind symbol resolution.

## Testing

- Regression-only commit `bfe6e1c5`:
  - Local: failed as expected because `ddtrace.bootstrap.preload` was present in `sys.modules`.
  - Remote: `dd-gitlab/core/crashtracker 1/2` failed as required.
- Fix commit `baeb209e`:
  - Local: `scripts/run-tests --venv 1ef26c5 -- -s -- tests/crashtracker/test_crashtracker.py -k receiver_pythonpath_isolation -vv` passed.
  - Local: `scripts/run-tests --venv 1ef26c5 -- -s -- tests/crashtracker/test_crashtracker.py -vv` passed all 28 tests on Python 3.13.
  - Local: `scripts/lint typing -- ddtrace/internal/core/crashtracking.py` and `scripts/lint checks` passed.
  - Remote: all four `dd-gitlab/core/crashtracker` shards passed.

## Risks

Do not merge this PR before the separate libdatadog receiver crash is fixed, or before equivalent receiver self-failure telemetry is added. The nested crashtracker currently makes that receiver segfault observable. Removing self-instrumentation alone would make the existing crash-report loss silent.

The code change is narrowly scoped to exact-match filtering of the receiver's bootstrap directory from `PYTHONPATH`.

## Additional Notes

The same bootstrap propagation occurs with SSI and `ddtrace-run`, so the fix is not SSI-specific.
