### PR TITLE
chore(appsec): tag spans with refreshed rc client id

### DIFF
--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -400,8 +400,15 @@ def finalize_asm_env(env: ASM_Environment) -> None:
                 entry_span._set_attribute(APPSEC.EVENT_RULE_ERROR_COUNT, info.failed)
             except Exception:
                 logger.debug("asm_context::finalize_asm_env::exception", extra=log_extra, exc_info=True)
-        if asm_config._rc_client_id is not None:
-            entry_span.set_tag(APPSEC.RC_CLIENT_ID, asm_config._rc_client_id)
+        if asm_config._rc_client_id_enabled:
+            from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
+
+            # Fetch the current id from the RC client at span finalization. asm_config only
+            # tracks whether AppSec RC enabled tagging; mirroring the id there would go stale
+            # when runtime identity refresh rebuilds the RC client.
+            rc_client_id = remoteconfig_poller._client.id
+            if rc_client_id is not None:
+                entry_span.set_tag(APPSEC.RC_CLIENT_ID, rc_client_id)
         waf_adresses = env.waf_addresses
         req_headers = waf_adresses.get(SPAN_DATA_NAMES.REQUEST_HEADERS_NO_COOKIES, {})
         if req_headers:

--- a/ddtrace/appsec/_remoteconfiguration.py
+++ b/ddtrace/appsec/_remoteconfiguration.py
@@ -80,10 +80,13 @@ def enable_appsec_rc(callback: "AppSecCallback") -> None:
 
     if asm_config._asm_enabled:
         telemetry_writer.product_activated(TELEMETRY_APM_PRODUCT.APPSEC, True)
-    asm_config._rc_client_id = remoteconfig_poller._client.id
+
+    asm_config._rc_client_id_enabled = True
 
 
 def disable_appsec_rc() -> None:
+    asm_config._rc_client_id_enabled = False
+
     for product_name in APPSEC_PRODUCTS:
         remoteconfig_poller.unregister_callback(product_name)
         remoteconfig_poller.disable_product(product_name)

--- a/ddtrace/internal/settings/asm.py
+++ b/ddtrace/internal/settings/asm.py
@@ -268,7 +268,9 @@ class ASMConfig(DDConfig):
         sys.platform.startswith("win") or sys.platform.startswith("cygwin")
     )
 
-    _rc_client_id: Optional[str] = None
+    # Set by enable_appsec_rc()/disable_appsec_rc(); gates _dd.rc.client_id span tagging so it's
+    # only emitted while AppSec RC is actually enabled, not just whenever a live RC client exists.
+    _rc_client_id_enabled: bool = False
 
     def __init__(self):
         super().__init__()

--- a/tests/appsec/appsec/test_asm_request_context.py
+++ b/tests/appsec/appsec/test_asm_request_context.py
@@ -14,6 +14,20 @@ _TEST_HEADERS = {"foo": "bar"}
 config_asm = {"_asm_enabled": True}
 
 
+@pytest.mark.parametrize("auto_enable_crashtracking", [False])
+def test_import_does_not_load_remoteconfig_worker(run_python_code_in_subprocess, auto_enable_crashtracking):
+    code = """
+import sys
+
+import ddtrace.appsec._asm_request_context  # noqa: F401
+
+assert "ddtrace.internal.remoteconfig.worker" not in sys.modules
+"""
+
+    _, stderr, status, _ = run_python_code_in_subprocess(code)
+    assert status == 0, stderr
+
+
 def test_context_set_and_reset():
     with asm_context(
         ip_addr=_TEST_IP,

--- a/tests/appsec/appsec/test_remoteconfiguration.py
+++ b/tests/appsec/appsec/test_remoteconfiguration.py
@@ -270,6 +270,46 @@ def test_rc_activation_validate_client_id(tracer, rc_poller, appsec_callback):
     disable_appsec_rc()
 
 
+def test_rc_client_id_tag_reflects_live_value_not_a_stale_cache(tracer, rc_poller, appsec_callback):
+    """_dd.rc.client_id must be read live at span-tagging time, not cached once at RC enable time.
+
+    Otherwise the tag would go stale after e.g. an AWS Lambda MicroVM identity refresh
+    regenerates the real client id.
+    """
+    from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
+
+    with override_global_config(dict(_asm_enabled=True, _remote_config_enabled=True, api_version="v0.4")):
+        tracer.configure(appsec_enabled=True)
+        enable_appsec_rc(appsec_callback)
+
+        with mock.patch.object(remoteconfig_poller._client, "id", "client-id-one"):
+            with asm_context(tracer) as span:
+                set_http_meta(span, {}, raw_uri="http://example.com/", status_code="200")
+            assert span._local_root._get_str_attribute(APPSEC.RC_CLIENT_ID) == "client-id-one"
+
+        with mock.patch.object(remoteconfig_poller._client, "id", "client-id-two"):
+            with asm_context(tracer) as span:
+                set_http_meta(span, {}, raw_uri="http://example.com/", status_code="200")
+            assert span._local_root._get_str_attribute(APPSEC.RC_CLIENT_ID) == "client-id-two"
+    disable_appsec_rc()
+
+
+def test_rc_client_id_tag_not_set_when_rc_disabled(tracer):
+    """_dd.rc.client_id must not be tagged when AppSec RC was never enabled, even though a live
+    RC client (and id) exists process-wide -- otherwise every ASM-tracked span would get tagged
+    with an id from a Remote Config subscription AppSec never activated.
+    """
+    from ddtrace.internal.remoteconfig.worker import remoteconfig_poller
+
+    with override_global_config(dict(_asm_enabled=True, api_version="v0.4")):
+        tracer.configure(appsec_enabled=True)
+
+        with mock.patch.object(remoteconfig_poller._client, "id", "client-id-one"):
+            with asm_context(tracer) as span:
+                set_http_meta(span, {}, raw_uri="http://example.com/", status_code="200")
+            assert span._local_root._get_str_attribute(APPSEC.RC_CLIENT_ID) is None
+
+
 @pytest.mark.parametrize(
     "env_rules, expected",
     [


### PR DESCRIPTION
Stacked PRs:
- #19778
  - #19816
    - #19817
    - #19825
    - #19818
      - 👉🏽 This PR #19819
    - #19820
    - #19821
    - #19822
    - #19823
    - #19824

## Description

Split from #19780.

AppSec reports the Remote Config client id on spans. This PR changes span tagging to read the live Remote Config client id at span finalization instead of copying the id into `asm_config` when AppSec RC is enabled.

This is necessary because MicroVM runtime identity refresh rebuilds the Remote Config client with a fresh client id. A cached `asm_config._rc_client_id` would keep tagging spans with the old id after refresh. `asm_config` now only tracks whether AppSec RC client-id tagging is enabled; the id itself comes from the current RC client so spans reflect identity refreshes.

## Testing

- `scripts/lint style ddtrace/appsec/_asm_request_context.py ddtrace/appsec/_remoteconfiguration.py ddtrace/internal/settings/asm.py tests/appsec/appsec/test_asm_request_context.py tests/appsec/appsec/test_remoteconfiguration.py`
- `git diff --check`
- `scripts/run-tests --venv 106f2d7 tests/appsec/appsec/test_asm_request_context.py tests/appsec/appsec/test_remoteconfiguration.py -- -- tests/appsec/appsec/test_asm_request_context.py tests/appsec/appsec/test_remoteconfiguration.py` attempted, but the riot env failed before tests due missing native extension: `ModuleNotFoundError: No module named 'ddtrace.internal.native._native'`

## Stack

Draft split branch. Stacked on the Remote Config split PR.
