### PR TITLE
fix(llmobs): preserve OpenAI spans on truncated response streams

### DIFF
--- a/ddtrace/llmobs/_integrations/openai.py
+++ b/ddtrace/llmobs/_integrations/openai.py
@@ -16,6 +16,7 @@ from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._integrations.utils import _compute_completion_tokens
 from ddtrace.llmobs._integrations.utils import _compute_prompt_tokens
 from ddtrace.llmobs._integrations.utils import get_openrouter_cost_metrics
+from ddtrace.llmobs._integrations.utils import openai_get_output_messages_from_response
 from ddtrace.llmobs._integrations.utils import openai_set_meta_tags_from_chat
 from ddtrace.llmobs._integrations.utils import openai_set_meta_tags_from_completion
 from ddtrace.llmobs._integrations.utils import openai_set_meta_tags_from_response
@@ -109,17 +110,17 @@ class OpenAIIntegration(BaseLLMIntegration):
 
         model_provider = self._get_model_provider(span)
 
-        metrics = self._extract_llmobs_metrics_tags(span, response, span_kind, kwargs)
         provider = span.get_tag("openai.request.provider") or "OpenAI"
         span_name = "{}.{}".format(provider, span.resource) if span.resource else None
-        # Set kind before helpers so that input/output messages are routed correctly
+        # Set the span identity before any response extraction. The public caller swallows
+        # extraction errors, so this must happen first or the LLMObs event is dropped for a
+        # missing span kind and its children become orphaned.
         _annotate_llmobs_span_data(
             span,
             name=span_name,
             kind=span_kind,
             model_name=model_name,
             model_provider=model_provider,
-            metrics=metrics,
         )
         if operation == "completion":
             openai_set_meta_tags_from_completion(span, kwargs, response)
@@ -131,6 +132,10 @@ class OpenAIIntegration(BaseLLMIntegration):
             openai_set_meta_tags_from_response(span, kwargs, response, self)
         elif operation == "tool":
             self._llmobs_set_tags_from_tool(span, kwargs, response)
+
+        metrics = self._extract_llmobs_metrics_tags(span, response, span_kind, kwargs)
+        if metrics:
+            _annotate_llmobs_span_data(span, metrics=metrics)
 
     @staticmethod
     def _llmobs_set_meta_tags_from_embedding(span: Span, kwargs: dict[str, Any], resp: Any) -> None:
@@ -280,7 +285,10 @@ class OpenAIIntegration(BaseLLMIntegration):
             return metrics
         elif kwargs.get("stream") and resp is not None:
             prompt_tokens = _compute_prompt_tokens(kwargs.get("prompt", None), kwargs.get("messages", None))
-            completion_tokens = _compute_completion_tokens(resp)
+            completion_source = resp
+            if _get_attr(resp, "output", None) is not None:
+                completion_source, _ = openai_get_output_messages_from_response(resp)
+            completion_tokens = _compute_completion_tokens(completion_source)
             total_tokens = prompt_tokens + completion_tokens
 
             return {

--- a/releasenotes/notes/llmobs-openai-truncated-response-stream-6f17a34d29ea9c81.yaml
+++ b/releasenotes/notes/llmobs-openai-truncated-response-stream-6f17a34d29ea9c81.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    LLM Observability, OpenAI: fixes an issue where truncated streamed Responses API calls could
+    drop the ``openai.request`` LLMObs span with ``missing span kind in span context`` when token
+    extraction encountered a partial response. Response output is now normalized before fallback
+    token estimation, and span identity is recorded before fallible response extraction.

--- a/tests/contrib/openai/test_openai_llmobs_truncated_stream.py
+++ b/tests/contrib/openai/test_openai_llmobs_truncated_stream.py
@@ -1,0 +1,68 @@
+import mock
+
+from ddtrace.llmobs._constants import CACHED_LLMOBS_EVENT_CTX_KEY
+from ddtrace.llmobs._constants import INPUT_TOKENS_METRIC_KEY
+from ddtrace.llmobs._constants import OUTPUT_TOKENS_METRIC_KEY
+from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
+from ddtrace.llmobs._integrations.openai import OpenAIIntegration
+from ddtrace.llmobs._integrations.utils import _est_tokens
+from ddtrace.llmobs._utils import get_llmobs_span_kind
+
+
+class _TupleIteratingResponse:
+    """Minimal Pydantic-like Responses object whose iteration yields field/value tuples."""
+
+    usage = None
+
+    def __init__(self):
+        self.output = [
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "partial response"}],
+            }
+        ]
+
+    def __iter__(self):
+        return iter((("id", "resp_test"), ("output", self.output)))
+
+
+def test_truncated_response_stream_metrics_do_not_iterate_response_model():
+    response = _TupleIteratingResponse()
+
+    metrics = OpenAIIntegration._extract_llmobs_metrics_tags(
+        mock.MagicMock(),
+        response,
+        "llm",
+        {"stream": True},
+    )
+
+    output_tokens = _est_tokens("partial response")
+    assert metrics == {
+        INPUT_TOKENS_METRIC_KEY: 0,
+        OUTPUT_TOKENS_METRIC_KEY: output_tokens,
+        TOTAL_TOKENS_METRIC_KEY: output_tokens,
+    }
+
+
+def test_response_span_kept_when_metrics_extraction_raises(openai, openai_llmobs):
+    integration = openai._datadog_integration
+    span = integration.trace("createResponse", submit_to_llmobs=True)
+
+    with mock.patch.object(
+        integration,
+        "_extract_llmobs_metrics_tags",
+        side_effect=ValueError("malformed streamed response"),
+    ):
+        integration.llmobs_set_tags(
+            span,
+            args=[],
+            kwargs={"input": "hello", "stream": True},
+            response=None,
+            operation="response",
+        )
+
+    assert get_llmobs_span_kind(span) == "llm"
+
+    span.finish()
+    assert span._get_ctx_item(CACHED_LLMOBS_EVENT_CTX_KEY) is not None


### PR DESCRIPTION
## Description

Fixes #19760.

Truncated OpenAI Responses API streams can finish without a terminal usage-bearing response. In that fallback path, LLMObs passed the OpenAI `Response` model directly to `_compute_completion_tokens`. Pydantic-style response models iterate as `(field, value)` pairs, while `_compute_completion_tokens` expects mapping-like message entries, producing the reported `'tuple' object has no attribute 'get'` error.

That extraction error was compounded by `_llmobs_set_tags` computing metrics before annotating the span kind. `BaseLLMIntegration.llmobs_set_tags` deliberately catches extraction errors, so the span could reach event preparation without a kind and be dropped with `missing span kind in span context`, orphaning child spans.

## Changes

- Normalize Responses API output with the existing `openai_get_output_messages_from_response` parser before fallback token estimation.
- Record the LLMObs span identity (`kind`, name, model and provider) before fallible response extraction so malformed/partial data cannot make the entire span disappear.
- Add a regression object that reproduces Pydantic-style tuple iteration and verifies partial response output can be token-estimated without raising.
- Add a regression test that forces metrics extraction to fail and verifies the `llm` span kind survives and an LLMObs event is still prepared.
- Add a release note.

## Testing

The new tests are intentionally isolated from network/VCR data. I could not execute the repository test suite in the current environment, so this is opened as a draft for the upstream CI matrix to validate formatting, imports and behavior.

## Risk

Low. The Responses-specific fallback only changes the no-usage streaming path. Normal responses with usage continue through the existing usage fast path, and chat/completion fallback behavior is unchanged.

## AI assistance

I used ChatGPT/Codex to inspect the issue and related fixes, trace the failure through the OpenAI Responses model and LLMObs span lifecycle, implement the patch, and write the regression tests. I reviewed the final diff and kept the change scoped to the reported failure modes.