### PR TITLE
perf(profiling): optimise greenlet unwinding

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -667,13 +667,22 @@ ThreadInfo::unwind_greenlets(EchionSampler& echion,
         if (greenlet_thread_map.find(cur_native_id) == greenlet_thread_map.end())
             return;
 
+        snapshots.reserve(greenlet_info_map.size());
+
         std::unordered_set<GreenletInfo::ID> parent_greenlets;
+        parent_greenlets.reserve(greenlet_parent_map.size());
 
         // Collect all parent greenlets
         std::transform(greenlet_parent_map.cbegin(),
                        greenlet_parent_map.cend(),
                        std::inserter(parent_greenlets, parent_greenlets.begin()),
                        [](const std::pair<GreenletInfo::ID, GreenletInfo::ID>& kv) { return kv.second; });
+
+        // Reuse visited set for cycle detection across all leaf greenlets to minimize allocations
+        // The limit here is arbitrary, but it should be more than enough for most use cases.
+        const size_t MAX_GREENLET_DEPTH = 512;
+        std::unordered_set<GreenletInfo::ID> visited;
+        visited.reserve(MAX_GREENLET_DEPTH);
 
         // Snapshot the leaf greenlets and precompute their parent chains
         for (auto& [gid, greenlet] : greenlet_info_map) {
@@ -690,10 +699,8 @@ ThreadInfo::unwind_greenlets(EchionSampler& echion,
 
             // Precompute parent chain while we still hold the lock
             auto current_id = gid;
-            std::unordered_set<GreenletInfo::ID> visited;
-            // The limit here is arbitrary, but it should be more than enough for
-            // most use cases.
-            const size_t MAX_GREENLET_DEPTH = 512;
+            visited.clear();
+
             // Safety: prevent infinite loops from cycles or corrupted parent maps
             for (size_t iteration_count = 0; iteration_count < MAX_GREENLET_DEPTH; ++iteration_count) {
                 // Check for cycles


### PR DESCRIPTION
## Description

This improves the performance of `greenlet` unwinding by
- Not re-allocating / re-reserving the same `visited` container all the time (and instead allocating once, and re-using across greenlets)
- Reserving memory ahead of time for `parent_greenlets` and `snapshots` to avoid having to re-allocate memory on the hot path

Note: this was originally generated by Bits Code to fix `DD_5KBPQ7` -- we'll see if it helps, but I think it's worth going ahead with no matter what. 

Performance-wise, this showed a 3x improvement on Bits Code's benchmarks.