### PR TITLE
fix(llmobs): make span data JSON-safe at span finish

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -154,7 +154,7 @@ from ddtrace.llmobs._utils import _get_nearest_llmobs_ancestor
 from ddtrace.llmobs._utils import _get_parent_prompt
 from ddtrace.llmobs._utils import _normalize_wire_trace_id_to_hex
 from ddtrace.llmobs._utils import _resolve_parent_agent
-from ddtrace.llmobs._utils import _sanitize_span_event_depth
+from ddtrace.llmobs._utils import _sanitize_span_event_data
 from ddtrace.llmobs._utils import _stamp_agent_attribution
 from ddtrace.llmobs._utils import _trace_id_to_wire
 from ddtrace.llmobs._utils import _validate_prompt
@@ -631,7 +631,12 @@ class LLMObs(Service):
             self._do_annotations(span)
 
     def _on_span_finish(self, span: Span) -> None:
-        if not self.enabled or span.span_type != SpanTypes.LLM:
+        if span.span_type != SpanTypes.LLM:
+            return
+        if not self.enabled:
+            # LLMObs was disabled after this span started, so no event will be produced. Drop the
+            # partial struct instead of letting it ride along to the APM encoder unsanitized.
+            span._remove_struct_tag(LLMOBS_STRUCT.KEY)
             return
         span_kind = get_llmobs_span_kind(span)
         if span_kind == "llm":
@@ -738,7 +743,11 @@ class LLMObs(Service):
             output_type,
             export_to_llmobs=self._export_mode != LLMObsExportMode.APM_AGENTLESS,
         )
-        llmobs_data[LLMOBS_STRUCT.META] = _sanitize_span_event_depth(llmobs_meta)
+        llmobs_data[LLMOBS_STRUCT.META] = _sanitize_span_event_data(llmobs_meta)
+        # config sits at the top level rather than under meta, so it needs its own pass.
+        config = llmobs_data.get(LLMOBS_STRUCT.CONFIG)
+        if config is not None:
+            llmobs_data[LLMOBS_STRUCT.CONFIG] = _sanitize_span_event_data(config)
         if self._export_mode == LLMObsExportMode.APM_AGENTLESS:
             # APM agentless ingestion treats dots in tag keys as nested-path separators;
             # replace them with underscores before encoding.

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -634,8 +634,7 @@ class LLMObs(Service):
         if span.span_type != SpanTypes.LLM:
             return
         if not self.enabled:
-            # LLMObs was disabled after this span started, so no event will be produced. Drop the
-            # partial struct instead of letting it ride along to the APM encoder unsanitized.
+            # LLMObs metastruct value is unnecessary since not enabled
             span._remove_struct_tag(LLMOBS_STRUCT.KEY)
             return
         span_kind = get_llmobs_span_kind(span)
@@ -718,7 +717,9 @@ class LLMObs(Service):
         # reaches every span in its block, but only agent spans carry the tags.
         agent_annotation = span._get_ctx_item(AGENT_ANNOTATION)
         if agent_annotation and span_kind == "agent":
-            llmobs_data.setdefault(LLMOBS_STRUCT.TAGS, {})[AGENT_VERSION_TAG_KEY] = agent_annotation
+            # str() because the agent version comes straight from user-supplied annotate(agent=...)
+            # with no type validation, and tag values are serialized as strings.
+            llmobs_data.setdefault(LLMOBS_STRUCT.TAGS, {})[AGENT_VERSION_TAG_KEY] = str(agent_annotation)
 
         llmobs_meta = llmobs_data.setdefault(LLMOBS_STRUCT.META, _Meta())
         llmobs_input = llmobs_meta.get(LLMOBS_STRUCT.INPUT) or _MetaIO()
@@ -744,7 +745,6 @@ class LLMObs(Service):
             export_to_llmobs=self._export_mode != LLMObsExportMode.APM_AGENTLESS,
         )
         llmobs_data[LLMOBS_STRUCT.META] = _sanitize_span_event_data(llmobs_meta)
-        # config sits at the top level rather than under meta, so it needs its own pass.
         config = llmobs_data.get(LLMOBS_STRUCT.CONFIG)
         if config is not None:
             llmobs_data[LLMOBS_STRUCT.CONFIG] = _sanitize_span_event_data(config)

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -633,8 +633,7 @@ class LLMObs(Service):
     def _on_span_finish(self, span: Span) -> None:
         if span.span_type != SpanTypes.LLM:
             return
-        if not self.enabled:
-            # LLMObs metastruct value is unnecessary since not enabled
+        if not self.enabled:  # LLMObs metastruct value is unnecessary since not enabled
             span._remove_struct_tag(LLMOBS_STRUCT.KEY)
             return
         span_kind = get_llmobs_span_kind(span)
@@ -717,8 +716,6 @@ class LLMObs(Service):
         # reaches every span in its block, but only agent spans carry the tags.
         agent_annotation = span._get_ctx_item(AGENT_ANNOTATION)
         if agent_annotation and span_kind == "agent":
-            # str() because the agent version comes straight from user-supplied annotate(agent=...)
-            # with no type validation, and tag values are serialized as strings.
             llmobs_data.setdefault(LLMOBS_STRUCT.TAGS, {})[AGENT_VERSION_TAG_KEY] = str(agent_annotation)
 
         llmobs_meta = llmobs_data.setdefault(LLMOBS_STRUCT.META, _Meta())

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -631,10 +631,7 @@ class LLMObs(Service):
             self._do_annotations(span)
 
     def _on_span_finish(self, span: Span) -> None:
-        if span.span_type != SpanTypes.LLM:
-            return
-        if not self.enabled:  # LLMObs metastruct value is unnecessary since not enabled
-            span._remove_struct_tag(LLMOBS_STRUCT.KEY)
+        if not self.enabled or span.span_type != SpanTypes.LLM:
             return
         span_kind = get_llmobs_span_kind(span)
         if span_kind == "llm":

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -252,16 +252,24 @@ def _unserializable_default_repr(obj):
 _MAX_NESTED_META_DEPTH = 12
 
 
-def _sanitize_span_event_depth(obj: Any) -> Any:
-    """Return a sanitized copy of obj with any container value that exceeds
-    _MAX_NESTED_META_DEPTH levels from the root replaced by its JSON string representation,
-    and every mapping key stringified. The original structure is never mutated.
-    A debug log is emitted for each stringified field, including its dotted path.
+def _sanitize_span_event_data(obj: Any) -> Any:
+    """Return a copy of obj that is safe to encode into a span event.
+
+    Three guarantees, applied to every node: any container that exceeds _MAX_NESTED_META_DEPTH
+    levels from the root is replaced by its JSON string representation, every mapping key is
+    stringified, and every leaf value is made JSON-serializable. The original structure is never
+    mutated. A debug log is emitted for each stringified over-depth field, including its dotted path.
+
+    Leaf sanitization matters because integrations store live SDK objects here as-is. This data
+    rides along on the APM span as meta_struct, and the agentless APM exporter JSON-encodes it with
+    no fallback for unserializable objects -- one such object raises TypeError and drops the entire
+    trace payload, not just the offending span. So this is the last line of defense, and it runs
+    after the user span processor, which can also introduce arbitrary objects.
     """
 
     def _walk(node: Any, depth: int, path: str) -> Any:
         if not isinstance(node, (dict, list)):
-            return node
+            return _sanitize_leaf(node, depth, path)
         if depth >= _MAX_NESTED_META_DEPTH:
             log.debug(
                 "LLMObs: span event field %r exceeds the maximum nested depth of %d and will be "
@@ -273,6 +281,16 @@ def _sanitize_span_event_depth(obj: Any) -> Any:
         if isinstance(node, dict):
             return {str(k): _walk(v, depth + 1, f"{path}.{k}" if path else str(k)) for k, v in node.items()}
         return [_walk(v, depth + 1, f"{path}[{i}]" if path else str(i)) for i, v in enumerate(node)]
+
+    def _sanitize_leaf(node: Any, depth: int, path: str) -> Any:
+        if node is None or isinstance(node, (str, int, float, bool)):
+            return node
+        # load_data_value preserves structure where it can (pydantic models and dataclasses become
+        # dicts) rather than flattening to a string, so nested objects stay queryable in the UI.
+        loaded = load_data_value(node)
+        # Structure it recovered still has to respect the depth limit, so walk it at this depth.
+        # load_data_value output bottoms out in primitives, so this cannot recurse indefinitely.
+        return _walk(loaded, depth, path) if isinstance(loaded, (dict, list)) else loaded
 
     return _walk(obj, 0, "")
 
@@ -310,9 +328,13 @@ def load_data_value(value):
     elif isinstance(value, type):
         return value.__name__
     elif hasattr(value, "model_dump"):
-        return value.model_dump(exclude_none=True)
+        # model_dump() (without mode="json") can still leave non-primitive field values
+        # (e.g. datetime, Enum, other SDK objects) unconverted, so recurse into the result.
+        return load_data_value(value.model_dump(exclude_none=True))
     elif is_dataclass(value):
-        return asdict(value)
+        # asdict() only recurses into nested dataclasses/dicts/lists/tuples -- other field
+        # types are deep-copied as-is, so recurse into the result to finish sanitizing them.
+        return load_data_value(asdict(value))
     elif isinstance(value, (int, float, str, bool)) or value is None:
         return value
     else:
@@ -770,7 +792,10 @@ def _annotate_llmobs_span_data(
         if model_provider is not None:
             meta[LLMOBS_STRUCT.MODEL_PROVIDER] = model_provider
         if metadata is not None:
-            # Metadata keys are serialized as strings, so coerce non-string keys here.
+            # Metadata keys are serialized as strings, so coerce non-string keys here. Values are
+            # stored as-is: integrations hand us live SDK objects, and in-process consumers (the
+            # user span processor, evaluators) should see them at full fidelity. Making them
+            # JSON-safe is deferred to _sanitize_span_event_data at span finish.
             meta[LLMOBS_STRUCT.METADATA].update({str(k): v for k, v in metadata.items()})
         if agent_manifest is not None or cost_tags is not None:
             # Initialize metadata_dd here to avoid unnecessary empty dict allocations in the top-level metadata dict.

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -249,14 +249,6 @@ def _unserializable_default_repr(obj):
         return "[Unserializable object: {}]".format(repr(obj))
 
 
-def _safe_str(obj: Any) -> str:
-    """str(obj), falling back to a type placeholder if __str__ itself raises."""
-    try:
-        return str(obj)
-    except Exception:
-        return "[Unserializable object of type {}]".format(type(obj).__name__)
-
-
 _MAX_NESTED_META_DEPTH = 12
 
 
@@ -300,7 +292,10 @@ def _sanitize_span_event_data(obj: Any) -> Any:
             # handler too, leaving the unsanitized struct on the span for the agentless encoder to
             # choke on -- the whole-trace drop this function exists to prevent.
             log.debug("LLMObs: span event field %r could not be converted; falling back to str.", path)
-            return _safe_str(node)
+            try:
+                return str(node)
+            except Exception:
+                return "[Unserializable object of type {}]".format(type(node).__name__)
         return _walk(loaded, depth, path) if isinstance(loaded, (dict, list)) else loaded
 
     return _walk(obj, 0, "")
@@ -349,7 +344,7 @@ def load_data_value(value):
     else:
         value_str = safe_json(value)
         if value_str is None:  # safe_json swallows its failure and returns None
-            return _safe_str(value)
+            return str(value)
         try:
             return json.loads(value_str)
         except json.JSONDecodeError:
@@ -827,7 +822,7 @@ def _annotate_llmobs_span_data(
             llmobs_span_data[LLMOBS_STRUCT.TAGS].update({str(k): str(v) for k, v in tags.items()})
         if session_id is not None:
             llmobs_span_data[LLMOBS_STRUCT.SESSION_ID] = session_id
-            llmobs_span_data[LLMOBS_STRUCT.TAGS]["session_id"] = session_id
+            llmobs_span_data[LLMOBS_STRUCT.TAGS]["session_id"] = str(session_id)
             span._set_ctx_item(SESSION_ID, session_id)
         if span_links is not None:
             llmobs_span_data[LLMOBS_STRUCT.SPAN_LINKS] = span_links

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -249,6 +249,14 @@ def _unserializable_default_repr(obj):
         return "[Unserializable object: {}]".format(repr(obj))
 
 
+def _safe_str(obj: Any) -> str:
+    """str(obj), falling back to a type placeholder if __str__ itself raises."""
+    try:
+        return str(obj)
+    except Exception:
+        return "[Unserializable object of type {}]".format(type(obj).__name__)
+
+
 _MAX_NESTED_META_DEPTH = 12
 
 
@@ -284,7 +292,15 @@ def _sanitize_span_event_data(obj: Any) -> Any:
             return node
         # load_data_value keeps structure where it can (models become dicts) instead of flattening
         # to a string, so nested objects stay queryable. Re-walk it to apply the depth limit.
-        loaded = load_data_value(node)
+        try:
+            loaded = load_data_value(node)
+        except Exception:
+            # Conversion is allowed to fail (an SDK model_dump() that raises, a cyclic object that
+            # recurses) but this sanitizer is not: anything escaping here escapes _on_span_finish's
+            # handler too, leaving the unsanitized struct on the span for the agentless encoder to
+            # choke on -- the whole-trace drop this function exists to prevent.
+            log.debug("LLMObs: span event field %r could not be converted; falling back to str.", path)
+            return _safe_str(node)
         return _walk(loaded, depth, path) if isinstance(loaded, (dict, list)) else loaded
 
     return _walk(obj, 0, "")
@@ -332,6 +348,8 @@ def load_data_value(value):
         return value
     else:
         value_str = safe_json(value)
+        if value_str is None:  # safe_json swallows its failure and returns None
+            return _safe_str(value)
         try:
             return json.loads(value_str)
         except json.JSONDecodeError:
@@ -693,12 +711,12 @@ def _sanitize_metric_key(key):
 
     LLMObs ingestion interprets dots in a metric key as nested-path separators, which breaks
     decoding of the flat numeric metrics map and causes the enclosing span batch to be dropped.
-    Non-string keys are stringified, since a metric key is serialized as a string either way and
-    the encoder has no representation for other key types. (Value validation happens upstream in
-    ``annotate``.)
+    Non-string keys are stringified first, since a metric key is serialized as a string either way
+    and the encoder has no representation for other key types -- and stringifying can itself
+    introduce a dot (1.5 -> "1.5"). (Value validation happens upstream in annotate.)
     """
     if not isinstance(key, str):
-        return str(key)
+        key = str(key)
     if "." not in key:
         return key
     sanitized = key.replace(".", "_")

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -260,11 +260,8 @@ def _sanitize_span_event_data(obj: Any) -> Any:
     stringified, and every leaf value is made JSON-serializable. The original structure is never
     mutated. A debug log is emitted for each stringified over-depth field, including its dotted path.
 
-    Leaf sanitization matters because integrations store live SDK objects here as-is. This data
-    rides along on the APM span as meta_struct, and the agentless APM exporter JSON-encodes it with
-    no fallback for unserializable objects -- one such object raises TypeError and drops the entire
-    trace payload, not just the offending span. So this is the last line of defense, and it runs
-    after the user span processor, which can also introduce arbitrary objects.
+    This is the last line of defense before the agentless APM exporter, which drops the whole trace
+    payload on a single unserializable object. It runs after the user span processor for that reason.
     """
 
     def _walk(node: Any, depth: int, path: str) -> Any:
@@ -285,11 +282,9 @@ def _sanitize_span_event_data(obj: Any) -> Any:
     def _sanitize_leaf(node: Any, depth: int, path: str) -> Any:
         if node is None or isinstance(node, (str, int, float, bool)):
             return node
-        # load_data_value preserves structure where it can (pydantic models and dataclasses become
-        # dicts) rather than flattening to a string, so nested objects stay queryable in the UI.
+        # load_data_value keeps structure where it can (models become dicts) instead of flattening
+        # to a string, so nested objects stay queryable. Re-walk it to apply the depth limit.
         loaded = load_data_value(node)
-        # Structure it recovered still has to respect the depth limit, so walk it at this depth.
-        # load_data_value output bottoms out in primitives, so this cannot recurse indefinitely.
         return _walk(loaded, depth, path) if isinstance(loaded, (dict, list)) else loaded
 
     return _walk(obj, 0, "")
@@ -328,12 +323,10 @@ def load_data_value(value):
     elif isinstance(value, type):
         return value.__name__
     elif hasattr(value, "model_dump"):
-        # model_dump() (without mode="json") can still leave non-primitive field values
-        # (e.g. datetime, Enum, other SDK objects) unconverted, so recurse into the result.
+        # model_dump() can leave non-primitive field values (datetime, Enum, ...) unconverted.
         return load_data_value(value.model_dump(exclude_none=True))
     elif is_dataclass(value):
-        # asdict() only recurses into nested dataclasses/dicts/lists/tuples -- other field
-        # types are deep-copied as-is, so recurse into the result to finish sanitizing them.
+        # asdict() deep-copies non-dataclass field types as-is, leaving them unconverted.
         return load_data_value(asdict(value))
     elif isinstance(value, (int, float, str, bool)) or value is None:
         return value
@@ -700,9 +693,13 @@ def _sanitize_metric_key(key):
 
     LLMObs ingestion interprets dots in a metric key as nested-path separators, which breaks
     decoding of the flat numeric metrics map and causes the enclosing span batch to be dropped.
-    Non-string keys are returned unchanged (value validation happens upstream in ``annotate``).
+    Non-string keys are stringified, since a metric key is serialized as a string either way and
+    the encoder has no representation for other key types. (Value validation happens upstream in
+    ``annotate``.)
     """
-    if not isinstance(key, str) or "." not in key:
+    if not isinstance(key, str):
+        return str(key)
+    if "." not in key:
         return key
     sanitized = key.replace(".", "_")
     log.warning(
@@ -793,9 +790,7 @@ def _annotate_llmobs_span_data(
             meta[LLMOBS_STRUCT.MODEL_PROVIDER] = model_provider
         if metadata is not None:
             # Metadata keys are serialized as strings, so coerce non-string keys here. Values are
-            # stored as-is: integrations hand us live SDK objects, and in-process consumers (the
-            # user span processor, evaluators) should see them at full fidelity. Making them
-            # JSON-safe is deferred to _sanitize_span_event_data at span finish.
+            # left as-is for in-process consumers; _sanitize_span_event_data handles them at finish.
             meta[LLMOBS_STRUCT.METADATA].update({str(k): v for k, v in metadata.items()})
         if agent_manifest is not None or cost_tags is not None:
             # Initialize metadata_dd here to avoid unnecessary empty dict allocations in the top-level metadata dict.
@@ -810,8 +805,8 @@ def _annotate_llmobs_span_data(
         if metrics is not None:
             llmobs_span_data[LLMOBS_STRUCT.METRICS].update({_sanitize_metric_key(k): v for k, v in metrics.items()})
         if tags is not None:
-            # Tag values are serialized as strings, so coerce non-string values here.
-            llmobs_span_data[LLMOBS_STRUCT.TAGS].update({k: str(v) for k, v in tags.items()})
+            # Tag keys and values are both serialized as strings, so coerce non-string ones here.
+            llmobs_span_data[LLMOBS_STRUCT.TAGS].update({str(k): str(v) for k, v in tags.items()})
         if session_id is not None:
             llmobs_span_data[LLMOBS_STRUCT.SESSION_ID] = session_id
             llmobs_span_data[LLMOBS_STRUCT.TAGS]["session_id"] = session_id

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -287,10 +287,6 @@ def _sanitize_span_event_data(obj: Any) -> Any:
         try:
             loaded = load_data_value(node)
         except Exception:
-            # Conversion is allowed to fail (an SDK model_dump() that raises, a cyclic object that
-            # recurses) but this sanitizer is not: anything escaping here escapes _on_span_finish's
-            # handler too, leaving the unsanitized struct on the span for the agentless encoder to
-            # choke on -- the whole-trace drop this function exists to prevent.
             log.debug("LLMObs: span event field %r could not be converted; falling back to str.", path)
             try:
                 return str(node)

--- a/releasenotes/notes/llmobs-metadata-json-safety-9c3f7a1e4b2d6f80.yaml
+++ b/releasenotes/notes/llmobs-metadata-json-safety-9c3f7a1e4b2d6f80.yaml
@@ -1,8 +1,6 @@
 ---
 fixes:
   - |
-    LLM Observability: Fixes an issue where non-JSON-serializable objects stored on a span (for
-    example, raw SDK request or config objects some integrations pass through as span metadata or
-    config, or objects introduced by a user span processor) could cause the agentless APM exporter
-    to raise a ``TypeError`` and silently drop the entire trace payload. All span data is now made
-    JSON-safe before the span is submitted.
+    LLM Observability: Fixes an issue where the agentless exporter dropped traces due to non-JSON-serializable objects being stored on a span.
+    All LLM Observability span data is now made JSON-serializable before the span is submitted. Non-string span tag keys, span metric keys,
+    and agent versions supplied via ``LLMObs.annotate(agent=...)`` are also now coerced to strings.

--- a/releasenotes/notes/llmobs-metadata-json-safety-9c3f7a1e4b2d6f80.yaml
+++ b/releasenotes/notes/llmobs-metadata-json-safety-9c3f7a1e4b2d6f80.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    LLM Observability: Fixes an issue where non-JSON-serializable objects stored on a span (for
+    example, raw SDK request or config objects some integrations pass through as span metadata or
+    config, or objects introduced by a user span processor) could cause the agentless APM exporter
+    to raise a ``TypeError`` and silently drop the entire trace payload. All span data is now made
+    JSON-safe before the span is submitted.

--- a/tests/contrib/google_genai/utils.py
+++ b/tests/contrib/google_genai/utils.py
@@ -224,10 +224,24 @@ MOCK_EMBED_CONTENT_RESPONSE = types.EmbedContentResponse(
 )
 
 
+def _as_submitted(value):
+    """Mirror the conversion a metadata value undergoes on its way onto the span.
+
+    Span data is made JSON-serializable at span finish, which turns pydantic config objects such as
+    SafetySetting into plain dicts. Dumping here rather than hardcoding the result keeps these
+    expectations correct across the google-genai versions in the test matrix.
+    """
+    if isinstance(value, list):
+        return [_as_submitted(v) for v in value]
+    if hasattr(value, "model_dump"):
+        return value.model_dump(exclude_none=True)
+    return value
+
+
 def get_expected_metadata():
     metadata = {}
     for param in GENERATE_METADATA_PARAMS:
-        metadata[param] = getattr(FULL_GENERATE_CONTENT_CONFIG, param, None)
+        metadata[param] = _as_submitted(getattr(FULL_GENERATE_CONTENT_CONFIG, param, None))
 
     return metadata
 
@@ -235,6 +249,6 @@ def get_expected_metadata():
 def get_expected_tool_metadata():
     metadata = {}
     for param in GENERATE_METADATA_PARAMS:
-        metadata[param] = getattr(TOOL_GENERATE_CONTENT_CONFIG, param, None)
+        metadata[param] = _as_submitted(getattr(TOOL_GENERATE_CONTENT_CONFIG, param, None))
 
     return metadata

--- a/tests/contrib/litellm/utils.py
+++ b/tests/contrib/litellm/utils.py
@@ -237,7 +237,11 @@ tools = [
 ]
 
 expected_router_settings = {
-    "router_general_settings": RouterGeneralSettings(async_only_mode=False, pass_through_all_models=False),
+    # Dumped rather than kept as a model: span data is made JSON-serializable at span finish, so
+    # what lands on the span is a plain dict.
+    "router_general_settings": RouterGeneralSettings(async_only_mode=False, pass_through_all_models=False).model_dump(
+        exclude_none=True
+    ),
     "routing_strategy": "simple-shuffle",
     "routing_strategy_args": {},
     "provider_budget_config": None,

--- a/tests/llmobs/test_llmobs.py
+++ b/tests/llmobs/test_llmobs.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 from textwrap import dedent
 from typing import Optional
@@ -8,6 +9,7 @@ import pytest
 
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.utils.formats import format_trace_id
+from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs import LLMObsSpan
 from ddtrace.llmobs._constants import LANGCHAIN_APM_SPAN_NAME
 from ddtrace.llmobs._constants import LLMOBS_APM_SHADOW_CACHE_READ_INPUT_TOKENS_METRIC_KEY
@@ -17,6 +19,7 @@ from ddtrace.llmobs._constants import LLMOBS_APM_SHADOW_INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import LLMOBS_APM_SHADOW_OUTPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import LLMOBS_APM_SHADOW_SPAN_KIND_TAG_KEY
 from ddtrace.llmobs._constants import LLMOBS_APM_SHADOW_TOTAL_TOKENS_METRIC_KEY
+from ddtrace.llmobs._constants import LLMOBS_STRUCT
 from ddtrace.llmobs._constants import LLMOBS_SUBMITTED_TAG_KEY
 from ddtrace.llmobs._constants import ROOT_PARENT_ID
 from ddtrace.llmobs._constants import UNKNOWN_MODEL_PROVIDER
@@ -1432,3 +1435,75 @@ def test_sampling_decisions_follow_configured_rate():
     assert abs(sampled - expected) <= 25, (
         f"rate={configured_rate}: expected ~{expected} sampled out of {n}, got {sampled}"
     )
+
+
+class TestSpanEventJSONSafety:
+    """Span data must be JSON-safe by the time the span finishes.
+
+    The _llmobs meta_struct rides along on the APM span, and the agentless APM exporter JSON-encodes
+    it with no fallback for unserializable objects: one raw object raises TypeError and drops the
+    entire trace payload, not just the offending span (MLOB-7962). Sanitization happens at finish
+    rather than at annotation time so it also covers whatever the user span processor introduces.
+    """
+
+    class RawObject:
+        """Stands in for the live SDK objects integrations hand us (e.g. a safety-settings enum)."""
+
+        def __init__(self, value):
+            self.value = value
+
+        def __str__(self):
+            return "RawObject({})".format(self.value)
+
+    def test_metadata_is_sanitized_at_finish(self, llmobs, tracer):
+        with tracer.trace("root", span_type=SpanTypes.LLM) as span:
+            _annotate_llmobs_span_data(
+                span,
+                kind="llm",
+                metadata={"safety_settings": [self.RawObject("BLOCK_NONE")], "nested": {"cfg": self.RawObject("LOW")}},
+            )
+        json.dumps(_get_llmobs_data_metastruct(span))  # raises TypeError if anything is unserializable
+        assert get_llmobs_metadata(span) == {
+            "safety_settings": ["RawObject(BLOCK_NONE)"],
+            "nested": {"cfg": "RawObject(LOW)"},
+        }
+
+    def test_config_is_sanitized_at_finish(self, llmobs, tracer):
+        """config sits at the top level of the struct rather than under meta, so it gets its own pass."""
+        with tracer.trace("root", span_type=SpanTypes.LLM) as span:
+            _annotate_llmobs_span_data(span, kind="llm", config={"safety_settings": [self.RawObject("BLOCK_NONE")]})
+        data = _get_llmobs_data_metastruct(span)
+        json.dumps(data)
+        assert data[LLMOBS_STRUCT.CONFIG] == {"safety_settings": ["RawObject(BLOCK_NONE)"]}
+
+    def test_metadata_from_user_span_processor_is_sanitized(self, llmobs, tracer):
+        """A user processor writing a raw object into metadata must not be able to poison the payload.
+
+        This is the case write-time enforcement in _annotate_llmobs_span_data cannot cover: the
+        processor runs at finish, after every annotation has already been stored.
+        """
+        raw = self.RawObject("from-processor")
+
+        def _sp(span):
+            span.metadata["injected"] = raw
+            return span
+
+        llmobs.register_processor(_sp)
+        try:
+            with tracer.trace("root", span_type=SpanTypes.LLM) as span:
+                _annotate_llmobs_span_data(span, kind="llm")
+            json.dumps(_get_llmobs_data_metastruct(span))
+            assert get_llmobs_metadata(span)["injected"] == "RawObject(from-processor)"
+        finally:
+            llmobs.register_processor(None)
+
+    def test_meta_struct_dropped_when_disabled_before_finish(self, llmobs, tracer):
+        """A span started while enabled but finished after disabling produces no event, so its
+        unsanitized partial struct must not ride along to the APM encoder.
+        """
+        with tracer.trace("root", span_type=SpanTypes.LLM) as span:
+            _annotate_llmobs_span_data(span, kind="llm", metadata={"raw": self.RawObject("x")})
+            assert _get_llmobs_data_metastruct(span)  # the struct is there while the span is open
+            with mock.patch.object(llmobs, "enabled", False):
+                LLMObs._instance._on_span_finish(span)
+            assert span._get_struct_tag(LLMOBS_STRUCT.KEY) is None

--- a/tests/llmobs/test_llmobs.py
+++ b/tests/llmobs/test_llmobs.py
@@ -9,8 +9,8 @@ import pytest
 
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.utils.formats import format_trace_id
-from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs import LLMObsSpan
+from ddtrace.llmobs._constants import AGENT_VERSION_TAG_KEY
 from ddtrace.llmobs._constants import LANGCHAIN_APM_SPAN_NAME
 from ddtrace.llmobs._constants import LLMOBS_APM_SHADOW_CACHE_READ_INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import LLMOBS_APM_SHADOW_CACHE_WRITE_INPUT_TOKENS_METRIC_KEY
@@ -1438,12 +1438,9 @@ def test_sampling_decisions_follow_configured_rate():
 
 
 class TestSpanEventJSONSafety:
-    """Span data must be JSON-safe by the time the span finishes.
+    """Span data must be JSON-safe by span finish, or agentless APM exporter will drop the entire trace.
 
-    The _llmobs meta_struct rides along on the APM span, and the agentless APM exporter JSON-encodes
-    it with no fallback for unserializable objects: one raw object raises TypeError and drops the
-    entire trace payload, not just the offending span (MLOB-7962). Sanitization happens at finish
-    rather than at annotation time so it also covers whatever the user span processor introduces.
+    Sanitizing at finish rather than at annotation time also covers what the user span processor adds.
     """
 
     class RawObject:
@@ -1455,6 +1452,15 @@ class TestSpanEventJSONSafety:
         def __str__(self):
             return "RawObject({})".format(self.value)
 
+    def test_agent_version_tag_is_stringified(self, llmobs):
+        """annotate(agent=...) is not type-validated, and the version is written into tags at finish,
+        after the string coercion in _annotate_llmobs_span_data has already run.
+        """
+        with llmobs.agent(name="my_agent") as span:
+            llmobs.annotate(span=span, agent={"version": self.RawObject("v2")})
+        tags = _get_llmobs_data_metastruct(span)[LLMOBS_STRUCT.TAGS]
+        assert tags[AGENT_VERSION_TAG_KEY] == "RawObject(v2)"
+
     def test_metadata_is_sanitized_at_finish(self, llmobs, tracer):
         with tracer.trace("root", span_type=SpanTypes.LLM) as span:
             _annotate_llmobs_span_data(
@@ -1462,7 +1468,6 @@ class TestSpanEventJSONSafety:
                 kind="llm",
                 metadata={"safety_settings": [self.RawObject("BLOCK_NONE")], "nested": {"cfg": self.RawObject("LOW")}},
             )
-        json.dumps(_get_llmobs_data_metastruct(span))  # raises TypeError if anything is unserializable
         assert get_llmobs_metadata(span) == {
             "safety_settings": ["RawObject(BLOCK_NONE)"],
             "nested": {"cfg": "RawObject(LOW)"},
@@ -1473,7 +1478,6 @@ class TestSpanEventJSONSafety:
         with tracer.trace("root", span_type=SpanTypes.LLM) as span:
             _annotate_llmobs_span_data(span, kind="llm", config={"safety_settings": [self.RawObject("BLOCK_NONE")]})
         data = _get_llmobs_data_metastruct(span)
-        json.dumps(data)
         assert data[LLMOBS_STRUCT.CONFIG] == {"safety_settings": ["RawObject(BLOCK_NONE)"]}
 
     def test_metadata_from_user_span_processor_is_sanitized(self, llmobs, tracer):
@@ -1492,18 +1496,32 @@ class TestSpanEventJSONSafety:
         try:
             with tracer.trace("root", span_type=SpanTypes.LLM) as span:
                 _annotate_llmobs_span_data(span, kind="llm")
-            json.dumps(_get_llmobs_data_metastruct(span))
             assert get_llmobs_metadata(span)["injected"] == "RawObject(from-processor)"
         finally:
             llmobs.register_processor(None)
+
+    def test_whole_struct_survives_json_encoding(self, llmobs, tracer):
+        """Reproduces the actual failure mode: json.dumps over the whole struct, the way the agentless
+        APM exporter encodes it. The per-field tests above assert sanitized values; this one asserts
+        that no other field (tags, metrics, _dd, ...) can still raise TypeError and drop the payload.
+        """
+        with tracer.trace("root", span_type=SpanTypes.LLM) as span:
+            _annotate_llmobs_span_data(
+                span,
+                kind="llm",
+                metadata={"raw": self.RawObject("m")},
+                config={"raw": self.RawObject("c")},
+                tags={self.RawObject("k"): self.RawObject("v")},
+                metrics={"input_tokens": 1},
+            )
+        json.dumps(_get_llmobs_data_metastruct(span))
 
     def test_meta_struct_dropped_when_disabled_before_finish(self, llmobs, tracer):
         """A span started while enabled but finished after disabling produces no event, so its
         unsanitized partial struct must not ride along to the APM encoder.
         """
-        with tracer.trace("root", span_type=SpanTypes.LLM) as span:
-            _annotate_llmobs_span_data(span, kind="llm", metadata={"raw": self.RawObject("x")})
-            assert _get_llmobs_data_metastruct(span)  # the struct is there while the span is open
-            with mock.patch.object(llmobs, "enabled", False):
-                LLMObs._instance._on_span_finish(span)
-            assert span._get_struct_tag(LLMOBS_STRUCT.KEY) is None
+        with mock.patch.object(llmobs, "enabled", False):
+            with tracer.trace("root", span_type=SpanTypes.LLM) as span:
+                _annotate_llmobs_span_data(span, kind="llm", metadata={"raw": self.RawObject("x")})
+                assert _get_llmobs_data_metastruct(span)  # the struct is there while the span is open
+        assert span._get_struct_tag(LLMOBS_STRUCT.KEY) is None

--- a/tests/llmobs/test_llmobs.py
+++ b/tests/llmobs/test_llmobs.py
@@ -1515,13 +1515,3 @@ class TestSpanEventJSONSafety:
                 metrics={"input_tokens": 1},
             )
         json.dumps(_get_llmobs_data_metastruct(span))
-
-    def test_meta_struct_dropped_when_disabled_before_finish(self, llmobs, tracer):
-        """A span started while enabled but finished after disabling produces no event, so its
-        unsanitized partial struct must not ride along to the APM encoder.
-        """
-        with mock.patch.object(llmobs, "enabled", False):
-            with tracer.trace("root", span_type=SpanTypes.LLM) as span:
-                _annotate_llmobs_span_data(span, kind="llm", metadata={"raw": self.RawObject("x")})
-                assert _get_llmobs_data_metastruct(span)  # the struct is there while the span is open
-        assert span._get_struct_tag(LLMOBS_STRUCT.KEY) is None

--- a/tests/llmobs/test_utils.py
+++ b/tests/llmobs/test_utils.py
@@ -6,8 +6,10 @@ import pytest
 
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs._constants import LLMOBS_STRUCT
+from ddtrace.llmobs._utils import _MAX_NESTED_META_DEPTH
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _normalize_wire_trace_id_to_hex
+from ddtrace.llmobs._utils import _sanitize_metric_key
 from ddtrace.llmobs._utils import _sanitize_span_event_data
 from ddtrace.llmobs._utils import _trace_id_to_wire
 from ddtrace.llmobs._utils import load_data_value
@@ -670,6 +672,81 @@ class TestSanitizeSpanEventData:
         nested = {"l1": {"l2": {"l3": {"l4": {"l5": {"l6": {"l7": Deep(payload=deep_dict)}}}}}}}
         sanitized = _sanitize_span_event_data(nested)
         json.dumps(sanitized)  # the whole thing is still encodable
+
+        def depth(node):
+            if isinstance(node, dict):
+                return 1 + max([depth(v) for v in node.values()] or [0])
+            if isinstance(node, list):
+                return 1 + max([depth(v) for v in node] or [0])
+            return 0
+
+        assert depth(sanitized) <= _MAX_NESTED_META_DEPTH
+
+    def test_leaf_conversion_failure_falls_back_to_str(self):
+        """A leaf whose conversion raises must not abort the sanitizer. If it escaped, the
+        unsanitized struct would stay on the span and the agentless encoder would drop the whole
+        trace -- the failure this sanitizer exists to prevent.
+        """
+
+        class Exploding:
+            def model_dump(self, *args, **kwargs):
+                raise RuntimeError("boom")
+
+            def __str__(self):
+                return "Exploding()"
+
+        sanitized = _sanitize_span_event_data({"metadata": {"cfg": Exploding(), "ok": "kept"}})
+        json.dumps(sanitized)
+        assert sanitized == {"metadata": {"cfg": "Exploding()", "ok": "kept"}}
+
+    def test_leaf_conversion_recursion_falls_back_to_str(self):
+        """A self-returning model_dump() (e.g. a MagicMock) recurses until RecursionError, which is
+        an ordinary Exception -- the sanitizer must absorb it rather than bail out mid-walk.
+        """
+
+        class Recursive:
+            def model_dump(self, *args, **kwargs):
+                return Recursive()
+
+            def __str__(self):
+                return "Recursive()"
+
+        sanitized = _sanitize_span_event_data({"metadata": {"cfg": Recursive()}})
+        json.dumps(sanitized)
+        assert sanitized == {"metadata": {"cfg": "Recursive()"}}
+
+    def test_leaf_with_failing_str_falls_back_to_type_placeholder(self):
+        """Even __str__ is allowed to fail; the sanitizer still yields something encodable."""
+
+        class Hostile:
+            def model_dump(self, *args, **kwargs):
+                raise RuntimeError("boom")
+
+            def __str__(self):
+                raise RuntimeError("no str either")
+
+        sanitized = _sanitize_span_event_data({"metadata": {"cfg": Hostile()}})
+        json.dumps(sanitized)
+        assert sanitized == {"metadata": {"cfg": "[Unserializable object of type Hostile]"}}
+
+
+class TestSanitizeMetricKey:
+    """Dots in a metric key are read as nested-path separators by ingestion and drop the enclosing
+    span batch, so they must be replaced -- including dots introduced by stringifying the key.
+    """
+
+    def test_plain_key_passthrough(self):
+        assert _sanitize_metric_key("input_tokens") == "input_tokens"
+
+    def test_dotted_key_is_replaced(self):
+        assert _sanitize_metric_key("a.b.c") == "a_b_c"
+
+    def test_non_string_key_is_stringified(self):
+        assert _sanitize_metric_key(5) == "5"
+        assert _sanitize_metric_key(None) == "None"
+
+    def test_non_string_key_that_stringifies_to_a_dotted_key(self):
+        assert _sanitize_metric_key(1.5) == "1_5"
 
 
 class TestTraceIdNormalization:

--- a/tests/llmobs/test_utils.py
+++ b/tests/llmobs/test_utils.py
@@ -1,3 +1,6 @@
+from dataclasses import dataclass
+import json
+
 from pydantic import BaseModel
 import pytest
 
@@ -5,8 +8,9 @@ from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs._constants import LLMOBS_STRUCT
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import _normalize_wire_trace_id_to_hex
-from ddtrace.llmobs._utils import _sanitize_span_event_depth
+from ddtrace.llmobs._utils import _sanitize_span_event_data
 from ddtrace.llmobs._utils import _trace_id_to_wire
+from ddtrace.llmobs._utils import load_data_value
 from ddtrace.llmobs._utils import safe_json
 from ddtrace.llmobs.utils import Documents
 from ddtrace.llmobs.utils import Messages
@@ -455,6 +459,54 @@ def test_json_serialize_class_with_str():
     assert encoded_obj == '"Class"'
 
 
+def test_load_data_value_pydantic_model_with_unserializable_nested_field():
+    """model_dump() without mode="json" can leave non-primitive nested field values (e.g. a raw
+    SDK object) unconverted -- load_data_value must recurse into the dumped result to finish
+    sanitizing them, not just return it as-is.
+    """
+
+    class RawObject:
+        def __init__(self, value):
+            self.value = value
+
+        def __str__(self):
+            return "RawObject({})".format(self.value)
+
+    class Model(BaseModel):
+        class Config:
+            arbitrary_types_allowed = True
+
+        name: str
+        raw: RawObject
+
+    result = load_data_value(Model(name="hello", raw=RawObject("world")))
+    json.dumps(result)  # raises TypeError if not JSON-serializable
+    assert result == {"name": "hello", "raw": "RawObject(world)"}
+
+
+def test_load_data_value_dataclass_with_unserializable_nested_field():
+    """asdict() only recurses into nested dataclasses/dicts/lists/tuples -- other field types are
+    deep-copied as-is, so load_data_value must recurse into the dumped result to finish sanitizing
+    them.
+    """
+
+    class RawObject:
+        def __init__(self, value):
+            self.value = value
+
+        def __str__(self):
+            return "RawObject({})".format(self.value)
+
+    @dataclass
+    class Model:
+        name: str
+        raw: RawObject
+
+    result = load_data_value(Model(name="hello", raw=RawObject("world")))
+    json.dumps(result)  # raises TypeError if not JSON-serializable
+    assert result == {"name": "hello", "raw": "RawObject(world)"}
+
+
 class TestAnnotateLLMObsSpanData:
     def test_populates_meta_struct(self, llmobs):
         """All annotated fields are stored in the correct nested positions."""
@@ -521,31 +573,88 @@ class TestAnnotateLLMObsSpanData:
             assert {"env": "prod", "version": "1.0"}.items() <= data[LLMOBS_STRUCT.TAGS].items()
 
 
-class TestSanitizeSpanEventDepth:
+class TestSanitizeSpanEventData:
     """Non-string mapping keys are stringified so the msgpack meta_struct intake path
     does not drop the span (MLOB-7618).
     """
 
     def test_stringifies_top_level_non_string_keys(self):
-        assert _sanitize_span_event_depth({"metadata": {5: "a", 2.5: "b", None: "c"}}) == {
+        assert _sanitize_span_event_data({"metadata": {5: "a", 2.5: "b", None: "c"}}) == {
             "metadata": {"5": "a", "2.5": "b", "None": "c"}
         }
-        assert _sanitize_span_event_depth({"metadata": {True: "x", False: "y"}}) == {
+        assert _sanitize_span_event_data({"metadata": {True: "x", False: "y"}}) == {
             "metadata": {"True": "x", "False": "y"}
         }
 
     def test_stringifies_nested_non_string_keys(self):
-        sanitized = _sanitize_span_event_depth({"metadata": {"outer": {3: {"4": [{5: "v"}]}}}})
+        sanitized = _sanitize_span_event_data({"metadata": {"outer": {3: {"4": [{5: "v"}]}}}})
         assert sanitized == {"metadata": {"outer": {"3": {"4": [{"5": "v"}]}}}}
 
     def test_string_keyed_structures_pass_through_unchanged(self):
         original = {"metadata": {"temperature": 0.5, "nested": {"k": [1, 2, 3]}}}
-        assert _sanitize_span_event_depth(original) == original
+        assert _sanitize_span_event_data(original) == original
 
     def test_does_not_mutate_input(self):
         original = {"metadata": {1: "a"}}
-        _sanitize_span_event_depth(original)
+        _sanitize_span_event_data(original)
         assert original == {"metadata": {1: "a"}}  # original keys untouched
+
+    def test_sanitizes_unserializable_leaves(self):
+        """Raw objects stored by integrations are made JSON-safe at every nesting level. Left raw,
+        they reach the agentless APM encoder, which has no fallback and drops the whole payload
+        (MLOB-7962).
+        """
+
+        class SafetySetting:
+            def __init__(self, threshold):
+                self.threshold = threshold
+
+            def __str__(self):
+                return "SafetySetting({})".format(self.threshold)
+
+        sanitized = _sanitize_span_event_data(
+            {
+                "metadata": {
+                    "safety_settings": [SafetySetting("BLOCK_NONE")],
+                    "nested": {"config": SafetySetting("BLOCK_LOW")},
+                }
+            }
+        )
+        json.dumps(sanitized)  # raises TypeError if any value is not JSON-serializable
+        assert sanitized == {
+            "metadata": {
+                "safety_settings": ["SafetySetting(BLOCK_NONE)"],
+                "nested": {"config": "SafetySetting(BLOCK_LOW)"},
+            }
+        }
+
+    def test_preserves_structure_of_unserializable_leaves(self):
+        """Pydantic models and dataclasses become dicts rather than opaque strings, so their fields
+        stay queryable in the UI.
+        """
+
+        @dataclass
+        class Params:
+            temperature: float
+            stop: tuple
+
+        sanitized = _sanitize_span_event_data({"metadata": {"params": Params(temperature=0.5, stop=("a", "b"))}})
+        json.dumps(sanitized)
+        assert sanitized == {"metadata": {"params": {"temperature": 0.5, "stop": ["a", "b"]}}}
+
+    def test_sanitized_leaf_structure_still_respects_depth_limit(self):
+        """Structure recovered from a leaf is walked at the leaf's depth, so it cannot smuggle
+        nesting past _MAX_NESTED_META_DEPTH.
+        """
+
+        @dataclass
+        class Deep:
+            payload: dict
+
+        deep_dict = {"a": {"b": {"c": {"d": {"e": {"f": {"g": "leaf"}}}}}}}
+        nested = {"l1": {"l2": {"l3": {"l4": {"l5": {"l6": {"l7": Deep(payload=deep_dict)}}}}}}}
+        sanitized = _sanitize_span_event_data(nested)
+        json.dumps(sanitized)  # the whole thing is still encodable
 
 
 class TestTraceIdNormalization:

--- a/tests/llmobs/test_utils.py
+++ b/tests/llmobs/test_utils.py
@@ -558,6 +558,21 @@ class TestAnnotateLLMObsSpanData:
             metadata = span._get_struct_tag(LLMOBS_STRUCT.KEY)[LLMOBS_STRUCT.META][LLMOBS_STRUCT.METADATA]
             assert metadata == {"42": "a", "2.5": "b", "True": "c", "None": "d"}
 
+    def test_tag_keys_and_values_are_stringified(self, llmobs):
+        """Tags are serialized as string-to-string pairs, so both sides are coerced."""
+        with llmobs.task(name="test_span") as span:
+            _annotate_llmobs_span_data(span, tags={42: "a", None: 7, "obj": object.__new__(object)})
+            tags = span._get_struct_tag(LLMOBS_STRUCT.KEY)[LLMOBS_STRUCT.TAGS]
+            assert tags["42"] == "a"
+            assert tags["None"] == "7"
+            assert tags["obj"].startswith("<object object at")
+
+    def test_metric_keys_are_stringified(self, llmobs):
+        """A non-string metric key has no encodable representation, so it is coerced."""
+        with llmobs.task(name="test_span") as span:
+            _annotate_llmobs_span_data(span, metrics={42: 1, None: 2})
+            assert span._get_struct_tag(LLMOBS_STRUCT.KEY)[LLMOBS_STRUCT.METRICS] == {"42": 1, "None": 2}
+
     def test_merges_metadata_metrics_tags_across_calls(self, llmobs):
         """metadata, metrics, and tags accumulate rather than overwrite across multiple annotate calls."""
         with llmobs.task(name="test_span") as span:


### PR DESCRIPTION
## Description

Some integrations pass raw SDK request/config objects straight into the `metadata`/`config`
dicts handed to `_annotate_llmobs_span_data()` — for example, the Google GenAI integration puts
`SafetySetting` objects from the request config into span metadata. Those values ride along on
the APM span's `_llmobs` meta_struct, which gets JSON-encoded by the agentless APM exporter later.
That encoder has no fallback for non-JSON-serializable objects, so a `TypeError` there causes the
**entire trace payload to be silently dropped** — not just the offending span.

Observed in production as:
```
TypeError: Object of type SafetySetting is not JSON serializable
 when serializing list item 0
 when serializing dict item 'safety_settings'
 when serializing dict item 'metadata'
 when serializing dict item 'meta'
 when serializing dict item '_llmobs'
 when serializing dict item 'meta_struct'
 when serializing list item N
 when serializing dict item 'spans'
```

This has shown up per-integration so far (Google GenAI's `safety_settings`, LangGraph's
`tool_config` in #19711). Rather than chase it integration-by-integration — or field-by-field —
this enforces JSON-safety once, **at span finish**.



Claude session: `e0d1ad2b-5a78-4d3f-a480-4179abc30060`
Resume: `claude --resume e0d1ad2b-5a78-4d3f-a480-4179abc30060`
