### PR TITLE
fix(tracing): widen Span.set_tag value annotation to match implementation

### DIFF
--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -240,13 +240,17 @@ class Span(SpanData):
         self.context._meta[SAMPLING_DECISION_TRACE_TAG_KEY] = value
         return value
 
-    def set_tag(self, key: str, value: Optional[str] = None) -> None:
-        """Set a tag key/value pair on the span."""
+    def set_tag(self, key: str, value: Any = None) -> None:
+        """Set a tag key/value pair on the span.
+
+        Boolean and bytes values are stored as their string representation.
+        ``int`` and ``float`` values are stored as metrics (see ``set_metric``).
+        """
         # Explicitly try to convert expected integers to `int`
         # DEV: Some integrations parse these values from strings, but don't call `int(value)` themselves
         if key == net.TARGET_PORT:
             try:
-                value = int(value)  # type: ignore
+                value = int(value)
             except (ValueError, TypeError):
                 pass
 
@@ -261,14 +265,14 @@ class Span(SpanData):
         elif key == SERVICE_VERSION_KEY:
             # Also set the `version` tag to the same value
             # DEV: Note that we do no return, we want to set both
-            self._set_attribute(VERSION_KEY, value)  # type: ignore[arg-type]
+            self._set_attribute(VERSION_KEY, value)
         elif key == _SPAN_MEASURED_KEY:
             # Set `_dd.measured` tag as a metric
             # DEV: `set_metric` will ensure it is an integer 0 or 1
             if value is None:
-                value = 1  # type: ignore
+                value = 1
 
-            self.set_metric(key, value)  # type: ignore[arg-type]  # ast-grep-ignore: span-set-metric
+            self.set_metric(key, value)  # ast-grep-ignore: span-set-metric
             return
 
         if isinstance(key, bytes):
@@ -278,7 +282,7 @@ class Span(SpanData):
             value = str(value)
 
         try:
-            self._set_attribute(key, value)  # type: ignore[arg-type]
+            self._set_attribute(key, value)
         except Exception:
             log.warning("error setting tag %s, ignoring it", key, exc_info=True)
 

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -243,8 +243,11 @@ class Span(SpanData):
     def set_tag(self, key: str, value: Any = None) -> None:
         """Set a tag key/value pair on the span.
 
-        Boolean and bytes values are stored as their string representation.
-        ``int`` and ``float`` values are stored as metrics (see ``set_metric``).
+        Boolean and bytes values are stored as their string representation. Finite floats
+        and integers within the signed 64-bit range are stored as metrics (see
+        ``set_metric``); integers outside that range fall back to their string
+        representation, and NaN or infinite floats are discarded. ``http.status_code`` is
+        always stored as a string.
         """
         # Explicitly try to convert expected integers to `int`
         # DEV: Some integrations parse these values from strings, but don't call `int(value)` themselves

--- a/releasenotes/notes/widen-set-tag-value-typing-40a41e0a8804ec18.yaml
+++ b/releasenotes/notes/widen-set-tag-value-typing-40a41e0a8804ec18.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    tracing: This fix resolves an issue where type checkers rejected valid application code passing
+    non-string values to ``Span.set_tag`` (for example ``span.set_tag("custom.tag", True)``). The
+    ``value`` parameter was annotated as ``Optional[str]``, but the implementation accepts the
+    historic domain: booleans and bytes are stringified into tags, and numeric values are stored
+    as metrics.


### PR DESCRIPTION
Fixes #19815

## Description

`Span.set_tag` is annotated as accepting `value: Optional[str]`, but the implementation accepts and
handles the historic domain — booleans and bytes are stringified into tags, and in-range `int` /
finite `float` values are stored as metrics. This PR widens the annotation back to `value: Any = None` (the annotation it
had before v4.0), documents the value handling in the docstring, and deletes the five internal
`# type: ignore` comments that existed only to silence the consequences of the too-narrow parameter.

No runtime behaviour changes — the diff touches only the annotation, the docstring, comments, and a
release note.

### Motivation

The `Optional[str]` annotation makes type checkers reject valid application code:

```python
span.set_tag("custom.handled_exception", True)
```

is correct at runtime — the body stringifies bools itself (the `isinstance(value, (bool, bytes))`
branch), and the emitted tag is byte-identical to passing `"True"` — yet mypy reports:

```
error: Argument 2 to "set_tag" of "Span" has incompatible type "bool"; expected "str | None"  [arg-type]
```

The implementation is the evidence that the annotation is too narrow. Five of its own
`# type: ignore` comments exist purely because the parameter type doesn't cover what the body does
with it: `int(value)` for `net.TARGET_PORT`, `value = 1` / `set_metric(key, value)` for
`_SPAN_MEASURED_KEY`, and the two `_set_attribute` calls. All five become dead with the widened
annotation and are removed here (the repository's `warn_unused_ignores = true` enforces their
removal).

The library's own test suite also pins the wider runtime contract:

- `tests/tracer/test_span_tags.py::test_tags` and `::test_numeric_tags` — ints and floats passed to
  `set_tag` are stored as metrics, across the ranges those tests cover.
- `tests/tracer/test_span_tags.py::test_set_tag_bool` — `set_tag("true", True)` produces the tag
  `"True"`.

### Relationship to the v4.0 typing change

I'm aware the narrowing was not accidental: it shipped in the v4.0 major-version PR (#14938,
commit `89d69bdfe`) together with an explicit upgrade release note
(`releasenotes/notes/explicit-span-tag-typing-99abb4d3ec065a55.yaml`):

> tracing: ``Span.set_tag`` typing is now ``set_tag(key: str, value: Optional[str] = None) -> None``

This PR argues that annotation and implementation should agree: v4.0 narrowed the signature but
deliberately kept the lenient runtime handling (and the tests above that pin it), so the annotation
now rejects code the library explicitly supports. There is also direct precedent for resolving this
in favour of the implementation: #7182 (fixing #7175) made the same correction for `Span.set_tags`
in 2023 — "type-checking would fail on valid application code due to a type hint … that was too
restrictive" — and chose `Any`. If the v4.0 intent is instead that non-string values become
unsupported, the five ignores and the bool/bytes/int handling would be the code to remove — a
behavioural break this PR deliberately does not make.

### Considered alternative: a precise union

`Optional[Union[str, bool, bytes, int, float]]` was tried first, under the repository's own
toolchain (the pinned mypy 1.15.0 with `mypy.ini`, which sets `warn_unused_ignores = true`). It is
strictly worse than `Any`:

- it makes only one of the five ignores removable (`value = 1`), and
- it introduces a new `[assignment]` error at `self.service = value` — `service` is
  `Optional[str]` in `ddtrace/internal/native/_native.pyi` — which would require a *new*
  suppression.

`value: Any` matches the pre-4.0 annotation and the #7182 precedent, removes all five suppressions,
and adds none.

## Testing

- Runtime behaviour is unchanged and already covered by the existing tests listed above
  (`tests/tracer/test_span_tags.py`).
- `mypy --config-file mypy.ini` (mypy 1.15.0, the pinned lint version): the reported error set is
  identical before and after the change, and `ddtrace/_trace/span.py` reports zero diagnostics —
  including zero `unused-ignore` warnings after deleting the five comments.
- `ruff check` / `ruff format --check` (ruff 0.14.10, the pinned version) pass on the touched file.

## Risks

None at runtime — no executable code changes. The typing change is a widening, so no currently
type-checking caller breaks; code that was previously (incorrectly) rejected now checks.

## Additional Notes

A release note is included
(`releasenotes/notes/widen-set-tag-value-typing-40a41e0a8804ec18.yaml`) since this changes the
public API's typing surface. `Span.set_tags` remains `dict[str, str]`; widening it to match (as
#7182 once did) would be a natural follow-up if this direction is accepted, but is deliberately out
of scope here.

