### PR TITLE
feat(tracing): synchronize OpenTelemetry thread context in asyncio

### DIFF
--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -245,14 +245,16 @@ class Tracer(object):
             self.sample(span)
 
     @contextmanager
-    def _activate_context(self, context: Context):
+    def _activate_context(self, context: Optional[Context]):
         prev_active = self.context_provider.active()
-        context._reactivate = True
+        if context is not None:
+            context._reactivate = True
         self.context_provider.activate(context)
         try:
             yield
         finally:
-            context._reactivate = False
+            if context is not None:
+                context._reactivate = False
             self.context_provider.activate(prev_active)
 
     @property

--- a/ddtrace/contrib/internal/asyncio/_context_switch.py
+++ b/ddtrace/contrib/internal/asyncio/_context_switch.py
@@ -5,6 +5,8 @@ asyncio scheduling points covered by this fallback:
 
 * Handle._run: its callback is temporarily wrapped to publish entry inside the
   Context run and exit after _run restores the loop's ambient Context.
+* BaseEventLoop.call_exception_handler on Python before 3.12: publish the
+  restored ambient Context before invoking the exception handler.
 * Eager task construction through the event loop or asyncio.eager_task_factory:
   the coroutine is instrumented to publish if its first step runs inline, before
   task construction returns.
@@ -42,6 +44,8 @@ def install() -> None:
         return
 
     wrap(asyncio.Handle._run, _wrapped_run_handle)  # type: ignore[arg-type]
+    if PYTHON_VERSION_INFO < (3, 12):
+        wrap(asyncio.BaseEventLoop.call_exception_handler, _wrapped_call_exception_handler)  # type: ignore[arg-type]
     _installed = True
     if _eager_task_factory_code is not None:
         wrap(asyncio.eager_task_factory, _wrapped_eager_task_factory)  # type: ignore[attr-defined]
@@ -57,6 +61,8 @@ def uninstall() -> None:
     if _eager_task_factory_code is not None:
         unwrap(asyncio.BaseEventLoop.create_task, _wrapped_create_task)
         unwrap(asyncio.eager_task_factory, _wrapped_eager_task_factory)  # type: ignore[attr-defined]
+    if PYTHON_VERSION_INFO < (3, 12):
+        unwrap(asyncio.BaseEventLoop.call_exception_handler, _wrapped_call_exception_handler)
     unwrap(asyncio.Handle._run, _wrapped_run_handle)
     _installed = False
 
@@ -85,6 +91,12 @@ def _wrapped_run_handle(wrapped: Callable[..., Any], args: tuple[Any, ...], kwar
         if getattr(handle._callback, _CONTEXT_SWITCH_HANDLE_MARKER, None) is handle:
             handle._callback = original_callback
         core.dispatch(PYTHON_CONTEXT_SWITCH_EVENT)
+
+
+def _wrapped_call_exception_handler(wrapped: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+    """Publish the ambient Context before a pre-3.12 exception handler runs."""
+    core.dispatch(PYTHON_CONTEXT_SWITCH_EVENT)
+    return wrapped(*args, **kwargs)
 
 
 def _instrument_inline_first_step(coro: Any) -> tuple[Any, Callable[[], None]]:

--- a/ddtrace/contrib/internal/asyncio/_context_switch.py
+++ b/ddtrace/contrib/internal/asyncio/_context_switch.py
@@ -5,8 +5,9 @@ asyncio scheduling points covered by this fallback:
 
 * Handle._run: its callback is temporarily wrapped to publish entry inside the
   Context run and exit after _run restores the loop's ambient Context.
-* Eager task construction through the event loop: the coroutine is instrumented to
-  publish if its first step runs inline, before create_task returns.
+* Eager task construction through the event loop or asyncio.eager_task_factory:
+  the coroutine is instrumented to publish if its first step runs inline, before
+  task construction returns.
 
 Thread offloads are handled by the default-on futures integration. This integration only
 covers the event loops built into asyncio.
@@ -43,6 +44,7 @@ def install() -> None:
     wrap(asyncio.Handle._run, _wrapped_run_handle)  # type: ignore[arg-type]
     _installed = True
     if _eager_task_factory_code is not None:
+        wrap(asyncio.eager_task_factory, _wrapped_eager_task_factory)  # type: ignore[attr-defined]
         wrap(asyncio.BaseEventLoop.create_task, _wrapped_create_task)  # type: ignore[arg-type]
 
 
@@ -54,6 +56,7 @@ def uninstall() -> None:
 
     if _eager_task_factory_code is not None:
         unwrap(asyncio.BaseEventLoop.create_task, _wrapped_create_task)
+        unwrap(asyncio.eager_task_factory, _wrapped_eager_task_factory)  # type: ignore[attr-defined]
     unwrap(asyncio.Handle._run, _wrapped_run_handle)
     _installed = False
 
@@ -105,15 +108,8 @@ def _instrument_inline_first_step(coro: Any) -> tuple[Any, Callable[[], None]]:
     return context_switched_coro(), finish_inline_step
 
 
-def _wrapped_create_task(wrapped: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
-    """Publish context changes caused by an inline first task step."""
-    task_factory = args[0].get_task_factory()
-    eager_factory = (
-        _eager_task_factory_code is not None and getattr(task_factory, "__code__", None) is _eager_task_factory_code
-    )
-    if not kwargs.get("eager_start") and not eager_factory:
-        return wrapped(*args, **kwargs)
-
+def _call_with_inline_first_step(wrapped: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+    """Instrument a task constructor's coroutine while preserving its return value."""
     coro = get_argument_value(args, kwargs, 1, "coro")
     if not asyncio.iscoroutine(coro):
         return wrapped(*args, **kwargs)
@@ -124,3 +120,20 @@ def _wrapped_create_task(wrapped: Callable[..., Any], args: tuple[Any, ...], kwa
         return wrapped(*args, **kwargs)
     finally:
         finish_inline_step()
+
+
+def _wrapped_eager_task_factory(wrapped: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+    """Publish context changes caused by direct eager task factory calls."""
+    return _call_with_inline_first_step(wrapped, args, kwargs)
+
+
+def _wrapped_create_task(wrapped: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+    """Publish context changes caused by an inline first task step."""
+    task_factory = args[0].get_task_factory()
+    eager_factory = (
+        _eager_task_factory_code is not None and getattr(task_factory, "__code__", None) is _eager_task_factory_code
+    )
+    if not kwargs.get("eager_start") and not eager_factory:
+        return wrapped(*args, **kwargs)
+
+    return _call_with_inline_first_step(wrapped, args, kwargs)

--- a/ddtrace/contrib/internal/asyncio/_context_switch.py
+++ b/ddtrace/contrib/internal/asyncio/_context_switch.py
@@ -1,4 +1,4 @@
-"""Publish python.context.switch on asyncio Context boundaries the native watcher cannot see.
+"""Publish python.context.switch on asyncio Context boundaries when native context watching is unavailable.
 
 Publishes right after entering a Context and again after it is restored, at the two
 places asyncio can hand control to a different Context:
@@ -8,7 +8,7 @@ places asyncio can hand control to a different Context:
 * Eager task construction: the coroutine is instrumented to publish if its first step
   runs inline, before the task constructor returns.
 
-Thread offloads are handled by the default-on futures integration. This fallback only
+Thread offloads are handled by the default-on futures integration. This integration only
 covers the event loops built into asyncio.
 """
 
@@ -19,6 +19,7 @@ from typing import Callable
 from ddtrace.internal import core
 from ddtrace.internal._context_watcher import PYTHON_CONTEXT_SWITCH_EVENT
 from ddtrace.internal._context_watcher import context_switches_require_fallback
+from ddtrace.internal.compat import PYTHON_VERSION_INFO
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils import set_argument_value
 from ddtrace.internal.wrapping import unwrap
@@ -27,13 +28,16 @@ from ddtrace.internal.wrapping import wrap
 
 _installed = False
 _original_task = asyncio.Task
-_eager_task_factory_code = getattr(getattr(asyncio, "eager_task_factory", None), "__code__", None)
+if PYTHON_VERSION_INFO >= (3, 12):
+    _eager_task_factory_code = asyncio.eager_task_factory.__code__  # type: ignore[attr-defined]  # Added in 3.12.
+else:
+    _eager_task_factory_code = None
 _create_task_coroutine_ids: set[int] = set()
 _task_replaced = False
 
 
 class _ContextSwitchTaskMeta(type):
-    def __instancecheck__(cls, instance: Any) -> bool:
+    def __instancecheck__(cls, instance: object) -> bool:
         if cls is _ContextSwitchTask:
             return isinstance(instance, _original_task)
         return super().__instancecheck__(instance)
@@ -69,7 +73,7 @@ class _ContextSwitchTaskMeta(type):
 
 
 class _ContextSwitchTask(asyncio.Task[Any], metaclass=_ContextSwitchTaskMeta):  # type: ignore[misc]
-    """Intercept direct eager Task construction while the Python fallback is active."""
+    """Intercept direct Task construction"""
 
 
 def install() -> None:
@@ -81,15 +85,11 @@ def install() -> None:
 
     wrap(asyncio.Handle._run, _wrapped_run_handle)  # type: ignore[arg-type]
     _installed = True
-    try:
-        if _eager_task_factory_code is not None:
-            wrap(asyncio.BaseEventLoop.create_task, _wrapped_create_task)  # type: ignore[arg-type]
-            if asyncio.Task is _original_task:
-                setattr(asyncio, "Task", _ContextSwitchTask)
-                _task_replaced = True
-    except BaseException:
-        uninstall()
-        raise
+    if _eager_task_factory_code is not None:
+        wrap(asyncio.BaseEventLoop.create_task, _wrapped_create_task)  # type: ignore[arg-type]
+        if asyncio.Task is _original_task:
+            setattr(asyncio, "Task", _ContextSwitchTask)
+            _task_replaced = True
 
 
 def uninstall() -> None:
@@ -113,16 +113,14 @@ def _wrapped_run_handle(wrapped: Callable[..., Any], args: tuple[Any, ...], kwar
     original_callback = handle._callback
 
     def _callback_with_entry_dispatch(*cb_args: Any, **cb_kwargs: Any) -> Any:
-        # Dispatching inside the callback reuses the Context.run performed by
-        # Handle._run instead of entering the captured Context a second time.
-        core.dispatch(PYTHON_CONTEXT_SWITCH_EVENT)
         try:
+            # Dispatching inside the callback reuses the Context.run performed by
+            # Handle._run instead of entering the captured Context a second time.
+            core.dispatch(PYTHON_CONTEXT_SWITCH_EVENT)
             return original_callback(*cb_args, **cb_kwargs)
-        except BaseException:
-            # Restore the application callback before asyncio formats its failure.
+        finally:
             if handle._callback is _callback_with_entry_dispatch:
                 handle._callback = original_callback
-            raise
 
     handle._callback = _callback_with_entry_dispatch
     try:

--- a/ddtrace/contrib/internal/asyncio/_context_switch.py
+++ b/ddtrace/contrib/internal/asyncio/_context_switch.py
@@ -1,12 +1,12 @@
 """Publish python.context.switch on asyncio Context boundaries when native context watching is unavailable.
 
-Publishes right after entering a Context and again after it is restored, at the two
-places asyncio can hand control to a different Context:
+Publishes right after entering a Context and again after it is restored, at the
+asyncio scheduling points covered by this fallback:
 
 * Handle._run: its callback is temporarily wrapped to publish entry inside the
   Context run and exit after _run restores the loop's ambient Context.
-* Eager task construction: the coroutine is instrumented to publish if its first step
-  runs inline, before the task constructor returns.
+* Eager task construction through the event loop: the coroutine is instrumented to
+  publish if its first step runs inline, before create_task returns.
 
 Thread offloads are handled by the default-on futures integration. This integration only
 covers the event loops built into asyncio.
@@ -27,59 +27,16 @@ from ddtrace.internal.wrapping import wrap
 
 
 _installed = False
-_original_task = asyncio.Task
 if PYTHON_VERSION_INFO >= (3, 12):
     _eager_task_factory_code = asyncio.eager_task_factory.__code__  # type: ignore[attr-defined]  # Added in 3.12.
 else:
     _eager_task_factory_code = None
-_create_task_coroutine_ids: set[int] = set()
-_task_replaced = False
-
-
-class _ContextSwitchTaskMeta(type):
-    def __instancecheck__(cls, instance: object) -> bool:
-        if cls is _ContextSwitchTask:
-            return isinstance(instance, _original_task)
-        return super().__instancecheck__(instance)
-
-    def __subclasscheck__(cls, subclass: type) -> bool:
-        if cls is _ContextSwitchTask:
-            return issubclass(subclass, _original_task)
-        return super().__subclasscheck__(subclass)
-
-    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
-        if not (_installed and kwargs.get("eager_start") and (args or "coro" in kwargs)):
-            return super().__call__(*args, **kwargs)
-
-        coro = get_argument_value(args, kwargs, 0, "coro")
-        if not asyncio.iscoroutine(coro) or id(coro) in _create_task_coroutine_ids:
-            return super().__call__(*args, **kwargs)
-
-        switch_loop = kwargs.get("loop")
-        if switch_loop is None:
-            try:
-                switch_loop = asyncio.get_running_loop()
-            except RuntimeError:
-                return super().__call__(*args, **kwargs)
-        if not switch_loop.is_running():
-            return super().__call__(*args, **kwargs)
-
-        coro, finish_inline_step = _instrument_inline_first_step(coro)
-        args, kwargs = set_argument_value(args, kwargs, 0, "coro", coro)
-        try:
-            return super().__call__(*args, **kwargs)
-        finally:
-            finish_inline_step()
-
-
-class _ContextSwitchTask(asyncio.Task[Any], metaclass=_ContextSwitchTaskMeta):  # type: ignore[misc]
-    """Intercept direct Task construction"""
+_CONTEXT_SWITCH_HANDLE_MARKER = "_dd_context_switch_handle"
 
 
 def install() -> None:
     """Install only the hooks needed by the current runtime capability."""
     global _installed
-    global _task_replaced
     if _installed or not context_switches_require_fallback():
         return
 
@@ -87,21 +44,14 @@ def install() -> None:
     _installed = True
     if _eager_task_factory_code is not None:
         wrap(asyncio.BaseEventLoop.create_task, _wrapped_create_task)  # type: ignore[arg-type]
-        if asyncio.Task is _original_task:
-            setattr(asyncio, "Task", _ContextSwitchTask)
-            _task_replaced = True
 
 
 def uninstall() -> None:
     """Remove every installed asyncio fallback hook."""
     global _installed
-    global _task_replaced
     if not _installed:
         return
 
-    if _task_replaced and asyncio.Task is _ContextSwitchTask:
-        setattr(asyncio, "Task", _original_task)
-    _task_replaced = False
     if _eager_task_factory_code is not None:
         unwrap(asyncio.BaseEventLoop.create_task, _wrapped_create_task)
     unwrap(asyncio.Handle._run, _wrapped_run_handle)
@@ -119,26 +69,19 @@ def _wrapped_run_handle(wrapped: Callable[..., Any], args: tuple[Any, ...], kwar
             core.dispatch(PYTHON_CONTEXT_SWITCH_EVENT)
             return original_callback(*cb_args, **cb_kwargs)
         finally:
-            if handle._callback is _callback_with_entry_dispatch:
+            if getattr(handle._callback, _CONTEXT_SWITCH_HANDLE_MARKER, None) is handle:
                 handle._callback = original_callback
 
+    setattr(_callback_with_entry_dispatch, _CONTEXT_SWITCH_HANDLE_MARKER, handle)
     handle._callback = _callback_with_entry_dispatch
     try:
         return wrapped(*args, **kwargs)
     finally:
         # Cancellation can set _callback to None to release references. Restore
         # only when the callback slot still contains our temporary wrapper.
-        if handle._callback is _callback_with_entry_dispatch:
+        if getattr(handle._callback, _CONTEXT_SWITCH_HANDLE_MARKER, None) is handle:
             handle._callback = original_callback
         core.dispatch(PYTHON_CONTEXT_SWITCH_EVENT)
-
-
-def _task_may_run_inline(loop: Any, kwargs: dict[str, Any]) -> bool:
-    """Whether create_task can execute the coroutine before returning to its caller."""
-    task_factory = loop.get_task_factory()
-    return bool(kwargs.get("eager_start")) or (
-        _eager_task_factory_code is not None and getattr(task_factory, "__code__", None) is _eager_task_factory_code
-    )
 
 
 def _instrument_inline_first_step(coro: Any) -> tuple[Any, Callable[[], None]]:
@@ -164,8 +107,11 @@ def _instrument_inline_first_step(coro: Any) -> tuple[Any, Callable[[], None]]:
 
 def _wrapped_create_task(wrapped: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
     """Publish context changes caused by an inline first task step."""
-    loop = args[0]
-    if not _task_may_run_inline(loop, kwargs):
+    task_factory = args[0].get_task_factory()
+    eager_factory = (
+        _eager_task_factory_code is not None and getattr(task_factory, "__code__", None) is _eager_task_factory_code
+    )
+    if not kwargs.get("eager_start") and not eager_factory:
         return wrapped(*args, **kwargs)
 
     coro = get_argument_value(args, kwargs, 1, "coro")
@@ -174,10 +120,7 @@ def _wrapped_create_task(wrapped: Callable[..., Any], args: tuple[Any, ...], kwa
 
     coro, finish_inline_step = _instrument_inline_first_step(coro)
     args, kwargs = set_argument_value(args, kwargs, 1, "coro", coro)
-    coro_id = id(coro)
-    _create_task_coroutine_ids.add(coro_id)
     try:
         return wrapped(*args, **kwargs)
     finally:
-        _create_task_coroutine_ids.discard(coro_id)
         finish_inline_step()

--- a/ddtrace/contrib/internal/asyncio/_context_switch.py
+++ b/ddtrace/contrib/internal/asyncio/_context_switch.py
@@ -1,0 +1,185 @@
+"""Publish python.context.switch on asyncio Context boundaries the native watcher cannot see.
+
+Publishes right after entering a Context and again after it is restored, at the two
+places asyncio can hand control to a different Context:
+
+* Handle._run: its callback is temporarily wrapped to publish entry inside the
+  Context run and exit after _run restores the loop's ambient Context.
+* Eager task construction: the coroutine is instrumented to publish if its first step
+  runs inline, before the task constructor returns.
+
+Thread offloads are handled by the default-on futures integration. This fallback only
+covers the event loops built into asyncio.
+"""
+
+import asyncio
+from typing import Any
+from typing import Callable
+
+from ddtrace.internal import core
+from ddtrace.internal._context_watcher import PYTHON_CONTEXT_SWITCH_EVENT
+from ddtrace.internal._context_watcher import context_switches_require_fallback
+from ddtrace.internal.utils import get_argument_value
+from ddtrace.internal.utils import set_argument_value
+from ddtrace.internal.wrapping import unwrap
+from ddtrace.internal.wrapping import wrap
+
+
+_installed = False
+_original_task = asyncio.Task
+_eager_task_factory_code = getattr(getattr(asyncio, "eager_task_factory", None), "__code__", None)
+_create_task_coroutine_ids: set[int] = set()
+_task_replaced = False
+
+
+class _ContextSwitchTaskMeta(type):
+    def __instancecheck__(cls, instance: Any) -> bool:
+        if cls is _ContextSwitchTask:
+            return isinstance(instance, _original_task)
+        return super().__instancecheck__(instance)
+
+    def __subclasscheck__(cls, subclass: type) -> bool:
+        if cls is _ContextSwitchTask:
+            return issubclass(subclass, _original_task)
+        return super().__subclasscheck__(subclass)
+
+    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
+        if not (_installed and kwargs.get("eager_start") and (args or "coro" in kwargs)):
+            return super().__call__(*args, **kwargs)
+
+        coro = get_argument_value(args, kwargs, 0, "coro")
+        if not asyncio.iscoroutine(coro) or id(coro) in _create_task_coroutine_ids:
+            return super().__call__(*args, **kwargs)
+
+        switch_loop = kwargs.get("loop")
+        if switch_loop is None:
+            try:
+                switch_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                return super().__call__(*args, **kwargs)
+        if not switch_loop.is_running():
+            return super().__call__(*args, **kwargs)
+
+        coro, finish_inline_step = _instrument_inline_first_step(coro)
+        args, kwargs = set_argument_value(args, kwargs, 0, "coro", coro)
+        try:
+            return super().__call__(*args, **kwargs)
+        finally:
+            finish_inline_step()
+
+
+class _ContextSwitchTask(asyncio.Task[Any], metaclass=_ContextSwitchTaskMeta):  # type: ignore[misc]
+    """Intercept direct eager Task construction while the Python fallback is active."""
+
+
+def install() -> None:
+    """Install only the hooks needed by the current runtime capability."""
+    global _installed
+    global _task_replaced
+    if _installed or not context_switches_require_fallback():
+        return
+
+    wrap(asyncio.Handle._run, _wrapped_run_handle)  # type: ignore[arg-type]
+    _installed = True
+    try:
+        if _eager_task_factory_code is not None:
+            wrap(asyncio.BaseEventLoop.create_task, _wrapped_create_task)  # type: ignore[arg-type]
+            if asyncio.Task is _original_task:
+                setattr(asyncio, "Task", _ContextSwitchTask)
+                _task_replaced = True
+    except BaseException:
+        uninstall()
+        raise
+
+
+def uninstall() -> None:
+    """Remove every installed asyncio fallback hook."""
+    global _installed
+    global _task_replaced
+    if not _installed:
+        return
+
+    if _task_replaced and asyncio.Task is _ContextSwitchTask:
+        setattr(asyncio, "Task", _original_task)
+    _task_replaced = False
+    if _eager_task_factory_code is not None:
+        unwrap(asyncio.BaseEventLoop.create_task, _wrapped_create_task)
+    unwrap(asyncio.Handle._run, _wrapped_run_handle)
+    _installed = False
+
+
+def _wrapped_run_handle(wrapped: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+    handle = args[0]
+    original_callback = handle._callback
+
+    def _callback_with_entry_dispatch(*cb_args: Any, **cb_kwargs: Any) -> Any:
+        # Dispatching inside the callback reuses the Context.run performed by
+        # Handle._run instead of entering the captured Context a second time.
+        core.dispatch(PYTHON_CONTEXT_SWITCH_EVENT)
+        try:
+            return original_callback(*cb_args, **cb_kwargs)
+        except BaseException:
+            # Restore the application callback before asyncio formats its failure.
+            if handle._callback is _callback_with_entry_dispatch:
+                handle._callback = original_callback
+            raise
+
+    handle._callback = _callback_with_entry_dispatch
+    try:
+        return wrapped(*args, **kwargs)
+    finally:
+        # Cancellation can set _callback to None to release references. Restore
+        # only when the callback slot still contains our temporary wrapper.
+        if handle._callback is _callback_with_entry_dispatch:
+            handle._callback = original_callback
+        core.dispatch(PYTHON_CONTEXT_SWITCH_EVENT)
+
+
+def _task_may_run_inline(loop: Any, kwargs: dict[str, Any]) -> bool:
+    """Whether create_task can execute the coroutine before returning to its caller."""
+    task_factory = loop.get_task_factory()
+    return bool(kwargs.get("eager_start")) or (
+        _eager_task_factory_code is not None and getattr(task_factory, "__code__", None) is _eager_task_factory_code
+    )
+
+
+def _instrument_inline_first_step(coro: Any) -> tuple[Any, Callable[[], None]]:
+    """Instrument a coroutine only if its first step runs before construction returns."""
+    construction_pending = True
+    switch_published = False
+
+    async def context_switched_coro() -> Any:
+        nonlocal switch_published
+        if construction_pending:
+            switch_published = True
+            core.dispatch(PYTHON_CONTEXT_SWITCH_EVENT)
+        return await coro
+
+    def finish_inline_step() -> None:
+        nonlocal construction_pending
+        construction_pending = False
+        if switch_published:
+            core.dispatch(PYTHON_CONTEXT_SWITCH_EVENT)
+
+    return context_switched_coro(), finish_inline_step
+
+
+def _wrapped_create_task(wrapped: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+    """Publish context changes caused by an inline first task step."""
+    loop = args[0]
+    if not _task_may_run_inline(loop, kwargs):
+        return wrapped(*args, **kwargs)
+
+    coro = get_argument_value(args, kwargs, 1, "coro")
+    if not asyncio.iscoroutine(coro):
+        return wrapped(*args, **kwargs)
+
+    coro, finish_inline_step = _instrument_inline_first_step(coro)
+    args, kwargs = set_argument_value(args, kwargs, 1, "coro", coro)
+    coro_id = id(coro)
+    _create_task_coroutine_ids.add(coro_id)
+    try:
+        return wrapped(*args, **kwargs)
+    finally:
+        _create_task_coroutine_ids.discard(coro_id)
+        finish_inline_step()

--- a/ddtrace/contrib/internal/asyncio/patch.py
+++ b/ddtrace/contrib/internal/asyncio/patch.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import Any
 
 from ddtrace._trace.pin import Pin
+from ddtrace.contrib.internal.asyncio import _context_switch
 from ddtrace.internal import core
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils import set_argument_value
@@ -24,9 +25,14 @@ def patch():
     """
     if getattr(asyncio, "_datadog_patch", False):
         return
-    asyncio._datadog_patch = True
     Pin().onto(asyncio)
-    wrap(asyncio.BaseEventLoop.create_task, _wrapped_create_task)
+    try:
+        _context_switch.install()
+        wrap(asyncio.BaseEventLoop.create_task, _wrapped_create_task)
+    except BaseException:
+        _context_switch.uninstall()
+        raise
+    asyncio._datadog_patch = True
 
 
 def unpatch():
@@ -34,8 +40,9 @@ def unpatch():
 
     if not getattr(asyncio, "_datadog_patch", False):
         return
-    asyncio._datadog_patch = False
     unwrap(asyncio.BaseEventLoop.create_task, _wrapped_create_task)
+    _context_switch.uninstall()
+    asyncio._datadog_patch = False
 
 
 def _wrapped_create_task(wrapped, args, kwargs):
@@ -57,6 +64,8 @@ def _wrapped_create_task(wrapped, args, kwargs):
 
     # Get the coroutine
     coro = get_argument_value(args, kwargs, 1, "coro")
+    if not asyncio.iscoroutine(coro):
+        return wrapped(*args, **kwargs)
 
     # Wrap the coroutine and ensure the current trace context is propagated
     async def traced_coro(*args_c, **kwargs_c):

--- a/ddtrace/contrib/internal/asyncio/patch.py
+++ b/ddtrace/contrib/internal/asyncio/patch.py
@@ -26,12 +26,8 @@ def patch():
     if getattr(asyncio, "_datadog_patch", False):
         return
     Pin().onto(asyncio)
-    try:
-        _context_switch.install()
-        wrap(asyncio.BaseEventLoop.create_task, _wrapped_create_task)
-    except BaseException:
-        _context_switch.uninstall()
-        raise
+    _context_switch.install()
+    wrap(asyncio.BaseEventLoop.create_task, _wrapped_create_task)
     asyncio._datadog_patch = True
 
 

--- a/ddtrace/contrib/internal/futures/threading.py
+++ b/ddtrace/contrib/internal/futures/threading.py
@@ -118,10 +118,8 @@ def _wrap_execution(
     if stack is not None:
         stack.link_origin_task(origin_task_id, origin_task_name)
     try:
-        if current_ctx is not None:
-            with ddtrace.tracer._activate_context(current_ctx):
-                return fn(*args, **kwargs)
-        return fn(*args, **kwargs)
+        with ddtrace.tracer._activate_context(current_ctx):
+            return fn(*args, **kwargs)
     finally:
         if stack is not None:
             stack.unlink_origin_task()

--- a/ddtrace/contrib/internal/gevent/greenlet.py
+++ b/ddtrace/contrib/internal/gevent/greenlet.py
@@ -9,6 +9,7 @@ from greenlet import gettrace
 from greenlet import settrace
 
 from ddtrace.internal import core
+from ddtrace.internal._context_watcher import PYTHON_CONTEXT_SWITCH_EVENT
 from ddtrace.internal.settings._config import config
 from ddtrace.trace import tracer
 
@@ -29,7 +30,7 @@ class _GreenletTrace:
             # A displaced watcher can remain in another callback's chain, so only
             # the current watcher publishes the context switch.
             if getattr(_state, "trace", None) is self:
-                core.dispatch("python.context.switch")
+                core.dispatch(PYTHON_CONTEXT_SWITCH_EVENT)
         elif gettrace() is self:
             settrace(self.previous)
             _state.trace = None

--- a/ddtrace/internal/_context_watcher.py
+++ b/ddtrace/internal/_context_watcher.py
@@ -1,0 +1,24 @@
+import sys
+
+from ddtrace.internal import core
+
+
+PYTHON_CONTEXT_SWITCH_EVENT = "python.context.switch"
+
+
+if sys.implementation.name == "cpython" and sys.version_info >= (3, 14):
+    from ddtrace.internal.native._native import is_context_watcher_registered as is_context_watcher_registered
+    from ddtrace.internal.native._native import register_context_watcher as register_context_watcher
+
+else:
+
+    def is_context_watcher_registered() -> bool:
+        return False
+
+    def register_context_watcher() -> bool:
+        return False
+
+
+def context_switches_require_fallback() -> bool:
+    """Whether integrations must publish context switches that the native watcher cannot observe."""
+    return core.has_listeners(PYTHON_CONTEXT_SWITCH_EVENT) and not is_context_watcher_registered()

--- a/ddtrace/internal/opentelemetry/thread_context.py
+++ b/ddtrace/internal/opentelemetry/thread_context.py
@@ -7,6 +7,8 @@ from typing import Union
 from ddtrace._trace.provider import BaseContextProvider
 from ddtrace._trace.span import Span
 from ddtrace.internal import core
+from ddtrace.internal._context_watcher import PYTHON_CONTEXT_SWITCH_EVENT
+from ddtrace.internal._context_watcher import register_context_watcher
 from ddtrace.internal.native._native import Context
 from ddtrace.internal.settings._config import config
 
@@ -49,13 +51,9 @@ if sys.platform == "linux":
             if provider is tracer.context_provider:
                 _sync_otel_thread_context(ctx)
 
+        register_context_watcher()
         core.on("ddtrace.context_provider.activate", _on_context_provider_activate)
-        core.on("python.context.switch", _sync_active_otel_thread_context)
-
-        if sys.implementation.name == "cpython" and sys.version_info >= (3, 14):
-            from ddtrace.internal.native._native import register_context_watcher
-
-            register_context_watcher()
+        core.on(PYTHON_CONTEXT_SWITCH_EVENT, _sync_active_otel_thread_context)
         return _on_context_provider_activate, _sync_active_otel_thread_context
 
 else:

--- a/ddtrace/internal/wrapping/__init__.py
+++ b/ddtrace/internal/wrapping/__init__.py
@@ -389,6 +389,7 @@ def wrap(f: FunctionType, wrapper: Wrapper) -> WrappedFunction:
     wrapped_code.posonlyargcount = code.co_posonlyargcount
     if PY >= (3, 11):
         wrapped_code.cellvars = list(code.co_cellvars)
+        wrapped_code.qualname = code.co_qualname  # type: ignore[attr-defined]
 
     # Replace the function code with the trampoline bytecode
     f.__code__ = wrapped_code.to_code()

--- a/releasenotes/notes/asyncio-otel-thread-context-c4efc3d2f37e5ec1.yaml
+++ b/releasenotes/notes/asyncio-otel-thread-context-c4efc3d2f37e5ec1.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    tracing: Adds OpenTelemetry thread-context synchronization for applications using Python's built-in asyncio event
+    loop on Linux with Python 3.13 and earlier. This is enabled by default and can be disabled with
+    ``DD_TRACE_OTEL_CTX_ENABLED=false``.
+fixes:
+  - |
+    tracing: Fixes an issue where untraced work in a reused thread-pool worker could expose stale OpenTelemetry trace
+    context.

--- a/tests/contrib/asyncio/test_context_switch.py
+++ b/tests/contrib/asyncio/test_context_switch.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextvars import ContextVar
 from contextvars import copy_context
 import sys
 
@@ -52,9 +53,14 @@ def test_context_switch_hooks_follow_runtime_capability(fallback_required, async
     patch()
 
     eager_fallback = fallback_required and _context_switch._eager_task_factory_code is not None
+    exception_handler_fallback = fallback_required and sys.version_info < (3, 12)
     assert is_wrapped_with(asyncio.BaseEventLoop.create_task, _wrapped_trace_create_task)
     assert is_wrapped_with(asyncio.BaseEventLoop.create_task, _context_switch._wrapped_create_task) is eager_fallback
     assert is_wrapped_with(asyncio.Handle._run, _context_switch._wrapped_run_handle) is fallback_required
+    assert (
+        is_wrapped_with(asyncio.BaseEventLoop.call_exception_handler, _context_switch._wrapped_call_exception_handler)
+        is exception_handler_fallback
+    )
     if eager_task_factory is not None:
         assert asyncio.eager_task_factory is eager_task_factory
         assert (
@@ -65,6 +71,7 @@ def test_context_switch_hooks_follow_runtime_capability(fallback_required, async
     unpatch()
     assert not is_wrapped(asyncio.BaseEventLoop.create_task)
     assert not is_wrapped(asyncio.Handle._run)
+    assert not is_wrapped(asyncio.BaseEventLoop.call_exception_handler)
     if eager_task_factory is not None:
         assert asyncio.eager_task_factory is eager_task_factory
         assert not is_wrapped(asyncio.eager_task_factory)
@@ -188,6 +195,35 @@ def test_callback_failure_reports_the_application_callback(context_switches):
     assert handled[0]["exception"].args == ("application failure",)
     assert "application_callback" in handled[0]["message"]
     assert handle._callback is application_callback
+
+
+@pytest.mark.skipif(sys.version_info >= (3, 12), reason="exception handlers inherit the originating context on 3.12+")
+def test_callback_failure_resynchronizes_before_exception_handler(context_switches):
+    """Publish the ambient context before a pre-3.12 exception handler runs."""
+    marker = ContextVar("marker", default="ambient")
+    published = []
+    handled = []
+
+    def record_context_switch():
+        published.append(marker.get())
+
+    def application_callback():
+        raise RuntimeError("application failure")
+
+    token = marker.set("callback")
+    callback_context = copy_context()
+    marker.reset(token)
+
+    loop = asyncio.new_event_loop()
+    loop.set_exception_handler(lambda _loop, _context: handled.append((marker.get(), published[-1])))
+    core.on(PYTHON_CONTEXT_SWITCH_EVENT, record_context_switch)
+    try:
+        asyncio.Handle(application_callback, (), loop, context=callback_context)._run()
+    finally:
+        core.reset_listeners(PYTHON_CONTEXT_SWITCH_EVENT, record_context_switch)
+        loop.close()
+
+    assert handled == [("ambient", "ambient")]
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/asyncio/test_context_switch.py
+++ b/tests/contrib/asyncio/test_context_switch.py
@@ -1,0 +1,240 @@
+import asyncio
+from contextvars import copy_context
+import sys
+
+import pytest
+
+from ddtrace.contrib.internal.asyncio import _context_switch
+from ddtrace.contrib.internal.asyncio.patch import _wrapped_create_task as _wrapped_trace_create_task
+from ddtrace.contrib.internal.asyncio.patch import patch
+from ddtrace.contrib.internal.asyncio.patch import unpatch
+from ddtrace.internal import core
+from ddtrace.internal._context_watcher import PYTHON_CONTEXT_SWITCH_EVENT
+from ddtrace.internal.wrapping import is_wrapped
+from ddtrace.internal.wrapping import is_wrapped_with
+
+
+@pytest.fixture
+def asyncio_patch_state():
+    was_patched = getattr(asyncio, "_datadog_patch", False)
+    unpatch()
+    try:
+        yield
+    finally:
+        unpatch()
+        if was_patched:
+            patch()
+
+
+@pytest.fixture
+def context_switches(tracer, asyncio_patch_state):
+    switches = []
+
+    def record_context_switch():
+        switches.append(tracer.context_provider.active())
+
+    core.on(PYTHON_CONTEXT_SWITCH_EVENT, record_context_switch)
+    try:
+        patch()
+        if not _context_switch.context_switches_require_fallback():
+            pytest.skip("the native context watcher is active")
+        yield switches
+    finally:
+        core.reset_listeners(PYTHON_CONTEXT_SWITCH_EVENT, record_context_switch)
+
+
+@pytest.mark.parametrize("fallback_required", [False, True])
+def test_context_switch_hooks_follow_runtime_capability(fallback_required, asyncio_patch_state, monkeypatch):
+    """Install fallback hooks only when needed, avoiding overlap with the native watcher."""
+    monkeypatch.setattr(_context_switch, "context_switches_require_fallback", lambda: fallback_required)
+    original_task = asyncio.Task
+
+    patch()
+
+    eager_fallback = fallback_required and _context_switch._eager_task_factory_code is not None
+    assert is_wrapped_with(asyncio.BaseEventLoop.create_task, _wrapped_trace_create_task)
+    assert is_wrapped_with(asyncio.BaseEventLoop.create_task, _context_switch._wrapped_create_task) is eager_fallback
+    assert is_wrapped_with(asyncio.Handle._run, _context_switch._wrapped_run_handle) is fallback_required
+    assert not is_wrapped(asyncio.to_thread)
+    assert (asyncio.Task is not original_task) is eager_fallback
+
+    unpatch()
+    assert not is_wrapped(asyncio.BaseEventLoop.create_task)
+    assert not is_wrapped(asyncio.Handle._run)
+    assert asyncio.Task is original_task
+
+
+@pytest.mark.subprocess(
+    env={"DD_TRACE_OTEL_CTX_ENABLED": "false"},
+    parametrize={
+        "TASK_MODE": [
+            "lazy",
+            pytest.param(
+                "eager_factory",
+                marks=pytest.mark.skipif(sys.version_info < (3, 12), reason="eager tasks require Python 3.12+"),
+            ),
+            pytest.param(
+                "direct_eager",
+                marks=pytest.mark.skipif(sys.version_info < (3, 12), reason="eager tasks require Python 3.12+"),
+            ),
+            pytest.param(
+                "eager_start",
+                marks=pytest.mark.skipif(
+                    sys.version_info < (3, 14), reason="loop.create_task(eager_start=...) requires Python 3.14+"
+                ),
+            ),
+        ]
+    },
+)
+def test_task_creation_publishes_only_inline_context_switches():
+    """Leave lazy tasks untouched and publish exactly one switch pair for every eager entry path."""
+    import asyncio
+    from contextvars import copy_context
+    import os
+
+    from ddtrace.contrib.internal.asyncio.patch import patch
+    from ddtrace.contrib.internal.asyncio.patch import unpatch
+    from ddtrace.internal import core
+    from ddtrace.internal._context_watcher import PYTHON_CONTEXT_SWITCH_EVENT
+    from ddtrace.trace import tracer
+
+    mode = os.environ["TASK_MODE"]
+    switches = []
+
+    def record_context_switch():
+        switches.append(tracer.context_provider.active())
+
+    async def child():
+        return "done"
+
+    async def main():
+        loop = asyncio.get_running_loop()
+        original_factory = loop.get_task_factory()
+        caller = tracer.trace("caller")
+        task_span = tracer.trace("task")
+        task_context = copy_context()
+        tracer.context_provider.activate(None if mode == "lazy" else caller)
+
+        try:
+            switches.clear()
+            if mode == "lazy":
+                received = []
+
+                def lazy_factory(loop, coro, **kwargs):
+                    received.append(coro)
+                    return asyncio.Task(coro, loop=loop, **kwargs)
+
+                loop.set_task_factory(lazy_factory)
+                coro = child()
+                task = loop.create_task(coro)
+                assert received == [coro]
+            elif mode == "eager_factory":
+                loop.set_task_factory(asyncio.create_eager_task_factory(CustomTask))
+                task = loop.create_task(child(), context=task_context)
+                assert type(task) is CustomTask
+            elif mode == "direct_eager":
+                task = CustomTask(child(), loop=loop, context=task_context, eager_start=True, marker="direct")
+                assert task.marker == "direct"
+                assert isinstance(asyncio.current_task(), asyncio.Task)
+            else:
+                task = loop.create_task(child(), context=task_context, eager_start=True)
+
+            assert switches == ([] if mode == "lazy" else [task_span, caller])
+            assert await task == "done"
+        finally:
+            loop.set_task_factory(original_factory)
+            tracer.context_provider.activate(None)
+            task_span.finish()
+            caller.finish()
+
+    core.on(PYTHON_CONTEXT_SWITCH_EVENT, record_context_switch)
+    unpatch()
+    patch()
+
+    class CustomTask(asyncio.Task):
+        def __init__(self, coro, *, marker=None, **kwargs):
+            self.marker = marker
+            super().__init__(coro, **kwargs)
+
+    try:
+        asyncio.run(main())
+    finally:
+        unpatch()
+        core.reset_listeners(PYTHON_CONTEXT_SWITCH_EVENT, record_context_switch)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="eager tasks require Python 3.12+")
+@pytest.mark.parametrize("traced", [False, True])
+async def test_eager_task_factory_rejects_non_coroutines_synchronously(
+    tracer, asyncio_patch_state, monkeypatch, traced
+):
+    """Preserve asyncio's synchronous input validation while the eager fallback is active."""
+    monkeypatch.setattr(_context_switch, "context_switches_require_fallback", lambda: True)
+    patch()
+
+    loop = asyncio.get_running_loop()
+    original_factory = loop.get_task_factory()
+    loop.set_task_factory(asyncio.eager_task_factory)
+    span = tracer.trace("parent") if traced else None
+    try:
+        with pytest.raises(TypeError):
+            loop.create_task(1)
+    finally:
+        loop.set_task_factory(original_factory)
+        tracer.context_provider.activate(None)
+        if span is not None:
+            span.finish()
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="eager tasks require Python 3.12+")
+def test_task_replacement_preserves_another_owner(asyncio_patch_state, monkeypatch):
+    """Do not overwrite a Task class already replaced by another integration."""
+    original_task = asyncio.Task
+
+    class ForeignTask(original_task):
+        pass
+
+    monkeypatch.setattr(asyncio, "Task", ForeignTask)
+    monkeypatch.setattr(_context_switch, "context_switches_require_fallback", lambda: True)
+    try:
+        _context_switch.install()
+        assert asyncio.Task is ForeignTask
+    finally:
+        _context_switch.uninstall()
+
+    assert asyncio.Task is ForeignTask
+
+
+def test_callback_failure_reports_the_application_callback(context_switches):
+    """Keep asyncio error reports attributed to the application despite the temporary callback wrapper."""
+
+    def application_callback():
+        raise RuntimeError("application failure")
+
+    loop = asyncio.new_event_loop()
+    handled = []
+    loop.set_exception_handler(lambda _loop, context: handled.append(context))
+    try:
+        handle = asyncio.Handle(application_callback, (), loop, context=copy_context())
+        handle._run()
+    finally:
+        loop.close()
+
+    assert len(handled) == 1
+    assert handled[0]["exception"].args == ("application failure",)
+    assert "application_callback" in handled[0]["message"]
+    assert handle._callback is application_callback
+
+
+@pytest.mark.asyncio
+async def test_task_switches_publish_the_resumed_context(tracer, context_switches):
+    """Publish each resumed task's context and detach it before another task runs."""
+
+    async def child(name):
+        with tracer.trace(name) as span:
+            await asyncio.sleep(0)
+            assert context_switches[-1] is span
+
+    await asyncio.gather(child("first"), child("second"))
+    assert None in context_switches

--- a/tests/contrib/asyncio/test_context_switch.py
+++ b/tests/contrib/asyncio/test_context_switch.py
@@ -47,7 +47,6 @@ def context_switches(tracer, asyncio_patch_state):
 def test_context_switch_hooks_follow_runtime_capability(fallback_required, asyncio_patch_state, monkeypatch):
     """Install fallback hooks only when needed, avoiding overlap with the native watcher."""
     monkeypatch.setattr(_context_switch, "context_switches_require_fallback", lambda: fallback_required)
-    original_task = asyncio.Task
 
     patch()
 
@@ -56,12 +55,10 @@ def test_context_switch_hooks_follow_runtime_capability(fallback_required, async
     assert is_wrapped_with(asyncio.BaseEventLoop.create_task, _context_switch._wrapped_create_task) is eager_fallback
     assert is_wrapped_with(asyncio.Handle._run, _context_switch._wrapped_run_handle) is fallback_required
     assert not is_wrapped(asyncio.to_thread)
-    assert (asyncio.Task is not original_task) is eager_fallback
 
     unpatch()
     assert not is_wrapped(asyncio.BaseEventLoop.create_task)
     assert not is_wrapped(asyncio.Handle._run)
-    assert asyncio.Task is original_task
 
 
 @pytest.mark.subprocess(
@@ -74,10 +71,6 @@ def test_context_switch_hooks_follow_runtime_capability(fallback_required, async
                 marks=pytest.mark.skipif(sys.version_info < (3, 12), reason="eager tasks require Python 3.12+"),
             ),
             pytest.param(
-                "direct_eager",
-                marks=pytest.mark.skipif(sys.version_info < (3, 12), reason="eager tasks require Python 3.12+"),
-            ),
-            pytest.param(
                 "eager_start",
                 marks=pytest.mark.skipif(
                     sys.version_info < (3, 14), reason="loop.create_task(eager_start=...) requires Python 3.14+"
@@ -87,8 +80,9 @@ def test_context_switch_hooks_follow_runtime_capability(fallback_required, async
     },
 )
 def test_task_creation_publishes_only_inline_context_switches():
-    """Leave lazy tasks untouched and publish exactly one switch pair for every eager entry path."""
+    """Leave lazy tasks untouched and publish one switch pair for eager loop task creation."""
     import asyncio
+    from contextvars import ContextVar
     from contextvars import copy_context
     import os
 
@@ -96,13 +90,13 @@ def test_task_creation_publishes_only_inline_context_switches():
     from ddtrace.contrib.internal.asyncio.patch import unpatch
     from ddtrace.internal import core
     from ddtrace.internal._context_watcher import PYTHON_CONTEXT_SWITCH_EVENT
-    from ddtrace.trace import tracer
 
     mode = os.environ["TASK_MODE"]
+    marker = ContextVar("marker", default=None)
     switches = []
 
     def record_context_switch():
-        switches.append(tracer.context_provider.active())
+        switches.append(marker.get())
 
     async def child():
         return "done"
@@ -110,51 +104,28 @@ def test_task_creation_publishes_only_inline_context_switches():
     async def main():
         loop = asyncio.get_running_loop()
         original_factory = loop.get_task_factory()
-        caller = tracer.trace("caller")
-        task_span = tracer.trace("task")
+        marker.set("task")
         task_context = copy_context()
-        tracer.context_provider.activate(None if mode == "lazy" else caller)
+        marker.set("caller")
 
         try:
             switches.clear()
             if mode == "lazy":
-                received = []
-
-                def lazy_factory(loop, coro, **kwargs):
-                    received.append(coro)
-                    return asyncio.Task(coro, loop=loop, **kwargs)
-
-                loop.set_task_factory(lazy_factory)
-                coro = child()
-                task = loop.create_task(coro)
-                assert received == [coro]
+                task = loop.create_task(child())
             elif mode == "eager_factory":
-                loop.set_task_factory(asyncio.create_eager_task_factory(CustomTask))
+                loop.set_task_factory(asyncio.eager_task_factory)
                 task = loop.create_task(child(), context=task_context)
-                assert type(task) is CustomTask
-            elif mode == "direct_eager":
-                task = CustomTask(child(), loop=loop, context=task_context, eager_start=True, marker="direct")
-                assert task.marker == "direct"
-                assert isinstance(asyncio.current_task(), asyncio.Task)
             else:
                 task = loop.create_task(child(), context=task_context, eager_start=True)
 
-            assert switches == ([] if mode == "lazy" else [task_span, caller])
+            assert switches == ([] if mode == "lazy" else ["task", "caller"])
             assert await task == "done"
         finally:
             loop.set_task_factory(original_factory)
-            tracer.context_provider.activate(None)
-            task_span.finish()
-            caller.finish()
 
     core.on(PYTHON_CONTEXT_SWITCH_EVENT, record_context_switch)
     unpatch()
     patch()
-
-    class CustomTask(asyncio.Task):
-        def __init__(self, coro, *, marker=None, **kwargs):
-            self.marker = marker
-            super().__init__(coro, **kwargs)
 
     try:
         asyncio.run(main())
@@ -165,10 +136,7 @@ def test_task_creation_publishes_only_inline_context_switches():
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="eager tasks require Python 3.12+")
-@pytest.mark.parametrize("traced", [False, True])
-async def test_eager_task_factory_rejects_non_coroutines_synchronously(
-    tracer, asyncio_patch_state, monkeypatch, traced
-):
+async def test_eager_task_factory_rejects_non_coroutines_synchronously(asyncio_patch_state, monkeypatch):
     """Preserve asyncio's synchronous input validation while the eager fallback is active."""
     monkeypatch.setattr(_context_switch, "context_switches_require_fallback", lambda: True)
     patch()
@@ -176,34 +144,11 @@ async def test_eager_task_factory_rejects_non_coroutines_synchronously(
     loop = asyncio.get_running_loop()
     original_factory = loop.get_task_factory()
     loop.set_task_factory(asyncio.eager_task_factory)
-    span = tracer.trace("parent") if traced else None
     try:
         with pytest.raises(TypeError):
             loop.create_task(1)
     finally:
         loop.set_task_factory(original_factory)
-        tracer.context_provider.activate(None)
-        if span is not None:
-            span.finish()
-
-
-@pytest.mark.skipif(sys.version_info < (3, 12), reason="eager tasks require Python 3.12+")
-def test_task_replacement_preserves_another_owner(asyncio_patch_state, monkeypatch):
-    """Do not overwrite a Task class already replaced by another integration."""
-    original_task = asyncio.Task
-
-    class ForeignTask(original_task):
-        pass
-
-    monkeypatch.setattr(asyncio, "Task", ForeignTask)
-    monkeypatch.setattr(_context_switch, "context_switches_require_fallback", lambda: True)
-    try:
-        _context_switch.install()
-        assert asyncio.Task is ForeignTask
-    finally:
-        _context_switch.uninstall()
-
-    assert asyncio.Task is ForeignTask
 
 
 def test_callback_failure_reports_the_application_callback(context_switches):

--- a/tests/contrib/asyncio/test_context_switch.py
+++ b/tests/contrib/asyncio/test_context_switch.py
@@ -47,6 +47,7 @@ def context_switches(tracer, asyncio_patch_state):
 def test_context_switch_hooks_follow_runtime_capability(fallback_required, asyncio_patch_state, monkeypatch):
     """Install fallback hooks only when needed, avoiding overlap with the native watcher."""
     monkeypatch.setattr(_context_switch, "context_switches_require_fallback", lambda: fallback_required)
+    eager_task_factory = getattr(asyncio, "eager_task_factory", None)
 
     patch()
 
@@ -54,11 +55,19 @@ def test_context_switch_hooks_follow_runtime_capability(fallback_required, async
     assert is_wrapped_with(asyncio.BaseEventLoop.create_task, _wrapped_trace_create_task)
     assert is_wrapped_with(asyncio.BaseEventLoop.create_task, _context_switch._wrapped_create_task) is eager_fallback
     assert is_wrapped_with(asyncio.Handle._run, _context_switch._wrapped_run_handle) is fallback_required
+    if eager_task_factory is not None:
+        assert asyncio.eager_task_factory is eager_task_factory
+        assert (
+            is_wrapped_with(asyncio.eager_task_factory, _context_switch._wrapped_eager_task_factory) is eager_fallback
+        )
     assert not is_wrapped(asyncio.to_thread)
 
     unpatch()
     assert not is_wrapped(asyncio.BaseEventLoop.create_task)
     assert not is_wrapped(asyncio.Handle._run)
+    if eager_task_factory is not None:
+        assert asyncio.eager_task_factory is eager_task_factory
+        assert not is_wrapped(asyncio.eager_task_factory)
 
 
 @pytest.mark.subprocess(
@@ -71,6 +80,10 @@ def test_context_switch_hooks_follow_runtime_capability(fallback_required, async
                 marks=pytest.mark.skipif(sys.version_info < (3, 12), reason="eager tasks require Python 3.12+"),
             ),
             pytest.param(
+                "direct_eager_factory",
+                marks=pytest.mark.skipif(sys.version_info < (3, 12), reason="eager tasks require Python 3.12+"),
+            ),
+            pytest.param(
                 "eager_start",
                 marks=pytest.mark.skipif(
                     sys.version_info < (3, 14), reason="loop.create_task(eager_start=...) requires Python 3.14+"
@@ -80,7 +93,7 @@ def test_context_switch_hooks_follow_runtime_capability(fallback_required, async
     },
 )
 def test_task_creation_publishes_only_inline_context_switches():
-    """Leave lazy tasks untouched and publish one switch pair for eager loop task creation."""
+    """Leave lazy tasks untouched and publish one switch pair for eager task construction."""
     import asyncio
     from contextvars import ContextVar
     from contextvars import copy_context
@@ -92,6 +105,7 @@ def test_task_creation_publishes_only_inline_context_switches():
     from ddtrace.internal._context_watcher import PYTHON_CONTEXT_SWITCH_EVENT
 
     mode = os.environ["TASK_MODE"]
+    eager_task_factory = getattr(asyncio, "eager_task_factory", None)
     marker = ContextVar("marker", default=None)
     switches = []
 
@@ -113,8 +127,12 @@ def test_task_creation_publishes_only_inline_context_switches():
             if mode == "lazy":
                 task = loop.create_task(child())
             elif mode == "eager_factory":
-                loop.set_task_factory(asyncio.eager_task_factory)
+                assert eager_task_factory is not None
+                loop.set_task_factory(eager_task_factory)
                 task = loop.create_task(child(), context=task_context)
+            elif mode == "direct_eager_factory":
+                assert eager_task_factory is not None
+                task = eager_task_factory(loop, child(), context=task_context)
             else:
                 task = loop.create_task(child(), context=task_context, eager_start=True)
 

--- a/tests/contrib/futures/test_propagation.py
+++ b/tests/contrib/futures/test_propagation.py
@@ -507,6 +507,20 @@ def test_submit_propagates_context_copy_with_profiler_meta(tracer):
     assert context_meta.PROFILING_LOCAL_ROOT_SPAN_ID_KEY not in parent_ctx._meta
 
 
+def test_submit_propagates_empty_context(tracer):
+    """Hide stale context left on a reused worker when the submitting thread has none."""
+    ambient_worker = tracer.start_span("ambient-worker")
+    try:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=1,
+            initializer=tracer.context_provider.activate,
+            initargs=(ambient_worker,),
+        ) as executor:
+            assert executor.submit(tracer.context_provider.active).result() is None
+    finally:
+        ambient_worker.finish()
+
+
 def test_submit_no_wait(tracer, test_spans):
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 

--- a/tests/internal/events/test_context_watcher.py
+++ b/tests/internal/events/test_context_watcher.py
@@ -15,8 +15,8 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture(autouse=True)
 def _register_context_watcher():
-    from ddtrace.internal.native._native import is_context_watcher_registered
-    from ddtrace.internal.native._native import register_context_watcher
+    from ddtrace.internal._context_watcher import is_context_watcher_registered
+    from ddtrace.internal._context_watcher import register_context_watcher
 
     assert register_context_watcher()
     assert is_context_watcher_registered()
@@ -108,8 +108,8 @@ def test_context_watcher_slot_exhaustion_disables_watcher():
         raise AssertionError("context watcher slots were not exhausted")
 
     try:
-        from ddtrace.internal.native._native import is_context_watcher_registered
-        from ddtrace.internal.native._native import register_context_watcher
+        from ddtrace.internal._context_watcher import is_context_watcher_registered
+        from ddtrace.internal._context_watcher import register_context_watcher
 
         assert register_context_watcher() is False
         assert is_context_watcher_registered() is False
@@ -127,8 +127,8 @@ def test_context_watcher_registration_is_idempotent():
     from contextvars import Context
 
     from ddtrace.internal import core
-    from ddtrace.internal.native._native import is_context_watcher_registered
-    from ddtrace.internal.native._native import register_context_watcher
+    from ddtrace.internal._context_watcher import is_context_watcher_registered
+    from ddtrace.internal._context_watcher import register_context_watcher
 
     assert is_context_watcher_registered() is False
 

--- a/tests/tracer/test_otel_thread_context.py
+++ b/tests/tracer/test_otel_thread_context.py
@@ -215,7 +215,11 @@ def test_asyncio_to_thread_clears_stale_thread_context(tracer: Tracer):
                 asyncio.get_running_loop().set_default_executor(executor)
                 assert await asyncio.to_thread(_published_span_id) is None
 
-            asyncio.run(exercise())
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(exercise())
+            finally:
+                loop.close()
     finally:
         unpatch_futures()
         ambient_worker.finish()

--- a/tests/tracer/test_otel_thread_context.py
+++ b/tests/tracer/test_otel_thread_context.py
@@ -1,3 +1,4 @@
+import asyncio
 import concurrent.futures
 from contextvars import Context
 import ctypes
@@ -10,6 +11,8 @@ import pytest
 from ddtrace._trace.context import Context as DDContext
 from ddtrace._trace.provider import DefaultContextProvider
 from ddtrace._trace.tracer import Tracer
+from ddtrace.contrib.internal.futures.patch import patch as patch_futures
+from ddtrace.contrib.internal.futures.patch import unpatch as unpatch_futures
 from ddtrace.internal import core
 from ddtrace.internal.opentelemetry.thread_context import register_otel_thread_context_listener
 
@@ -195,6 +198,27 @@ def test_python_context_switch_syncs_active_context(tracer: Tracer):
     core.dispatch("python.context.switch")
 
     assert _published_context() == (context.trace_id, context.span_id, 1, 0)
+
+
+def test_asyncio_to_thread_clears_stale_thread_context(tracer: Tracer):
+    """Do not expose native TLS left on a reused worker to an untraced to_thread call."""
+    ambient_worker = tracer.start_span("ambient-worker")
+    try:
+        patch_futures()
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=1,
+            initializer=tracer.context_provider.activate,
+            initargs=(ambient_worker,),
+        ) as executor:
+
+            async def exercise():
+                asyncio.get_running_loop().set_default_executor(executor)
+                assert await asyncio.to_thread(_published_span_id) is None
+
+            asyncio.run(exercise())
+    finally:
+        unpatch_futures()
+        ambient_worker.finish()
 
 
 def test_span_context_is_reactivated_after_fork(tracer: Tracer):

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -2139,7 +2139,8 @@ def test_activate_context_nesting_and_restoration(tracer):
     1. A context can be activated and its values are accessible
     2. A nested context can be activated and its values override the outer context
     3. When the nested context exits, the outer context is properly restored
-    4. When all contexts exit, the active context is None
+    4. An empty nested context clears and then restores the outer context
+    5. When all contexts exit, the active context is None
     """
 
     with tracer._activate_context(Context(trace_id=1, span_id=1)):
@@ -2155,5 +2156,10 @@ def test_activate_context_nesting_and_restoration(tracer):
         active = tracer.context_provider.active()
         assert active.trace_id == 1
         assert active.span_id == 1
+
+        with tracer._activate_context(None):
+            assert tracer.context_provider.active() is None
+
+        assert tracer.context_provider.active() is active
 
     assert tracer.context_provider.active() is None


### PR DESCRIPTION
## Description

Asyncio tasks can share one OS thread while carrying independent contexts. Without synchronization, native OpenTelemetry readers can observe the context of the task that ran previously.

This PR:

- Publishes python.context.switch while asyncio runs callbacks in their captured contexts.
- Covers eager tasks created through event-loop task APIs.
- Uses the native context watcher when available and installs fallback hooks only when required.
- Leaves asyncio.Task unchanged.
- Leaves thread offloads to the default futures integration, which clears stale worker context for untraced submissions.
- Centralizes watcher capability checks in ddtrace.internal._context_watcher.

## Testing

- Regression testing suite

## Risks

- Low. Fallback hooks affect built-in asyncio event loops only when native context watching is unavailable.