### PR TITLE
test(appsec): bound and instrument the test servers' /shutdown endpoints

### DIFF
--- a/tests/appsec/_shutdown.py
+++ b/tests/appsec/_shutdown.py
@@ -1,0 +1,98 @@
+"""Bounded tracer shutdown for the test servers' /shutdown endpoints.
+
+The endpoints exist to flush traces before the server is killed. They run inside a request, so
+whatever they do has to finish well before appsec_utils gives up on the response after 10s.
+
+Two things make that hard under a gevent worker. tracer.shutdown() blocks the calling thread on a
+native condvar in PeriodicThread_join, and under gevent that thread is the hub -- measured: 0
+greenlets scheduled for the whole call, so the response cannot be written even after the view
+returns. And the bound is only as good as the timeout that is passed; an untimed shutdown parks
+forever, and a shutdown timed at the caller's own 10s is a coin flip.
+
+So: run it off the hub, and cap it. Overrunning the cap loses some traces, which is strictly
+better than losing the response.
+"""
+
+import sys
+import time
+
+
+DEFAULT_TIMEOUT = 5.0
+
+
+def _log(message: str) -> None:
+    """Report to the server's stderr, which is the output appsec_utils points a failure at.
+
+    The response body carries the same status, but a failure here is precisely the case where the
+    response never arrives, so the log is the only copy that survives. The wall clock is included
+    so these lines can be lined up against gunicorn's own timestamped output.
+    """
+    print("[shutdown %s] %s" % (time.strftime("%H:%M:%S"), message), file=sys.stderr, flush=True)
+
+
+def start_hub_watchdog(threshold: float = 1.0, poll: float = 0.1) -> None:
+    """Report gevent event-loop stalls, so a silent gap in the log can be attributed.
+
+    When the /shutdown response is late there are three candidates: the endpoint was slow, the
+    event loop stopped running so nothing could be read or written, or the delay was outside the
+    server entirely. The endpoint already times itself, and this covers the second -- otherwise a
+    frozen loop and a slow client look identical from the log.
+
+    A blocked loop cannot run this greenlet either, which is the point: the gap it measures on
+    resuming is the length of the freeze. Silent unless something actually stalls.
+    """
+    if not _gevent_patched():
+        return
+
+    import gevent
+
+    def _watch() -> None:
+        last = time.monotonic()
+        while True:
+            gevent.sleep(poll)
+            now = time.monotonic()
+            stalled = now - last - poll
+            if stalled >= threshold:
+                _log("event loop stalled for %.3fs" % stalled)
+            last = now
+
+    gevent.spawn(_watch)
+
+
+def _gevent_patched():
+    try:
+        from gevent import monkey
+    except ImportError:
+        return False
+    return monkey.is_module_patched("threading")
+
+
+def bounded_tracer_shutdown(timeout: float = DEFAULT_TIMEOUT) -> str:
+    """Shut the tracer down in at most `timeout` seconds. Returns a short status for the response.
+
+    The status is echoed into the endpoint's body so a CI failure shows how long this took and
+    whether it hit the cap, instead of leaving a silent gap in the server log.
+    """
+    from ddtrace.trace import tracer
+
+    started = time.monotonic()
+    _log("entered, timeout=%.1fs gevent=%s" % (timeout, _gevent_patched()))
+
+    if not _gevent_patched():
+        tracer.shutdown(timeout=timeout)
+        status = "direct"
+    else:
+        import gevent
+
+        worker = gevent.get_hub().threadpool.spawn(tracer.shutdown, timeout=timeout)
+        try:
+            worker.get(timeout=timeout + 1.0)
+            status = "offloaded"
+        except gevent.Timeout:
+            status = "offloaded, CAPPED (traces dropped)"
+        except Exception as exc:
+            status = "offloaded, failed: %r" % (exc,)
+
+    result = "shutdown %s in %.3fs" % (status, time.monotonic() - started)
+    _log(result)
+    return result

--- a/tests/appsec/app.py
+++ b/tests/appsec/app.py
@@ -26,6 +26,7 @@ from ddtrace.appsec._iast import ddtrace_iast_flask_patch
 from ddtrace.appsec._iast._iast_request_context_base import is_iast_request_enabled
 from ddtrace.appsec._iast._taint_tracking._taint_objects_base import is_pyobject_tainted
 from ddtrace.internal.utils.formats import asbool
+from tests.appsec._shutdown import bounded_tracer_shutdown
 from tests.appsec.iast_packages.packages.pkg_aiohttp import pkg_aiohttp
 from tests.appsec.iast_packages.packages.pkg_aiosignal import pkg_aiosignal
 from tests.appsec.iast_packages.packages.pkg_annotated_types import pkg_annotated_types
@@ -337,7 +338,8 @@ def iast_code_injection_vulnerability():
 
 @app.route("/shutdown", methods=["GET"])
 def shutdown_view():
-    tracer.shutdown(timeout=10)
+    # Was timeout=10, the same budget the caller allows for the whole response.
+    bounded_tracer_shutdown()
     sys.exit(0)
 
 

--- a/tests/appsec/appsec_utils.py
+++ b/tests/appsec/appsec_utils.py
@@ -503,13 +503,20 @@ def appsec_application_server(
         children = parent.children(recursive=True)
 
         yield server_process, client, (children[1].pid if len(children) > 1 else None)
+        shutdown_started = time.monotonic()
         try:
             client.get_ignored("/shutdown", timeout=10)
         except ConnectionError:
             pass
         except Exception:
+            # How long the client actually waited, to pair with the endpoint's own timing in the
+            # captured output above: the endpoint reports how long it took and the watchdog
+            # reports any event-loop stall, so between the three it is clear whether the time
+            # went into the shutdown, into a frozen worker, or somewhere outside the server.
             raise AssertionError(
-                "Server shutdown request failed; its output is in the captured stdout/stderr above.\n"
+                "Server shutdown request failed after %.3fs; its output is in the captured "
+                "stdout/stderr above.\n"
+                % (time.monotonic() - shutdown_started)
                 + _server_diagnostics(server_process, port, cmd)
                 + "\n"
                 + _dump_server_stacks(server_process)

--- a/tests/appsec/integrations/django_tests/django_app/urls.py
+++ b/tests/appsec/integrations/django_tests/django_app/urls.py
@@ -2,7 +2,8 @@ import django
 from django.http import HttpResponse
 from django.urls import path
 
-from ddtrace.trace import tracer
+from tests.appsec._shutdown import bounded_tracer_shutdown
+from tests.appsec._shutdown import start_hub_watchdog
 from tests.appsec.integrations.django_tests.django_app import views
 
 
@@ -13,12 +14,12 @@ else:
     from django.urls import re_path as handler
 
 
+start_hub_watchdog()
+
+
 def shutdown(request):
     # Endpoint used to flush traces to the agent when doing snapshots.
-    # Bounded because the default never gives up, and gevent can park an untimed wait forever.
-    # Stays under the caller's 10s read timeout in appsec_utils.
-    tracer.shutdown(timeout=5)
-    return HttpResponse(status=200)
+    return HttpResponse(bounded_tracer_shutdown(), status=200)
 
 
 urlpatterns = [

--- a/tests/appsec/integrations/django_tests/test_iast_django_testagent.py
+++ b/tests/appsec/integrations/django_tests/test_iast_django_testagent.py
@@ -142,64 +142,23 @@ def test_iast_untrusted_serialization_yaml(server, iast_test_token):
     assert vulnerability["hash"]
 
 
+# DD_APM_TRACING_ENABLED cannot be set through "env": appsec_application_server writes the
+# apm_tracing_enabled argument into the child environment afterwards and overwrites it. Pass it
+# as a server argument instead; it reaches the config dict as a keyword argument.
 @pytest.mark.parametrize(
     "server, config",
     (
         (
             gunicorn_django_server,
-            {
-                "workers": "3",
-                "use_threads": False,
-                "use_gevent": False,
-                "env": {
-                    "DD_APM_TRACING_ENABLED": "false",
-                },
-            },
+            {"workers": "3", "use_threads": False, "use_gevent": False},
         ),
         (
             gunicorn_django_server,
-            {
-                "workers": "3",
-                "use_threads": True,
-                "use_gevent": False,
-                "env": {
-                    "DD_APM_TRACING_ENABLED": "false",
-                },
-            },
+            {"workers": "3", "use_threads": True, "use_gevent": False},
         ),
         (
             gunicorn_django_server,
-            {
-                "workers": "3",
-                "use_threads": True,
-                "use_gevent": True,
-                "env": {
-                    "DD_APM_TRACING_ENABLED": "false",
-                },
-            },
-        ),
-        (
-            gunicorn_django_server,
-            {
-                "workers": "1",
-                "use_threads": True,
-                "use_gevent": True,
-                "env": {
-                    "DD_APM_TRACING_ENABLED": "false",
-                    "_DD_IAST_PROPAGATION_ENABLED": "false",
-                },
-            },
-        ),
-        (
-            gunicorn_django_server,
-            {
-                "workers": "1",
-                "use_threads": True,
-                "use_gevent": True,
-                "env": {
-                    "DD_APM_TRACING_ENABLED": "false",
-                },
-            },
+            {"workers": "3", "use_threads": True, "use_gevent": True},
         ),
         (
             gunicorn_django_server,
@@ -210,7 +169,24 @@ def test_iast_untrusted_serialization_yaml(server, iast_test_token):
                 "env": {"_DD_IAST_PROPAGATION_ENABLED": "false"},
             },
         ),
-        (django_server, {"env": {"DD_APM_TRACING_ENABLED": "false"}}),
+        (
+            gunicorn_django_server,
+            {"workers": "1", "use_threads": True, "use_gevent": True},
+        ),
+        (
+            # As config3, but with APM tracing off, which is what the whole file used to ask for
+            # through the (ignored) env key. Mirrors the flask test's apm_tracing_enabled
+            # parametrization.
+            gunicorn_django_server,
+            {
+                "workers": "1",
+                "use_threads": True,
+                "use_gevent": True,
+                "apm_tracing_enabled": "false",
+                "env": {"_DD_IAST_PROPAGATION_ENABLED": "false"},
+            },
+        ),
+        (django_server, {}),
     ),
 )
 def test_iast_vulnerable_request_downstream_django(server, config, iast_test_token):
@@ -220,15 +196,9 @@ def test_iast_vulnerable_request_downstream_django(server, config, iast_test_tok
     vulnerability and then calls a downstream endpoint to echo headers. Asserts that headers are
     properly propagated and that an IAST WEAK_HASH vulnerability is reported.
     """
-    env = {
-        "DD_APM_TRACING_ENABLED": "false",
-        "DD_TRACE_URLLIB3_ENABLED": "true",
-    }
-    # Merge base env with parametrized env overrides
-    cfg_env = dict(config.get("env", {}))
-    cfg_env.update(env)
+    # Base env, overridden by the parametrized config.
     config = dict(config)
-    config["env"] = cfg_env
+    config["env"] = {"DD_TRACE_URLLIB3_ENABLED": "true", **config.get("env", {})}
     with server(use_ddtrace_cmd=True, iast_enabled="true", token=iast_test_token, port=8050, **config) as context:
         _, django_client, pid = context
 


### PR DESCRIPTION
APPSEC-69718

## Description

**Diagnostic, not a confirmed fix.** The root cause of the flakiness is not established — this bounds the endpoint that times out and adds the logs needed to attribute the next failure.

The `/shutdown` endpoints flush traces from inside a request, but nothing bounded how long that takes, and `appsec_utils` gives up on the response after 10s. `tests/appsec/app.py` used `timeout=10` — the caller's entire budget.

- Cap the shutdown and run it off the gevent hub, so the endpoint returns whether or not the flush finishes.
- Make django `config5` distinct from `config3`: it omitted `DD_APM_TRACING_ENABLED`, which the base env then supplied, so the two parametrizations were byte-identical (5 distinct configs, not 6).

## Logs added

A late `/shutdown` response had three possible causes and the output could not tell them apart:

| Signal | Answers |
|---|---|
| endpoint logs its own elapsed time | was the shutdown slow? |
| watchdog greenlet logs event-loop stalls | was the worker frozen? |
| `appsec_utils` logs how long the client waited | did the time go outside the server? |

Verified locally: the watchdog reports `event loop stalled for 1.966s` for a real 2s block and is silent otherwise.

## Flaky test

`tests.appsec.integrations.django_tests.test_iast_django_testagent.py::test_iast_vulnerable_request_downstream_django`

| attempt_to_fix_id | fingerprint_fqn | parametrization |
|---|---|---|
| U55XLN | 50244629d266fe01 | config5, py3.13 |
| 4FSP2S | 510713355a313fd0 | config5, py3.14 |
| D07T24 | 8ac683d25efa1f5d | config5, py3.11 |
| KUBWIR | 137269568180c6f2 | config3, py3.10 |
| WQNXQ5 | c79c73db4fa90628 | config3, py3.14 |

Kept so attempt-to-fix retries run these repeatedly — with the new logs, the pathology may be captured on this PR's own CI.

## Notes

Test-only; no product change. An earlier revision fixed gevent hub starvation in `PeriodicThread.join` (verified 1 greenlet tick → 825) but it regressed system tests and did not reduce the client-observed latency, so it was dropped for a separate PR.

Not verified locally: the django test itself — the testagent is unreachable in my environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)