### PR TITLE
fix(llmobs): honor Feature Flags configuration source for prompts

### DIFF
--- a/ddtrace/internal/openfeature/_source_selection.py
+++ b/ddtrace/internal/openfeature/_source_selection.py
@@ -15,54 +15,14 @@ from typing import Optional
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.openfeature._agentless import build_agentless_endpoint
 from ddtrace.internal.openfeature._agentless_source import AgentlessConfigurationSource
-from ddtrace.internal.settings._core import ValueSource
+from ddtrace.internal.settings.openfeature import AGENTLESS
+from ddtrace.internal.settings.openfeature import DISABLED as DISABLED
+from ddtrace.internal.settings.openfeature import REMOTE_CONFIG as REMOTE_CONFIG
 from ddtrace.internal.settings.openfeature import OpenFeatureConfig
+from ddtrace.internal.settings.openfeature import resolve_configuration_source as resolve_configuration_source
 
 
 log = get_logger(__name__)
-
-AGENTLESS = "agentless"
-REMOTE_CONFIG = "remote_config"
-DISABLED = "disabled"
-
-_SOURCE_ENV = "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE"
-_LEGACY_ENV = "DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED"
-
-
-def _provided(ffe_config: OpenFeatureConfig, env_name: str) -> bool:
-    """True when the value came from an external source rather than the default."""
-    return ffe_config.value_source(env_name) != ValueSource.DEFAULT
-
-
-def resolve_configuration_source(ffe_config: OpenFeatureConfig) -> str:
-    """Resolve the active source: ``agentless``, ``remote_config`` or ``disabled``.
-
-    Precedence (mirrors dd-trace-js):
-
-    1. Stable kill switch off -> disabled.
-    2. Explicit source -> use it; an unsupported/reserved value (e.g. ``offline``)
-       fails closed to disabled without contacting any source.
-    3. Source absent -> grandfather on the legacy experimental flag: explicitly
-       true -> remote_config, explicitly false -> disabled.
-    4. Otherwise the default -> agentless.
-    """
-    if not ffe_config.feature_flags_enabled:
-        return DISABLED
-
-    source = ffe_config.configuration_source or ""
-    if _provided(ffe_config, _SOURCE_ENV) and source:
-        if source == AGENTLESS:
-            return AGENTLESS
-        if source == REMOTE_CONFIG:
-            return REMOTE_CONFIG
-        log.warning("Unsupported Feature Flagging configuration source %r; provider disabled", source)
-        return DISABLED
-
-    # Source absent (unset or blank): preserve legacy Remote Config grandfathering.
-    if _provided(ffe_config, _LEGACY_ENV):
-        return REMOTE_CONFIG if ffe_config.experimental_flagging_provider_enabled else DISABLED
-
-    return AGENTLESS
 
 
 def create_agentless_source(

--- a/ddtrace/internal/settings/openfeature.py
+++ b/ddtrace/internal/settings/openfeature.py
@@ -7,9 +7,17 @@ from typing import Optional
 
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings._core import DDConfig
+from ddtrace.internal.settings._core import ValueSource
 
 
 log = get_logger(__name__)
+
+AGENTLESS = "agentless"
+REMOTE_CONFIG = "remote_config"
+DISABLED = "disabled"
+
+_CONFIGURATION_SOURCE_ENV = "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE"
+_LEGACY_PROVIDER_ENABLED_ENV = "DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED"
 
 
 # AIDEV-NOTE: numeric settings here parse leniently on purpose. This class is instantiated at
@@ -47,7 +55,7 @@ class OpenFeatureConfig(DDConfig):
     # Experimental flagging provider
     experimental_flagging_provider_enabled = DDConfig.var(
         bool,
-        "DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED",
+        _LEGACY_PROVIDER_ENABLED_ENV,
         default=False,
     )
 
@@ -111,7 +119,7 @@ class OpenFeatureConfig(DDConfig):
     # grandfathering are resolved by the source-selection layer.
     configuration_source = DDConfig.var(
         str,
-        "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE",
+        _CONFIGURATION_SOURCE_ENV,
         default="agentless",
         parser=lambda v: v.strip().lower(),
     )
@@ -154,6 +162,42 @@ class OpenFeatureConfig(DDConfig):
         "configuration_source_agentless_poll_interval_seconds",
         "configuration_source_agentless_request_timeout_seconds",
     ]
+
+
+def _provided(ffe_config: OpenFeatureConfig, env_name: str) -> bool:
+    """True when the value came from an external source rather than the default."""
+    return ffe_config.value_source(env_name) != ValueSource.DEFAULT
+
+
+def resolve_configuration_source(ffe_config: OpenFeatureConfig) -> str:
+    """Resolve the active source: ``agentless``, ``remote_config`` or ``disabled``.
+
+    Precedence (mirrors dd-trace-js):
+
+    1. Stable kill switch off -> disabled.
+    2. Explicit source -> use it; an unsupported/reserved value (e.g. ``offline``)
+       fails closed to disabled without contacting any source.
+    3. Source absent -> grandfather on the legacy experimental flag: explicitly
+       true -> remote_config, explicitly false -> disabled.
+    4. Otherwise the default -> agentless.
+    """
+    if not ffe_config.feature_flags_enabled:
+        return DISABLED
+
+    source = ffe_config.configuration_source or ""
+    if _provided(ffe_config, _CONFIGURATION_SOURCE_ENV) and source:
+        if source == AGENTLESS:
+            return AGENTLESS
+        if source == REMOTE_CONFIG:
+            return REMOTE_CONFIG
+        log.warning("Unsupported Feature Flagging configuration source %r; provider disabled", source)
+        return DISABLED
+
+    # Source absent (unset or blank): preserve legacy Remote Config grandfathering.
+    if _provided(ffe_config, _LEGACY_PROVIDER_ENABLED_ENV):
+        return REMOTE_CONFIG if ffe_config.experimental_flagging_provider_enabled else DISABLED
+
+    return AGENTLESS
 
 
 # Global config instance

--- a/ddtrace/internal/settings/openfeature.py
+++ b/ddtrace/internal/settings/openfeature.py
@@ -16,8 +16,8 @@ AGENTLESS = "agentless"
 REMOTE_CONFIG = "remote_config"
 DISABLED = "disabled"
 
-_CONFIGURATION_SOURCE_ENV = "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE"
-_LEGACY_PROVIDER_ENABLED_ENV = "DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED"
+_SOURCE_ENV = "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE"
+_LEGACY_ENV = "DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED"
 
 
 # AIDEV-NOTE: numeric settings here parse leniently on purpose. This class is instantiated at
@@ -55,7 +55,7 @@ class OpenFeatureConfig(DDConfig):
     # Experimental flagging provider
     experimental_flagging_provider_enabled = DDConfig.var(
         bool,
-        _LEGACY_PROVIDER_ENABLED_ENV,
+        _LEGACY_ENV,
         default=False,
     )
 
@@ -119,7 +119,7 @@ class OpenFeatureConfig(DDConfig):
     # grandfathering are resolved by the source-selection layer.
     configuration_source = DDConfig.var(
         str,
-        _CONFIGURATION_SOURCE_ENV,
+        _SOURCE_ENV,
         default="agentless",
         parser=lambda v: v.strip().lower(),
     )
@@ -185,7 +185,7 @@ def resolve_configuration_source(ffe_config: OpenFeatureConfig) -> str:
         return DISABLED
 
     source = ffe_config.configuration_source or ""
-    if _provided(ffe_config, _CONFIGURATION_SOURCE_ENV) and source:
+    if _provided(ffe_config, _SOURCE_ENV) and source:
         if source == AGENTLESS:
             return AGENTLESS
         if source == REMOTE_CONFIG:
@@ -194,7 +194,7 @@ def resolve_configuration_source(ffe_config: OpenFeatureConfig) -> str:
         return DISABLED
 
     # Source absent (unset or blank): preserve legacy Remote Config grandfathering.
-    if _provided(ffe_config, _LEGACY_PROVIDER_ENABLED_ENV):
+    if _provided(ffe_config, _LEGACY_ENV):
         return REMOTE_CONFIG if ffe_config.experimental_flagging_provider_enabled else DISABLED
 
     return AGENTLESS

--- a/ddtrace/llmobs/_prompts/manager.py
+++ b/ddtrace/llmobs/_prompts/manager.py
@@ -391,9 +391,13 @@ class PromptManager:
         Returns a prompt only on a positive FF hit. All other outcomes (not ready, disabled,
         no flag, error) return None and fall through to the HTTP floor.
         """
+        from ddtrace.internal.openfeature._source_selection import DISABLED
+        from ddtrace.internal.openfeature._source_selection import REMOTE_CONFIG
+        from ddtrace.internal.openfeature._source_selection import resolve_configuration_source
         from ddtrace.internal.settings.openfeature import config as ffe_config
 
-        if not ffe_config.experimental_flagging_provider_enabled:
+        source = resolve_configuration_source(ffe_config)
+        if source == DISABLED:
             return None
 
         try:
@@ -404,7 +408,8 @@ class PromptManager:
             log.debug("OpenFeature SDK unavailable for FF prompt evaluation")
             return None
 
-        self._ensure_ffe_rc()
+        if source == REMOTE_CONFIG:
+            self._ensure_ffe_rc()
         self._ensure_ffe_provider()
 
         try:

--- a/ddtrace/llmobs/_prompts/manager.py
+++ b/ddtrace/llmobs/_prompts/manager.py
@@ -391,13 +391,10 @@ class PromptManager:
         Returns a prompt only on a positive FF hit. All other outcomes (not ready, disabled,
         no flag, error) return None and fall through to the HTTP floor.
         """
-        from ddtrace.internal.openfeature._source_selection import DISABLED
-        from ddtrace.internal.openfeature._source_selection import REMOTE_CONFIG
-        from ddtrace.internal.openfeature._source_selection import resolve_configuration_source
-        from ddtrace.internal.settings.openfeature import config as ffe_config
+        from ddtrace.internal.settings import openfeature as ffe_settings
 
-        source = resolve_configuration_source(ffe_config)
-        if source == DISABLED:
+        source = ffe_settings.resolve_configuration_source(ffe_settings.config)
+        if source == ffe_settings.DISABLED:
             return None
 
         try:
@@ -408,7 +405,7 @@ class PromptManager:
             log.debug("OpenFeature SDK unavailable for FF prompt evaluation")
             return None
 
-        if source == REMOTE_CONFIG:
+        if source == ffe_settings.REMOTE_CONFIG:
             self._ensure_ffe_rc()
         self._ensure_ffe_provider()
 

--- a/releasenotes/notes/fix-prompt-configuration-source-dad0f34c1e181c43.yaml
+++ b/releasenotes/notes/fix-prompt-configuration-source-dad0f34c1e181c43.yaml
@@ -1,6 +1,4 @@
 fixes:
   - |
-    LLM Observability: Fixes an issue where environment-scoped managed prompts do not produce
-    Prompt Experimentation exposures when Feature Flagging is enabled with
-    ``DD_FEATURE_FLAGS_CONFIGURATION_SOURCE=agentless`` or
-    ``DD_FEATURE_FLAGS_CONFIGURATION_SOURCE=remote_config``.
+    LLM Observability: Fixes missing Prompt Experimentation exposures when
+    ``DD_FEATURE_FLAGS_CONFIGURATION_SOURCE`` is set to ``agentless`` or ``remote_config``.

--- a/releasenotes/notes/fix-prompt-configuration-source-dad0f34c1e181c43.yaml
+++ b/releasenotes/notes/fix-prompt-configuration-source-dad0f34c1e181c43.yaml
@@ -1,0 +1,6 @@
+fixes:
+  - |
+    LLM Observability: Fixes an issue where environment-scoped managed prompts do not produce
+    Prompt Experimentation exposures when Feature Flagging is enabled with
+    ``DD_FEATURE_FLAGS_CONFIGURATION_SOURCE=agentless`` or
+    ``DD_FEATURE_FLAGS_CONFIGURATION_SOURCE=remote_config``.

--- a/tests/llmobs/test_prompts.py
+++ b/tests/llmobs/test_prompts.py
@@ -3,12 +3,16 @@ import json
 import os
 from typing import Optional
 from typing import Union
+from unittest.mock import Mock
 from unittest.mock import patch
 import warnings
 
 import pytest
 
 from ddtrace import config
+from ddtrace.internal.openfeature._source_selection import AGENTLESS
+from ddtrace.internal.openfeature._source_selection import DISABLED
+from ddtrace.internal.openfeature._source_selection import REMOTE_CONFIG
 from ddtrace.internal.settings.integration import IntegrationConfig
 from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.llmobs import LLMObs
@@ -521,6 +525,44 @@ class TestPrompts:
         assert prompt.source == "ff"
         assert prompt.version == "ff-v1"
         assert prompt.template == "FF Hello!"
+
+    @pytest.mark.parametrize(
+        "source,expected_source,provider_calls,rc_calls",
+        [
+            (AGENTLESS, "ff", 1, 0),
+            (REMOTE_CONFIG, "ff", 1, 1),
+            (DISABLED, "resolve", 0, 0),
+        ],
+    )
+    def test_route_env_honors_ffe_configuration_source(self, source, expected_source, provider_calls, rc_calls):
+        manager = _make_manager()
+        client = Mock()
+        client.get_object_details.return_value = Mock(
+            error_code=None,
+            value={"prompt_id": "greeting", "version": "ff-v1", "template": "FF Hello!"},
+        )
+        resolved_prompt = ManagedPrompt(
+            id="greeting", version="v1", label=None, source="resolve", template="HTTP Hello!"
+        )
+
+        with patch("ddtrace.internal.openfeature._source_selection.resolve_configuration_source", return_value=source):
+            with patch("ddtrace.internal.openfeature._remoteconfiguration.enable_featureflags_rc") as enable_rc:
+                with patch("openfeature.api.set_provider") as set_provider:
+                    with patch("openfeature.api.get_client", return_value=client):
+                        with patch.object(manager, "_get_prompt_http", return_value=resolved_prompt) as fetch_http:
+                            with patch("ddtrace.llmobs._prompts.manager.config") as cfg:
+                                cfg.env = "staging"
+                                prompts = [manager.get_prompt("greeting") for _ in range(2)]
+
+        assert [prompt.source for prompt in prompts] == [expected_source, expected_source]
+        assert set_provider.call_count == provider_calls
+        assert client.get_object_details.call_count == provider_calls * 2
+        assert enable_rc.call_count == rc_calls
+        assert fetch_http.call_count == (0 if provider_calls else 2)
+        if provider_calls:
+            from ddtrace.internal.openfeature._provider import DataDogProvider
+
+            assert isinstance(set_provider.call_args.args[0], DataDogProvider)
 
     def test_route_env_agentless_to_http_resolve(self):
         manager = _make_manager(agentless=True)

--- a/tests/llmobs/test_prompts.py
+++ b/tests/llmobs/test_prompts.py
@@ -545,7 +545,7 @@ class TestPrompts:
             id="greeting", version="v1", label=None, source="resolve", template="HTTP Hello!"
         )
 
-        with patch("ddtrace.internal.openfeature._source_selection.resolve_configuration_source", return_value=source):
+        with patch("ddtrace.internal.settings.openfeature.resolve_configuration_source", return_value=source):
             with patch("ddtrace.internal.openfeature._remoteconfiguration.enable_featureflags_rc") as enable_rc:
                 with patch("openfeature.api.set_provider") as set_provider:
                     with patch("openfeature.api.get_client", return_value=client):


### PR DESCRIPTION
## Description

### Problem

`PromptManager._fetch_from_ff()` uses the now-deprecated `DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED` value as a separate activation gate and then enables Remote Configuration unconditionally.

That became incorrect when https://github.com/DataDog/dd-trace-py/pull/19331 introduced `agentless`, `remote_config`, and `disabled` as the authoritative resolved sources, defaulting to `agentless`. `PromptManager` was never updated to follow that resolved decision. Consequently, stable `agentless` and `remote_config` configurations can silently use `/resolve`. Prompt retrieval still works, but **the local Feature Flag exposure needed for experiment attribution is lost**.

The required lifecycle is:
Resolved source | Required action
-- | --
`disabled` | Neither helper; fall back to /resolve
`agentless` | `_ensure_ffe_provider()` only
`remote_config` | `_ensure_ffe_rc()` and `_ensure_ffe_provider()`


Just as a quick reminder:
* `_ensure_ffe_provider()` is essential as `PromptManager` evaluates against the private `datadog-llmobs-prompts` OpenFeature domain; Without it, the SDK uses its no-op provider or potentially an unrelated application provider.
* `_ensure_ffe_rc()` is necessary only for `remote_config`, as removing would effectively make local RC prompt evaluation supported only under `ddtrace-run`, an unintended compatibility break.

### What changes

Prompt-backed Feature Flags now honor the existing resolved Feature Flagging configuration source.

- `disabled` retains the existing HTTP `/resolve` fallback.
- `remote_config` lazily enables the existing Remote Configuration path.
- `agentless` and `remote_config` register and use the existing `DataDogProvider` for local evaluation.

## Testing

Added a regression test

## Risks

Low. The change only replaces the obsolete Prompt Manager activation gate with the already-resolved Feature Flagging source and preserves the HTTP fallback.

## Additional Notes

I also had to add move resolver/constants to `openfeature.py` since the [detect_layering_violation](https://mosaic.us1.ddbuild.io/change-request/3539408316382087817?owner=datadog&repository=dd-trace-py&taskId=gitlab&taskExecutionId=1972050526) would otherwise fail as I'm using them in LLMObs's code and i couldn't find a way to elegantly work around that without adding code there. It's simply moving code around. 
