### PR TITLE
build: allow skipping the native profiling build

### DIFF
--- a/releasenotes/notes/build-optional-native-profiling-8a1d2c3b4e5f6a02.yaml
+++ b/releasenotes/notes/build-optional-native-profiling-8a1d2c3b4e5f6a02.yaml
@@ -1,10 +1,8 @@
 ---
 features:
   - |
-    build: the native profiling components (the ``profiling`` feature of the
-    Rust extension, ``libdd_wrapper`` and the ``memalloc``/``ddup``/``stack``
-    extensions) can be skipped at build time by setting
-    ``DD_BUILD_PROFILING_NATIVE=0``.  Building them requires installing the
+    build: the native profiling components can be skipped at build time by setting
+    ``DD_BUILD_PROFILING_NATIVE=0``. #19740
     ``dedup_headers`` tool over the network, which fully offline (e.g. Linux
     distribution) builds cannot do.  The profiler then reports itself as
     unavailable at runtime; the default behaviour is unchanged.

--- a/releasenotes/notes/build-optional-native-profiling-8a1d2c3b4e5f6a02.yaml
+++ b/releasenotes/notes/build-optional-native-profiling-8a1d2c3b4e5f6a02.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    build: the native profiling components (the ``profiling`` feature of the
+    Rust extension, ``libdd_wrapper`` and the ``memalloc``/``ddup``/``stack``
+    extensions) can be skipped at build time by setting
+    ``DD_BUILD_PROFILING_NATIVE=0``.  Building them requires installing the
+    ``dedup_headers`` tool over the network, which fully offline (e.g. Linux
+    distribution) builds cannot do.  The profiler then reports itself as
+    unavailable at runtime; the default behaviour is unchanged.

--- a/setup.py
+++ b/setup.py
@@ -131,6 +131,13 @@ CARGO_TARGET_DIR = NATIVE_CRATE.absolute() / f"target{sys.version_info.major}.{s
 DD_CARGO_ARGS = shlex.split(os.getenv("DD_CARGO_ARGS", ""))
 
 BUILD_PROFILING_NATIVE_TESTS = os.getenv("DD_PROFILING_NATIVE_TESTS", "0").lower() in ("1", "yes", "on", "true")
+# Build the native profiling components (the profiling feature of the Rust
+# extension, libdd_wrapper and the memalloc/ddup/stack CMake extensions).
+# Building them requires the dedup_headers tool, which setup.py installs on
+# demand with `cargo install --git`, so offline builds can set
+# DD_BUILD_PROFILING_NATIVE=0 to skip the native profiling support entirely;
+# the pure-Python side then reports profiling as unavailable at runtime.
+BUILD_PROFILING_NATIVE = os.getenv("DD_BUILD_PROFILING_NATIVE", "1").lower() in ("1", "yes", "on", "true")
 
 # Opt-in build of the native heap-gotter cdylib.
 # Off by default so normal builds don't pay the extra cargo fetch/compile and
@@ -310,7 +317,8 @@ def is_64_bit_python():
 
 rust_features = ["stats"]
 if CURRENT_OS in ("Linux", "Darwin") and is_64_bit_python() and sys.version_info < (3, 15):
-    rust_features.append("profiling")
+    if BUILD_PROFILING_NATIVE:
+        rust_features.append("profiling")
     if not SERVERLESS_BUILD:
         rust_features.append("crashtracker")
 if not SERVERLESS_BUILD:
@@ -863,7 +871,12 @@ class CustomBuildExt(build_ext):
             self.build_rust()
 
         # Build libdd_wrapper before building other extensions that depend on it
-        if CURRENT_OS in ("Linux", "Darwin") and is_64_bit_python() and sys.version_info < (3, 15):
+        if (
+            BUILD_PROFILING_NATIVE
+            and CURRENT_OS in ("Linux", "Darwin")
+            and is_64_bit_python()
+            and sys.version_info < (3, 15)
+        ):
             with _time_phase("build_libdd_wrapper"):
                 self.build_libdd_wrapper()
 
@@ -1784,7 +1797,12 @@ if not IS_PYSTON:
             CMakeExtension("ddtrace.appsec._iast._taint_tracking._native", source_dir=IAST_DIR, optional=False)
         )
 
-    if CURRENT_OS in ("Linux", "Darwin") and is_64_bit_python() and sys.version_info < (3, 15):
+    if (
+        BUILD_PROFILING_NATIVE
+        and CURRENT_OS in ("Linux", "Darwin")
+        and is_64_bit_python()
+        and sys.version_info < (3, 15)
+    ):
         # Memory profiler now uses CMake to support Abseil dependency
         MEMALLOC_DIR = HERE / "ddtrace" / "profiling" / "collector"
         memalloc_cmake_args = []


### PR DESCRIPTION
## Description

Building the native profiling components requires the `dedup_headers` tool, which `setup.py` installs on demand with `cargo install --git https://github.com/DataDog/libdatadog ...`. Fully offline builds — e.g. Linux distribution packages built in hermetic environments with vendored crates — cannot perform that network access, and there is currently no way to skip it.

This adds `DD_BUILD_PROFILING_NATIVE` (default on, so nothing changes for normal builds). Setting it to `0` skips the `profiling` feature of the Rust extension, the `libdd_wrapper` build and the `memalloc`/`ddup`/`stack` CMake extensions (all of which link `libdd_wrapper`). The pure-Python side already degrades gracefully: `ddtrace.internal.datadog.profiling.ddup`/`stack` report `is_available = False` and profiling is disabled at runtime.

## Testing

Used by the (in progress) openSUSE `python-ddtrace` package, which builds with `DD_BUILD_PROFILING_NATIVE=0` in an offline chroot; the tracer, AppSec/WAF, IAST and the Rust `_native` extension (stats/crashtracker/ffe features) all build and import fine.

## Risks

None for default builds; the switch only removes components from the build when explicitly requested.

## Additional Notes

None
