### PR TITLE
fix(internal): shared mutable default arguments and type identity comparisons

### DIFF
--- a/ddtrace/internal/README.md
+++ b/ddtrace/internal/README.md
@@ -137,7 +137,7 @@ The two operations are deliberately separate because a product may need its
 callback to be active (e.g. for periodic housekeeping) without yet requesting
 configuration from the agent, or vice-versa.
 
-#### `register_callback(product, callback, capabilities=[])`
+#### `register_callback(product, callback, capabilities=())`
 
 Installs a callback for a product.  The callback will receive all payloads
 dispatched by the RC subscriber, as well as periodic calls.  If this is the

--- a/ddtrace/internal/encoding.py
+++ b/ddtrace/internal/encoding.py
@@ -70,7 +70,7 @@ class _EncoderBase(object):
         # int. let's special case that here, because it's sure to happen in
         # customer code.
         err = d.get("error")
-        if err and type(err) == bool:
+        if err and type(err) is bool:
             d["error"] = 1
 
         if span.start_ns:

--- a/ddtrace/internal/gitmetadata.py
+++ b/ddtrace/internal/gitmetadata.py
@@ -57,7 +57,7 @@ def _get_tags_from_env() -> tuple[str, str, str]:
     if not commit_sha:
         commit_sha = tags.get(COMMIT_SHA, "")
     filtered_git_url = _filter_sensitive_info(repository_url)
-    if type(filtered_git_url) != str:
+    if type(filtered_git_url) is not str:
         return "", commit_sha, main_package
     return filtered_git_url, commit_sha, main_package
 
@@ -83,7 +83,7 @@ def _get_tags_from_package(main_package: str) -> tuple[str, str]:
             repository_url, commit_sha = source_code_link.split("#")
             commit_sha = commit_sha.split("&")[0]
             filtered_git_url = _filter_sensitive_info(repository_url)
-            if type(filtered_git_url) != str:
+            if type(filtered_git_url) is not str:
                 return "", commit_sha
             return filtered_git_url, commit_sha
         return "", ""

--- a/ddtrace/internal/remoteconfig/worker.py
+++ b/ddtrace/internal/remoteconfig/worker.py
@@ -208,7 +208,7 @@ class RemoteConfigPoller(periodic.PeriodicService):
         self,
         product: "RemoteConfigProduct",
         callback: RCCallback,
-        capabilities: "Iterable[RemoteConfigCapabilities]" = [],
+        capabilities: "Iterable[RemoteConfigCapabilities]" = (),
     ) -> None:
         """Register a product callback for remote configuration updates.
 


### PR DESCRIPTION
## Summary

Small correctness fixes in `ddtrace/internal/` (ruff B006/E721), no behavior change:

1. **`remoteconfig/worker.py`** — `register_callback(..., capabilities=[])` → `= ()`: the annotation is `Iterable`, so an immutable empty tuple satisfies it with zero call-site changes and removes the shared-mutable-default hazard. The RemoteConfigPoller API guide in `ddtrace/internal/README.md` is updated to match (per review feedback).
2. **`gitmetadata.py`** — two `type(x) != str` → `is not str` (identity is the intended semantics for type objects).
3. **`encoding.py`** — `type(err) == bool` → `is bool` (same intent, E721-clean; deliberately not `isinstance` to preserve the exact-type check that excludes int).

Rebased onto current `main`; an earlier `http.py` headers-default fix in this PR was dropped as obsolete — upstream's refactor already uses `headers=None`.

## Checklist notes
Lint-only/internal hygiene — no user-facing behavior change, so presumably `no-changelog`; happy to add a release note if maintainers prefer. `python -m py_compile` and `ruff check --select B006,E721` pass on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)