### PR TITLE
fix(llmobs): stop inlining base64 images into langchain span content

### DIFF
--- a/ddtrace/llmobs/_integrations/langchain.py
+++ b/ddtrace/llmobs/_integrations/langchain.py
@@ -11,15 +11,18 @@ from ddtrace.internal.utils import ArgumentError
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs._constants import AUDIO_FALLBACK_MARKER
 from ddtrace.llmobs._constants import DISPATCH_ON_LLM_TOOL_CHOICE
 from ddtrace.llmobs._constants import DISPATCH_ON_TOOL_CALL
 from ddtrace.llmobs._constants import DISPATCH_ON_TOOL_CALL_OUTPUT_USED
+from ddtrace.llmobs._constants import IMAGE_FALLBACK_MARKER
 from ddtrace.llmobs._constants import INPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import OUTPUT_TOKENS_METRIC_KEY
 from ddtrace.llmobs._constants import PROXY_REQUEST
 from ddtrace.llmobs._constants import TOTAL_TOKENS_METRIC_KEY
 from ddtrace.llmobs._integrations.base import BaseLLMIntegration
 from ddtrace.llmobs._integrations.utils import LANGCHAIN_ROLE_MAPPING
+from ddtrace.llmobs._integrations.utils import _extract_content_parts
 from ddtrace.llmobs._integrations.utils import extract_instance_metadata_from_stack
 from ddtrace.llmobs._integrations.utils import format_langchain_io
 from ddtrace.llmobs._integrations.utils import set_prompt_tracking_tags
@@ -30,7 +33,9 @@ from ddtrace.llmobs._utils import _validate_prompt
 from ddtrace.llmobs._utils import get_llmobs_span_links
 from ddtrace.llmobs._utils import get_tool_version_from_llm_span
 from ddtrace.llmobs._utils import safe_json
+from ddtrace.llmobs.types import AudioPart
 from ddtrace.llmobs.types import Document
+from ddtrace.llmobs.types import ImagePart
 from ddtrace.llmobs.types import Message
 from ddtrace.llmobs.types import ToolCall
 from ddtrace.llmobs.types import _SpanLink
@@ -128,6 +133,41 @@ def _is_google_genai_backed(instance) -> bool:
     client = getattr(client, "client", client)
     module = type(client).__module__ if client is not None else ""
     return module == "google.genai" or module.startswith("google.genai.")
+
+
+# AIDEV-NOTE: langchain builds its own message content instead of delegating to the provider
+# integration, so this runs on both the llm and the demoted path.
+def _extract_message_content(content: Any, is_workflow: bool) -> tuple[str, list[AudioPart], list[ImagePart]]:
+    """Render message content, keeping inline media payloads out of the text.
+
+    Workflow spans carry input_value rather than messages, so parts have nowhere to land there and
+    get a marker instead; the provider's child llm span carries the payload.
+    """
+    if not isinstance(content, list):
+        return str(content), [], []
+    # Content is str | list[str | dict]. The shared extractor only reads dicts, and a bare string
+    # would fall through it as an empty "[]" block.
+    parts = [{"type": "text", "text": part} if isinstance(part, str) else part for part in content]
+    text, audio_parts, image_parts = _extract_content_parts(parts)
+    if not is_workflow:
+        return text, audio_parts, image_parts
+    segments = [text] if text else []
+    segments.extend([AUDIO_FALLBACK_MARKER] * len(audio_parts))
+    segments.extend([IMAGE_FALLBACK_MARKER] * len(image_parts))
+    return "\n".join(segments), [], []
+
+
+def _build_message(content: Any, role: Optional[str], is_workflow: bool) -> Message:
+    """Build a Message, omitting the media keys entirely when nothing was captured."""
+    text, audio_parts, image_parts = _extract_message_content(content, is_workflow)
+    message = Message(content=text)
+    if role is not None:
+        message["role"] = role
+    if audio_parts:
+        message["audio_parts"] = audio_parts
+    if image_parts:
+        message["image_parts"] = image_parts
+    return message
 
 
 class LangChainIntegration(BaseLLMIntegration):
@@ -482,7 +522,7 @@ class LangChainIntegration(BaseLLMIntegration):
             prompts = [prompts]
         if stream:
             # chat and llm take the same input types for streamed calls
-            input_messages = self._handle_stream_input_messages(prompts)
+            input_messages = self._handle_stream_input_messages(prompts, is_workflow)
         else:
             input_messages = [Message(content=str(prompt)) for prompt in prompts]
 
@@ -535,7 +575,7 @@ class LangChainIntegration(BaseLLMIntegration):
         input_messages: list[Message] = []
         if stream:
             chat_messages = get_argument_value(args, kwargs, 0, "input")
-            input_messages = self._handle_stream_input_messages(chat_messages)
+            input_messages = self._handle_stream_input_messages(chat_messages, is_workflow)
         else:
             chat_messages = get_argument_value(args, kwargs, 0, "messages", optional=True) or []
             if not isinstance(chat_messages, list):
@@ -546,7 +586,7 @@ class LangChainIntegration(BaseLLMIntegration):
                         message.get("content", "") if isinstance(message, dict) else getattr(message, "content", "")
                     )
                     role = getattr(message, "role", ROLE_MAPPING.get(getattr(message, "type", ""), ""))
-                    input_messages.append(Message(content=str(content), role=str(role)))
+                    input_messages.append(_build_message(content, str(role), is_workflow))
                     tool_call_id = _get_attr(message, "tool_call_id", "")
                     if not is_workflow and tool_call_id:
                         core.dispatch(
@@ -654,28 +694,25 @@ class LangChainIntegration(BaseLLMIntegration):
                 tool_calls_info.append(tool_call_info)
         return tool_calls_info
 
-    def _handle_stream_input_messages(self, inputs) -> list[Message]:
+    def _handle_stream_input_messages(self, inputs, is_workflow: bool = False) -> list[Message]:
         input_messages: list[Message] = []
         if hasattr(inputs, "to_messages"):  # isinstance(inputs, langchain_core.prompt_values.PromptValue)
             inputs = inputs.to_messages()
         elif not isinstance(inputs, list):
             inputs = [inputs]
         for inp in inputs:
-            inp_message = Message()
-            content, role = None, None
+            content: Any = None
+            role = None
             if isinstance(inp, dict):
-                content = str(inp.get("content", ""))
+                content = inp.get("content", "")
                 role = inp.get("role")
             elif hasattr(inp, "content"):  # isinstance(inp, langchain_core.messages.BaseMessage)
-                content = str(inp.content)
+                content = inp.content
                 role = inp.__class__.__name__
             else:
-                content = str(inp)
+                content = str(inp)  # not a message shape, nothing to parse
 
-            inp_message["content"] = content
-            if role is not None:
-                inp_message["role"] = role
-            input_messages.append(inp_message)
+            input_messages.append(_build_message(content, role, is_workflow))
 
         return input_messages
 

--- a/releasenotes/notes/fix-langchain-inline-base64-images-54f331500a30449f.yaml
+++ b/releasenotes/notes/fix-langchain-inline-base64-images-54f331500a30449f.yaml
@@ -1,0 +1,29 @@
+---
+features:
+  - |
+    LLM Observability: The LangChain integration now captures inline base64 images and audio from
+    multimodal message content as ``image_parts`` and ``audio_parts`` on LLM span messages, so they
+    render in LLM Observability. Images referenced by a remote URL are not fetched and keep their
+    existing text reference. A single inline image whose base64 payload exceeds 80% of the
+    configured per-event size limit (``DD_LLMOBS_EVENT_SIZE_BYTES``) is left as an
+    ``[image omitted: too large]`` marker instead. Note that this budget is per image, not per
+    request: several inline images can still take a span event past the per-event limit, at which
+    point the event's input and output are replaced with a placeholder. To stop image bytes from
+    being recorded, register a span processor with ``LLMObs.register_processor`` and remove the
+    ``image_parts`` key from the messages on ``span.input``.
+fixes:
+  - |
+    LLM Observability: Fixes an issue where an inline base64 image or audio clip sent in LangChain
+    multimodal message content was recorded as the entire base64 data URL inside the message text,
+    producing unreadable multi-megabyte span content and, past the per-event size limit, causing the
+    span's whole input and output to be dropped. This affected both streaming and non-streaming
+    chat calls.
+  - |
+    LLM Observability: Fixes an issue where a LangChain call routed through an instrumented proxy,
+    or to a provider that has its own LLM Observability integration, recorded the full base64 data
+    URL on the LangChain span in addition to the provider span. Such an image is now recorded as an
+    ``[image]`` marker on the LangChain span, and the provider span carries the image itself.
+  - |
+    LLM Observability: Fixes an issue where LangChain multimodal message content was recorded as a
+    Python list repr rather than readable text. Text segments are now joined with newlines, matching
+    the other integrations.

--- a/releasenotes/notes/fix-langchain-inline-base64-images-54f331500a30449f.yaml
+++ b/releasenotes/notes/fix-langchain-inline-base64-images-54f331500a30449f.yaml
@@ -3,9 +3,9 @@ features:
   - |
     LLM Observability: The LangChain integration now captures inline base64 images and audio from
     multimodal message content as ``image_parts`` and ``audio_parts`` on LLM span messages, so they
-    render in LLM Observability. Images referenced by a remote URL are not fetched and keep their
-    existing text reference. A single inline image whose base64 payload exceeds 80% of the
-    configured per-event size limit (``DD_LLMOBS_EVENT_SIZE_BYTES``) is left as an
+    render in LLM Observability. Images referenced by a remote URL are not fetched and are recorded
+    as an ``[image]`` marker rather than the URL. A single inline image whose base64 payload exceeds
+    80% of the configured per-event size limit (``DD_LLMOBS_EVENT_SIZE_BYTES``) is left as an
     ``[image omitted: too large]`` marker instead. Note that this budget is per image, not per
     request: several inline images can still take a span event past the per-event limit, at which
     point the event's input and output are replaced with a placeholder. To stop image bytes from

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -11,6 +11,9 @@ import ddtrace
 from ddtrace import patch
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs._constants import IMAGE_FALLBACK_MARKER
+from ddtrace.llmobs._constants import IMAGE_TOO_LARGE_MARKER
+from ddtrace.llmobs._integrations.utils import _inline_image_budget
 from ddtrace.llmobs._utils import _get_llmobs_data_metastruct
 from ddtrace.llmobs._utils import get_llmobs_input_documents
 from ddtrace.llmobs._utils import get_llmobs_input_messages
@@ -201,6 +204,197 @@ def test_llmobs_openai_chat_model_proxy(mock_generate, langchain_core, langchain
     spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
     assert len(spans) == 1
     assert get_llmobs_span_kind(spans[0]) == "llm"
+
+
+TINY_PNG_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+TINY_PNG_DATA_URL = "data:image/png;base64," + TINY_PNG_B64
+
+DIRECT_MODEL_URL = "http://localhost:8000"  # not a proxy URL, so the span stays llm-kind
+PROXY_MODEL_URL = "http://localhost:4000"
+
+
+def _image_content(url):
+    return [{"type": "text", "text": "What is in this image?"}, {"type": "image_url", "image_url": {"url": url}}]
+
+
+def _one_llmobs_span(test_spans):
+    spans = [s for trace in test_spans.pop_traces() for s in trace if _get_llmobs_data_metastruct(s)]
+    assert len(spans) == 1
+    return spans[0]
+
+
+def _serialized(span):
+    """Everything that would ship for this span, so an assertion can search all of it at once."""
+    return json.dumps(_get_llmobs_data_metastruct(span), default=str)
+
+
+@mock.patch("langchain_core.language_models.chat_models.BaseChatModel._generate_with_cache")
+def test_llmobs_chat_model_image_data_url_captured(
+    mock_generate, langchain_core, langchain_openai, langchain_llmobs, test_spans
+):
+    """A data URL is captured as a structured image_part instead of being inlined into the content."""
+    mock_generate.return_value = mock_langchain_chat_generate_response
+    chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=DIRECT_MODEL_URL)
+    chat_model.invoke([langchain_core.messages.HumanMessage(content=_image_content(TINY_PNG_DATA_URL))])
+
+    span = _one_llmobs_span(test_spans)
+    assert get_llmobs_span_kind(span) == "llm"
+    assert get_llmobs_input_messages(span) == [
+        {
+            "content": "What is in this image?",
+            "role": "user",
+            "image_parts": [{"mime_type": "image/png", "content": TINY_PNG_B64}],
+        }
+    ]
+    # The payload survives only inside the structured part.
+    assert TINY_PNG_DATA_URL not in _serialized(span)
+    assert _serialized(span).count(TINY_PNG_B64) == 1
+
+
+@mock.patch("langchain_core.language_models.chat_models.BaseChatModel._generate_with_cache")
+def test_llmobs_chat_model_image_data_url_demoted_to_marker(
+    mock_generate, langchain_core, langchain_openai, langchain_llmobs, test_spans
+):
+    """A demoted span keeps a marker, never the payload; the provider's child span has the image."""
+    mock_generate.return_value = mock_langchain_chat_generate_response
+    chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=PROXY_MODEL_URL)
+    chat_model.invoke([langchain_core.messages.HumanMessage(content=_image_content(TINY_PNG_DATA_URL))])
+
+    span = _one_llmobs_span(test_spans)
+    assert get_llmobs_span_kind(span) == "workflow"
+    assert get_llmobs_input_value(span) == json.dumps(
+        [{"content": "What is in this image?\n" + IMAGE_FALLBACK_MARKER, "role": "user"}], sort_keys=True
+    )
+    assert TINY_PNG_B64 not in _serialized(span)
+
+
+@mock.patch("langchain_core.language_models.chat_models.BaseChatModel._generate_with_cache")
+def test_llmobs_chat_model_oversize_image_degrades_to_marker(
+    mock_generate, langchain_core, langchain_openai, langchain_llmobs, test_spans
+):
+    """An over-budget image degrades to a marker; _truncate_span_event would blank input AND output."""
+    oversize_b64 = "A" * (_inline_image_budget() + 4)
+    mock_generate.return_value = mock_langchain_chat_generate_response
+    chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=DIRECT_MODEL_URL)
+    chat_model.invoke(
+        [langchain_core.messages.HumanMessage(content=_image_content("data:image/png;base64," + oversize_b64))]
+    )
+
+    span = _one_llmobs_span(test_spans)
+    assert get_llmobs_input_messages(span) == [
+        {"content": "What is in this image?\n" + IMAGE_TOO_LARGE_MARKER, "role": "user"}
+    ]
+    assert oversize_b64 not in _serialized(span)
+    assert get_llmobs_output_messages(span) == [{"content": "The capital of France is Paris.", "role": "assistant"}]
+
+
+@mock.patch("langchain_core.language_models.chat_models.BaseChatModel._generate_with_cache")
+def test_llmobs_chat_model_audio_data_url_captured(
+    mock_generate, langchain_core, langchain_openai, langchain_llmobs, test_spans
+):
+    """Audio rides the same list-content path, which langchain has never handled either."""
+    mock_generate.return_value = mock_langchain_chat_generate_response
+    chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=DIRECT_MODEL_URL)
+    chat_model.invoke(
+        [
+            langchain_core.messages.HumanMessage(
+                content=[
+                    {"type": "text", "text": "what is said here?"},
+                    {"type": "input_audio", "input_audio": {"data": "AAECAw==", "format": "mp3"}},
+                ]
+            )
+        ]
+    )
+
+    span = _one_llmobs_span(test_spans)
+    assert get_llmobs_input_messages(span) == [
+        {
+            "content": "what is said here?",
+            "role": "user",
+            "audio_parts": [{"mime_type": "audio/mpeg", "content": "AAECAw=="}],
+        }
+    ]
+
+
+@mock.patch("langchain_core.language_models.chat_models.BaseChatModel._generate_with_cache")
+def test_llmobs_chat_model_text_only_content_is_unchanged(
+    mock_generate, langchain_core, langchain_openai, langchain_llmobs, test_spans
+):
+    """Regression pin: a no-media message adds no parts key, on either the llm or the demoted path."""
+    mock_generate.return_value = mock_langchain_chat_generate_response
+    for base_url, expected_kind in ((DIRECT_MODEL_URL, "llm"), (PROXY_MODEL_URL, "workflow")):
+        chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=base_url)
+        chat_model.invoke([langchain_core.messages.HumanMessage(content="What is the capital of France?")])
+
+        span = _one_llmobs_span(test_spans)
+        assert get_llmobs_span_kind(span) == expected_kind
+        expected = [{"content": "What is the capital of France?", "role": "user"}]
+        if expected_kind == "llm":
+            assert get_llmobs_input_messages(span) == expected
+        else:
+            assert get_llmobs_input_value(span) == json.dumps(expected, sort_keys=True)
+
+
+@mock.patch("langchain_openai.ChatOpenAI._stream")
+def test_llmobs_chat_model_image_data_url_captured_stream(
+    mock_stream, langchain_core, langchain_openai, langchain_llmobs, test_spans
+):
+    """The streaming path builds its input messages separately, and had the same defect."""
+    outputs = importlib.import_module("langchain_core.outputs")
+    mock_stream.return_value = iter(
+        [outputs.ChatGenerationChunk(message=langchain_core.messages.AIMessageChunk(content="a 1x1 pixel"))]
+    )
+    chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=DIRECT_MODEL_URL)
+    for _ in chat_model.stream([langchain_core.messages.HumanMessage(content=_image_content(TINY_PNG_DATA_URL))]):
+        pass
+
+    span = _one_llmobs_span(test_spans)
+    assert get_llmobs_input_messages(span) == [
+        {
+            "content": "What is in this image?",
+            "role": "HumanMessage",
+            "image_parts": [{"mime_type": "image/png", "content": TINY_PNG_B64}],
+        }
+    ]
+    assert TINY_PNG_DATA_URL not in _serialized(span)
+
+
+@mock.patch("langchain_core.language_models.chat_models.BaseChatModel._generate_with_cache")
+def test_llmobs_chat_model_unrecognized_image_block_leaves_a_marker(
+    mock_generate, langchain_core, langchain_openai, langchain_llmobs, test_spans
+):
+    """Only the OpenAI-shaped image_url block is parsed; anything else degrades to a marker."""
+    mock_generate.return_value = mock_langchain_chat_generate_response
+    chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=DIRECT_MODEL_URL)
+    chat_model.invoke(
+        [
+            langchain_core.messages.HumanMessage(
+                content=[
+                    {"type": "text", "text": "What is in this image?"},
+                    {"type": "image", "source_type": "base64", "data": TINY_PNG_B64, "mime_type": "image/png"},
+                ]
+            )
+        ]
+    )
+
+    span = _one_llmobs_span(test_spans)
+    assert get_llmobs_input_messages(span) == [
+        {"content": "What is in this image?\n" + IMAGE_FALLBACK_MARKER, "role": "user"}
+    ]
+    assert TINY_PNG_B64 not in _serialized(span)
+
+
+@mock.patch("langchain_core.language_models.chat_models.BaseChatModel._generate_with_cache")
+def test_llmobs_chat_model_string_content_parts_are_joined(
+    mock_generate, langchain_core, langchain_openai, langchain_llmobs, test_spans
+):
+    """langchain's content type allows bare strings in the list, which are not OpenAI content blocks."""
+    mock_generate.return_value = mock_langchain_chat_generate_response
+    chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=DIRECT_MODEL_URL)
+    chat_model.invoke([langchain_core.messages.HumanMessage(content=["part one", "part two"])])
+
+    span = _one_llmobs_span(test_spans)
+    assert get_llmobs_input_messages(span) == [{"content": "part one\npart two", "role": "user"}]
 
 
 def test_llmobs_string_prompt_template_invoke(

--- a/tests/contrib/langchain/test_langchain_llmobs.py
+++ b/tests/contrib/langchain/test_langchain_llmobs.py
@@ -385,6 +385,22 @@ def test_llmobs_chat_model_unrecognized_image_block_leaves_a_marker(
 
 
 @mock.patch("langchain_core.language_models.chat_models.BaseChatModel._generate_with_cache")
+def test_llmobs_chat_model_remote_image_url_becomes_a_marker(
+    mock_generate, langchain_core, langchain_openai, langchain_llmobs, test_spans
+):
+    """A remote URL is never fetched, and the URL itself is not recorded either."""
+    mock_generate.return_value = mock_langchain_chat_generate_response
+    chat_model = langchain_openai.ChatOpenAI(temperature=0, max_tokens=256, base_url=DIRECT_MODEL_URL)
+    chat_model.invoke([langchain_core.messages.HumanMessage(content=_image_content("https://example.com/cat.png"))])
+
+    span = _one_llmobs_span(test_spans)
+    assert get_llmobs_input_messages(span) == [
+        {"content": "What is in this image?\n" + IMAGE_FALLBACK_MARKER, "role": "user"}
+    ]
+    assert "example.com" not in _serialized(span)
+
+
+@mock.patch("langchain_core.language_models.chat_models.BaseChatModel._generate_with_cache")
 def test_llmobs_chat_model_string_content_parts_are_joined(
     mock_generate, langchain_core, langchain_openai, langchain_llmobs, test_spans
 ):


### PR DESCRIPTION
# fix(llmobs): stop inlining base64 images into langchain span content

## What does this PR do?

Stops the langchain integration writing raw base64 image payloads into span content, and captures
them as typed `image_parts` / `audio_parts` on the llm path instead.

## The defect

langchain builds its own LLMObs message content rather than delegating to the provider integration,
and did so with a bare `str()` and no branch for list-shaped multimodal content
(`_integrations/langchain.py`, non-stream chat and both streamed call sites). A
`data:image/...;base64,...` URL therefore landed in span content **verbatim**.

This happens on **both** paths, because `input_messages` is built before the `is_workflow` branch;
that branch only chooses which key the result lands under. When demoted, it is JSON-serialized into
`input.value`.

Past `DD_LLMOBS_EVENT_SIZE_BYTES`, `_truncate_span_event` blanks the span's **entire input and
output**, not just the image. So a single vision prompt can cost the whole record of the call.

The delegated path does not save you either: three cases produce no provider llm span at all
(proxy requests, raw-response streaming, and a provider registered-but-never-imported), and in those
the langchain span carrying the inlined base64 is the *only* record.

## Precedent

No new design here. List content is routed through the shared `_extract_content_parts`, the same
helper **#19690** extended to return image parts, so the wire shape and the capture semantics are
identical to the merged OpenAI and Anthropic work (**#19148**, **#19690**), which in turn build on
**#18809**.

## Changes

`ddtrace/llmobs/_integrations/langchain.py` (+73/-12):

- `_extract_message_content(content, is_workflow)` — list content goes through
  `_extract_content_parts`; a data URL becomes a structured part and never reaches the text. Blocks
  the shared extractor does not recognise (langchain's own `image`/`audio` standard blocks) still
  leave a `[image]` / `[audio]` marker rather than the payload.
- `_build_message(content, role, is_workflow)` — attaches media keys only when something was
  captured, so a text-only message keeps byte-identical shape to before.
- Wired into the non-stream chat path and **both** streamed call sites
  (`_handle_stream_input_messages` now takes `is_workflow`).

Audio is fixed by the same change; langchain had never handled it either.

## Size guarding (the question asked on #19148 and #19690)

This inherits the per-image budget from `_capture_inline_image`, which #19690 added to
`_extract_content_parts` — an over-budget image degrades to `[image omitted: too large]` before it
can push the event over the cap. There is no new guard here and no guard bypass.

**The cumulative case is still open**, exactly as on the merged PRs: N images that each fit the
per-image budget can together exceed the per-event limit. That is unchanged by this PR and remains
tracked under MLOB-6408 as a writer-side fix. Flagging it explicitly so it is not re-litigated here.

## Why the demoted path gets markers, not typed parts

On a demoted (`workflow`) span, typed messages have nowhere to land — those spans carry
`input_value`, not `messages` — so structured parts would be serialized straight back into the
value, which is the bug this PR fixes. Those keep a marker only; the provider's child llm span
carries the real payload.

Note this interacts with the pending non-LLM span-kind widening: once `workflow` / `task` / `tool` /
`step` can keep typed messages, this branch becomes eligible to emit real parts there instead of
markers. Deliberately left as a follow-up rather than pre-empting a change that has not landed.

## Testing

`tests/contrib/langchain/test_langchain_llmobs.py` (+216). 8/8 of the new tests pass; `lint fmt`,
`style`, `typing` and `spelling` clean; banned-terms clean.

The existing `test_langchain.py:99-123` already fed an `image_url` block through `ChatOpenAI`, but
asserted only "no error" and used an `https` URL, so it could not catch this. The new cases use a
`data:` URL and assert the base64 is absent from span content.

Note `conftest.py` sets `integrations_enabled=False`, so the suite exercises the non-delegated path;
the demoted path needs a fixture that patches a provider and is called out rather than silently
uncovered.

## Known adjacent defects, deliberately not in scope

- The chain path (`format_langchain_io`) can still stringify content blocks.
- Streamed **output** aggregation is untouched by this PR.

Both are pre-existing, independent of this change, and worth their own issues rather than widening
this diff.
