### PR TITLE
chore(tracer): tracer/writer identity refresh and stale-buffer reset

### DIFF
--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -571,6 +571,7 @@ class SpanAggregator(SpanProcessor):
         llmobs_enabled: Optional[bool] = None,
         reset_buffer: bool = True,
         flush_writer: Optional[bool] = None,
+        drop_buffered_traces: bool = False,
     ) -> None:
         """
         Resets the internal state of the SpanAggregator, including the writer, sampling processor,
@@ -586,6 +587,8 @@ class SpanAggregator(SpanProcessor):
             # Flush any encoded spans in the writer's buffer. This operation ensures encoded spans
             # are not dropped when the writer is recreated. This operation should not be handled after a fork.
             self.writer.flush_queue()
+        elif drop_buffered_traces:
+            self.writer.drop_buffered_traces()
         # Re-create the writer to ensure it is consistent with updated configurations (ex: api_version)
         self.writer = self.writer.recreate(appsec_enabled=appsec_enabled, llmobs_enabled=llmobs_enabled)
 

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -433,6 +433,10 @@ class Tracer(object):
         if active is not None:
             core.dispatch("ddtrace.context_provider.activate", (self.context_provider, active))
 
+    def _refresh_runtime_identity(self, _runtime_id: str) -> None:
+        self._recreate(reset_buffer=True, drop_buffered_traces=True)
+        self._store_metadata()
+
     def _recreate(
         self,
         trace_processors: Optional[list[TraceProcessor]] = None,
@@ -442,6 +446,7 @@ class Tracer(object):
         llmobs_enabled: Optional[bool] = None,
         reset_buffer: bool = True,
         flush_writer: Optional[bool] = None,
+        drop_buffered_traces: bool = False,
     ) -> None:
         """Re-initialize the tracer's processors and trace writer"""
         # Stop the writer.
@@ -454,6 +459,7 @@ class Tracer(object):
             llmobs_enabled=llmobs_enabled,
             reset_buffer=reset_buffer,
             flush_writer=flush_writer,
+            drop_buffered_traces=drop_buffered_traces,
         )
         self._span_processors = _default_span_processors_factory(
             self._endpoint_call_counter_span_processor,

--- a/ddtrace/internal/native/_native.pyi
+++ b/ddtrace/internal/native/_native.pyi
@@ -849,6 +849,9 @@ class TraceExporterBuilder:
         :param restart_after_fork: Whether inherited workers restart in the child.
         """
         ...
+    def set_runtime_id(self, runtime_id: str) -> TraceExporterBuilder:
+        """Set the runtime id of the TraceExporter."""
+        ...
     def build(self, shared_runtime: SharedRuntime) -> TraceExporter:
         """
         Build and return a TraceExporter instance with the configured settings.

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -140,6 +140,10 @@ class TraceWriter(metaclass=abc.ABCMeta):
     def flush_queue(self) -> None:
         pass
 
+    def drop_buffered_traces(self) -> None:
+        """Discard traces buffered by the writer without flushing them."""
+        pass
+
 
 class LogWriter(TraceWriter):
     def __init__(
@@ -477,6 +481,10 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
         finally:
             self._set_drop_rate()
 
+    def drop_buffered_traces(self) -> None:
+        for client in self._clients:
+            getattr(client.encoder, "get")()
+
     def _flush_queue_with_client(self, client: WriterClientBase, raise_exc: bool = False) -> None:
         n_traces = len(client.encoder)
         # Snapshot the number of buffered spans before encoding so we can attribute spans_dropped
@@ -699,6 +707,7 @@ def _build_base_exporter_builder(
         .set_language_version(compat.PYTHON_VERSION)
         .set_language_interpreter(compat.PYTHON_INTERPRETER)
         .set_tracer_version(__version__)
+        .set_runtime_id(get_runtime_id())
         .set_git_commit_sha(commit_sha)
         .set_client_computed_top_level()
     )
@@ -1153,6 +1162,10 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
                 self._flush_queue_with_client(client, raise_exc=raise_exc)
         finally:
             self._set_drop_rate()
+
+    def drop_buffered_traces(self) -> None:
+        for client in self._clients:
+            getattr(client.encoder, "flush")()
 
     def _flush_queue_with_client(self, client: WriterClientBase, raise_exc: bool = False) -> None:
         n_traces = len(client.encoder)

--- a/ddtrace/trace/__init__.py
+++ b/ddtrace/trace/__init__.py
@@ -6,11 +6,13 @@ from ddtrace._trace.provider import BaseContextProvider
 from ddtrace._trace.span import Span
 from ddtrace._trace.tracer import Tracer
 from ddtrace.internal import core
+from ddtrace.internal.runtime import on_runtime_identity_refresh
 
 
 # a global tracer instance with integration settings
 tracer = Tracer()
 core.root.set_item("tracer", tracer)
+on_runtime_identity_refresh(tracer._refresh_runtime_identity)
 
 if sys.platform == "linux":
     from ddtrace.internal.opentelemetry.thread_context import register_otel_thread_context_listener

--- a/releasenotes/notes/aws-lambda-microvm-identity-refresh-3a672cd6bcbad16d.yaml
+++ b/releasenotes/notes/aws-lambda-microvm-identity-refresh-3a672cd6bcbad16d.yaml
@@ -2,4 +2,5 @@
 features:
   - |
     wsgi,asgi: Adds support for refreshing the runtime ID when applications
-    start in AWS Lambda MicroVM environments.
+    start in AWS Lambda MicroVM environments. Discards traces buffered before
+    the refresh so they are not sent with a stale runtime ID.

--- a/src/native/data_pipeline/mod.rs
+++ b/src/native/data_pipeline/mod.rs
@@ -93,6 +93,11 @@ impl TraceExporterBuilderPy {
         Ok(slf.into())
     }
 
+    fn set_runtime_id(mut slf: PyRefMut<'_, Self>, runtime_id: &'_ str) -> PyResult<Py<Self>> {
+        slf.try_as_mut()?.set_runtime_id(runtime_id);
+        Ok(slf.into())
+    }
+
     fn set_language(mut slf: PyRefMut<'_, Self>, language: &'_ str) -> PyResult<Py<Self>> {
         slf.try_as_mut()?.set_language(language);
         Ok(slf.into())

--- a/tests/tracer/runtime/test_runtime_id.py
+++ b/tests/tracer/runtime/test_runtime_id.py
@@ -649,3 +649,120 @@ assert seen == [runtime.get_runtime_id()]
 """
     _, err, status, _ = run_python_code_in_subprocess(code)
     assert status == 0, err
+
+
+def test_tracer_microvm_identity_refresh_recreates_exporter_without_fork_side_effects():
+    """Tracer MicroVM refresh must not reuse fork recreation semantics."""
+    from unittest import mock
+
+    from ddtrace._trace.tracer import Tracer
+    from ddtrace.internal import runtime
+
+    with mock.patch("ddtrace._trace.tracer.store_metadata"):
+        tracer = Tracer()
+
+    try:
+        tracer._new_process = False
+        with (
+            mock.patch.object(tracer, "_recreate") as recreate,
+            mock.patch.object(tracer, "_store_metadata") as store_metadata,
+        ):
+            tracer._refresh_runtime_identity(runtime.get_runtime_id())
+
+        recreate.assert_called_once_with(reset_buffer=True, drop_buffered_traces=True)
+        store_metadata.assert_called_once_with()
+        assert tracer._new_process is False
+    finally:
+        tracer.shutdown()
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12"}, err=None)
+def test_identity_refresh_hook_notifies_global_tracer():
+    """The global tracer must rebuild its identity-bound state on the MicroVM /run hook."""
+    from unittest import mock
+
+    from ddtrace import tracer
+    from ddtrace.contrib._events.web_framework import WebFrameworkEvents
+    from ddtrace.internal import core
+    import ddtrace.internal.runtime as runtime
+
+    with (
+        mock.patch.object(tracer, "_recreate") as recreate,
+        mock.patch.object(tracer, "_store_metadata") as store_metadata,
+    ):
+        core.dispatch(
+            WebFrameworkEvents.WEB_REQUEST_STARTING.value,
+            (runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH),
+        )
+
+    recreate.assert_called_once_with(reset_buffer=True, drop_buffered_traces=True)
+    store_metadata.assert_called_once_with()
+
+
+def test_tracer_microvm_identity_refresh_drops_direct_and_indirect_trace_buffers():
+    """Identity refresh drops queued spans and active traces carrying the old runtime ID."""
+    from unittest import mock
+
+    from ddtrace._trace.tracer import Tracer
+    from ddtrace.internal import runtime
+
+    class BufferedWriter:
+        def __init__(self):
+            self.traces = []
+            self.dropped = False
+
+        def write(self, spans):
+            self.traces.append(spans)
+
+        def drop_buffered_traces(self):
+            self.traces.clear()
+            self.dropped = True
+
+        def recreate(self, **kwargs):
+            self.recreate_kwargs = kwargs
+            return BufferedWriter()
+
+        def flush_queue(self):
+            raise AssertionError("identity refresh must drop buffered traces, not flush them")
+
+        def stop(self, timeout=None):
+            pass
+
+    writers = []
+
+    def create_writer(**kwargs):
+        writer = BufferedWriter()
+        writers.append(writer)
+        return writer
+
+    with (
+        mock.patch("ddtrace._trace.processor.create_trace_writer", side_effect=create_writer),
+        mock.patch("ddtrace._trace.tracer.store_metadata"),
+    ):
+        tracer = Tracer()
+
+    try:
+        old_writer = writers[-1]
+        queued_root = tracer.start_span("queued-root")
+        old_runtime_id = queued_root.get_tag("runtime-id")
+        queued_root.finish()
+
+        active_root = tracer.start_span("active-root")
+        active_child = tracer.start_span("active-child", child_of=active_root)
+        active_child.finish()
+        assert active_root.trace_id in tracer._span_aggregator._traces
+        assert tracer._span_aggregator._traces[active_root.trace_id].spans == [active_root, active_child]
+        assert old_writer.traces
+
+        runtime._refresh_runtime_id()
+        tracer._refresh_runtime_identity(runtime.get_runtime_id())
+
+        assert old_writer.dropped is True
+        assert old_writer.traces == []
+        assert tracer._span_aggregator._traces == {}
+
+        refreshed_root = tracer.start_span("refreshed-root")
+        assert refreshed_root.get_tag("runtime-id") != old_runtime_id
+        refreshed_root.finish()
+    finally:
+        tracer.shutdown()

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -1010,6 +1010,20 @@ def test_writer_recreate_keeps_response_callback():
     assert writer._response_cb is response_callback
 
 
+def test_native_writer_drops_buffered_traces():
+    writer = NativeWriter("http://dne:1234")
+    try:
+        span = Span("span")
+        writer._clients[0].encoder.put([span])
+        assert len(writer._clients[0].encoder) == 1
+
+        writer.drop_buffered_traces()
+
+        assert len(writer._clients[0].encoder) == 0
+    finally:
+        writer.shutdown_exporter()
+
+
 @pytest.mark.parametrize(
     "sys_platform, api_version, ddtrace_api_version, raises_error, expected",
     [
@@ -1171,6 +1185,7 @@ def test_writer_telemetry_enabled_on_linux(
         "set_tracer_version",
         "set_git_commit_sha",
         "set_client_computed_top_level",
+        "set_runtime_id",
         "set_input_format",
         "set_output_format",
         "enable_telemetry",
@@ -1181,6 +1196,7 @@ def test_writer_telemetry_enabled_on_linux(
         with override_global_config(dict(_telemetry_enabled=config_value)):
             _writer = NativeWriter("http://localhost:8126/v0.5/traces", sync_mode=True)
 
+            mock_builder.set_runtime_id.assert_called_once_with(get_runtime_id())
             if expected_enabled:
                 mock_builder.enable_telemetry.assert_called_once_with(60000, get_runtime_id(), config._debug_mode)
             else:
@@ -1209,6 +1225,7 @@ def test_otlp_metric_tags_configured():
         "set_tracer_version",
         "set_git_commit_sha",
         "set_client_computed_top_level",
+        "set_runtime_id",
     ]:
         getattr(mock_builder, method_name).return_value = mock_builder
 


### PR DESCRIPTION
Stacked PRs:
- #19778 — runtime identity foundation
  - #19898 — WSGI/ASGI request-start hook
    - #19939 — central MicroVM /run identity refresh
      - 👉 This PR #19820 — tracer/writer identity refresh and stale-buffer reset
        - #19821 — telemetry worker refresh
          - #19822 — runtime metrics runtime-id tags

## Description

After runtime identity changes, the native trace exporter can retain the runtime ID captured when it was built. This change registers the global tracer with the explicit identity-refresh callback registry, rebuilds the native exporter with the current runtime ID, and resets trace aggregation state and writer-buffered entities from the previous identity during that refresh.

The reset is enabled only for explicit MicroVM identity refresh. Normal configuration and post-fork recreation paths retain their existing behavior. The stale-buffer reset previously proposed in #20089 is included here because it is part of the tracer and writer identity-refresh behavior.

## Testing

Added focused coverage for:

- global tracer notification on explicit identity refresh
- current runtime ID propagation into the native exporter builder
- exporter recreation without fork-side effects
- dropping buffered entities from the trace writers
- clearing trace aggregation state during identity refresh

Validation included lint, compile, and diff checks.

## Risks

Pre-refresh trace data is intentionally discarded during explicit MicroVM identity refresh so it cannot be exported with a stale runtime ID.
