### PR TITLE
chore(flask): emit pre-request web event

### DIFF
--- a/ddtrace/contrib/_events/web_framework.py
+++ b/ddtrace/contrib/_events/web_framework.py
@@ -13,6 +13,7 @@ from ddtrace.internal.schema import schematize_url_operation
 
 class WebFrameworkEvents(str, Enum):
     WEB_REQUEST = "web.request"
+    WEB_REQUEST_STARTING = "web.request.starting"
 
 
 @dataclass

--- a/ddtrace/contrib/internal/flask/patch.py
+++ b/ddtrace/contrib/internal/flask/patch.py
@@ -7,6 +7,7 @@ from werkzeug.exceptions import BadRequest
 from werkzeug.exceptions import NotFound
 
 from ddtrace.contrib import trace_utils
+from ddtrace.contrib._events.web_framework import WebFrameworkEvents
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
 from ddtrace.internal.constants import COMPONENT
@@ -391,6 +392,9 @@ def unpatch():
 
 def patched_wsgi_app(wrapped, instance, args, kwargs):
     environ, start_response = args
+    core.dispatch(
+        WebFrameworkEvents.WEB_REQUEST_STARTING.value, (environ.get("REQUEST_METHOD"), environ.get("PATH_INFO"))
+    )
     # Registration is gated on asm_config, not tracing — keep this above the tracing short-circuit.
     _collect_routes_once(instance, environ.get("SCRIPT_NAME") or "")
     if not is_tracing_enabled():

--- a/tests/contrib/flask/test_microvm_identity_refresh.py
+++ b/tests/contrib/flask/test_microvm_identity_refresh.py
@@ -1,0 +1,71 @@
+import mock
+
+from ddtrace.contrib._events.web_framework import WebFrameworkEvents
+from ddtrace.contrib.internal.flask.patch import patched_wsgi_app
+from ddtrace.internal import core
+
+from . import BaseFlaskTestCase
+
+
+REQUEST_STARTING_PATH = "/web-request-starting"
+
+
+class FlaskMicrovmIdentityRefreshTestCase(BaseFlaskTestCase):
+    """patched_wsgi_app() must dispatch every request's method/path before tracing starts.
+
+    The matching logic itself is tested in tests/tracer/runtime/test_runtime_id.py.
+    """
+
+    def test_microvm_run_hook_request(self):
+        """No route is registered at the hook path: wsgi_app() runs before routing, so it
+        must fire even on a 404 -- the stronger, more general form of this check (whether the
+        route matches doesn't change what gets dispatched).
+        """
+        with mock.patch("ddtrace.contrib.internal.flask.patch.core.dispatch", wraps=core.dispatch) as m:
+            res = self.client.post(REQUEST_STARTING_PATH)
+
+        self.assertEqual(res.status_code, 404)
+        m.assert_any_call(WebFrameworkEvents.WEB_REQUEST_STARTING.value, ("POST", REQUEST_STARTING_PATH))
+
+    def test_other_request(self):
+        @self.app.route("/")
+        def index():
+            return "ok", 200
+
+        with mock.patch("ddtrace.contrib.internal.flask.patch.core.dispatch", wraps=core.dispatch) as m:
+            res = self.client.get("/")
+
+        self.assertEqual(res.status_code, 200)
+        m.assert_any_call(WebFrameworkEvents.WEB_REQUEST_STARTING.value, ("GET", "/"))
+
+    def test_pre_request_event_dispatches_before_wsgi_middleware(self):
+        events = []
+        environ = {"REQUEST_METHOD": "POST", "PATH_INFO": REQUEST_STARTING_PATH, "SCRIPT_NAME": ""}
+
+        def start_response(status, headers, exc_info=None):
+            pass
+
+        def wrapped(environ, start_response):
+            return []
+
+        def dispatch(name, args):
+            if name == WebFrameworkEvents.WEB_REQUEST_STARTING.value:
+                events.append("starting")
+
+        class WSGIMiddleware:
+            def __init__(self, app, tracer, integration_config):
+                pass
+
+            def __call__(self, environ, start_response):
+                events.append("middleware")
+                return []
+
+        with (
+            mock.patch("ddtrace.contrib.internal.flask.patch.core.dispatch", side_effect=dispatch),
+            mock.patch("ddtrace.contrib.internal.flask.patch._collect_routes_once"),
+            mock.patch("ddtrace.contrib.internal.flask.patch.is_tracing_enabled", return_value=True),
+            mock.patch("ddtrace.contrib.internal.flask.patch._FlaskWSGIMiddleware", WSGIMiddleware),
+        ):
+            patched_wsgi_app(wrapped, self.app, (environ, start_response), {})
+
+        assert events == ["starting", "middleware"]


### PR DESCRIPTION
## Description

The MicroVM `/run` request has to be observed before a web root span reads runtime identity. This PR keeps the request-starting event coverage scoped to Flask.

This adds a generic `WEB_REQUEST_STARTING` core event and emits it from Flask once method and path are known, before request context/root span creation. The event is intentionally not tied to MicroVMs or runtime-id refresh in this PR.

## Testing

- `scripts/lint fmt ddtrace/internal/core/__init__.py ddtrace/contrib/internal/flask/patch.py tests/contrib/flask/test_microvm_identity_refresh.py`
- `scripts/run-tests --venv e6872f6 tests/contrib/flask/test_microvm_identity_refresh.py -- -- -k microvm_identity_refresh`

## Risks

Low. The event is emitted on Flask request entry, but it has no listener in this PR. The no-listener path should be cheap.

## Release note

None. This PR adds an internal event emitter with no customer-visible listener. Use `changelog/no-changelog`.

## Additional Notes

Depends on #19778. Follow-up PR adds stdlib `http.server` support.