### PR TITLE
ci(profiling): fail fuzz build on startup crash

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/fuzz/build.sh
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/build.sh
@@ -95,6 +95,28 @@ cmake -S "${SOURCE_DIR}" -B "${BUILD_DIR}" \
 # Copy LSan suppression file next to the binaries so it can be referenced at runtime
 cp "${SCRIPT_DIR}/lsan.supp" "${BUILD_DIR}/fuzz/lsan.supp"
 
+# ---- Step 4: Smoke test each built binary ----
+# libFuzzer's -help=1 prints usage and exits 0 without running any iterations, but
+# it still forces the dynamic loader to resolve every shared library (libpython,
+# libdd_wrapper, _native) and runs the binary's static initializers. A target that
+# segfaults on startup (e.g. an unresolvable or incompatible libpython) therefore
+# fails here at build time instead of being silently shipped to the fuzzing fleet.
+echo "=== Smoke testing fuzz binaries (-help=1) ==="
+for TARGET in "${FUZZ_TARGETS[@]}"; do
+    BINARY_PATH="${BUILD_DIR}/fuzz/${TARGET}"
+    echo "Smoke test: ${BINARY_PATH} -help=1"
+    if LD_LIBRARY_PATH="${LIB_INSTALL_DIR}:${PYTHON_LIBDIR}:${LD_LIBRARY_PATH:-}" \
+       ASAN_OPTIONS=detect_leaks=0 \
+       "${BINARY_PATH}" -help=1 > /dev/null; then
+        echo "Smoke test passed: ${TARGET}"
+    else
+        status=$?
+        echo "Smoke test FAILED: ${BINARY_PATH} could not start (exit status ${status})"
+        exit 1
+    fi
+done
+echo "All fuzz binaries passed the startup smoke test"
+
 # Register the built binaries in the manifest file for the CI infrastructure to discover
 for TARGET in "${FUZZ_TARGETS[@]}"; do
     BINARY_PATH="${BUILD_DIR}/fuzz/${TARGET}"

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/build.sh
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/build.sh
@@ -96,26 +96,46 @@ cmake -S "${SOURCE_DIR}" -B "${BUILD_DIR}" \
 cp "${SCRIPT_DIR}/lsan.supp" "${BUILD_DIR}/fuzz/lsan.supp"
 
 # ---- Step 4: Smoke test each built binary ----
-# libFuzzer's -help=1 prints usage and exits 0 without running any iterations, but
-# it still forces the dynamic loader to resolve every shared library (libpython,
-# libdd_wrapper, _native) and runs the binary's static initializers. A target that
-# segfaults on startup (e.g. an unresolvable or incompatible libpython) therefore
-# fails here at build time instead of being silently shipped to the fuzzing fleet.
+# Verify each fuzzer can actually start. libFuzzer's -help=1 forces the dynamic
+# loader to resolve every shared library (libpython, libdd_wrapper, _native) and
+# runs the binary's global constructors before printing its help to stderr. A
+# binary that cannot start (unresolvable/incompatible libpython, a crashing
+# global constructor, a missing symbol, ...) never reaches that help output, so
+# we treat reaching libFuzzer's help as proof of a successful startup.
+#
+# AIDEV-NOTE: Success is keyed on the help OUTPUT, not the exit code. These
+# harnesses embed CPython/echion global state and can hit a flaky SIGSEGV in
+# global teardown at process exit on some Python versions (observed on 3.13/3.14,
+# non-deterministic across targets and runs). That teardown crash is irrelevant
+# to fuzzing -- the fuzzer runs with runs=-1 and never exits normally -- so
+# gating on the exit status made this build fail non-deterministically. Reaching
+# help proves the binary starts; the exit-time teardown crash is tracked
+# separately and must not fail the build here.
 echo "=== Smoke testing fuzz binaries (-help=1) ==="
+SMOKE_FAILURES=0
 for TARGET in "${FUZZ_TARGETS[@]}"; do
     BINARY_PATH="${BUILD_DIR}/fuzz/${TARGET}"
     echo "Smoke test: ${BINARY_PATH} -help=1"
-    if LD_LIBRARY_PATH="${LIB_INSTALL_DIR}:${PYTHON_LIBDIR}:${LD_LIBRARY_PATH:-}" \
-       ASAN_OPTIONS=detect_leaks=0 \
-       "${BINARY_PATH}" -help=1 > /dev/null; then
-        echo "Smoke test passed: ${TARGET}"
+    # Capture stdout+stderr and ignore the exit status (see AIDEV-NOTE above);
+    # success is decided from the presence of libFuzzer's help output.
+    SMOKE_OUTPUT="$(LD_LIBRARY_PATH="${LIB_INSTALL_DIR}:${PYTHON_LIBDIR}:${LD_LIBRARY_PATH:-}" \
+        ASAN_OPTIONS=detect_leaks=0 \
+        "${BINARY_PATH}" -help=1 2>&1 || true)"
+    if printf '%s\n' "${SMOKE_OUTPUT}" | grep -qi "Verbosity level"; then
+        echo "Smoke test passed: ${TARGET} (reached libFuzzer initialization)"
     else
-        status=$?
-        echo "Smoke test FAILED: ${BINARY_PATH} could not start (exit status ${status})"
-        exit 1
+        echo "Smoke test FAILED: ${TARGET} did not reach libFuzzer initialization"
+        echo "----- ${TARGET} -help=1 output -----"
+        printf '%s\n' "${SMOKE_OUTPUT}"
+        echo "------------------------------------"
+        SMOKE_FAILURES=$((SMOKE_FAILURES + 1))
     fi
 done
-echo "All fuzz binaries passed the startup smoke test"
+if [ "${SMOKE_FAILURES}" -ne 0 ]; then
+    echo "Startup smoke test failed for ${SMOKE_FAILURES} target(s)"
+    exit 1
+fi
+echo "All fuzz binaries reached libFuzzer initialization"
 
 # Register the built binaries in the manifest file for the CI infrastructure to discover
 for TARGET in "${FUZZ_TARGETS[@]}"; do

--- a/docker/Dockerfile.fuzz
+++ b/docker/Dockerfile.fuzz
@@ -46,9 +46,20 @@ RUN while IFS= read -r bin; do cp "$bin" /fuzzer/builds/; done < /fuzz_binaries.
 # Copy shared libraries (libpython, libdd_wrapper) next to the fuzz binaries so they
 # are always resolvable via $ORIGIN rpath or LD_LIBRARY_PATH, even if fuzzydog runs
 # the binary in an environment where the original pyenv/build paths are unavailable.
-RUN PYTHON_LIBDIR="$(python3 -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")" \
-  && echo "PYTHON_LIBDIR=${PYTHON_LIBDIR}" \
-  && cp -v "${PYTHON_LIBDIR}"/libpython*.so* /fuzzer/builds/ 2>/dev/null || true
+RUN set -eu; \
+    PYTHON_LIBDIR="$(python3 -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))")"; \
+    echo "PYTHON_LIBDIR=${PYTHON_LIBDIR}"; \
+    copied=0; \
+    for lib in "${PYTHON_LIBDIR}"/libpython*.so*; do \
+        [ -e "$lib" ] || continue; \
+        cp -v "$lib" /fuzzer/builds/; \
+        copied=$((copied + 1)); \
+    done; \
+    if [ "$copied" -eq 0 ]; then \
+        echo "ERROR: no libpython*.so* found under ${PYTHON_LIBDIR}; fuzz binaries would segfault at startup" >&2; \
+        exit 1; \
+    fi; \
+    echo "Copied ${copied} libpython shared object(s) to /fuzzer/builds/"
 RUN cp -v /tmp/fuzz/build/lib/*.so* /fuzzer/builds/ 2>/dev/null || true
 RUN ls -la /fuzzer/builds/
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"00000000-0000-0000-0000-000000000000","source":"chat","resourceId":"ff47139c-dab6-40c1-a2f7-9af90835aab2","workflowId":"e0bb61d6-2559-4dd2-a9e0-ee17c720e7a9","codeChangeId":"e0bb61d6-2559-4dd2-a9e0-ee17c720e7a9","sourceType":"assistant"} -->
## Description

The `fuzz_infra` CI jobs for Python 3.13 and 3.14 were failing. This PR adds build-time guardrails around the stack_v2/echion fuzz harnesses and makes the startup smoke test robust to a pre-existing, flaky teardown crash.

Two changes:

- `docker/Dockerfile.fuzz`: the libpython copy into `/fuzzer/builds/` previously used `cp ... 2>/dev/null || true`, silently swallowing failures. If py3.13+ had a different library path/naming and nothing was copied, the deployed binary could not resolve libpython at runtime and segfaulted on startup. The step now counts how many `libpython*.so*` files were actually copied and fails the build (exit 1) when none are found.
- `ddtrace/internal/datadog/profiling/stack/fuzz/build.sh`: after building all targets, each binary is smoke-tested with libFuzzer's `-help=1`, which forces the dynamic loader to resolve every shared library and run the binary's global constructors. Success is keyed on reaching libFuzzer's help output, NOT on the process exit code. These harnesses embed CPython/echion global state and hit a flaky SIGSEGV in global teardown at process exit on py3.13/3.14 — non-deterministic across targets and runs (frame_read, greenlet, mirrors, thread_unwind each crashed on different runs, always after printing full help). That teardown crash is irrelevant to fuzzing (the fuzzer runs with runs=-1 and never exits normally), so the first version of this smoke test, which gated on exit status, failed the build non-deterministically. Keying on help output still catches genuine startup failures (unresolvable/incompatible libpython, crashing global constructor, missing symbol) while tolerating the exit-time crash.

## Testing

- `bash -n` on build.sh passes.
- Simulated the smoke-test decision logic with fake binaries: one that prints libFuzzer-style help and then raises SIGSEGV at exit is correctly treated as PASS; one that fails to load a shared library (no help output) is correctly treated as FAIL. The wrapping script survives the child SIGSEGV.
- Verified the Dockerfile copy logic against a real pyenv layout (copies matching libs and reports the count; an empty/mismatched LIBDIR prints the error and exits 1).
- Root-caused the failures from the two GitLab jobs (py3.13 job 1966960140, py3.14 job 1966960141): every target printed full libFuzzer help before a non-deterministic exit-time SIGSEGV, confirming the binaries start correctly.
- A full image build requires the `fuzz_base` image + network, so end-to-end validation runs in CI / the fuzzing pipeline.

## Risks

Low. Changes are limited to fuzzing build tooling and do not touch runtime or profiler code shipped to customers. The startup smoke test is now deterministic (help output always precedes the teardown crash) and still blocks genuinely broken binaries. No public API or customer-facing behavior change, so this warrants the `changelog/no-changelog` label rather than a release note.

## Additional Notes

The flaky py3.13/3.14 exit-time teardown SIGSEGV in the echion fuzz harnesses is a separate, pre-existing bug tracked outside this PR (documented via an AIDEV-NOTE in build.sh); it does not affect fuzzing itself. The libdd_wrapper copy line in the Dockerfile still uses `2>/dev/null || true`; it was left unchanged to keep this PR focused on the libpython startup regression.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/ff47139c-dab6-40c1-a2f7-9af90835aab2)

Comment @datadog to request changes