### PR TITLE
fix: exit only entered wrapping context [backport 4.12]

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -613,7 +613,7 @@ experiments:
           # packagespackageforrootmodulemapping
           - name: packagespackageforrootmodulemapping-cache_off
             thresholds:
-              - execution_time < 354.30 ms
+              - execution_time < 370.00 ms
           - name: packagespackageforrootmodulemapping-cache_on
             thresholds:
               - execution_time < 0.01 ms

--- a/ddtrace/internal/wrapping/context.py
+++ b/ddtrace/internal/wrapping/context.py
@@ -79,6 +79,10 @@ log = get_logger(__name__)
 
 T = t.TypeVar("T")
 
+# Hoisted out of the hot enter/exit/return paths: subscripting a generic alias
+# like dict[str, t.Any] allocates a new types.GenericAlias on every evaluation,
+# so re-typing it inline on each call is not free.
+WrappingContextStorage = dict[str, t.Any]
 StorageVar = ContextVar[t.Optional[dict[str, t.Any]]]
 
 _STORAGE_PREV = "__dd_wrapping_context_prev__"
@@ -438,7 +442,7 @@ class BaseWrappingContext(ABC):
         return self
 
     def _pop_storage(self) -> dict[str, t.Any]:
-        storage = t.cast(dict[str, t.Any], self._storage.get())
+        storage = t.cast(WrappingContextStorage, self._storage.get())
         self._storage.set(storage.pop(_STORAGE_PREV))
         del storage[_STORAGE_OWNER]
         return storage
@@ -456,10 +460,10 @@ class BaseWrappingContext(ABC):
         self._pop_storage()
 
     def get(self, key: str) -> t.Any:
-        return t.cast(dict[str, t.Any], self._storage.get())[key]
+        return t.cast(WrappingContextStorage, self._storage.get())[key]
 
     def set(self, key: str, value: T) -> T:
-        t.cast(dict[str, t.Any], self._storage.get())[key] = value
+        t.cast(WrappingContextStorage, self._storage.get())[key] = value
         return value
 
     @classmethod
@@ -647,11 +651,25 @@ class _UniversalWrappingContext(BaseWrappingContext):
     def __enter__(self) -> "_UniversalWrappingContext":
         super().__enter__()
 
-        # Make the frame object available to the contexts
-        self.set("__frame__", sys._getframe(1))
+        storage = t.cast(WrappingContextStorage, self._storage.get())
 
+        # Make the frame object available to the contexts
+        storage["__frame__"] = sys._getframe(1)
+
+        # Freeze the list of contexts so that we know exactly which ones to
+        # exit, in case new contexts are registered during the execution of
+        # the wrapped function. Contexts are appended only once entered, so
+        # that a failure partway through does not leave contexts that never
+        # entered in the snapshot.
+        entered: list[WrappingContext] = []
+        storage["__contexts__"] = entered
         for context in self._contexts:
-            context.__enter__()
+            try:
+                context.__enter__()
+            except Exception:
+                log.debug("Failed to enter wrapping context %r", context, exc_info=True)
+                continue
+            entered.append(context)
 
         return self
 
@@ -667,13 +685,25 @@ class _UniversalWrappingContext(BaseWrappingContext):
         if exc_value is None:
             return
 
-        for context in self._contexts[::-1]:
+        try:
+            contexts = t.cast(WrappingContextStorage, self._storage.get())["__contexts__"]
+        except (TypeError, KeyError):
+            log.debug("Universal wrapping context exited without entering")
+            return
+
+        for context in contexts[::-1]:
             context.__exit__(exc_type, exc_value, traceback)
 
         super().__exit__(exc_type, exc_value, traceback)
 
     def __return__(self, value: T) -> T:
-        for context in self._contexts[::-1]:
+        try:
+            contexts = t.cast(WrappingContextStorage, self._storage.get())["__contexts__"]
+        except (TypeError, KeyError):
+            log.debug("Universal wrapping context returned without entering")
+            return super().__return__(value)
+
+        for context in contexts[::-1]:
             context.__return__(value)
 
         return super().__return__(value)

--- a/releasenotes/notes/fix-wrapping-context-exit-race-b2ba3bd382059248.yaml
+++ b/releasenotes/notes/fix-wrapping-context-exit-race-b2ba3bd382059248.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    code origin for spans: prevent view or traced functions from raising an
+    exception in situations where their number is large.

--- a/tests/internal/test_wrapping.py
+++ b/tests/internal/test_wrapping.py
@@ -823,6 +823,116 @@ def test_wrapping_context_exc_on_exit():
     assert exc.args == ("foo",)
 
 
+def test_wrapping_context_mid_call_registration():
+    """Registering a new context on a function while a call is in flight must not crash that call.
+
+    Regression for: https://github.com/DataDog/dd-trace-py/issues/19372
+
+    _UniversalWrappingContext used to read its (mutable) list of contexts twice per call: once on
+    entry, once on exit/return. register() can mutate that list in between if a new context is
+    wrapped onto the same function while a call is in flight. A context added this way was never
+    entered for that call, so exiting it crashed with AttributeError in _pop_storage. The fix
+    freezes the list of contexts on entry so that exit/return only ever see contexts that were
+    actually entered.
+    """
+    import threading
+
+    class WrappingContextA(DummyWrappingContext):
+        pass
+
+    class WrappingContextB(DummyWrappingContext):
+        pass
+
+    in_call = threading.Event()
+    released = threading.Event()
+
+    def foo(x):
+        in_call.set()
+        released.wait(5)
+        return x * 2
+
+    wc_a = WrappingContextA(foo)
+    wc_a.wrap()
+
+    results = []
+
+    def call():
+        results.append(foo(21))
+
+    thread = threading.Thread(target=call)
+    thread.start()
+    in_call.wait(5)
+
+    # Register a second context while the call above is still in flight.
+    wc_b = WrappingContextB(foo)
+    wc_b.wrap()
+
+    released.set()
+    thread.join()
+
+    assert results == [42]
+    assert wc_a.entered
+    assert wc_a.return_value == 42
+    assert not wc_a.exited
+
+    # wc_b was registered after the in-flight call had already taken its snapshot of contexts, so
+    # it must not have taken part in that call.
+    assert not wc_b.entered
+    assert wc_b.return_value is NOTSET
+    assert not wc_b.exited
+
+
+def test_wrapping_context_mid_call_registration_does_not_mask_exception():
+    """A real exception from the wrapped function must not be replaced by an AttributeError.
+
+    Regression for: https://github.com/DataDog/dd-trace-py/issues/19372
+
+    Same root cause as test_wrapping_context_mid_call_registration, but on the exception path: the
+    AttributeError raised while exiting an un-entered context used to shadow the application's own
+    exception.
+    """
+    import threading
+
+    class WrappingContextA(DummyWrappingContext):
+        pass
+
+    class WrappingContextB(DummyWrappingContext):
+        pass
+
+    in_call = threading.Event()
+    released = threading.Event()
+
+    def foo(x):
+        in_call.set()
+        released.wait(5)
+        raise ValueError("the real error")
+
+    wc_a = WrappingContextA(foo)
+    wc_a.wrap()
+
+    errors = []
+
+    def call():
+        try:
+            foo(21)
+        except BaseException as e:
+            errors.append(e)
+
+    thread = threading.Thread(target=call)
+    thread.start()
+    in_call.wait(5)
+
+    # Register a second context while the call above is still in flight.
+    WrappingContextB(foo).wrap()
+
+    released.set()
+    thread.join()
+
+    assert len(errors) == 1
+    assert isinstance(errors[0], ValueError)
+    assert errors[0].args == ("the real error",)
+
+
 def test_wrapping_context_priority():
     class HighPriorityWrappingContext(DummyWrappingContext):
         def __enter__(self):


### PR DESCRIPTION
## Description

Backport of #19380 to 4.12.

We make sure that only wrapping contexts that have been opened are later closed when the wrapped function either returns or throws an exception.

Resolves #19372.

## Testing

Cherry-picked from `ef3b7b02301013bc2b079d7dbf6c8749468a8b28`. Regression tests for mid-call registration landed in `tests/internal/test_wrapping.py`.

`tests/wrapping/test_generators.py` does not exist on 4.12. The original PR only removed an xfail there, so that hunk was dropped.

## Risks

Same as #19380: wrapping-context enter/exit bookkeeping. The change is a correctness fix for a race that could crash in-flight wrapped calls.

## Additional Notes

Cherry-pick of #19380. Release note included.
