### PR TITLE
fix(openfeature): ignore RC deletions for a replaced config path

### DIFF
--- a/ddtrace/internal/openfeature/_remoteconfiguration.py
+++ b/ddtrace/internal/openfeature/_remoteconfiguration.py
@@ -26,6 +26,19 @@ FFE_FLAGS_PRODUCT = RemoteConfigProduct.FfeFlags
 class FeatureFlagCallback(RCCallback):
     """Remote Configuration callback for Feature Flagging and Experimentation (FFE)."""
 
+    def __init__(self) -> None:
+        # AIDEV-NOTE: Path of the configuration currently loaded, so a removal only
+        # clears it when it names that same path. Replacing one UFC config with
+        # another arrives as remove(old) + add(new), and in a forked child those two
+        # do not necessarily arrive together: the native shared-memory distribution
+        # publishes a manifest per file operation (see src/native/rc_shm.rs), with
+        # the add published during the fetch and the remove right after it. A child
+        # whose reader wakes between the two publishes dispatches the add first and
+        # the remove second, so an unqualified clear would wipe the configuration
+        # that just became current and every later evaluation would report
+        # PROVIDER_NOT_READY until the next unrelated config change.
+        self._applied_path: t.Optional[str] = None
+
     def __call__(self, payloads: t.Sequence[Payload]) -> None:
         """
         Process FFE configuration payloads from Remote Configuration.
@@ -46,12 +59,20 @@ class FeatureFlagCallback(RCCallback):
                     payload.metadata.product_name,
                     payload.path,
                 )
-                # Handle deletion/removal of configuration by clearing the stored config
+                if self._applied_path is not None and payload.path != self._applied_path:
+                    log.debug(
+                        "Ignoring FFE config deletion for %s; %s is the applied configuration",
+                        payload.path,
+                        self._applied_path,
+                    )
+                    continue
                 _set_ffe_config(None)
+                self._applied_path = None
                 continue
 
             try:
-                process_ffe_configuration(payload.content)
+                if process_ffe_configuration(payload.content):
+                    self._applied_path = payload.path
                 log.debug("Processing FFE config ID: %s, size: %d bytes", payload.metadata.id, len(payload.content))
             except Exception as e:
                 log.debug("Error processing FFE config payload: %s", e, exc_info=True)

--- a/ddtrace/internal/openfeature/_remoteconfiguration.py
+++ b/ddtrace/internal/openfeature/_remoteconfiguration.py
@@ -28,15 +28,11 @@ class FeatureFlagCallback(RCCallback):
 
     def __init__(self) -> None:
         # AIDEV-NOTE: Path of the configuration currently loaded, so a removal only
-        # clears it when it names that same path. Replacing one UFC config with
-        # another arrives as remove(old) + add(new), and in a forked child those two
-        # do not necessarily arrive together: the native shared-memory distribution
-        # publishes a manifest per file operation (see src/native/rc_shm.rs), with
-        # the add published during the fetch and the remove right after it. A child
-        # whose reader wakes between the two publishes dispatches the add first and
-        # the remove second, so an unqualified clear would wipe the configuration
-        # that just became current and every later evaluation would report
-        # PROVIDER_NOT_READY until the next unrelated config change.
+        # clears it when it names that same path. Replacing a config is remove(old) +
+        # add(new), and a forked child can see the two in either order because the
+        # shared-memory distribution publishes a manifest per file operation (see
+        # src/native/rc_shm.rs). An unqualified clear would then wipe the config that
+        # just became current, leaving every evaluation on PROVIDER_NOT_READY.
         self._applied_path: t.Optional[str] = None
 
     def __call__(self, payloads: t.Sequence[Payload]) -> None:

--- a/releasenotes/notes/fix-openfeature-rc-stale-deletion-89e3b86c50363ce1.yaml
+++ b/releasenotes/notes/fix-openfeature-rc-stale-deletion-89e3b86c50363ce1.yaml
@@ -3,8 +3,5 @@ fixes:
   - |
     openfeature: This fix resolves an issue where replacing the feature flag configuration could
     leave a forked worker process (for example under ``gunicorn`` or ``uWSGI``) with no
-    configuration at all, so every subsequent flag evaluation returned the caller-provided default
-    with the ``PROVIDER_NOT_READY`` error code. A replacement is delivered as a removal of the old
-    configuration plus an addition of the new one, and a worker could observe the two out of order;
-    the removal then discarded the configuration that had just been applied. Removals are now
-    matched against the configuration currently loaded and ignored when they do not refer to it.
+    configuration, so every subsequent flag evaluation returned the caller-provided default with
+    the ``PROVIDER_NOT_READY`` error code.

--- a/releasenotes/notes/fix-openfeature-rc-stale-deletion-89e3b86c50363ce1.yaml
+++ b/releasenotes/notes/fix-openfeature-rc-stale-deletion-89e3b86c50363ce1.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    openfeature: This fix resolves an issue where replacing the feature flag configuration could
+    leave a forked worker process (for example under ``gunicorn`` or ``uWSGI``) with no
+    configuration at all, so every subsequent flag evaluation returned the caller-provided default
+    with the ``PROVIDER_NOT_READY`` error code. A replacement is delivered as a removal of the old
+    configuration plus an addition of the new one, and a worker could observe the two out of order;
+    the removal then discarded the configuration that had just been applied. Removals are now
+    matched against the configuration currently loaded and ignored when they do not refer to it.

--- a/tests/openfeature/test_remoteconfig.py
+++ b/tests/openfeature/test_remoteconfig.py
@@ -1,6 +1,30 @@
+import pytest
+
+from ddtrace.internal.openfeature._config import _get_ffe_config
+from ddtrace.internal.openfeature._config import _set_ffe_config
 from ddtrace.internal.openfeature._remoteconfiguration import FeatureFlagCallback
 from ddtrace.internal.remoteconfig import ConfigMetadata
 from ddtrace.internal.remoteconfig import Payload
+from tests.openfeature.config_helpers import create_boolean_flag
+from tests.openfeature.config_helpers import create_config
+
+
+@pytest.fixture(autouse=True)
+def clear_config():
+    _set_ffe_config(None)
+    yield
+    _set_ffe_config(None)
+
+
+def _payload(path, content):
+    metadata = ConfigMetadata(
+        id=path.rsplit("/", 2)[-2],
+        product_name="FFE_FLAGS",
+        sha256_hash=None,
+        length=None,
+        tuf_version=1,
+    )
+    return Payload(metadata=metadata, path=path, content=content)
 
 
 def test_rc_callback_with_deletion():
@@ -99,3 +123,54 @@ def test_rc_callback_with_complex_config():
     # Should process without errors
     callback = FeatureFlagCallback()
     callback([payload])
+
+
+_OLD_PATH = "datadog/2/FFE_FLAGS/old-config/config"
+_NEW_PATH = "datadog/2/FFE_FLAGS/new-config/config"
+
+
+def test_deletion_of_replaced_config_keeps_the_current_one():
+    """Regression: an add and the removal it replaces may arrive in separate batches.
+
+    A forked child reads configuration from shared memory, which publishes one
+    manifest per file operation, so replacing a config can reach the child as
+    add(new) followed by remove(old) instead of the removals-first batch the origin
+    dispatches. Clearing on the late removal would drop a live configuration and make
+    every later evaluation report PROVIDER_NOT_READY.
+    """
+    callback = FeatureFlagCallback()
+
+    callback([_payload(_NEW_PATH, create_config(create_boolean_flag("my-flag")))])
+    assert _get_ffe_config() is not None
+
+    callback([_payload(_OLD_PATH, None)])
+
+    assert _get_ffe_config() is not None
+
+
+def test_deletion_of_applied_config_clears_it():
+    """The removal that does name the applied config still clears it."""
+    callback = FeatureFlagCallback()
+
+    callback([_payload(_NEW_PATH, create_config(create_boolean_flag("my-flag")))])
+    callback([_payload(_NEW_PATH, None)])
+
+    assert _get_ffe_config() is None
+
+
+def test_removals_first_batch_keeps_the_new_config():
+    """The origin's own ordering (removals first, then the add) is unaffected."""
+    callback = FeatureFlagCallback()
+
+    callback([_payload(_OLD_PATH, create_config(create_boolean_flag("old-flag")))])
+    callback(
+        [
+            _payload(_OLD_PATH, None),
+            _payload(_NEW_PATH, create_config(create_boolean_flag("new-flag"))),
+        ]
+    )
+
+    assert _get_ffe_config() is not None
+    # A later removal of the config that was replaced must not clear the new one.
+    callback([_payload(_OLD_PATH, None)])
+    assert _get_ffe_config() is not None


### PR DESCRIPTION
## Description

Replacing the UFC configuration over Agent Remote Config is delivered as `remove(old_path)` + `add(new_path)`. `FeatureFlagCallback` cleared the entire configuration on any deletion payload without checking which path it named, so whether this worked depended on the order the two arrived in:

- **Single process:** `poll()` returns removals first (`src/native/remote_config.rs`), so remove-then-add. Fine.
- **Forked worker** (gunicorn, uWSGI): the child reads configuration from shared memory, and `src/native/rc_shm.rs` publishes a manifest *per file operation* — the add during the fetch, the remove immediately after. A child whose reader wakes between the two publishes dispatches `add(new)` first and `remove(old)` second, and the removal wipes the configuration that had just become current.

The worker is then left with no configuration at all, so every later evaluation returns the caller-provided default with `PROVIDER_NOT_READY`, until an unrelated config change happens to re-deliver.

The callback now records the path of the configuration it applied and ignores a deletion that names a different path. The path is only recorded when `process_ffe_configuration` returns `True`, so a payload the native evaluator rejects does not move the pointer away from the configuration actually loaded.

This is the source of the `provider_not_ready` flakes in the FFE system tests (`tests/ffe/test_flag_eval_metrics.py`, `test_dynamic_evaluation.py`, `test_exposure_egress.py`): each test does `rc.tracer_rc_state.reset().set_config(<new path>, ...)`, and the flask weblog runs `gunicorn -w 1 -k gevent`, so `/ffe` is served by a forked child. The window is microseconds wide, which matches the observed ~1.2% failure rate.

Note that dd-trace-js has the same unqualified clear (`packages/dd-trace/src/openfeature/remote_config.js`) but is single-process, so it cannot hit this.

## Testing

Three regression tests in `tests/openfeature/test_remoteconfig.py`:

- `test_deletion_of_replaced_config_keeps_the_current_one` — the split-batch order a forked child can observe (`add(new)`, then `remove(old)`). Fails on `main`.
- `test_deletion_of_applied_config_clears_it` — a removal that *does* name the applied config still clears it.
- `test_removals_first_batch_keeps_the_new_config` — the origin's batched removals-first order is unaffected.

`openfeature` suite green on venv `13c4b39` (py3.13).

## Risks

A deletion for a path this process never applied is now ignored rather than clearing. That path was by definition not the loaded configuration, so nothing observable changes; the only behaviour difference is the bug being fixed.

## Additional Notes

Worth considering for backport — it affects any forked-worker deployment (gunicorn, uWSGI) using RC-delivered flags. Leaving the labels to the reviewer.

The report that prompted this also lists two things **not** addressed here: a timeout flake in `tests/openfeature/test_agentless_provider_e2e.py` (different failure mode, unpinned) and docker-in-docker setup failures in `system_tests_run_python_PARAMETRIC_3` (infrastructure).
