### PR TITLE
fix: exit only entered wrapping context [backport 4.14]

### DIFF
--- a/ddtrace/aiguard/_api_client.py
+++ b/ddtrace/aiguard/_api_client.py
@@ -6,12 +6,16 @@ from typing import Any
 from typing import Literal
 from typing import Optional  # noqa:F401
 from typing import TypedDict
-from typing import Union
 
 from ddtrace import config
 from ddtrace.aiguard._constants import AI_GUARD
 from ddtrace.aiguard._redaction import redact_messages
 from ddtrace.aiguard._trace_utils import _aiguard_manual_keep
+from ddtrace.aiguard._types import ContentPart  # noqa:F401
+from ddtrace.aiguard._types import Function  # noqa:F401
+from ddtrace.aiguard._types import ImageURL  # noqa:F401
+from ddtrace.aiguard._types import Message
+from ddtrace.aiguard._types import ToolCall  # noqa:F401
 from ddtrace.ext import http
 from ddtrace.internal import core
 from ddtrace.internal import span_bus
@@ -26,39 +30,15 @@ from ddtrace.internal.utils.http import get_connection
 from ddtrace.version import __version__
 
 
+__all__ = ["ToolCall", "Message", "Function", "ContentPart", "ImageURL"]
+
+
 logger = ddlogger.get_logger(__name__)
 
 ALLOW = "ALLOW"
 DENY = "DENY"
 ABORT = "ABORT"
 ACTIONS = [ALLOW, DENY, ABORT]
-
-
-class Function(TypedDict):
-    name: str
-    arguments: str
-
-
-class ToolCall(TypedDict):
-    id: str
-    function: Function
-
-
-class ImageURL(TypedDict, total=False):
-    url: str
-
-
-class ContentPart(TypedDict, total=False):
-    type: str
-    text: Optional[str]
-    image_url: Optional[ImageURL]
-
-
-class Message(TypedDict, total=False):
-    role: str
-    content: Union[str, list[ContentPart]]
-    tool_call_id: str
-    tool_calls: list[ToolCall]
 
 
 class Evaluation(TypedDict):

--- a/ddtrace/aiguard/_redaction.py
+++ b/ddtrace/aiguard/_redaction.py
@@ -8,16 +8,12 @@ from collections.abc import Mapping
 from collections.abc import MutableMapping
 from copy import deepcopy
 import re
-from typing import TYPE_CHECKING
 from typing import Any
 from typing import Optional
 from typing import Union
 
+from ddtrace.aiguard._types import Message
 import ddtrace.internal.logger as ddlogger
-
-
-if TYPE_CHECKING:
-    from ddtrace.aiguard._api_client import Message
 
 
 logger = ddlogger.get_logger(__name__)
@@ -139,7 +135,7 @@ def _collect_replacements(replacements: object) -> dict[str, object]:
     return by_path
 
 
-def redact_messages(messages: "list[Message]", replacements: object) -> "list[Message]":
+def redact_messages(messages: list[Message], replacements: object) -> list[Message]:
     """Apply the replacements to the messages and return the redacted list.
 
     Copy-on-write: the caller's messages are never mutated, and the very same list object is returned

--- a/ddtrace/aiguard/_types.py
+++ b/ddtrace/aiguard/_types.py
@@ -1,0 +1,36 @@
+"""Shared message types for AI Guard evaluation and redaction.
+
+Split out from ``_api_client`` so that ``_redaction`` can depend on ``Message`` without
+creating an import cycle back into ``_api_client``.
+"""
+
+from typing import Optional
+from typing import TypedDict
+from typing import Union
+
+
+class Function(TypedDict):
+    name: str
+    arguments: str
+
+
+class ToolCall(TypedDict):
+    id: str
+    function: Function
+
+
+class ImageURL(TypedDict, total=False):
+    url: str
+
+
+class ContentPart(TypedDict, total=False):
+    type: str
+    text: Optional[str]
+    image_url: Optional[ImageURL]
+
+
+class Message(TypedDict, total=False):
+    role: str
+    content: Union[str, list[ContentPart]]
+    tool_call_id: str
+    tool_calls: list[ToolCall]

--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -42,7 +42,6 @@ def _patch_subprocess(module):
 
 def patch_common_modules():
     global _is_patched
-
     if _is_patched:
         return
 
@@ -108,10 +107,9 @@ def _get_rasp_capability(capability: str) -> bool:
 
         try:
             from ddtrace.appsec._processor import AppSecSpanProcessor
-        except Exception as e:
-            from ddtrace.appsec._listeners import _abort_appsec
-
-            _abort_appsec(str(e))
+        except Exception:
+            # load_appsec owns fatal processor load failures; wrappers only need to
+            # report the capability as unavailable while imports are in progress.
             return False
 
         return AppSecSpanProcessor._instance is not None and getattr(

--- a/ddtrace/appsec/_listeners.py
+++ b/ddtrace/appsec/_listeners.py
@@ -36,8 +36,6 @@ def _abort_appsec(failure_msg: str) -> None:
 
     This is called in case of non-recoverable AppSec load-time failure, such as a libddwaf loading error.
     """
-    from ddtrace.trace import tracer
-
     log.warning("Disabling AppSec: libddwaf failed to load (%s)", failure_msg or "unknown error")
 
     if asm_config._asm_enabled:

--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 import os
-from typing import Any
+from typing import Callable
 from typing import Optional
 from typing import Sequence
+from typing import TypedDict
+from typing import cast
 
 from ddtrace.appsec._capabilities import _ALL_ASM_CAPABILITIES
 from ddtrace.appsec._capabilities import _asm_feature_is_required
 from ddtrace.appsec._capabilities import _rc_capabilities
-from ddtrace.appsec._constants import APPSEC
 from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.native import RemoteConfigProduct
@@ -30,7 +31,24 @@ APPSEC_PRODUCTS = {
 }
 
 
-def enable_appsec_rc() -> None:
+class _AsmFeatureState(TypedDict, total=False):
+    enabled: bool
+
+
+class _AutoUserInstrumState(TypedDict, total=False):
+    mode: Optional[str]
+
+
+class AsmFeaturesResult(TypedDict, total=False):
+    """Shape of an ASM_FEATURES RC payload's content, and of the dict _update_asm_features
+    derives from a batch of such payloads.
+    """
+
+    asm: _AsmFeatureState
+    auto_user_instrum: _AutoUserInstrumState
+
+
+def enable_appsec_rc(callback: "AppSecCallback") -> None:
     """Remote config will be used by ASM libraries to receive four different updates from the backend.
     Each update has it's own product:
     - ASM_FEATURES product - To allow users enable or disable ASM remotely
@@ -46,27 +64,19 @@ def enable_appsec_rc() -> None:
     if _asm_feature_is_required():
         remoteconfig_poller.register_callback(
             RemoteConfigProduct.AsmFeatures,
-            _appsec_callback,
+            callback,
             capabilities=_rc_capabilities(),
         )
         remoteconfig_poller.enable_product(RemoteConfigProduct.AsmFeatures)
 
     # Register other ASM products if AppSec is enabled
     if asm_config._asm_enabled and asm_config._asm_static_rule_file is None:
-        remoteconfig_poller.register_callback(RemoteConfigProduct.AsmData, _appsec_callback)  # IP Blocking
+        remoteconfig_poller.register_callback(RemoteConfigProduct.AsmData, callback)  # IP Blocking
         remoteconfig_poller.enable_product(RemoteConfigProduct.AsmData)
-        remoteconfig_poller.register_callback(
-            RemoteConfigProduct.Asm, _appsec_callback
-        )  # Exclusion Filters & Custom Rules
+        remoteconfig_poller.register_callback(RemoteConfigProduct.Asm, callback)  # Exclusion Filters & Custom Rules
         remoteconfig_poller.enable_product(RemoteConfigProduct.Asm)
-        remoteconfig_poller.register_callback(RemoteConfigProduct.AsmDd, _appsec_callback)  # DD Rules
+        remoteconfig_poller.register_callback(RemoteConfigProduct.AsmDd, callback)  # DD Rules
         remoteconfig_poller.enable_product(RemoteConfigProduct.AsmDd)
-
-    # ensure exploit prevention patches are loaded by one-click activation
-    if asm_config._asm_enabled:
-        from ddtrace.appsec._listeners import load_common_appsec_modules
-
-        load_common_appsec_modules()
 
     if asm_config._asm_enabled:
         telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, True)
@@ -82,9 +92,11 @@ def disable_appsec_rc() -> None:
 class AppSecCallback(RCCallback):
     """Remote config callback for AppSec products."""
 
-    def __init__(self) -> None:
+    def __init__(self, enable_asm: Callable[[], None], disable_asm: Callable[[], None]) -> None:
         """Initialize the AppSec callback."""
-        self._cache: dict[str, dict[str, Any]] = {}
+        self._cache: dict[str, AsmFeaturesResult] = {}
+        self._enable_asm = enable_asm
+        self._disable_asm = disable_asm
 
     def __call__(self, payloads: Sequence[Payload]) -> None:
         """Process AppSec configuration payloads.
@@ -94,6 +106,11 @@ class AppSecCallback(RCCallback):
         """
         if not payloads:
             return
+        # ASM_FEATURES payloads are folded into `result` here, once, and reused below for both
+        # the immediate product (de)registration and the enable_asm/disable_asm decision. Calling
+        # _update_asm_features a second time on the same payloads against the same cache would
+        # consume the pop-on-removal transition it just recorded and silently drop the second
+        # decision (e.g. missing a disable_asm() call on an ASM_FEATURES removal payload).
         result = _update_asm_features(payloads, self._cache)
         if "asm" in result:
             if asm_config._asm_static_rule_file is None:
@@ -115,32 +132,27 @@ class AppSecCallback(RCCallback):
                     remoteconfig_poller.unregister_callback(RemoteConfigProduct.AsmDd)
                     remoteconfig_poller.disable_product(RemoteConfigProduct.AsmDd)
         debug_info = (
-            f"appsec._remoteconfiguration.deb::_appsec_callback::payload"
+            f"appsec._remoteconfiguration.deb::AppSecCallback::payload"
             f"{tuple(p.path for p in payloads)}[{os.getpid()}][P: {os.getppid()}]"
         )
         log.debug(debug_info)
 
         for_the_waf_updates: list[tuple[str, str, PayloadType]] = []
         for_the_waf_removals: list[tuple[str, str]] = []
-        for_the_tracer: list[Payload] = []
         for payload in payloads:
             if payload.metadata.product_name == "ASM_FEATURES":
-                for_the_tracer.append(payload)
+                continue  # already folded into `result` above
             elif payload.content is None:
                 for_the_waf_removals.append((payload.metadata.product_name, payload.path))
             else:
                 for_the_waf_updates.append((payload.metadata.product_name, payload.path, payload.content))
-        _process_asm_features(for_the_tracer)
+        _process_asm_features(result, enable_asm=self._enable_asm, disable_asm=self._disable_asm)
         if (for_the_waf_removals or for_the_waf_updates) and asm_config._asm_enabled:
             core.dispatch("waf.update", (for_the_waf_removals, for_the_waf_updates))
 
 
-# Create singleton instance for global usage
-_appsec_callback = AppSecCallback()
-
-
-def _update_asm_features(payload_list: Sequence[Payload], cache: dict[str, dict[str, Any]]) -> dict[str, Any]:
-    res: dict[str, dict[str, Optional[bool]]] = {}
+def _update_asm_features(payload_list: Sequence[Payload], cache: dict[str, AsmFeaturesResult]) -> AsmFeaturesResult:
+    res: AsmFeaturesResult = {}
     for payload in payload_list:
         if payload.metadata.product_name == "ASM_FEATURES":
             payload_content = payload.content
@@ -152,12 +164,17 @@ def _update_asm_features(payload_list: Sequence[Payload], cache: dict[str, dict[
                         res["auto_user_instrum"] = {"mode": None}
                 cache.pop(payload.path, None)
             else:
-                res.update(payload_content)
-                cache[payload.path] = payload_content
+                asm_features_content = cast(AsmFeaturesResult, payload_content)
+                res.update(asm_features_content)
+                cache[payload.path] = asm_features_content
     return res
 
 
-def _process_asm_features(payload_list: list[Payload], cache: dict[str, dict[str, Any]] = {}) -> None:
+def _process_asm_features(
+    result: AsmFeaturesResult,
+    enable_asm: Callable[[], None],
+    disable_asm: Callable[[], None],
+) -> None:
     """This callback updates appsec enabled in tracer and config instances following this logic:
     ```
     | DD_APPSEC_ENABLED | RC Enabled | Result   |
@@ -170,8 +187,11 @@ def _process_asm_features(payload_list: list[Payload], cache: dict[str, dict[str
     | false             | true       | Disabled |
     | true              | true       | Enabled  |
     ```
+
+    `result` is the dict already produced by _update_asm_features for the current payload batch;
+    callers must not call _update_asm_features again for the same batch (it pops the cache entry
+    on a removal payload, so a second call would silently miss the enable/disable decision).
     """
-    result = _update_asm_features(payload_list, cache)
     if "asm" in result and asm_config._asm_can_be_enabled:
         if result["asm"].get("enabled", False):
             enable_asm()
@@ -182,20 +202,3 @@ def _process_asm_features(payload_list: list[Payload], cache: dict[str, dict[str
     if "asm" in result or "auto_user_instrum" in result:
         # Re-advertise capabilities so blocking/RASP follow one-click activation/deactivation.
         remoteconfig_poller.update_capabilities(_ALL_ASM_CAPABILITIES, _rc_capabilities())
-
-
-def disable_asm() -> None:
-    if asm_config._asm_enabled:
-        from ddtrace.appsec._listeners import disable_appsec
-
-        disable_appsec(reconfigure_tracer=True)
-        if not asm_config._asm_enabled:
-            telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, False)
-
-
-def enable_asm() -> None:
-    if asm_config._asm_can_be_enabled and not asm_config._asm_enabled:
-        from ddtrace.appsec._listeners import load_appsec
-
-        if load_appsec(reconfigure_tracer=True, origin=APPSEC.ENABLED_ORIGIN_RC):
-            telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, True)

--- a/ddtrace/contrib/internal/pytorch/_distributed.py
+++ b/ddtrace/contrib/internal/pytorch/_distributed.py
@@ -9,8 +9,10 @@ from typing import Optional
 
 import torch
 
+from ddtrace.contrib.internal.pytorch._utils import distributed_available
 from ddtrace.contrib.internal.pytorch._utils import get_cached_job_id
 from ddtrace.contrib.internal.pytorch._utils import job_id_env_set
+from ddtrace.contrib.internal.pytorch._utils import reset_cached_backend
 from ddtrace.contrib.internal.pytorch._utils import resolve_job_id_from_env
 from ddtrace.contrib.internal.pytorch._utils import set_cached_job_id
 from ddtrace.contrib.internal.trace_utils import unwrap as _unwrap
@@ -36,8 +38,6 @@ _rank_ctx: contextvars.ContextVar[Optional[core.ExecutionContext[Any]]] = contex
     "pytorch_rank_ctx", default=None
 )
 
-_cached_distributed_backend: Optional[str] = None
-
 
 def _step_profiling_enabled() -> bool:
     return env.get("DD_TRAINING_STEP_PROFILING", "false").lower() in ("true", "1")
@@ -53,12 +53,7 @@ _RAY_RUN_METADATA_ENV = "_DD_RAY_RUN_METADATA"
 
 
 def _reset_child_state() -> None:
-    global \
-        _no_env_job_id_warned, \
-        _cached_distributed_backend, \
-        _fsdp_hook_registered, \
-        _deepspeed_hook_registered, \
-        _optimizer_wrapped
+    global _no_env_job_id_warned, _fsdp_hook_registered, _deepspeed_hook_registered, _optimizer_wrapped
     ctx = _rank_ctx.get()
     if ctx is not None:
         _rank_ctx.set(None)
@@ -72,36 +67,13 @@ def _reset_child_state() -> None:
         except Exception:  # nosec B110
             pass
     _no_env_job_id_warned = False
-    _cached_distributed_backend = None
+    reset_cached_backend()
     _fsdp_hook_registered = False
     _deepspeed_hook_registered = False
     _optimizer_wrapped = False
 
 
 forksafe.register(_reset_child_state)
-
-
-def _distributed_available() -> bool:
-    try:
-        return bool(torch.distributed.is_available())
-    except Exception:
-        return False
-
-
-def _get_cached_backend() -> Optional[str]:
-    """One-shot lookup of ``torch.distributed.get_backend()``. Caches the
-    result on first successful call. The backend (nccl/gloo/mpi) does not
-    change during the lifetime of a process group.
-    """
-    global _cached_distributed_backend
-    if _cached_distributed_backend is not None:
-        return _cached_distributed_backend
-    try:
-        if _distributed_available() and torch.distributed.is_initialized():
-            _cached_distributed_backend = str(torch.distributed.get_backend())
-    except Exception:
-        return None
-    return _cached_distributed_backend
 
 
 def _populate_ray_run_metadata() -> None:
@@ -123,19 +95,6 @@ def _populate_ray_run_metadata() -> None:
         set_cached_run_metadata(submission_id=sub, run_name=rn, metadata=metadata or None)
 
 
-def _detect_launcher() -> Optional[str]:
-    """Return a best-guess launcher name from env, or None."""
-    if env.get("TORCHELASTIC_RUN_ID"):
-        return "torchrun"
-    if env.get("RAY_JOB_ID"):
-        return "ray"
-    if env.get("SLURM_JOB_ID"):
-        return "slurm"
-    if env.get("KUBEFLOW_TRAINING_JOB_ID"):
-        return "kubeflow"
-    return None
-
-
 def _bootstrap_distributed() -> None:
     """Capture rank/world_size and open the pytorch.rank span.
 
@@ -152,7 +111,7 @@ def _bootstrap_distributed() -> None:
     rank: int = 0
     world_size: int = 1
     try:
-        if _distributed_available() and torch.distributed.is_initialized():
+        if distributed_available() and torch.distributed.is_initialized():
             rank = torch.distributed.get_rank()
             world_size = torch.distributed.get_world_size()
     except Exception:
@@ -261,8 +220,7 @@ def _wrapped_destroy_process_group(wrapped: Any, instance: Any, args: Any, kwarg
                 ctx.dispatch_ended_event()
                 ctx.__exit__(None, None, None)
                 _rank_ctx.set(None)
-            global _cached_distributed_backend
-            _cached_distributed_backend = None
+            reset_cached_backend()
             try:
                 from ddtrace.contrib.internal.pytorch._utils import set_cached_job_id  # noqa: PLC0415
 
@@ -444,9 +402,9 @@ def install() -> None:
     if _installed:
         return
     _installed = True
-    if _distributed_available() and hasattr(torch.distributed, "init_process_group"):
+    if distributed_available() and hasattr(torch.distributed, "init_process_group"):
         _wrap("torch.distributed", "init_process_group", _wrapped_init_process_group)
-    if _distributed_available() and hasattr(torch.distributed, "destroy_process_group"):
+    if distributed_available() and hasattr(torch.distributed, "destroy_process_group"):
         _wrap("torch.distributed", "destroy_process_group", _wrapped_destroy_process_group)
     _install_ddp()
     _install_fsdp()
@@ -454,7 +412,7 @@ def install() -> None:
     _install_optimizer_step()
     # Late-patch bootstrap: if init_process_group was called before patch(),
     # our wrapper will never fire. Run bootstrap now.
-    if _distributed_available():
+    if distributed_available():
         try:
             if torch.distributed.is_initialized() and _rank_ctx.get() is None:
                 ctx = core.context_with_data("pytorch.rank", dispatch_end_event=False)  # type: ignore[no-untyped-call]
@@ -469,7 +427,7 @@ def uninstall() -> None:
     global _installed, _fsdp_hook_registered, _deepspeed_hook_registered
     if _installed:
         _installed = False
-        if _distributed_available():
+        if distributed_available():
             for fn in ("destroy_process_group", "init_process_group"):
                 if hasattr(torch.distributed, fn):
                     try:
@@ -512,6 +470,6 @@ def uninstall() -> None:
         _utils_mod._tls_job_id = threading.local()
     except Exception:
         log.debug("pytorch: failed to reset cached job id on uninstall", exc_info=True)
-    global _no_env_job_id_warned, _cached_distributed_backend
+    global _no_env_job_id_warned
     _no_env_job_id_warned = False
-    _cached_distributed_backend = None
+    reset_cached_backend()

--- a/ddtrace/contrib/internal/pytorch/_rank_root.py
+++ b/ddtrace/contrib/internal/pytorch/_rank_root.py
@@ -167,13 +167,13 @@ def _build_span(kwargs: dict[str, Any]) -> Optional[Any]:
             log.debug("pytorch.rank: env-signal tagging failed", exc_info=True)
 
         try:
-            from ddtrace.contrib.internal.pytorch._distributed import _detect_launcher  # noqa: PLC0415
-            from ddtrace.contrib.internal.pytorch._distributed import _get_cached_backend  # noqa: PLC0415
+            from ddtrace.contrib.internal.pytorch._utils import detect_launcher  # noqa: PLC0415
+            from ddtrace.contrib.internal.pytorch._utils import get_cached_backend  # noqa: PLC0415
 
-            launcher = _detect_launcher()
+            launcher = detect_launcher()
             if launcher:
                 span._set_attribute("launcher", launcher)
-            backend = _get_cached_backend()
+            backend = get_cached_backend()
             if backend:
                 span._set_attribute("torch.distributed.backend", backend)
         except Exception:

--- a/ddtrace/contrib/internal/pytorch/_utils.py
+++ b/ddtrace/contrib/internal/pytorch/_utils.py
@@ -5,6 +5,8 @@ from typing import Any
 from typing import Optional
 import uuid
 
+import torch
+
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings import env
 
@@ -113,6 +115,54 @@ def job_id_env_set() -> bool:
         if raw and raw.strip():
             return True
     return False
+
+
+# Process-wide cache of torch.distributed.get_backend(); shared by _distributed
+# (which populates/resets it) and _rank_root (which reads it for span tags).
+# Lives here rather than in _distributed to avoid a _distributed <-> _rank_root
+# import cycle.
+_cached_distributed_backend: Optional[str] = None
+
+
+def distributed_available() -> bool:
+    try:
+        return bool(torch.distributed.is_available())
+    except Exception:
+        return False
+
+
+def get_cached_backend() -> Optional[str]:
+    """One-shot lookup of ``torch.distributed.get_backend()``. Caches the
+    result on first successful call. The backend (nccl/gloo/mpi) does not
+    change during the lifetime of a process group.
+    """
+    global _cached_distributed_backend
+    if _cached_distributed_backend is not None:
+        return _cached_distributed_backend
+    try:
+        if distributed_available() and torch.distributed.is_initialized():
+            _cached_distributed_backend = str(torch.distributed.get_backend())
+    except Exception:
+        return None
+    return _cached_distributed_backend
+
+
+def reset_cached_backend() -> None:
+    global _cached_distributed_backend
+    _cached_distributed_backend = None
+
+
+def detect_launcher() -> Optional[str]:
+    """Return a best-guess launcher name from env, or None."""
+    if env.get("TORCHELASTIC_RUN_ID"):
+        return "torchrun"
+    if env.get("RAY_JOB_ID"):
+        return "ray"
+    if env.get("SLURM_JOB_ID"):
+        return "slurm"
+    if env.get("KUBEFLOW_TRAINING_JOB_ID"):
+        return "kubeflow"
+    return None
 
 
 # Ray Train run-context cache. Writers use _run_metadata_lock; readers use the lock-free view.

--- a/ddtrace/internal/appsec/product.py
+++ b/ddtrace/internal/appsec/product.py
@@ -14,14 +14,16 @@ def enabled():
 
 def start():
     if config._asm_enabled or config._asm_can_be_enabled:
+        # The product owns common-patch setup for both static and remote activation.
         from ddtrace.appsec._listeners import load_common_appsec_modules
 
         load_common_appsec_modules()
 
     if config._asm_rc_enabled:
+        from ddtrace.appsec._remoteconfiguration import AppSecCallback
         from ddtrace.appsec._remoteconfiguration import enable_appsec_rc
 
-        enable_appsec_rc()
+        enable_appsec_rc(AppSecCallback(_enable_asm, _disable_asm))
 
     if config._asm_enabled:
         from ddtrace.appsec._listeners import load_appsec
@@ -35,3 +37,25 @@ def restart(join=False):
 
 def stop(join=False):
     pass
+
+
+def _disable_asm() -> None:
+    if config._asm_enabled:
+        from ddtrace.appsec._listeners import disable_appsec
+        from ddtrace.internal.telemetry import telemetry_writer
+        from ddtrace.internal.telemetry.constants import TELEMETRY_APM_PRODUCT
+
+        disable_appsec(reconfigure_tracer=True)
+        if not config._asm_enabled:
+            telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, False)
+
+
+def _enable_asm() -> None:
+    if config._asm_can_be_enabled and not config._asm_enabled:
+        from ddtrace.appsec._constants import APPSEC
+        from ddtrace.appsec._listeners import load_appsec
+        from ddtrace.internal.telemetry import telemetry_writer
+        from ddtrace.internal.telemetry.constants import TELEMETRY_APM_PRODUCT
+
+        if load_appsec(reconfigure_tracer=True, origin=APPSEC.ENABLED_ORIGIN_RC):
+            telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, True)

--- a/ddtrace/internal/wrapping/context.py
+++ b/ddtrace/internal/wrapping/context.py
@@ -110,6 +110,10 @@ _CONTEXT_PLACEHOLDER = object()
 
 T = t.TypeVar("T")
 
+# Hoisted out of the hot enter/exit/return paths: subscripting a generic alias
+# like dict[str, t.Any] allocates a new types.GenericAlias on every evaluation,
+# so re-typing it inline on each call is not free.
+WrappingContextStorage = dict[str, t.Any]
 StorageVar = ContextVar[t.Optional[dict[str, t.Any]]]
 
 _STORAGE_PREV = "__dd_wrapping_context_prev__"
@@ -469,7 +473,7 @@ class BaseWrappingContext(ABC):
         return self
 
     def _pop_storage(self) -> dict[str, t.Any]:
-        storage = t.cast(dict[str, t.Any], self._storage.get())
+        storage = t.cast(WrappingContextStorage, self._storage.get())
         self._storage.set(storage.pop(_STORAGE_PREV))
         del storage[_STORAGE_OWNER]
         return storage
@@ -487,10 +491,10 @@ class BaseWrappingContext(ABC):
         self._pop_storage()
 
     def get(self, key: str) -> t.Any:
-        return t.cast(dict[str, t.Any], self._storage.get())[key]
+        return t.cast(WrappingContextStorage, self._storage.get())[key]
 
     def set(self, key: str, value: T) -> T:
-        t.cast(dict[str, t.Any], self._storage.get())[key] = value
+        t.cast(WrappingContextStorage, self._storage.get())[key] = value
         return value
 
     @classmethod
@@ -678,11 +682,25 @@ class _UniversalWrappingContext(BaseWrappingContext):
     def __enter__(self) -> "_UniversalWrappingContext":
         super().__enter__()
 
-        # Make the frame object available to the contexts
-        self.set("__frame__", sys._getframe(1))
+        storage = t.cast(WrappingContextStorage, self._storage.get())
 
+        # Make the frame object available to the contexts
+        storage["__frame__"] = sys._getframe(1)
+
+        # Freeze the list of contexts so that we know exactly which ones to
+        # exit, in case new contexts are registered during the execution of
+        # the wrapped function. Contexts are appended only once entered, so
+        # that a failure partway through does not leave contexts that never
+        # entered in the snapshot.
+        entered: list[WrappingContext] = []
+        storage["__contexts__"] = entered
         for context in self._contexts:
-            context.__enter__()
+            try:
+                context.__enter__()
+            except Exception:
+                log.debug("Failed to enter wrapping context %r", context, exc_info=True)
+                continue
+            entered.append(context)
 
         return self
 
@@ -698,13 +716,25 @@ class _UniversalWrappingContext(BaseWrappingContext):
         if exc_value is None:
             return
 
-        for context in self._contexts[::-1]:
+        try:
+            contexts = t.cast(WrappingContextStorage, self._storage.get())["__contexts__"]
+        except (TypeError, KeyError):
+            log.debug("Universal wrapping context exited without entering")
+            return
+
+        for context in contexts[::-1]:
             context.__exit__(exc_type, exc_value, traceback)
 
         super().__exit__(exc_type, exc_value, traceback)
 
     def __return__(self, value: T) -> T:
-        for context in self._contexts[::-1]:
+        try:
+            contexts = t.cast(WrappingContextStorage, self._storage.get())["__contexts__"]
+        except (TypeError, KeyError):
+            log.debug("Universal wrapping context returned without entering")
+            return super().__return__(value)
+
+        for context in contexts[::-1]:
             context.__return__(value)
 
         return super().__return__(value)

--- a/releasenotes/notes/fix-wrapping-context-exit-race-b2ba3bd382059248.yaml
+++ b/releasenotes/notes/fix-wrapping-context-exit-race-b2ba3bd382059248.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    code origin for spans: prevent view or traced functions from raising an
+    exception in situations where their number is large.

--- a/tests/appsec/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/appsec/test_remoteconfiguration.py
@@ -8,11 +8,13 @@ from ddtrace.appsec._capabilities import _appsec_rc_capabilities
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import DEFAULT
 from ddtrace.appsec._processor import AppSecSpanProcessor
-from ddtrace.appsec._remoteconfiguration import _appsec_callback
+from ddtrace.appsec._remoteconfiguration import AppSecCallback
 from ddtrace.appsec._remoteconfiguration import disable_appsec_rc
 from ddtrace.appsec._remoteconfiguration import enable_appsec_rc
 from ddtrace.appsec._utils import get_triggers
 from ddtrace.contrib.internal.trace_utils import set_http_meta
+from ddtrace.internal.appsec.product import _disable_asm
+from ddtrace.internal.appsec.product import _enable_asm
 from ddtrace.internal.native import RemoteConfigProduct
 from ddtrace.internal.service import ServiceStatus
 from ddtrace.internal.settings.asm import config as asm_config
@@ -24,6 +26,11 @@ from tests.appsec.utils import build_payload
 from tests.appsec.utils import get_waf_addresses
 from tests.utils import override_env
 from tests.utils import override_global_config
+
+
+@pytest.fixture
+def appsec_callback():
+    return AppSecCallback(_enable_asm, _disable_asm)
 
 
 @pytest.fixture(autouse=True)
@@ -47,6 +54,35 @@ def _set_and_get_appsec_tags(tracer, check_client_id=False):
     return get_triggers(span)
 
 
+def test_appsec_callback_uses_injected_lifecycle(rc_poller):
+    enable_asm = mock.Mock()
+    disable_asm = mock.Mock()
+    callback = AppSecCallback(enable_asm, disable_asm)
+
+    with mock.patch("ddtrace.appsec._remoteconfiguration._process_asm_features") as process_asm_features:
+        callback([build_payload("ASM_FEATURES", {"asm": {"enabled": True}}, "config")])
+
+    process_asm_features.assert_called_once()
+    assert process_asm_features.call_args.kwargs["enable_asm"] is enable_asm
+    assert process_asm_features.call_args.kwargs["disable_asm"] is disable_asm
+
+
+def test_appsec_product_wires_remote_configuration():
+    from ddtrace.internal.appsec import product
+
+    with (
+        mock.patch.object(product.config, "_asm_enabled", False),
+        mock.patch.object(product.config, "_asm_can_be_enabled", False),
+        mock.patch.object(product.config, "_asm_rc_enabled", True),
+        mock.patch("ddtrace.appsec._remoteconfiguration.enable_appsec_rc") as enable_rc,
+    ):
+        product.start()
+
+        callback = enable_rc.call_args.args[0]
+        assert callback._enable_asm is product._enable_asm
+        assert callback._disable_asm is product._disable_asm
+
+
 @pytest.mark.xfail(
     reason="DD_REMOTE_CONFIGURATION_ENABLED is set to false for all riot venvs, "
     "this is not the default behavior for users"
@@ -58,19 +94,19 @@ def test_rc_enabled_by_default(tracer):
     assert asm_config._asm_can_be_enabled
 
 
-def test_rc_activate_is_active_and_get_processor_tags(tracer, rc_poller):
+def test_rc_activate_is_active_and_get_processor_tags(tracer, rc_poller, appsec_callback):
     with override_global_config(dict(_remote_config_enabled=True)):
         rc_config = build_payload("ASM_FEATURES", {"asm": {"enabled": True}}, "config")
-        _appsec_callback([rc_config])
+        appsec_callback([rc_config])
         assert AppSecSpanProcessor._instance
         assert _set_and_get_appsec_tags(tracer)
         rc_config = build_payload("ASM_FEATURES", None, "config")
-        _appsec_callback([rc_config])
+        appsec_callback([rc_config])
         result = _set_and_get_appsec_tags(tracer)
         assert result is None
         assert AppSecSpanProcessor._instance is None
         rc_config = build_payload("ASM_FEATURES", {"asm": {"enabled": True}}, "config")
-        _appsec_callback([rc_config])
+        appsec_callback([rc_config])
         assert AppSecSpanProcessor._instance
         assert _set_and_get_appsec_tags(tracer)
 
@@ -83,7 +119,7 @@ def test_rc_activate_is_active_and_get_processor_tags(tracer, rc_poller):
         ("true", False),
     ],
 )
-def test_rc_activation_states_on(tracer, appsec_enabled, rc_value, rc_poller):
+def test_rc_activation_states_on(tracer, appsec_enabled, rc_value, rc_poller, appsec_callback):
     with (
         override_env({APPSEC.ENV: appsec_enabled} if appsec_enabled else {}),
         override_global_config(dict(_asm_enabled=asbool(appsec_enabled), _remote_config_enabled=True)),
@@ -91,7 +127,7 @@ def test_rc_activation_states_on(tracer, appsec_enabled, rc_value, rc_poller):
         if appsec_enabled:
             tracer.configure(appsec_enabled=asbool(appsec_enabled))
         rc_config = build_payload("ASM_FEATURES", {"asm": {"enabled": rc_value}}, "config")
-        _appsec_callback([rc_config])
+        appsec_callback([rc_config])
         result = _set_and_get_appsec_tags(tracer)
         assert result
 
@@ -104,7 +140,7 @@ def test_rc_activation_states_on(tracer, appsec_enabled, rc_value, rc_poller):
         ("false", True),
     ],
 )
-def test_rc_activation_states_off(tracer, appsec_enabled, rc_value, rc_poller):
+def test_rc_activation_states_off(tracer, appsec_enabled, rc_value, rc_poller, appsec_callback):
     with override_env({APPSEC.ENV: appsec_enabled}):
         if appsec_enabled == "":
             del os.environ[APPSEC.ENV]
@@ -115,7 +151,7 @@ def test_rc_activation_states_off(tracer, appsec_enabled, rc_value, rc_poller):
             if rc_value is False:
                 rc_configs = []
 
-            _appsec_callback(rc_configs)
+            appsec_callback(rc_configs)
             result = _set_and_get_appsec_tags(tracer)
             assert result is None
 
@@ -151,7 +187,7 @@ def test_rc_capabilities(rc_enabled, appsec_enabled, capability, tracer):
         ({"_asm_static_rule_file": DEFAULT.RULES}, "gAAAAg=="),  # Only ASM_FEATURES
     ],
 )
-def test_rc_activation_capabilities(tracer, rc_poller, env_rules, expected):
+def test_rc_activation_capabilities(tracer, rc_poller, env_rules, expected, appsec_callback):
     global_config = dict(_asm_enabled=False, _remote_config_enabled=True)
     global_config.update(env_rules)
     with override_global_config(global_config):
@@ -159,19 +195,19 @@ def test_rc_activation_capabilities(tracer, rc_poller, env_rules, expected):
         # flaky test
         # assert not rc_poller._worker
 
-        _appsec_callback(rc_configs)
+        appsec_callback(rc_configs)
 
         assert _appsec_rc_capabilities() == expected
 
 
-def test_rc_capabilities_updated_after_one_click_activation(tracer, rc_poller):
+def test_rc_capabilities_updated_after_one_click_activation(tracer, rc_poller, appsec_callback):
     """Regression test: advertised capabilities must follow one-click ASM activation/deactivation.
 
     Capabilities are registered once (while AppSec is still disabled for a remotely-activated
-    service). The client must *re-advertise* blocking/RASP once ASM is turned on and *drop*
+    service). The client must re-advertise blocking/RASP once ASM is turned on and drop
     them again when it is turned off, otherwise the backend reports "UPDATE REQUIRED" for
     blocking even though it is functional. This exercises the appsec wiring
-    (``_appsec_callback`` -> ``update_capabilities(_ALL_ASM_CAPABILITIES, _rc_capabilities())``);
+    (AppSecCallback -> update_capabilities(_ALL_ASM_CAPABILITIES, _rc_capabilities()));
     the replace-within-mask mechanics themselves are covered by the native RC tests.
     """
     from ddtrace.appsec._capabilities import _ALL_ASM_BLOCKING
@@ -187,20 +223,20 @@ def test_rc_capabilities_updated_after_one_click_activation(tracer, rc_poller):
     disable_config = [build_payload("ASM_FEATURES", {"asm": {}}, "config")]
 
     with override_global_config(dict(_remote_config_enabled=True, _asm_enabled=False, _asm_can_be_enabled=True)):
-        enable_appsec_rc()
+        enable_appsec_rc(appsec_callback)
 
         # AppSec is not enabled yet (remote activation pending): activation only, no blocking.
         assert Cap.AsmActivation in advertised()
         assert advertised().isdisjoint(_ALL_ASM_BLOCKING)
 
         # One-click activation: blocking (and RASP) capabilities must now be advertised.
-        _appsec_callback(enable_config)
+        appsec_callback(enable_config)
         assert asm_config._asm_enabled
         assert set(_ALL_ASM_BLOCKING) <= advertised()
         assert advertised() == set(_rc_capabilities())
 
         # One-click deactivation: blocking capabilities must be dropped again.
-        _appsec_callback(disable_config)
+        appsec_callback(disable_config)
         assert not asm_config._asm_enabled
         assert Cap.AsmActivation in advertised()
         assert advertised().isdisjoint(_ALL_ASM_BLOCKING)
@@ -209,20 +245,20 @@ def test_rc_capabilities_updated_after_one_click_activation(tracer, rc_poller):
     disable_appsec_rc()
 
 
-def test_rc_activation_validate_products(tracer, rc_poller):
+def test_rc_activation_validate_products(tracer, rc_poller, appsec_callback):
     with override_global_config(dict(_asm_enabled=False, _remote_config_enabled=True, api_version="v0.4")):
         assert not rc_poller._worker
 
-        enable_appsec_rc()
+        enable_appsec_rc(appsec_callback)
 
         assert rc_poller._client._product_callbacks[RemoteConfigProduct.AsmFeatures]
     disable_appsec_rc()
 
 
-def test_rc_activation_validate_client_id(tracer, rc_poller):
+def test_rc_activation_validate_client_id(tracer, rc_poller, appsec_callback):
     with override_global_config(dict(_asm_enabled=True, _remote_config_enabled=True, api_version="v0.4")):
         tracer.configure(appsec_enabled=True)
-        enable_appsec_rc()
+        enable_appsec_rc(appsec_callback)
         _set_and_get_appsec_tags(tracer, True)
     disable_appsec_rc()
 
@@ -249,7 +285,7 @@ def test_rc_activation_validate_client_id(tracer, rc_poller):
     ],
 )
 def test_rc_activation_check_asm_features_product_disables_rest_of_products(
-    tracer, rc_poller, env_rules, expected, enable_config_content, disable_config_content
+    tracer, rc_poller, env_rules, expected, enable_config_content, disable_config_content, appsec_callback
 ):
     global_config = dict(_remote_config_enabled=True, _asm_enabled=True)
     global_config.update(env_rules)
@@ -261,33 +297,33 @@ def test_rc_activation_check_asm_features_product_disables_rest_of_products(
     disable_config = [build_payload("ASM_FEATURES", disable_config_content, "config")]
     with override_global_config(global_config):
         tracer.configure(appsec_enabled=True)
-        enable_appsec_rc()
+        enable_appsec_rc(appsec_callback)
         assert bool(rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmData)) is expected
         assert bool(rc_poller._client._product_callbacks.get(RemoteConfigProduct.Asm)) is expected
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmFeatures)
 
         # sending nothing should not change anything (configuration is the same)
-        _appsec_callback(empty_config)
+        appsec_callback(empty_config)
 
         assert bool(rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmData)) is expected
         assert bool(rc_poller._client._product_callbacks.get(RemoteConfigProduct.Asm)) is expected
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmFeatures)
 
         # sending empty config for asm should disable asm (meaning asm was deleted)
-        _appsec_callback(disable_config)
+        appsec_callback(disable_config)
 
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmData) is None
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.Asm) is None
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmFeatures)
 
         # sending nothing should not change anything (configuration is the same)
-        _appsec_callback(empty_config)
+        appsec_callback(empty_config)
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmData) is None
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.Asm) is None
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmFeatures)
 
         # sending config should enable asm again
-        _appsec_callback(enable_config)
+        appsec_callback(enable_config)
         assert bool(rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmData)) is expected
         assert bool(rc_poller._client._product_callbacks.get(RemoteConfigProduct.Asm)) is expected
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmFeatures)
@@ -296,7 +332,7 @@ def test_rc_activation_check_asm_features_product_disables_rest_of_products(
 
 
 @pytest.mark.parametrize("auto_user", [True, False])
-def test_rc_activation_with_auto_user_appsec_fixed(tracer, rc_poller, auto_user):
+def test_rc_activation_with_auto_user_appsec_fixed(tracer, rc_poller, auto_user, appsec_callback):
     with (
         override_env({APPSEC.ENV: "true"}),
         override_global_config(
@@ -309,7 +345,7 @@ def test_rc_activation_with_auto_user_appsec_fixed(tracer, rc_poller, auto_user)
         ),
     ):
         tracer.configure(appsec_enabled=True)
-        enable_appsec_rc()
+        enable_appsec_rc(appsec_callback)
 
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.AsmData)
         assert rc_poller._client._product_callbacks.get(RemoteConfigProduct.Asm)
@@ -318,7 +354,7 @@ def test_rc_activation_with_auto_user_appsec_fixed(tracer, rc_poller, auto_user)
     disable_appsec_rc()
 
 
-def test_rc_activation_ip_blocking_data(tracer, rc_poller):
+def test_rc_activation_ip_blocking_data(tracer, rc_poller, appsec_callback):
     with override_global_config({"_asm_enabled": True}):
         rc_config = {
             "rules_data": [
@@ -338,7 +374,7 @@ def test_rc_activation_ip_blocking_data(tracer, rc_poller):
         }
         assert rc_poller.status == ServiceStatus.STOPPED
 
-        _appsec_callback([build_payload("ASM_DATA", rc_config, "data")])
+        appsec_callback([build_payload("ASM_DATA", rc_config, "data")])
         with asm_context(tracer, ip_addr="8.8.4.4") as span:
             set_http_meta(
                 span,
@@ -348,7 +384,7 @@ def test_rc_activation_ip_blocking_data(tracer, rc_poller):
         assert get_waf_addresses("http.request.remote_ip") == "8.8.4.4"
 
 
-def test_rc_activation_ip_blocking_data_expired(tracer, rc_poller):
+def test_rc_activation_ip_blocking_data_expired(tracer, rc_poller, appsec_callback):
     with override_env({APPSEC.ENV: "true"}), override_global_config({}):
         tracer.configure(appsec_enabled=True)
         rc_config = {
@@ -365,7 +401,7 @@ def test_rc_activation_ip_blocking_data_expired(tracer, rc_poller):
 
         assert rc_poller.status == ServiceStatus.STOPPED
 
-        _appsec_callback([build_payload("ASM_DATA", rc_config, "data")])
+        appsec_callback([build_payload("ASM_DATA", rc_config, "data")])
 
         with asm_context(tracer, ip_addr="8.8.4.4") as span:
             set_http_meta(
@@ -375,7 +411,7 @@ def test_rc_activation_ip_blocking_data_expired(tracer, rc_poller):
         assert get_triggers(span) is None
 
 
-def test_rc_activation_ip_blocking_data_not_expired(tracer, rc_poller):
+def test_rc_activation_ip_blocking_data_not_expired(tracer, rc_poller, appsec_callback):
     with override_global_config({"_asm_enabled": True}):
         rc_config = {
             "rules_data": [
@@ -391,7 +427,7 @@ def test_rc_activation_ip_blocking_data_not_expired(tracer, rc_poller):
 
         assert rc_poller.status == ServiceStatus.STOPPED
 
-        _appsec_callback([build_payload("ASM_DATA", rc_config, "data")])
+        appsec_callback([build_payload("ASM_DATA", rc_config, "data")])
 
         with asm_context(tracer, ip_addr="8.8.4.4") as span:
             set_http_meta(
@@ -402,11 +438,11 @@ def test_rc_activation_ip_blocking_data_not_expired(tracer, rc_poller):
         assert get_waf_addresses("http.request.remote_ip") == "8.8.4.4"
 
 
-def test_rc_activation_does_not_report_appsec_product_when_only_rc_enabled(tracer, rc_poller):
+def test_rc_activation_does_not_report_appsec_product_when_only_rc_enabled(tracer, rc_poller, appsec_callback):
     """Regression test: registering RC listeners should not report AppSec as an enabled product in telemetry."""
     with override_global_config(dict(_asm_enabled=False, _asm_can_be_enabled=True, _remote_config_enabled=True)):
         with mock.patch("ddtrace.appsec._remoteconfiguration.telemetry_writer") as mock_tw:
-            enable_appsec_rc()
+            enable_appsec_rc(appsec_callback)
 
             # RC listeners are registered but AppSec is not enabled
             assert rc_poller._client._product_callbacks[RemoteConfigProduct.AsmFeatures]
@@ -416,37 +452,41 @@ def test_rc_activation_does_not_report_appsec_product_when_only_rc_enabled(trace
     disable_appsec_rc()
 
 
-def test_rc_activation_reports_appsec_product_when_enabled(tracer, rc_poller):
+def test_rc_activation_reports_appsec_product_when_enabled(tracer, rc_poller, appsec_callback):
     """When AppSec is explicitly enabled, enable_appsec_rc should report the product as activated."""
     with override_global_config(dict(_asm_enabled=True, _remote_config_enabled=True)):
         tracer.configure(appsec_enabled=True)
         with mock.patch("ddtrace.appsec._remoteconfiguration.telemetry_writer") as mock_tw:
-            enable_appsec_rc()
+            enable_appsec_rc(appsec_callback)
 
             mock_tw.product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, True)
 
     disable_appsec_rc()
 
 
-def test_rc_enable_then_disable_asm_reports_telemetry(tracer, rc_poller):
-    """When AppSec is enabled/disabled via RC, telemetry should reflect the changes."""
-    with override_global_config(dict(_asm_enabled=False, _asm_can_be_enabled=True, _remote_config_enabled=True)):
-        with mock.patch("ddtrace.appsec._remoteconfiguration.telemetry_writer") as mock_tw:
-            enable_appsec_rc()
+def test_enable_asm_reports_telemetry():
+    with (
+        mock.patch.object(asm_config, "_asm_enabled", False),
+        mock.patch.object(asm_config, "_asm_can_be_enabled", True),
+        mock.patch("ddtrace.appsec._listeners.load_appsec", return_value=True) as load_appsec,
+        mock.patch("ddtrace.internal.telemetry.telemetry_writer.product_activated") as product_activated,
+    ):
+        _enable_asm()
 
-            # Initially not activated
-            mock_tw.product_activated.assert_not_called()
+    load_appsec.assert_called_once_with(reconfigure_tracer=True, origin=APPSEC.ENABLED_ORIGIN_RC)
+    product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, True)
 
-            # Simulate RC enabling AppSec
-            enable_config = [build_payload("ASM_FEATURES", {"asm": {"enabled": True}}, "config")]
-            _appsec_callback(enable_config)
-            mock_tw.product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, True)
 
-            mock_tw.product_activated.reset_mock()
+def test_disable_asm_reports_telemetry():
+    def disable_appsec(*, reconfigure_tracer):
+        assert reconfigure_tracer is True
+        asm_config._asm_enabled = False
 
-            # Simulate RC disabling AppSec
-            disable_config = [build_payload("ASM_FEATURES", {"asm": {}}, "config")]
-            _appsec_callback(disable_config)
-            mock_tw.product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, False)
+    with (
+        mock.patch.object(asm_config, "_asm_enabled", True),
+        mock.patch("ddtrace.appsec._listeners.disable_appsec", side_effect=disable_appsec),
+        mock.patch("ddtrace.internal.telemetry.telemetry_writer.product_activated") as product_activated,
+    ):
+        _disable_asm()
 
-    disable_appsec_rc()
+    product_activated.assert_called_once_with(TELEMETRY_APM_PRODUCT.APPSEC, False)

--- a/tests/appsec/appsec/test_telemetry.py
+++ b/tests/appsec/appsec/test_telemetry.py
@@ -13,12 +13,14 @@ import ddtrace.appsec._ddwaf.ddwaf_types
 import ddtrace.appsec._ddwaf.waf
 from ddtrace.appsec._deduplications import deduplication
 from ddtrace.appsec._processor import AppSecSpanProcessor
-from ddtrace.appsec._remoteconfiguration import enable_asm
+from ddtrace.appsec._remoteconfiguration import AppSecCallback
 from ddtrace.appsec._utils import DDWaf_result
 from ddtrace.appsec._utils import _observator
 from ddtrace.constants import APPSEC_ENV
 from ddtrace.contrib.internal.trace_utils import set_http_meta
 from ddtrace.ext import SpanTypes
+from ddtrace.internal.appsec.product import _disable_asm
+from ddtrace.internal.appsec.product import _enable_asm
 from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.telemetry.constants import TELEMETRY_NAMESPACE
 from ddtrace.trace import tracer
@@ -218,13 +220,12 @@ def test_metrics_when_appsec_block(telemetry_writer, test_agent_session, tracer)
 
 
 def test_metrics_when_appsec_block_custom(telemetry_writer, test_agent_session, tracer):
+    appsec_callback = AppSecCallback(_enable_asm, _disable_asm)
     with asm_context(tracer=tracer, ip_addr=rules._IP.BLOCKED, span_name="test", config=config_asm) as span:
-        from ddtrace.appsec._remoteconfiguration import _appsec_callback
-
         actions = {
             "actions": [{"id": "block", "type": "block_request", "parameters": {"status_code": 429, "type": "json"}}]
         }
-        _appsec_callback(
+        appsec_callback(
             [
                 build_payload("ASM", actions, "actions"),
             ],
@@ -502,7 +503,7 @@ def test_appsec_enabled_metric(
     ):
         tracer.configure(appsec_enabled=appsec_enabled, appsec_enabled_origin=APPSEC.ENABLED_ORIGIN_DEFAULT)
         if rc_enabled:
-            enable_asm()
+            _enable_asm()
 
         # Drain telemetry queued while configuring, then capture only the change-driven
         # DD_APPSEC_ENABLED report for the final state.

--- a/tests/contrib/pytorch/test_rank_root.py
+++ b/tests/contrib/pytorch/test_rank_root.py
@@ -273,47 +273,47 @@ def test_rank_root_close_flush_is_bounded(monkeypatch):
 
 
 def test_detect_launcher_torchrun(monkeypatch):
-    from ddtrace.contrib.internal.pytorch import _distributed
+    from ddtrace.contrib.internal.pytorch import _utils
 
     monkeypatch.setenv("TORCHELASTIC_RUN_ID", "tr-123")
     monkeypatch.delenv("RAY_JOB_ID", raising=False)
     monkeypatch.delenv("SLURM_JOB_ID", raising=False)
     monkeypatch.delenv("KUBEFLOW_TRAINING_JOB_ID", raising=False)
-    assert _distributed._detect_launcher() == "torchrun"
+    assert _utils.detect_launcher() == "torchrun"
 
 
 def test_detect_launcher_ray(monkeypatch):
-    from ddtrace.contrib.internal.pytorch import _distributed
+    from ddtrace.contrib.internal.pytorch import _utils
 
     monkeypatch.delenv("TORCHELASTIC_RUN_ID", raising=False)
     monkeypatch.setenv("RAY_JOB_ID", "rayjob-99")
     monkeypatch.delenv("SLURM_JOB_ID", raising=False)
     monkeypatch.delenv("KUBEFLOW_TRAINING_JOB_ID", raising=False)
-    assert _distributed._detect_launcher() == "ray"
+    assert _utils.detect_launcher() == "ray"
 
 
 def test_detect_launcher_slurm(monkeypatch):
-    from ddtrace.contrib.internal.pytorch import _distributed
+    from ddtrace.contrib.internal.pytorch import _utils
 
     monkeypatch.delenv("TORCHELASTIC_RUN_ID", raising=False)
     monkeypatch.delenv("RAY_JOB_ID", raising=False)
     monkeypatch.setenv("SLURM_JOB_ID", "slurm-42")
     monkeypatch.delenv("KUBEFLOW_TRAINING_JOB_ID", raising=False)
-    assert _distributed._detect_launcher() == "slurm"
+    assert _utils.detect_launcher() == "slurm"
 
 
 def test_detect_launcher_kubeflow(monkeypatch):
-    from ddtrace.contrib.internal.pytorch import _distributed
+    from ddtrace.contrib.internal.pytorch import _utils
 
     monkeypatch.delenv("TORCHELASTIC_RUN_ID", raising=False)
     monkeypatch.delenv("RAY_JOB_ID", raising=False)
     monkeypatch.delenv("SLURM_JOB_ID", raising=False)
     monkeypatch.setenv("KUBEFLOW_TRAINING_JOB_ID", "kf-job-1")
-    assert _distributed._detect_launcher() == "kubeflow"
+    assert _utils.detect_launcher() == "kubeflow"
 
 
 def test_detect_launcher_none(monkeypatch):
-    from ddtrace.contrib.internal.pytorch import _distributed
+    from ddtrace.contrib.internal.pytorch import _utils
 
     for var in (
         "TORCHELASTIC_RUN_ID",
@@ -322,14 +322,14 @@ def test_detect_launcher_none(monkeypatch):
         "KUBEFLOW_TRAINING_JOB_ID",
     ):
         monkeypatch.delenv(var, raising=False)
-    assert _distributed._detect_launcher() is None
+    assert _utils.detect_launcher() is None
 
 
 def test_get_cached_backend_caches_result(monkeypatch):
-    from ddtrace.contrib.internal.pytorch import _distributed
+    from ddtrace.contrib.internal.pytorch import _utils
 
     # Reset the cache.
-    _distributed._cached_distributed_backend = None
+    _utils._cached_distributed_backend = None
     monkeypatch.setattr(
         "ddtrace.contrib.internal.pytorch._distributed.torch.distributed.is_available",
         lambda: True,
@@ -342,23 +342,23 @@ def test_get_cached_backend_caches_result(monkeypatch):
         "ddtrace.contrib.internal.pytorch._distributed.torch.distributed.get_backend",
         lambda: "nccl",
     )
-    result1 = _distributed._get_cached_backend()
+    result1 = _utils.get_cached_backend()
     assert result1 == "nccl"
     # Second call should return cached value without calling get_backend again.
     monkeypatch.setattr(
         "ddtrace.contrib.internal.pytorch._distributed.torch.distributed.get_backend",
         lambda: "SHOULD_NOT_BE_CALLED",
     )
-    result2 = _distributed._get_cached_backend()
+    result2 = _utils.get_cached_backend()
     assert result2 == "nccl"
     # Clean up.
-    _distributed._cached_distributed_backend = None
+    _utils._cached_distributed_backend = None
 
 
 def test_get_cached_backend_returns_none_when_not_initialized(monkeypatch):
-    from ddtrace.contrib.internal.pytorch import _distributed
+    from ddtrace.contrib.internal.pytorch import _utils
 
-    _distributed._cached_distributed_backend = None
+    _utils._cached_distributed_backend = None
     monkeypatch.setattr(
         "ddtrace.contrib.internal.pytorch._distributed.torch.distributed.is_available",
         lambda: True,
@@ -367,8 +367,8 @@ def test_get_cached_backend_returns_none_when_not_initialized(monkeypatch):
         "ddtrace.contrib.internal.pytorch._distributed.torch.distributed.is_initialized",
         lambda: False,
     )
-    assert _distributed._get_cached_backend() is None
-    _distributed._cached_distributed_backend = None
+    assert _utils.get_cached_backend() is None
+    _utils._cached_distributed_backend = None
 
 
 def test_rank_span_carries_torch_invariants(monkeypatch):

--- a/tests/internal/test_wrapping.py
+++ b/tests/internal/test_wrapping.py
@@ -864,6 +864,116 @@ def test_wrapping_context_exc_on_exit():
     assert exc.args == ("foo",)
 
 
+def test_wrapping_context_mid_call_registration():
+    """Registering a new context on a function while a call is in flight must not crash that call.
+
+    Regression for: https://github.com/DataDog/dd-trace-py/issues/19372
+
+    _UniversalWrappingContext used to read its (mutable) list of contexts twice per call: once on
+    entry, once on exit/return. register() can mutate that list in between if a new context is
+    wrapped onto the same function while a call is in flight. A context added this way was never
+    entered for that call, so exiting it crashed with AttributeError in _pop_storage. The fix
+    freezes the list of contexts on entry so that exit/return only ever see contexts that were
+    actually entered.
+    """
+    import threading
+
+    class WrappingContextA(DummyWrappingContext):
+        pass
+
+    class WrappingContextB(DummyWrappingContext):
+        pass
+
+    in_call = threading.Event()
+    released = threading.Event()
+
+    def foo(x):
+        in_call.set()
+        released.wait(5)
+        return x * 2
+
+    wc_a = WrappingContextA(foo)
+    wc_a.wrap()
+
+    results = []
+
+    def call():
+        results.append(foo(21))
+
+    thread = threading.Thread(target=call)
+    thread.start()
+    in_call.wait(5)
+
+    # Register a second context while the call above is still in flight.
+    wc_b = WrappingContextB(foo)
+    wc_b.wrap()
+
+    released.set()
+    thread.join()
+
+    assert results == [42]
+    assert wc_a.entered
+    assert wc_a.return_value == 42
+    assert not wc_a.exited
+
+    # wc_b was registered after the in-flight call had already taken its snapshot of contexts, so
+    # it must not have taken part in that call.
+    assert not wc_b.entered
+    assert wc_b.return_value is NOTSET
+    assert not wc_b.exited
+
+
+def test_wrapping_context_mid_call_registration_does_not_mask_exception():
+    """A real exception from the wrapped function must not be replaced by an AttributeError.
+
+    Regression for: https://github.com/DataDog/dd-trace-py/issues/19372
+
+    Same root cause as test_wrapping_context_mid_call_registration, but on the exception path: the
+    AttributeError raised while exiting an un-entered context used to shadow the application's own
+    exception.
+    """
+    import threading
+
+    class WrappingContextA(DummyWrappingContext):
+        pass
+
+    class WrappingContextB(DummyWrappingContext):
+        pass
+
+    in_call = threading.Event()
+    released = threading.Event()
+
+    def foo(x):
+        in_call.set()
+        released.wait(5)
+        raise ValueError("the real error")
+
+    wc_a = WrappingContextA(foo)
+    wc_a.wrap()
+
+    errors = []
+
+    def call():
+        try:
+            foo(21)
+        except BaseException as e:
+            errors.append(e)
+
+    thread = threading.Thread(target=call)
+    thread.start()
+    in_call.wait(5)
+
+    # Register a second context while the call above is still in flight.
+    WrappingContextB(foo).wrap()
+
+    released.set()
+    thread.join()
+
+    assert len(errors) == 1
+    assert isinstance(errors[0], ValueError)
+    assert errors[0].args == ("the real error",)
+
+
 def test_wrapping_context_priority():
     class HighPriorityWrappingContext(DummyWrappingContext):
         def __enter__(self):

--- a/tests/wrapping/test_generators.py
+++ b/tests/wrapping/test_generators.py
@@ -4,8 +4,6 @@ Drives each lifecycle operation explicitly and asserts the exact sequence the
 wrapped generator must produce.
 """
 
-import sys
-
 import pytest
 
 from tests.wrapping.mechanisms import xfail_mechanism
@@ -74,11 +72,6 @@ def test_close_runs_finally(mech):
     assert log == ["cleanup"]
 
 
-@xfail_mechanism(
-    "wrapping_context",
-    reason="WrappingContext.throw() on an unstarted generator crashes on 3.11+ (internal AttributeError)",
-    condition=sys.version_info >= (3, 11),
-)
 def test_throw_on_unstarted_generator(mech):
     def g():
         yield 1


### PR DESCRIPTION
## Description

Backport of #19380 to 4.14 (currently in RC).

We make sure that only wrapping contexts that have been opened are later closed when the wrapped function either returns or throws an exception.

Resolves #19372.

## Testing

Clean cherry-pick of `ef3b7b02301013bc2b079d7dbf6c8749468a8b28`. Includes the wrapping-context regression tests from the original PR.

## Risks

Same as #19380: wrapping-context enter/exit bookkeeping. The change is a correctness fix for a race that could crash in-flight wrapped calls.

## Additional Notes

Cherry-pick of #19380. Release note included.
