### PR TITLE
build: support linking against a system-provided libddwaf

### DIFF
--- a/ddtrace/internal/settings/asm.py
+++ b/ddtrace/internal/settings/asm.py
@@ -61,9 +61,22 @@ def build_libddwaf_filename() -> str:
             ARCHI = "x86"
     TRANSLATE_ARCH = {"amd64": "x64", "i686": "x86_64", "x86": "win32"}
     ARCHITECTURE = TRANSLATE_ARCH.get(ARCHI, ARCHI)
-    return os.path.join(
+    filename = os.path.join(
         _DIRNAME, "..", "appsec", "_ddwaf", "libddwaf", ARCHITECTURE, "lib", "libddwaf." + FILE_EXTENSION
     )
+    if not os.path.exists(filename):
+        # The build may have recorded the path of a system-provided libddwaf
+        # instead of bundling the library (setup.py with
+        # DD_USE_SYSTEM_LIBDDWAF=1).
+        link_file = os.path.join(os.path.dirname(filename), "libddwaf.link")
+        try:
+            with open(link_file) as f:
+                recorded = f.read().strip()
+        except OSError:
+            recorded = ""
+        if recorded:
+            return recorded
+    return filename
 
 
 class ASMConfig(DDConfig):

--- a/releasenotes/notes/build-system-libddwaf-2f4c1a7b9d3e5a01.yaml
+++ b/releasenotes/notes/build-system-libddwaf-2f4c1a7b9d3e5a01.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    build: the AppSec WAF binding can now use a system-provided libddwaf
+    instead of the prebuilt binaries downloaded from GitHub releases.  Setting
+    ``DD_USE_SYSTEM_LIBDDWAF=1`` at build time locates the library via
+    pkg-config and records its path for the runtime loader.  This is intended
+    for system integrators and Linux distribution packagers that must build
+    everything from source; the default behaviour is unchanged.

--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,10 @@ SERVERLESS_BUILD = os.getenv("DD_SERVERLESS_BUILD", "0").lower() in ("1", "yes",
 WHEEL_FLAVOR = "-serverless" if SERVERLESS_BUILD else ""
 
 LIBDDWAF_VERSION = "2.0.1"
+# Link against a system-provided libddwaf (located via pkg-config) instead of
+# downloading the prebuilt binaries from GitHub releases.  Intended for system
+# integrators and distribution packagers that build everything from source.
+USE_SYSTEM_LIBDDWAF = os.getenv("DD_USE_SYSTEM_LIBDDWAF", "0").lower() in ("1", "yes", "on", "true")
 
 # DEV: update this accordingly when src/native upgrades libdatadog dependency.
 # libdatadog v35.0.0 requires rust 1.87.0.
@@ -644,6 +648,55 @@ class LibDDWafDownload(LibraryDownload):
         else:
             archive_dir = "lib%s-%s-%s-%s.tar.gz" % (cls.name, cls.version, os_name, arch)
         return archive_dir
+
+    @classmethod
+    def link_system_library(cls):
+        """Record the location of a system-provided libddwaf.
+
+        Instead of downloading the prebuilt libddwaf binaries, locate the
+        library installed on the build system via pkg-config and record its
+        resolved path in a small ``libddwaf.link`` text file placed where the
+        bundled library would normally live.  The runtime loader
+        (``build_libddwaf_filename``) falls back to this file when no bundled
+        library is present.
+        """
+        libdir = subprocess.run(
+            ["pkg-config", "--variable=libdir", "libddwaf"],
+            stdout=subprocess.PIPE,
+            check=True,
+            text=True,
+        ).stdout.strip()
+        modversion = subprocess.run(
+            ["pkg-config", "--modversion", "libddwaf"],
+            stdout=subprocess.PIPE,
+            check=True,
+            text=True,
+        ).stdout.strip()
+        if modversion != cls.version:
+            print(
+                "WARNING: system lib%s version %s does not match the version %s pinned by ddtrace"
+                % (cls.name, modversion, cls.version)
+            )
+        suffix = cls.translate_suffix[CURRENT_OS][0]
+        library = Path(libdir) / ("lib%s%s" % (cls.name, suffix))
+        if not library.exists():
+            raise FileNotFoundError("system lib%s not found at %s" % (cls.name, library))
+        # Resolve symlinks so the recorded path stays valid at runtime even
+        # when the development symlink (libddwaf.so -> libddwaf.so.X) is not
+        # installed.
+        target = library.resolve()
+        arch_dir = Path(cls.download_dir) / platform.machine().lower() / "lib"
+        arch_dir.mkdir(parents=True, exist_ok=True)
+        link_file = arch_dir / ("lib%s.link" % cls.name)
+        link_file.write_text(str(target) + "\n")
+        print("Using system lib%s %s: %s" % (cls.name, modversion, target))
+
+    @classmethod
+    def run(cls) -> None:
+        if USE_SYSTEM_LIBDDWAF:
+            cls.link_system_library()
+        else:
+            cls.download_artifacts()
 
 
 # Source/build file extensions that should never appear in a binary wheel.


### PR DESCRIPTION
## Description

Linux distribution packages must be built entirely from source in offline build environments, so they cannot use the prebuilt libddwaf binaries that `setup.py` downloads from GitHub releases — but they typically already package libddwaf itself as a system library.

This adds an opt-in escape hatch for that case: with `DD_USE_SYSTEM_LIBDDWAF=1` set at build time, `setup.py` locates libddwaf via `pkg-config`, resolves the real library path (following the development `libddwaf.so` symlink so the recorded path stays valid without the -devel package installed) and records it in a small `libddwaf.link` text file in the place where the bundled library would normally live. At runtime `build_libddwaf_filename()` falls back to the recorded path when no bundled library is present. A plain text file is used instead of a symlink because symlinks do not survive wheel archiving.

The default behaviour — downloading and bundling the prebuilt binaries — is completely unchanged, as is the runtime lookup when a bundled library exists.

## Testing

Used by the (in progress) openSUSE `python-ddtrace` package: built against the distribution's libddwaf 2.0.1 package, `ddwaf_get_version()` reports 2.0.1 (the bundled version would be pinned differently, so this proves the system library is loaded), `/proc/self/maps` shows the system library mapped, and a `DDWaf` instance built from the shipped default ruleset works.

## Risks

None for default builds (the new code path is only reached with `DD_USE_SYSTEM_LIBDDWAF=1`). A version mismatch between the pinned and the system libddwaf prints a warning at build time.

## Additional Notes

The system-library mode intentionally fails loudly (pkg-config error / missing library) instead of silently falling back to the download, since it is only ever enabled deliberately.
