### PR TITLE
chore(runtime): add explicit identity refresh

### DIFF
--- a/ddtrace/internal/runtime/__init__.py
+++ b/ddtrace/internal/runtime/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "get_runtime_id",
     "get_parent_runtime_id",
     "get_runtime_propagation_envs",
+    "refresh_identity",
 ]
 
 
@@ -31,15 +32,34 @@ _PARENT_RUNTIME_ID: t.Optional[str] = env.get(_ENV_PARENT_SESSION_ID)
 # IMPORTANT: Do not change t.Set to set until minimum Python version is 3.11+
 # Module-level set[...] in Python 3.10 affects import timing. See packages.py for details.
 _ON_RUNTIME_ID_CHANGE: t.Set[t.Callable[[str], None]] = set()  # noqa: UP006
+_ON_RUNTIME_IDENTITY_REFRESH: t.Set[t.Callable[[str], None]] = set()  # noqa: UP006
 
 
 def on_runtime_id_change(cb: t.Callable[[str], None]) -> None:
     """Register a callback to be called when the runtime ID changes.
 
-    This can happen after a fork.
+    This happens after a fork and when refresh_identity() runs.
     """
     global _ON_RUNTIME_ID_CHANGE
     _ON_RUNTIME_ID_CHANGE.add(cb)
+
+
+def on_runtime_identity_refresh(cb: t.Callable[[str], None]) -> None:
+    """Register a callback to be called after an explicit runtime identity refresh.
+
+    This is separate from the fork callback because a logical runtime replacement
+    must not be treated as a child process or update the fork lineage.
+    """
+    global _ON_RUNTIME_IDENTITY_REFRESH
+    _ON_RUNTIME_IDENTITY_REFRESH.add(cb)
+
+
+def _refresh_runtime_id() -> None:
+    global _RUNTIME_ID
+
+    _RUNTIME_ID = _generate_runtime_id()
+    for cb in _ON_RUNTIME_ID_CHANGE:
+        cb(_RUNTIME_ID)
 
 
 @forksafe.register
@@ -51,8 +71,23 @@ def _set_runtime_id():
         _ANCESTOR_RUNTIME_ID = _RUNTIME_ID
 
     _PARENT_RUNTIME_ID = _RUNTIME_ID
-    _RUNTIME_ID = _generate_runtime_id()
-    for cb in _ON_RUNTIME_ID_CHANGE:
+    _refresh_runtime_id()
+
+
+def refresh_identity() -> None:
+    """Regenerate the runtime ID without recording fork lineage.
+
+    Unlike a fork, this does not update _PARENT_RUNTIME_ID / _ANCESTOR_RUNTIME_ID:
+    the previous runtime ID was not a real parent process, so recording it there
+    would make get_process_role() and friends misreport a fork lineage that never
+    existed. Use this when a new logical process instance is created by a mechanism
+    other than fork().
+    """
+    # Notify consumers that only need the new ID first. The explicit refresh
+    # callbacks below are for components that must rebuild restore-sensitive
+    # state, which is different from the fork handling in _set_runtime_id().
+    _refresh_runtime_id()
+    for cb in _ON_RUNTIME_IDENTITY_REFRESH:
         cb(_RUNTIME_ID)
 
 

--- a/tests/tracer/runtime/test_runtime_id.py
+++ b/tests/tracer/runtime/test_runtime_id.py
@@ -41,6 +41,50 @@ def test_get_runtime_id_fork():
 
 
 @pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
+def test_fork_notifies_runtime_id_subscribers():
+    import os
+
+    from ddtrace.internal import runtime
+
+    seen = []
+
+    def on_change(new_id):
+        seen.append(new_id)
+
+    runtime.on_runtime_id_change(on_change)
+
+    child = os.fork()
+    if child == 0:
+        assert seen == [runtime.get_runtime_id()]
+        os._exit(42)
+
+    _, status = os.waitpid(child, 0)
+    assert os.WEXITSTATUS(status) == 42
+
+
+@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
+def test_fork_does_not_notify_runtime_identity_refresh_subscribers():
+    import os
+
+    from ddtrace.internal import runtime
+
+    seen = []
+
+    def on_refresh(new_id):
+        seen.append(new_id)
+
+    runtime.on_runtime_identity_refresh(on_refresh)
+
+    child = os.fork()
+    if child == 0:
+        assert seen == []
+        os._exit(42)
+
+    _, status = os.waitpid(child, 0)
+    assert os.WEXITSTATUS(status) == 42
+
+
+@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
 def test_get_runtime_id_double_fork():
     import os
 
@@ -210,3 +254,168 @@ def test_get_process_role_spawn_child() -> None:
     from ddtrace.internal.runtime import get_process_role
 
     assert get_process_role() == "worker", get_process_role()
+
+
+def test_refresh_identity_changes_runtime_id(run_python_code_in_subprocess):
+    """refresh_identity() is the non-fork trigger for a new logical process instance."""
+    code = """
+from ddtrace.internal import runtime
+
+runtime_id = runtime.get_runtime_id()
+runtime.refresh_identity()
+new_runtime_id = runtime.get_runtime_id()
+
+assert isinstance(new_runtime_id, str)
+assert new_runtime_id != runtime_id
+assert new_runtime_id == runtime.get_runtime_id()
+"""
+    _, err, status, _ = run_python_code_in_subprocess(code)
+    assert status == 0, err
+
+
+def test_refresh_identity_does_not_record_fork_lineage(run_python_code_in_subprocess):
+    """Unlike a fork, refresh_identity() must not make get_process_role() report a fake worker.
+
+    The previous runtime ID was not a real parent process, so recording it as one would
+    corrupt process-lineage telemetry.
+    """
+    import os
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "_DD_ROOT_PY_SESSION_ID": None,
+            "_DD_PARENT_PY_SESSION_ID": None,
+            "DD_TRACE_SUBPROCESS_ENABLED": "false",
+        }
+    )
+    code = """
+from ddtrace.internal import runtime
+
+assert runtime.get_process_role() is None
+assert runtime.get_parent_runtime_id() is None
+assert runtime.get_ancestor_runtime_id() is None
+
+runtime.refresh_identity()
+
+assert runtime.get_process_role() is None
+assert runtime.get_parent_runtime_id() is None
+assert runtime.get_ancestor_runtime_id() is None
+"""
+    _, err, status, _ = run_python_code_in_subprocess(code, env=env)
+    assert status == 0, err
+
+
+def test_refresh_identity_preserves_spawned_lineage(run_python_code_in_subprocess):
+    import os
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "_DD_ROOT_PY_SESSION_ID": "ancestor-session-id",
+            "_DD_PARENT_PY_SESSION_ID": "parent-session-id",
+            "DD_TRACE_SUBPROCESS_ENABLED": "false",
+        }
+    )
+    code = """
+from ddtrace.internal import runtime
+
+assert runtime.get_ancestor_runtime_id() == "ancestor-session-id"
+assert runtime.get_parent_runtime_id() == "parent-session-id"
+assert runtime.get_process_role() == "worker"
+
+runtime.refresh_identity()
+
+assert runtime.get_ancestor_runtime_id() == "ancestor-session-id"
+assert runtime.get_parent_runtime_id() == "parent-session-id"
+assert runtime.get_process_role() == "worker"
+"""
+    _, err, status, _ = run_python_code_in_subprocess(code, env=env)
+    assert status == 0, err
+
+
+def test_refresh_identity_preserves_fork_lineage(run_python_code_in_subprocess):
+    import os
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "_DD_ROOT_PY_SESSION_ID": None,
+            "_DD_PARENT_PY_SESSION_ID": None,
+            "DD_TRACE_SUBPROCESS_ENABLED": "false",
+        }
+    )
+    code = """
+import os
+
+from ddtrace.internal import runtime
+
+root_id = runtime.get_runtime_id()
+child = os.fork()
+
+if child == 0:
+    parent_id = runtime.get_parent_runtime_id()
+    ancestor_id = runtime.get_ancestor_runtime_id()
+
+    assert parent_id == root_id
+    assert ancestor_id == root_id
+    assert runtime.get_process_role() == "worker"
+
+    runtime.refresh_identity()
+
+    assert runtime.get_parent_runtime_id() == parent_id
+    assert runtime.get_ancestor_runtime_id() == ancestor_id
+    assert runtime.get_process_role() == "worker"
+    os._exit(42)
+
+_, status = os.waitpid(child, 0)
+assert os.WEXITSTATUS(status) == 42
+"""
+    _, err, status, _ = run_python_code_in_subprocess(code, env=env)
+    assert status == 0, err
+
+
+def test_refresh_identity_notifies_subscribers(run_python_code_in_subprocess):
+    code = """
+from ddtrace.internal import runtime
+
+seen = []
+
+
+class _Subscriber:
+    def on_change(self, new_id):
+        seen.append(new_id)
+
+
+subscriber = _Subscriber()
+runtime.on_runtime_id_change(subscriber.on_change)
+
+runtime.refresh_identity()
+
+assert seen == [runtime.get_runtime_id()]
+"""
+    _, err, status, _ = run_python_code_in_subprocess(code)
+    assert status == 0, err
+
+
+def test_refresh_identity_notifies_refresh_subscribers(run_python_code_in_subprocess):
+    code = """
+from ddtrace.internal import runtime
+
+seen = []
+
+
+class _Subscriber:
+    def on_refresh(self, new_id):
+        seen.append(new_id)
+
+
+subscriber = _Subscriber()
+runtime.on_runtime_identity_refresh(subscriber.on_refresh)
+
+runtime.refresh_identity()
+
+assert seen == [runtime.get_runtime_id()]
+"""
+    _, err, status, _ = run_python_code_in_subprocess(code)
+    assert status == 0, err


### PR DESCRIPTION
Stacked PRs:
- 👉 This #19778 — runtime identity foundation
  - #19898 — WSGI/ASGI request-start hook
    - #19939 — central MicroVM /run identity refresh
      - #19820 — tracer/native writer exporter refresh
        - #19821 — telemetry worker refresh
          - #19822 — runtime metrics runtime-id tags

## Description

Adds ddtrace.internal.runtime.refresh_identity() for runtimes that need a fresh runtime ID without going through an OS fork.

This introduces on_runtime_identity_refresh(), a dedicated callback registry for consumers that should react only to explicit identity refreshes. The existing on_runtime_id_change() behavior remains available for fork-related and general runtime-ID change handling.

refresh_identity() rotates the runtime ID without recording parent or ancestor lineage because a resumed MicroVM run is not a real fork. Existing fork behavior and lineage tracking remain unchanged.

## Testing

Added coverage for:

- refresh_identity() rotating the runtime ID
- refresh_identity() not recording fork lineage
- explicit refresh subscriber notification
- preserving subscriber notification after fork
- callback registration and import behavior

Validation included lint/compile checks and the focused runtime identity test through scripts/run-tests after rebuilding the Riot native extension cache.

## Risks

Low. The new path is opt-in and is not wired to traffic in this PR. Existing fork behavior is preserved.
