### PR TITLE
feat(openfeature): add serial id to exposure events

### DIFF
--- a/ddtrace/internal/openfeature/_exposure.py
+++ b/ddtrace/internal/openfeature/_exposure.py
@@ -19,6 +19,7 @@ def build_exposure_event(
     variant_key: Optional[str],
     allocation_key: Optional[str],
     evaluation_context: Optional[EvaluationContext],
+    serial_id: Optional[int] = None,
 ) -> Optional[ExposureEvent]:
     """
     Build an exposure event that will be batched and sent with context.
@@ -31,6 +32,9 @@ def build_exposure_event(
         variant_key: The variant key returned by the evaluation
         allocation_key: The allocation key
         evaluation_context: The evaluation context with subject information
+        serial_id: Serial id of the split the subject landed in. The intake resolves it
+            back to the holdout the allocation was generated from, which an exposure
+            does not otherwise record.
     """
     # Validate required fields
     if not flag_key:
@@ -58,5 +62,8 @@ def build_exposure_event(
             "attributes": evaluation_context.attributes or {},
         },
     }
+
+    if serial_id is not None:
+        exposure_event["serial_id"] = serial_id
 
     return exposure_event

--- a/ddtrace/internal/openfeature/_provider.py
+++ b/ddtrace/internal/openfeature/_provider.py
@@ -497,6 +497,7 @@ class DataDogProvider(AbstractProvider):
                             variant_key=None,
                             allocation_key=None,
                             evaluation_context=evaluation_context,
+                            serial_id=details.serial_id,
                         )
                     return FlagResolutionDetails(
                         value=default_value,
@@ -525,6 +526,7 @@ class DataDogProvider(AbstractProvider):
                     variant_key=details.variant,
                     allocation_key=details.allocation_key,
                     evaluation_context=evaluation_context,
+                    serial_id=details.serial_id,
                 )
 
             # Add allocation_key to the provider-entry timestamp metadata when present.
@@ -572,6 +574,7 @@ class DataDogProvider(AbstractProvider):
         variant_key: typing.Optional[str],
         allocation_key: typing.Optional[str],
         evaluation_context: typing.Optional[EvaluationContext],
+        serial_id: typing.Optional[int] = None,
     ) -> None:
         """
         Report a feature flag exposure event to the EVP proxy intake.
@@ -587,6 +590,8 @@ class DataDogProvider(AbstractProvider):
             variant_key: The variant key returned by evaluation
             allocation_key: The allocation key
             evaluation_context: The evaluation context with subject information
+            serial_id: Serial id of the split the subject landed in, used by the intake
+                to resolve the holdout behind the allocation
         """
         try:
             exposure_event = build_exposure_event(
@@ -594,6 +599,7 @@ class DataDogProvider(AbstractProvider):
                 variant_key=variant_key,
                 allocation_key=allocation_key,
                 evaluation_context=evaluation_context,
+                serial_id=serial_id,
             )
             if not exposure_event:
                 return

--- a/ddtrace/internal/openfeature/_provider.py
+++ b/ddtrace/internal/openfeature/_provider.py
@@ -138,11 +138,13 @@ class DataDogProvider(AbstractProvider):
         self._initialization_timeout = initialization_timeout
 
         # Cache for reported exposures to prevent duplicates
-        # Stores mapping of (flag_key, subject_id) -> (allocation_key, variant_key)
+        # Stores mapping of (flag_key, subject_id) -> (allocation_key, variant_key, serial_id)
+        # The serial id is part of the value because a configuration refresh can add or
+        # change it while the allocation and variant stay the same, and that must be sent.
         # Using LRU cache with maxsize of 65536 to prevent unbounded memory growth
-        self._exposure_cache: LRUCache[tuple[str, str], tuple[typing.Optional[str], typing.Optional[str]]] = LRUCache(
-            maxsize=65536
-        )
+        self._exposure_cache: LRUCache[
+            tuple[str, str], tuple[typing.Optional[str], typing.Optional[str], typing.Optional[int]]
+        ] = LRUCache(maxsize=65536)
 
         # Master gate: the resolved configuration source (stable kill switch +
         # source selection, with legacy grandfathering). Mirrors dd-trace-js,
@@ -606,7 +608,7 @@ class DataDogProvider(AbstractProvider):
 
             # Check cache to prevent duplicate exposure events
             key = (flag_key, exposure_event["subject"]["id"])
-            value = (allocation_key, variant_key)
+            value = (allocation_key, variant_key, serial_id)
 
             cached_value = self._exposure_cache.get(key, None)
             if cached_value and cached_value == value:

--- a/ddtrace/internal/openfeature/_provider.py
+++ b/ddtrace/internal/openfeature/_provider.py
@@ -499,7 +499,7 @@ class DataDogProvider(AbstractProvider):
                             variant_key=None,
                             allocation_key=None,
                             evaluation_context=evaluation_context,
-                            serial_id=details.serial_id,
+                            serial_id=None,
                         )
                     return FlagResolutionDetails(
                         value=default_value,

--- a/ddtrace/internal/openfeature/writer.py
+++ b/ddtrace/internal/openfeature/writer.py
@@ -37,16 +37,20 @@ DEFAULT_INTERVAL = 1.0
 DEFAULT_TIMEOUT = 2.0
 
 
-class ExposureEvent(TypedDict):
-    """
-    Feature flag exposure event structure.
-    """
-
+class _RequiredExposureEvent(TypedDict):
     timestamp: int
     allocation: dict[str, str]
     flag: dict[str, str]
     variant: dict[str, str]
     subject: dict[str, Any]
+
+
+class ExposureEvent(_RequiredExposureEvent, total=False):
+    """
+    Feature flag exposure event structure.
+    """
+
+    serial_id: int
 
 
 class GeoContext(TypedDict, total=False):

--- a/releasenotes/notes/openfeature-exposure-serial-id-8015c1c0dcc85015.yaml
+++ b/releasenotes/notes/openfeature-exposure-serial-id-8015c1c0dcc85015.yaml
@@ -1,7 +1,5 @@
 ---
 features:
   - |
-    openfeature: The Feature Flagging and Experimentation (FFE) OpenFeature provider
-    adds a serial id to the exposure events that it sends to Datadog. Datadog uses the
-    serial id to attribute an exposure to the experiment or holdout that assigned the
-    variant.
+    openfeature: Datadog now uses a serial id to attribute an exposure
+    to the experiment or holdout that assigned the variant.

--- a/releasenotes/notes/openfeature-exposure-serial-id-8015c1c0dcc85015.yaml
+++ b/releasenotes/notes/openfeature-exposure-serial-id-8015c1c0dcc85015.yaml
@@ -1,8 +1,7 @@
 ---
 features:
   - |
-    openfeature: Feature flag exposure events now include the serial id of the split that
-    the subject was assigned to, when the Universal Flag Configuration supplies one. The
-    serial id lets Datadog attribute an exposure to the holdout that an allocation was
-    generated from. A holdout is compiled into an ordinary allocation before the provider
-    receives it, so an exposure does not otherwise record it.
+    openfeature: The Feature Flagging and Experimentation (FFE) OpenFeature provider
+    adds a serial id to the exposure events that it sends to Datadog. Datadog uses the
+    serial id to attribute an exposure to the experiment or holdout that assigned the
+    variant.

--- a/releasenotes/notes/openfeature-exposure-serial-id-8015c1c0dcc85015.yaml
+++ b/releasenotes/notes/openfeature-exposure-serial-id-8015c1c0dcc85015.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    openfeature: Feature flag exposure events now include the serial id of the split that
+    the subject was assigned to, when the Universal Flag Configuration supplies one. The
+    serial id lets Datadog attribute an exposure to the holdout that an allocation was
+    generated from. A holdout is compiled into an ordinary allocation before the provider
+    receives it, so an exposure does not otherwise record it.

--- a/tests/openfeature/test_exposure.py
+++ b/tests/openfeature/test_exposure.py
@@ -113,3 +113,62 @@ class TestBuildExposureEvent:
         assert event is not None
         assert event["subject"]["id"] == "user-789"
         assert event["subject"]["attributes"] == {}
+
+    def test_build_exposure_event_with_serial_id(self):
+        """Test that a serial id is carried onto the event."""
+        context = EvaluationContext(targeting_key="user-123")
+
+        event = build_exposure_event(
+            flag_key="test-flag",
+            variant_key="variant-a",
+            allocation_key="allocation-1",
+            evaluation_context=context,
+            serial_id=340132,
+        )
+
+        assert event is not None
+        assert event["serial_id"] == 340132
+
+    def test_build_exposure_event_without_serial_id(self):
+        """Test that the key is absent, not null, when no serial id is given."""
+        context = EvaluationContext(targeting_key="user-123")
+
+        event = build_exposure_event(
+            flag_key="test-flag",
+            variant_key="variant-a",
+            allocation_key="allocation-1",
+            evaluation_context=context,
+        )
+
+        assert event is not None
+        assert "serial_id" not in event
+
+    def test_build_exposure_event_serial_id_zero(self):
+        """Test that a serial id of zero is carried, not dropped as falsy."""
+        context = EvaluationContext(targeting_key="user-123")
+
+        event = build_exposure_event(
+            flag_key="test-flag",
+            variant_key="variant-a",
+            allocation_key="allocation-1",
+            evaluation_context=context,
+            serial_id=0,
+        )
+
+        assert event is not None
+        assert event["serial_id"] == 0
+
+    def test_build_exposure_event_serial_id_not_validated(self):
+        """Test that the serial id is sent unchanged. The UFC layer validates it."""
+        context = EvaluationContext(targeting_key="user-123")
+
+        event = build_exposure_event(
+            flag_key="test-flag",
+            variant_key="variant-a",
+            allocation_key="allocation-1",
+            evaluation_context=context,
+            serial_id=-1,
+        )
+
+        assert event is not None
+        assert event["serial_id"] == -1

--- a/tests/openfeature/test_provider_exposure.py
+++ b/tests/openfeature/test_provider_exposure.py
@@ -574,3 +574,69 @@ class TestExposureConnectionErrors:
         assert result.value is True
         # Verify writer.enqueue was called (even though it raised)
         mock_writer.enqueue.assert_called()
+
+
+class TestExposureSerialId:
+    """Test that the split serial id reaches the exposure event."""
+
+    @staticmethod
+    def _config_with_serial_id(serial_id=None):
+        split = {"variationKey": "true", "shards": []}
+        if serial_id is not None:
+            split["serialId"] = serial_id
+
+        return {
+            "id": "1",
+            "createdAt": "2025-10-30T18:36:06.108540853Z",
+            "format": "SERVER",
+            "environment": {"name": "staging"},
+            "flags": {
+                "holdout-flag": {
+                    "key": "holdout-flag",
+                    "enabled": True,
+                    "variationType": "BOOLEAN",
+                    "variations": {"false": {"key": "false", "value": False}, "true": {"key": "true", "value": True}},
+                    "allocations": [
+                        {
+                            "key": "allocation-default",
+                            "splits": [split],
+                            "doLog": True,
+                        },
+                    ],
+                }
+            },
+        }
+
+    @mock.patch("ddtrace.internal.openfeature._provider.get_exposure_writer")
+    def test_serial_id_reported_on_exposure(self, mock_get_writer, provider, evaluation_context):
+        """Test that a serial id on the resolved split is sent with the exposure."""
+        mock_writer = mock.Mock()
+        mock_get_writer.return_value = mock_writer
+
+        process_ffe_configuration(self._config_with_serial_id(340132))
+
+        result = provider.resolve_boolean_details("holdout-flag", False, evaluation_context)
+
+        assert result.value is True
+        mock_writer.enqueue.assert_called_once()
+
+        exposure_event = mock_writer.enqueue.call_args[0][0]
+        assert exposure_event["flag"]["key"] == "holdout-flag"
+        assert exposure_event["serial_id"] == 340132
+
+    @mock.patch("ddtrace.internal.openfeature._provider.get_exposure_writer")
+    def test_no_serial_id_key_when_split_has_none(self, mock_get_writer, provider, evaluation_context):
+        """Test that the exposure omits the key when the split carries no serial id."""
+        mock_writer = mock.Mock()
+        mock_get_writer.return_value = mock_writer
+
+        process_ffe_configuration(self._config_with_serial_id())
+
+        result = provider.resolve_boolean_details("holdout-flag", False, evaluation_context)
+
+        assert result.value is True
+        mock_writer.enqueue.assert_called_once()
+
+        exposure_event = mock_writer.enqueue.call_args[0][0]
+        assert exposure_event["flag"]["key"] == "holdout-flag"
+        assert "serial_id" not in exposure_event

--- a/tests/openfeature/test_provider_exposure.py
+++ b/tests/openfeature/test_provider_exposure.py
@@ -261,6 +261,7 @@ class TestExposureReporting:
             mock_details_a.error_code = None
             mock_details_a.error_message = None
             mock_details_a.do_log = True  # Enable exposure logging
+            mock_details_a.serial_id = None
             mock_resolve.return_value = mock_details_a
 
             result = provider.resolve_boolean_details("cycling-flag", False, evaluation_context)
@@ -280,6 +281,7 @@ class TestExposureReporting:
             mock_details_b.error_code = None
             mock_details_b.error_message = None
             mock_details_b.do_log = True  # Enable exposure logging
+            mock_details_b.serial_id = None
             mock_resolve.return_value = mock_details_b
 
             result = provider.resolve_boolean_details("cycling-flag", False, evaluation_context)
@@ -299,6 +301,7 @@ class TestExposureReporting:
             mock_details_b2.error_code = None
             mock_details_b2.error_message = None
             mock_details_b2.do_log = True  # Enable exposure logging
+            mock_details_b2.serial_id = None
             mock_resolve.return_value = mock_details_b2
 
             result = provider.resolve_boolean_details("cycling-flag", False, evaluation_context)
@@ -315,6 +318,7 @@ class TestExposureReporting:
             mock_details_a2.error_code = None
             mock_details_a2.error_message = None
             mock_details_a2.do_log = True  # Enable exposure logging
+            mock_details_a2.serial_id = None
             mock_resolve.return_value = mock_details_a2
 
             result = provider.resolve_boolean_details("cycling-flag", False, evaluation_context)
@@ -361,6 +365,7 @@ class TestExposureReporting:
             mock_details.error_code = None
             mock_details.error_message = None
             mock_details.do_log = False  # Exposure logging disabled
+            mock_details.serial_id = None
             mock_resolve.return_value = mock_details
 
             result = provider.resolve_boolean_details("no-log-flag", False, evaluation_context)
@@ -391,6 +396,7 @@ class TestExposureReporting:
             mock_details.error_code = None
             mock_details.error_message = None
             mock_details.do_log = True  # Exposure logging enabled
+            mock_details.serial_id = None
             mock_resolve.return_value = mock_details
 
             result = provider.resolve_boolean_details("log-flag", False, evaluation_context)
@@ -640,3 +646,50 @@ class TestExposureSerialId:
         exposure_event = mock_writer.enqueue.call_args[0][0]
         assert exposure_event["flag"]["key"] == "holdout-flag"
         assert "serial_id" not in exposure_event
+
+    @mock.patch("ddtrace.internal.openfeature._provider.get_exposure_writer")
+    def test_serial_id_that_appears_reports_a_new_exposure(self, mock_get_writer, provider, evaluation_context):
+        """Test that a serial id added by a later configuration reaches the intake."""
+        mock_writer = mock.Mock()
+        mock_get_writer.return_value = mock_writer
+
+        process_ffe_configuration(self._config_with_serial_id())
+        provider.resolve_boolean_details("holdout-flag", False, evaluation_context)
+
+        process_ffe_configuration(self._config_with_serial_id(340132))
+        provider.resolve_boolean_details("holdout-flag", False, evaluation_context)
+
+        assert mock_writer.enqueue.call_count == 2
+        first, second = [call[0][0] for call in mock_writer.enqueue.call_args_list]
+        assert "serial_id" not in first
+        assert second["serial_id"] == 340132
+
+    @mock.patch("ddtrace.internal.openfeature._provider.get_exposure_writer")
+    def test_serial_id_that_changes_reports_a_new_exposure(self, mock_get_writer, provider, evaluation_context):
+        """Test that a changed serial id reaches the intake, so attribution is not stale."""
+        mock_writer = mock.Mock()
+        mock_get_writer.return_value = mock_writer
+
+        process_ffe_configuration(self._config_with_serial_id(340132))
+        provider.resolve_boolean_details("holdout-flag", False, evaluation_context)
+
+        process_ffe_configuration(self._config_with_serial_id(999999))
+        provider.resolve_boolean_details("holdout-flag", False, evaluation_context)
+
+        assert mock_writer.enqueue.call_count == 2
+        first, second = [call[0][0] for call in mock_writer.enqueue.call_args_list]
+        assert first["serial_id"] == 340132
+        assert second["serial_id"] == 999999
+
+    @mock.patch("ddtrace.internal.openfeature._provider.get_exposure_writer")
+    def test_unchanged_serial_id_reports_one_exposure(self, mock_get_writer, provider, evaluation_context):
+        """Test that the cache still removes duplicates when the serial id does not change."""
+        mock_writer = mock.Mock()
+        mock_get_writer.return_value = mock_writer
+
+        process_ffe_configuration(self._config_with_serial_id(340132))
+        provider.resolve_boolean_details("holdout-flag", False, evaluation_context)
+        provider.resolve_boolean_details("holdout-flag", False, evaluation_context)
+
+        assert mock_writer.enqueue.call_count == 1
+        assert mock_writer.enqueue.call_args[0][0]["serial_id"] == 340132


### PR DESCRIPTION
## Description

This change adds a `serial_id` field to the exposure event.

The serial id identifies the split that the subject was assigned to. The intake uses the serial id to find more information about the exposure, for example the holdout that the allocation comes from. The exposure event does not record that information in another way.

The provider already receives the serial id and uses it for span enrichment. This change also sends the serial id on the exposure event.

Three source files change:

| File | Change |
|---|---|
| `internal/openfeature/writer.py` | Add the optional field to the `ExposureEvent` type. |
| `internal/openfeature/_exposure.py` | Set the field when the evaluation gives a serial id. |
| `internal/openfeature/_provider.py` | Send the serial id from the evaluation result, and include it in the exposure cache. |

The provider does not validate the value. The flag configuration layer validates it.

## Testing

Nine new tests: four for `build_exposure_event`, and five that send a flag configuration through the native evaluator.

```
scripts/ddtest riot -v run --pass-env -p3.12 openfeature
```

638 tests pass on Python 3.12. CI runs the other supported versions.

`test_exposure_variant_allocation_cycling` also changes. It builds the evaluation result with `mock.Mock` and does not set `serial_id`, so each mock gave a different automatic attribute. The mocks now set `serial_id` to `None`, which is the value that the evaluator gives for a split without a serial id.

## Risks

Low. The field is optional. An exposure event without a serial id does not change.

The exposure cache now compares the serial id in addition to the allocation key and the variant key. A subject therefore reports one more exposure when its serial id appears or changes. This is intended: a configuration refresh can add a serial id, or change it, while both keys stay the same, and the intake must receive that value.

*This description was generated by Claude.*
