### PR TITLE
chore(runtime): refresh runtime metric identity tags

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -12,7 +12,9 @@ from ._logger import configure_ddtrace_logger  # noqa: E402
 configure_ddtrace_logger()  # noqa: E402
 
 # Enable telemetry writer and excepthook as early as possible to ensure we capture any exceptions from initialization
-import ddtrace.internal.telemetry  # noqa: E402, F401
+from ddtrace.internal.runtime import listen_for_identity_refresh_hooks  # noqa: E402,I001
+from ddtrace.internal.serverless import in_aws_lambda_microvm  # noqa: E402
+import ddtrace.internal.telemetry  # noqa: F401,E402
 
 from ._monkey import patch  # noqa: E402
 from ._monkey import patch_all  # noqa: E402
@@ -23,6 +25,12 @@ from .internal.utils.deprecations import DDTraceDeprecationWarning  # noqa: E402
 from .internal.utils.deprecations import deprecate  # noqa: E402
 from .version import __version__  # noqa: E402
 
+
+# Register import-time hooks that depend on ddtrace.config being exported.
+if in_aws_lambda_microvm():
+    from .internal import core as _core  # noqa: E402
+
+    listen_for_identity_refresh_hooks(_core.on)
 
 # TODO: Deprecate accessing tracer from ddtrace.__init__ module in v4.0
 if env.get("_DD_GLOBAL_TRACER_INIT", "true").lower() in ("1", "true"):

--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -571,6 +571,7 @@ class SpanAggregator(SpanProcessor):
         llmobs_enabled: Optional[bool] = None,
         reset_buffer: bool = True,
         flush_writer: Optional[bool] = None,
+        drop_buffered_traces: bool = False,
     ) -> None:
         """
         Resets the internal state of the SpanAggregator, including the writer, sampling processor,
@@ -586,6 +587,8 @@ class SpanAggregator(SpanProcessor):
             # Flush any encoded spans in the writer's buffer. This operation ensures encoded spans
             # are not dropped when the writer is recreated. This operation should not be handled after a fork.
             self.writer.flush_queue()
+        elif drop_buffered_traces:
+            self.writer.drop_buffered_traces()
         # Re-create the writer to ensure it is consistent with updated configurations (ex: api_version)
         self.writer = self.writer.recreate(appsec_enabled=appsec_enabled, llmobs_enabled=llmobs_enabled)
 

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -433,6 +433,10 @@ class Tracer(object):
         if active is not None:
             core.dispatch("ddtrace.context_provider.activate", (self.context_provider, active))
 
+    def _refresh_runtime_identity(self, _runtime_id: str) -> None:
+        self._recreate(reset_buffer=True, drop_buffered_traces=True)
+        self._store_metadata()
+
     def _recreate(
         self,
         trace_processors: Optional[list[TraceProcessor]] = None,
@@ -442,6 +446,7 @@ class Tracer(object):
         llmobs_enabled: Optional[bool] = None,
         reset_buffer: bool = True,
         flush_writer: Optional[bool] = None,
+        drop_buffered_traces: bool = False,
     ) -> None:
         """Re-initialize the tracer's processors and trace writer"""
         # Stop the writer.
@@ -454,6 +459,7 @@ class Tracer(object):
             llmobs_enabled=llmobs_enabled,
             reset_buffer=reset_buffer,
             flush_writer=flush_writer,
+            drop_buffered_traces=drop_buffered_traces,
         )
         self._span_processors = _default_span_processors_factory(
             self._endpoint_call_counter_span_processor,

--- a/ddtrace/contrib/_events/web_framework.py
+++ b/ddtrace/contrib/_events/web_framework.py
@@ -13,7 +13,7 @@ from ddtrace.internal.schema import schematize_url_operation
 
 class WebFrameworkEvents(str, Enum):
     WEB_REQUEST = "web.request"
-
+    WEB_REQUEST_STARTING = "web.request.starting"
 
 @dataclass
 class WebFrameworkRequestEvent(HttpRequestBaseEvent, TracingEvent):

--- a/ddtrace/contrib/internal/asgi/middleware.py
+++ b/ddtrace/contrib/internal/asgi/middleware.py
@@ -12,6 +12,7 @@ from ddtrace.contrib import trace_utils
 from ddtrace.contrib.internal.asgi.utils import bytes_to_str
 from ddtrace.contrib.internal.asgi.utils import extract_headers
 from ddtrace.contrib.internal.asgi.utils import guarantee_single_callable
+from ddtrace.contrib.internal.web import dispatch_web_request_starting
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import http
@@ -231,6 +232,9 @@ class TraceMiddleware:
         operation_name = self.integration_config.get("request_span_name", "asgi.request")
         if scope["type"] == "http":
             operation_name = schematize_url_operation(operation_name, direction=SpanDirection.INBOUND, protocol="http")
+            if not is_subapp:
+                path = (scope.get("root_path") or "").rstrip("/") + (scope.get("path") or "")
+                dispatch_web_request_starting(method, path)
 
         with (
             core.context_with_data(

--- a/ddtrace/contrib/internal/web.py
+++ b/ddtrace/contrib/internal/web.py
@@ -2,12 +2,11 @@ from typing import Optional
 
 from ddtrace.contrib._events.web_framework import WebFrameworkEvents
 from ddtrace.internal import core
+from ddtrace.internal.serverless import MICROVM_RUN_HOOK_METHOD
+from ddtrace.internal.serverless import MICROVM_RUN_HOOK_PATH
 from ddtrace.internal.serverless import in_aws_lambda_microvm
 
 
-_LAMBDA_MICROVM_RUN_PATH = "/aws/lambda-microvms/runtime/v1/run"
-
-
 def dispatch_web_request_starting(method: Optional[str], path: str) -> None:
-    if method == "POST" and path == _LAMBDA_MICROVM_RUN_PATH and in_aws_lambda_microvm():
+    if method == MICROVM_RUN_HOOK_METHOD and path == MICROVM_RUN_HOOK_PATH and in_aws_lambda_microvm():
         core.dispatch(WebFrameworkEvents.WEB_REQUEST_STARTING.value, (method, path))

--- a/ddtrace/contrib/internal/web.py
+++ b/ddtrace/contrib/internal/web.py
@@ -1,0 +1,13 @@
+from typing import Optional
+
+from ddtrace.contrib._events.web_framework import WebFrameworkEvents
+from ddtrace.internal import core
+from ddtrace.internal.serverless import in_aws_lambda_microvm
+
+
+_LAMBDA_MICROVM_RUN_PATH = "/aws/lambda-microvms/runtime/v1/run"
+
+
+def dispatch_web_request_starting(method: Optional[str], path: str) -> None:
+    if method == "POST" and path == _LAMBDA_MICROVM_RUN_PATH and in_aws_lambda_microvm():
+        core.dispatch(WebFrameworkEvents.WEB_REQUEST_STARTING.value, (method, path))

--- a/ddtrace/contrib/internal/wsgi/wsgi.py
+++ b/ddtrace/contrib/internal/wsgi/wsgi.py
@@ -22,6 +22,7 @@ import wrapt
 from ddtrace import config
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
+from ddtrace.contrib.internal.web import dispatch_web_request_starting
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
@@ -102,6 +103,10 @@ class _DDWSGIMiddlewareBase(object):
         raise NotImplementedError
 
     def __call__(self, environ: Iterable, start_response: Callable) -> wrapt.ObjectProxy:
+        method = environ.get("REQUEST_METHOD")
+        path = (environ.get("SCRIPT_NAME") or "").rstrip("/") + (environ.get("PATH_INFO") or "")
+        dispatch_web_request_starting(method, path)
+
         headers = get_request_headers(environ)
         closing_iterable = ()
         not_blocked = True

--- a/ddtrace/internal/native/_native.pyi
+++ b/ddtrace/internal/native/_native.pyi
@@ -849,6 +849,9 @@ class TraceExporterBuilder:
         :param restart_after_fork: Whether inherited workers restart in the child.
         """
         ...
+    def set_runtime_id(self, runtime_id: str) -> TraceExporterBuilder:
+        """Set the runtime id of the TraceExporter."""
+        ...
     def build(self, shared_runtime: SharedRuntime) -> TraceExporter:
         """
         Build and return a TraceExporter instance with the configured settings.

--- a/ddtrace/internal/runtime/__init__.py
+++ b/ddtrace/internal/runtime/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "get_runtime_id",
     "get_parent_runtime_id",
     "get_runtime_propagation_envs",
+    "refresh_identity",
 ]
 
 
@@ -31,15 +32,34 @@ _PARENT_RUNTIME_ID: t.Optional[str] = env.get(_ENV_PARENT_SESSION_ID)
 # IMPORTANT: Do not change t.Set to set until minimum Python version is 3.11+
 # Module-level set[...] in Python 3.10 affects import timing. See packages.py for details.
 _ON_RUNTIME_ID_CHANGE: t.Set[t.Callable[[str], None]] = set()  # noqa: UP006
+_ON_RUNTIME_IDENTITY_REFRESH: t.Set[t.Callable[[str], None]] = set()  # noqa: UP006
 
 
 def on_runtime_id_change(cb: t.Callable[[str], None]) -> None:
     """Register a callback to be called when the runtime ID changes.
 
-    This can happen after a fork.
+    This happens after a fork and when refresh_identity() runs.
     """
     global _ON_RUNTIME_ID_CHANGE
     _ON_RUNTIME_ID_CHANGE.add(cb)
+
+
+def on_runtime_identity_refresh(cb: t.Callable[[str], None]) -> None:
+    """Register a callback to be called after an explicit runtime identity refresh.
+
+    This is separate from the fork callback because a logical runtime replacement
+    must not be treated as a child process or update the fork lineage.
+    """
+    global _ON_RUNTIME_IDENTITY_REFRESH
+    _ON_RUNTIME_IDENTITY_REFRESH.add(cb)
+
+
+def _refresh_runtime_id() -> None:
+    global _RUNTIME_ID
+
+    _RUNTIME_ID = _generate_runtime_id()
+    for cb in _ON_RUNTIME_ID_CHANGE:
+        cb(_RUNTIME_ID)
 
 
 @forksafe.register
@@ -51,8 +71,23 @@ def _set_runtime_id():
         _ANCESTOR_RUNTIME_ID = _RUNTIME_ID
 
     _PARENT_RUNTIME_ID = _RUNTIME_ID
-    _RUNTIME_ID = _generate_runtime_id()
-    for cb in _ON_RUNTIME_ID_CHANGE:
+    _refresh_runtime_id()
+
+
+def refresh_identity() -> None:
+    """Regenerate the runtime ID without recording fork lineage.
+
+    Unlike a fork, this does not update _PARENT_RUNTIME_ID / _ANCESTOR_RUNTIME_ID:
+    the previous runtime ID was not a real parent process, so recording it there
+    would make get_process_role() and friends misreport a fork lineage that never
+    existed. Use this when a new logical process instance is created by a mechanism
+    other than fork().
+    """
+    # Notify consumers that only need the new ID first. The explicit refresh
+    # callbacks below are for components that must rebuild restore-sensitive
+    # state, which is different from the fork handling in _set_runtime_id().
+    _refresh_runtime_id()
+    for cb in _ON_RUNTIME_IDENTITY_REFRESH:
         cb(_RUNTIME_ID)
 
 

--- a/ddtrace/internal/runtime/__init__.py
+++ b/ddtrace/internal/runtime/__init__.py
@@ -1,6 +1,9 @@
 import typing as t
 import uuid
 
+from ddtrace.internal.serverless import MICROVM_RUN_HOOK_METHOD
+from ddtrace.internal.serverless import MICROVM_RUN_HOOK_PATH
+from ddtrace.internal.serverless import in_aws_lambda_microvm
 from ddtrace.internal.settings import env
 
 from .. import forksafe
@@ -12,6 +15,8 @@ __all__ = [
     "get_runtime_id",
     "get_parent_runtime_id",
     "get_runtime_propagation_envs",
+    "listen_for_identity_refresh_hooks",
+    "maybe_refresh_identity",
     "refresh_identity",
 ]
 
@@ -89,6 +94,36 @@ def refresh_identity() -> None:
     _refresh_runtime_id()
     for cb in _ON_RUNTIME_IDENTITY_REFRESH:
         cb(_RUNTIME_ID)
+
+
+# Multiple request layers can observe the same /run hook. Refresh identity once per
+# process so a single logical MicroVM instance gets one runtime-id rotation.
+_IDENTITY_REFRESH_HOOK_REFRESHED = forksafe.Event()
+_IDENTITY_REFRESH_HOOK_REFRESH_LOCK = forksafe.Lock()
+
+
+def listen_for_identity_refresh_hooks(
+    on_event: t.Callable[[str, t.Callable[[t.Optional[str], t.Optional[str]], None]], None],
+) -> None:
+    """Refresh MicroVM identity from request events emitted before root span creation."""
+    if not in_aws_lambda_microvm():
+        return
+
+    on_event("web.request.starting", maybe_refresh_identity)
+
+
+def maybe_refresh_identity(method: t.Optional[str], path: t.Optional[str]) -> None:
+    """Call refresh_identity() if this request is the AWS Lambda MicroVM /run hook."""
+    if not method or not path:
+        return
+    if method != MICROVM_RUN_HOOK_METHOD or path != MICROVM_RUN_HOOK_PATH:
+        return
+
+    with _IDENTITY_REFRESH_HOOK_REFRESH_LOCK:
+        if _IDENTITY_REFRESH_HOOK_REFRESHED.is_set():
+            return
+        refresh_identity()
+        _IDENTITY_REFRESH_HOOK_REFRESHED.set()
 
 
 def get_runtime_id() -> str:

--- a/ddtrace/internal/runtime/runtime_metrics.py
+++ b/ddtrace/internal/runtime/runtime_metrics.py
@@ -93,11 +93,7 @@ class RuntimeWorker(periodic.PeriodicService):
         else:
             self.send_metric = self._dogstatsd_client.distribution
 
-        if config._runtime_metrics_runtime_id_enabled:
-            # Enables tagging runtime metrics with runtime-id (as well as all the v1 tags)
-            self._platform_tags = self._format_tags(PlatformTagsV2())
-        else:
-            self._platform_tags = self._format_tags(PlatformTags())
+        self._platform_tags = self._collect_platform_tags()
 
         self._process_tags: list[str] = list(ProcessTags())
         # Only dd.internal.entity_id needs preserving here: service/env/version are already
@@ -144,7 +140,9 @@ class RuntimeWorker(periodic.PeriodicService):
             cls.enabled = True
 
     def flush(self) -> None:
-        # Ensure runtime metrics have up-to-date tags (ex: service, env, version)
+        # Refresh runtime-id tags when enabled; service/env/version are collected below via TracerTags().
+        if config._runtime_metrics_runtime_id_enabled:
+            self._platform_tags = self._collect_platform_tags()
         runtime_tags = self._format_tags(TracerTags()) + self._platform_tags + self._process_tags
         # Re-add dd.internal.entity_id on every flush, deduping in case it also arrives via
         # TracerTags() (e.g. a DD_TAGS=dd.internal.entity_id:... workaround).
@@ -156,6 +154,11 @@ class RuntimeWorker(periodic.PeriodicService):
             for key, value in self._runtime_metrics:
                 log.debug("Sending ddtrace runtime metric %s:%s", key, value)
                 self.send_metric(key, value)
+
+    def _collect_platform_tags(self) -> list[str]:
+        if config._runtime_metrics_runtime_id_enabled:
+            return self._format_tags(PlatformTagsV2())
+        return self._format_tags(PlatformTags())
 
     def _format_tags(self, tags: RuntimeCollectorsIterable) -> list[str]:
         # DEV: ddstatsd expects tags in the form ['key1:value1', 'key2:value2', ...]

--- a/ddtrace/internal/serverless/__init__.py
+++ b/ddtrace/internal/serverless/__init__.py
@@ -3,6 +3,11 @@ from os import path
 from ddtrace.internal.settings import env
 
 
+# Fixed platform request details for the AWS Lambda MicroVM /run lifecycle hook.
+MICROVM_RUN_HOOK_METHOD = "POST"
+MICROVM_RUN_HOOK_PATH = "/aws/lambda-microvms/runtime/v1/run"
+
+
 def in_aws_lambda():
     # type: () -> bool
     """Returns whether the environment is an AWS Lambda.

--- a/ddtrace/internal/serverless/__init__.py
+++ b/ddtrace/internal/serverless/__init__.py
@@ -35,3 +35,9 @@ def in_azure_function():
     # type: () -> bool
     """Returns whether the environment is an Azure Function."""
     return env.get("FUNCTIONS_WORKER_RUNTIME", "") != "" and env.get("FUNCTIONS_EXTENSION_VERSION", "") != ""
+
+
+def in_aws_lambda_microvm():
+    # type: () -> bool
+    """Returns whether the environment is an AWS Lambda MicroVM."""
+    return bool(env.get("AWS_LAMBDA_MICROVM_IMAGE_ARN", "").strip())

--- a/ddtrace/internal/telemetry/noop_writer.py
+++ b/ddtrace/internal/telemetry/noop_writer.py
@@ -108,6 +108,9 @@ class NoOpTelemetryWriter(object):
     def _restart_sequence(self) -> None:
         pass
 
+    def _refresh_runtime_identity(self, _runtime_id: str) -> None:
+        pass
+
     def _fork_writer(self) -> None:
         pass
 

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -24,6 +24,7 @@ from ..periodic import PeriodicService
 from ..runtime import get_ancestor_runtime_id
 from ..runtime import get_parent_runtime_id
 from ..runtime import get_runtime_id
+from ..runtime import on_runtime_identity_refresh
 from ..utils.formats import get_test_session_token
 from ..utils.version import version as tracer_version
 from .constants import TELEMETRY_APM_PRODUCT
@@ -209,6 +210,7 @@ class TelemetryWriter:
             # after_fork_child callback runs before this callback, ensuring the shared runtime
             # has been restarted before we drop and lazily rebuild the telemetry worker.
             forksafe.register(self._fork_writer)
+            on_runtime_identity_refresh(self._refresh_runtime_identity)
             get_logger("ddtrace").addHandler(DDTelemetryErrorHandler(self))
 
     def _build_worker(self) -> "TelemetryWorker":
@@ -914,6 +916,24 @@ class TelemetryWriter:
         # Reset the configuration seq_id counter (test determinism). The native
         # worker owns the message-batch seq_id and resets it when rebuilt.
         TelemetryWriter._sequence_configurations = itertools.count(1)
+
+    def _refresh_runtime_identity(self, _runtime_id: str) -> None:
+        if not self._enabled:
+            return
+        was_started = self.started
+        if self._worker is not None:
+            try:
+                self._worker.stop(send_app_closing=False)
+            except Exception:
+                log.debug("Failed to stop the native telemetry worker while refreshing runtime identity", exc_info=True)
+            self._worker = None
+            self.started = False
+            _unbind_metric_recorders(self)
+            self._notify_worker_changed(None)
+        self._dependency_tracker.reset()
+        self.enable()
+        if was_started:
+            self.app_started()
 
     def _fork_writer(self) -> None:
         # Runs in the child after a Python-managed fork. Drop the inherited worker and rebuild

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -140,6 +140,10 @@ class TraceWriter(metaclass=abc.ABCMeta):
     def flush_queue(self) -> None:
         pass
 
+    def drop_buffered_traces(self) -> None:
+        """Discard traces buffered by the writer without flushing them."""
+        pass
+
 
 class LogWriter(TraceWriter):
     def __init__(
@@ -477,6 +481,10 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
         finally:
             self._set_drop_rate()
 
+    def drop_buffered_traces(self) -> None:
+        for client in self._clients:
+            getattr(client.encoder, "get")()
+
     def _flush_queue_with_client(self, client: WriterClientBase, raise_exc: bool = False) -> None:
         n_traces = len(client.encoder)
         # Snapshot the number of buffered spans before encoding so we can attribute spans_dropped
@@ -699,6 +707,7 @@ def _build_base_exporter_builder(
         .set_language_version(compat.PYTHON_VERSION)
         .set_language_interpreter(compat.PYTHON_INTERPRETER)
         .set_tracer_version(__version__)
+        .set_runtime_id(get_runtime_id())
         .set_git_commit_sha(commit_sha)
         .set_client_computed_top_level()
     )
@@ -1153,6 +1162,10 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
                 self._flush_queue_with_client(client, raise_exc=raise_exc)
         finally:
             self._set_drop_rate()
+
+    def drop_buffered_traces(self) -> None:
+        for client in self._clients:
+            getattr(client.encoder, "flush")()
 
     def _flush_queue_with_client(self, client: WriterClientBase, raise_exc: bool = False) -> None:
         n_traces = len(client.encoder)

--- a/ddtrace/trace/__init__.py
+++ b/ddtrace/trace/__init__.py
@@ -6,11 +6,13 @@ from ddtrace._trace.provider import BaseContextProvider
 from ddtrace._trace.span import Span
 from ddtrace._trace.tracer import Tracer
 from ddtrace.internal import core
+from ddtrace.internal.runtime import on_runtime_identity_refresh
 
 
 # a global tracer instance with integration settings
 tracer = Tracer()
 core.root.set_item("tracer", tracer)
+on_runtime_identity_refresh(tracer._refresh_runtime_identity)
 
 if sys.platform == "linux":
     from ddtrace.internal.opentelemetry.thread_context import register_otel_thread_context_listener

--- a/releasenotes/notes/aws-lambda-microvm-identity-refresh-3a672cd6bcbad16d.yaml
+++ b/releasenotes/notes/aws-lambda-microvm-identity-refresh-3a672cd6bcbad16d.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    wsgi,asgi: Adds support for refreshing the runtime ID when applications
+    start in AWS Lambda MicroVM environments.

--- a/releasenotes/notes/aws-lambda-microvm-identity-refresh-3a672cd6bcbad16d.yaml
+++ b/releasenotes/notes/aws-lambda-microvm-identity-refresh-3a672cd6bcbad16d.yaml
@@ -2,4 +2,5 @@
 features:
   - |
     wsgi,asgi: Adds support for refreshing the runtime ID when applications
-    start in AWS Lambda MicroVM environments.
+    start in AWS Lambda MicroVM environments. Discards traces buffered before
+    the refresh so they are not sent with a stale runtime ID.

--- a/src/native/data_pipeline/mod.rs
+++ b/src/native/data_pipeline/mod.rs
@@ -93,6 +93,11 @@ impl TraceExporterBuilderPy {
         Ok(slf.into())
     }
 
+    fn set_runtime_id(mut slf: PyRefMut<'_, Self>, runtime_id: &'_ str) -> PyResult<Py<Self>> {
+        slf.try_as_mut()?.set_runtime_id(runtime_id);
+        Ok(slf.into())
+    }
+
     fn set_language(mut slf: PyRefMut<'_, Self>, language: &'_ str) -> PyResult<Py<Self>> {
         slf.try_as_mut()?.set_language(language);
         Ok(slf.into())

--- a/tests/contrib/asgi/test_asgi.py
+++ b/tests/contrib/asgi/test_asgi.py
@@ -216,6 +216,42 @@ async def test_web_request_starting_dispatch_precedes_span_creation(scope):
     assert events.index("request_starting") < events.index("span")
 
 
+async def test_microvm_run_hook_refreshes_identity(scope):
+    from ddtrace.internal import runtime
+
+    event_name = WebFrameworkEvents.WEB_REQUEST_STARTING.value
+    app = TraceMiddleware(basic_app)
+    scope.update({"method": "POST", "path": "/run", "root_path": "/aws/lambda-microvms/runtime/v1"})
+    runtime._IDENTITY_REFRESH_HOOK_REFRESHED.clear()
+    web.core.reset_listeners(event_name, runtime.maybe_refresh_identity)
+
+    try:
+        with (
+            mock.patch.object(web, "in_aws_lambda_microvm", return_value=True),
+            mock.patch.object(runtime, "in_aws_lambda_microvm", return_value=True),
+        ):
+            runtime.listen_for_identity_refresh_hooks(web.core.on)
+            runtime_id = runtime.get_runtime_id()
+
+            instance = ApplicationCommunicator(app, scope)
+            await instance.send_input({"type": "http.request", "body": b""})
+            await instance.receive_output(1)
+            await instance.receive_output(1)
+
+            refreshed_runtime_id = runtime.get_runtime_id()
+            assert refreshed_runtime_id != runtime_id
+
+            instance = ApplicationCommunicator(app, scope)
+            await instance.send_input({"type": "http.request", "body": b""})
+            await instance.receive_output(1)
+            await instance.receive_output(1)
+
+            assert runtime.get_runtime_id() == refreshed_runtime_id
+    finally:
+        web.core.reset_listeners(event_name, runtime.maybe_refresh_identity)
+        runtime._IDENTITY_REFRESH_HOOK_REFRESHED.clear()
+
+
 @pytest.mark.asyncio
 async def test_basic_asgi(scope, test_spans):
     app = TraceMiddleware(basic_app)

--- a/tests/contrib/asgi/test_asgi.py
+++ b/tests/contrib/asgi/test_asgi.py
@@ -3,6 +3,7 @@ from functools import partial
 import logging
 import os
 import random
+from unittest import mock
 
 from asgiref.testing import ApplicationCommunicator
 import httpx
@@ -11,6 +12,9 @@ import pytest
 from ddtrace.constants import _SAMPLING_PRIORITY_KEY
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import USER_KEEP
+from ddtrace.contrib._events.web_framework import WebFrameworkEvents
+from ddtrace.contrib.internal import web
+from ddtrace.contrib.internal.asgi import middleware as asgi_middleware
 from ddtrace.contrib.internal.asgi.middleware import TraceMiddleware
 from ddtrace.contrib.internal.asgi.middleware import _parse_response_cookies
 from ddtrace.contrib.internal.asgi.middleware import span_from_scope
@@ -150,6 +154,66 @@ def _check_span_tags(scope, span):
         or scope["asgi"].get("spec_version") is None
         or span.get_tag("asgi.spec_version") == scope["asgi"]["spec_version"]
     )
+
+
+@pytest.mark.parametrize(
+    "method,path,root_path,in_microvm,dispatches",
+    [
+        ("POST", "/run", "/aws/lambda-microvms/runtime/v1", True, True),
+        ("GET", "/run", "/aws/lambda-microvms/runtime/v1", True, False),
+        ("POST", "/other", "/aws/lambda-microvms/runtime/v1", True, False),
+        ("POST", "/run", "/aws/lambda-microvms/runtime/v1", False, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_microvm_dispatches_web_request_starting(scope, method, path, root_path, in_microvm, dispatches):
+    scope.update({"method": method, "path": path, "root_path": root_path})
+    app = TraceMiddleware(basic_app)
+    instance = ApplicationCommunicator(app, scope)
+
+    with (
+        mock.patch.object(web, "in_aws_lambda_microvm", return_value=in_microvm),
+        mock.patch.object(web.core, "dispatch", wraps=web.core.dispatch) as dispatch,
+    ):
+        await instance.send_input({"type": "http.request", "body": b""})
+        await instance.receive_output(1)
+        await instance.receive_output(1)
+
+    request_starting_calls = [
+        call.args for call in dispatch.call_args_list if call.args[0] == WebFrameworkEvents.WEB_REQUEST_STARTING.value
+    ]
+    if dispatches:
+        assert request_starting_calls == [
+            (WebFrameworkEvents.WEB_REQUEST_STARTING.value, ("POST", "/aws/lambda-microvms/runtime/v1/run"))
+        ]
+    else:
+        assert request_starting_calls == []
+
+
+@pytest.mark.asyncio
+async def test_web_request_starting_dispatch_precedes_span_creation(scope):
+    events = []
+    original_span_from_context = asgi_middleware.span_from_context
+
+    def record_request_starting(*args, **kwargs):
+        events.append("request_starting")
+
+    def record_span_from_context(*args, **kwargs):
+        events.append("span")
+        return original_span_from_context(*args, **kwargs)
+
+    app = TraceMiddleware(basic_app)
+    instance = ApplicationCommunicator(app, scope)
+
+    with (
+        mock.patch.object(asgi_middleware, "dispatch_web_request_starting", side_effect=record_request_starting),
+        mock.patch.object(asgi_middleware, "span_from_context", side_effect=record_span_from_context),
+    ):
+        await instance.send_input({"type": "http.request", "body": b""})
+        await instance.receive_output(1)
+        await instance.receive_output(1)
+
+    assert events.index("request_starting") < events.index("span")
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/wsgi/test_wsgi.py
+++ b/tests/contrib/wsgi/test_wsgi.py
@@ -1,9 +1,12 @@
 import os
+from unittest import mock
 
 import pytest
 from webtest import TestApp
 
 from ddtrace import config
+from ddtrace.contrib._events.web_framework import WebFrameworkEvents
+from ddtrace.contrib.internal import web
 from ddtrace.contrib.internal.wsgi.wsgi import DDWSGIMiddleware
 from ddtrace.contrib.internal.wsgi.wsgi import _DDWSGIMiddlewareBase
 from ddtrace.contrib.internal.wsgi.wsgi import construct_url
@@ -83,6 +86,36 @@ class WsgiCustomMiddleware(_DDWSGIMiddlewareBase):
         resp_span.set_tag("response_tag", "resp test tag set")
         resp_span._set_attribute("response_metric", 3)
         resp_span.resource = "response resource was modified"
+
+
+@pytest.mark.parametrize(
+    "method,path,script_name,in_microvm,dispatches",
+    [
+        ("post", "/run", "/aws/lambda-microvms/runtime/v1", True, True),
+        ("get", "/run", "/aws/lambda-microvms/runtime/v1", True, False),
+        ("post", "/other", "/aws/lambda-microvms/runtime/v1", True, False),
+        ("post", "/run", "/aws/lambda-microvms/runtime/v1", False, False),
+    ],
+)
+def test_microvm_dispatches_web_request_starting(tracer, method, path, script_name, in_microvm, dispatches):
+    app = TestApp(DDWSGIMiddleware(application, tracer=tracer))
+
+    with (
+        mock.patch.object(web, "in_aws_lambda_microvm", return_value=in_microvm),
+        mock.patch.object(web.core, "dispatch", wraps=web.core.dispatch) as dispatch,
+    ):
+        resp = getattr(app, method)(path, extra_environ={"SCRIPT_NAME": script_name})
+
+    assert resp.status == "200 OK"
+    request_starting_calls = [
+        call.args for call in dispatch.call_args_list if call.args[0] == WebFrameworkEvents.WEB_REQUEST_STARTING.value
+    ]
+    if dispatches:
+        assert request_starting_calls == [
+            (WebFrameworkEvents.WEB_REQUEST_STARTING.value, ("POST", "/aws/lambda-microvms/runtime/v1/run"))
+        ]
+    else:
+        assert request_starting_calls == []
 
 
 def test_middleware(tracer, test_spans):

--- a/tests/contrib/wsgi/test_wsgi.py
+++ b/tests/contrib/wsgi/test_wsgi.py
@@ -118,6 +118,37 @@ def test_microvm_dispatches_web_request_starting(tracer, method, path, script_na
         assert request_starting_calls == []
 
 
+def test_microvm_run_hook_refreshes_identity(tracer):
+    from ddtrace.internal import runtime
+
+    event_name = WebFrameworkEvents.WEB_REQUEST_STARTING.value
+    app = TestApp(DDWSGIMiddleware(application, tracer=tracer))
+    runtime._IDENTITY_REFRESH_HOOK_REFRESHED.clear()
+    web.core.reset_listeners(event_name, runtime.maybe_refresh_identity)
+
+    try:
+        with (
+            mock.patch.object(web, "in_aws_lambda_microvm", return_value=True),
+            mock.patch.object(runtime, "in_aws_lambda_microvm", return_value=True),
+        ):
+            runtime.listen_for_identity_refresh_hooks(web.core.on)
+            runtime_id = runtime.get_runtime_id()
+
+            resp = app.post("/run", extra_environ={"SCRIPT_NAME": "/aws/lambda-microvms/runtime/v1"})
+
+            assert resp.status == "200 OK"
+            refreshed_runtime_id = runtime.get_runtime_id()
+            assert refreshed_runtime_id != runtime_id
+
+            resp = app.post("/run", extra_environ={"SCRIPT_NAME": "/aws/lambda-microvms/runtime/v1"})
+
+            assert resp.status == "200 OK"
+            assert runtime.get_runtime_id() == refreshed_runtime_id
+    finally:
+        web.core.reset_listeners(event_name, runtime.maybe_refresh_identity)
+        runtime._IDENTITY_REFRESH_HOOK_REFRESHED.clear()
+
+
 def test_middleware(tracer, test_spans):
     app = TestApp(DDWSGIMiddleware(application, tracer=tracer))
     resp = app.get("/")

--- a/tests/internal/test_serverless.py
+++ b/tests/internal/test_serverless.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ddtrace.internal.serverless import in_aws_lambda_microvm
 from ddtrace.internal.serverless import in_azure_function
 from ddtrace.internal.serverless import in_gcp_function
 from tests.utils import override_env
@@ -26,6 +27,19 @@ def test_is_azure_function():
 
 def test_not_azure_function():
     assert in_azure_function() is False
+
+
+@pytest.mark.parametrize(
+    "environment,expected",
+    [
+        ({"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1:123456789012:image:test"}, True),
+        ({}, False),
+        ({"AWS_LAMBDA_MICROVM_IMAGE_ARN": "   "}, False),
+    ],
+)
+def test_is_aws_lambda_microvm(environment, expected):
+    with override_env(environment, replace_os_env=True):
+        assert in_aws_lambda_microvm() is expected
 
 
 standard_blocklist = [

--- a/tests/runtime/test_runtime_metrics_api.py
+++ b/tests/runtime/test_runtime_metrics_api.py
@@ -232,6 +232,54 @@ def test_runtime_metrics_experimental_runtime_tag():
         )
 
 
+@pytest.mark.subprocess(env={"DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED": "true"}, err=None)
+def test_runtime_metrics_refresh_identity_updates_runtime_id_tag():
+    """Runtime metrics must not keep reporting the pre-refresh runtime-id tag."""
+    from ddtrace.internal import runtime
+    from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker
+
+    RuntimeWorker.enable()
+    try:
+        worker = RuntimeWorker._instance
+        assert worker is not None
+
+        old_runtime_id = runtime.get_runtime_id()
+        assert f"runtime-id:{old_runtime_id}" in worker._platform_tags
+
+        runtime.refresh_identity()
+        worker.flush()
+
+        new_runtime_id = runtime.get_runtime_id()
+        assert f"runtime-id:{new_runtime_id}" in worker._platform_tags
+        assert f"runtime-id:{old_runtime_id}" not in worker._platform_tags
+    finally:
+        RuntimeWorker.disable()
+
+
+@pytest.mark.subprocess(env={"DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED": "false"}, err=None)
+def test_runtime_metrics_flush_keeps_platform_tags_cached_without_runtime_id():
+    """Runtime metrics must not rebuild static platform tags on every flush."""
+    from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker
+
+    RuntimeWorker.enable()
+    try:
+        worker = RuntimeWorker._instance
+        assert worker is not None
+
+        platform_tags = worker._platform_tags
+        worker._runtime_metrics = ()
+
+        def fail_collect_platform_tags():
+            raise AssertionError("platform tags should stay cached when runtime-id tagging is disabled")
+
+        worker._collect_platform_tags = fail_collect_platform_tags
+        worker.flush()
+
+        assert worker._platform_tags is platform_tags
+    finally:
+        RuntimeWorker.disable()
+
+
 @pytest.mark.subprocess(
     parametrize={"DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED": ["DD_RUNTIME_METRICS_ENABLED,someotherfeature", ""]},
     err=None,

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -810,6 +810,60 @@ import opentelemetry
     assert "OTEL_EXPORTER_OTLP_TIMEOUT" in configurations
 
 
+def test_microvm_identity_refresh_rebuilds_worker_with_new_runtime_id(monkeypatch):
+    """MicroVM identity refresh must not leave native telemetry on the old runtime ID."""
+    from ddtrace.internal import runtime
+    import ddtrace.internal.native as native
+    from ddtrace.internal.telemetry.writer import TelemetryWriter
+
+    workers = []
+
+    class FakeTelemetryWorker:
+        def __init__(self, native_runtime, **kwargs):
+            self.native_runtime = native_runtime
+            self.kwargs = kwargs
+            self.start_calls = 0
+            self.stop_calls = []
+            workers.append(self)
+
+        def start(self):
+            self.start_calls += 1
+
+        def stop(self, send_app_closing=True):
+            self.stop_calls.append(send_app_closing)
+
+        def __getattr__(self, name):
+            def _noop(*args, **kwargs):
+                pass
+
+            return _noop
+
+    with (
+        mock.patch.object(telemetry_config, "TELEMETRY_ENABLED", True),
+        mock.patch.object(telemetry_config, "DEPENDENCY_COLLECTION", False),
+        mock.patch.object(native, "TelemetryWorker", FakeTelemetryWorker),
+        mock.patch("ddtrace.internal.native_runtime.get_native_runtime", return_value=object()),
+    ):
+        writer = TelemetryWriter(agentless=False)
+        monkeypatch.setattr(ddtrace.internal.telemetry, "telemetry_writer", writer)
+        try:
+            writer.app_started()
+            first_worker = workers[-1]
+            first_runtime_id = first_worker.kwargs["runtime_id"]
+            assert first_worker.start_calls == 1
+
+            runtime.refresh_identity()
+
+            assert first_worker.stop_calls == [False]
+            assert workers[-1] is writer._worker
+            assert workers[-1].kwargs["runtime_id"] == runtime.get_runtime_id()
+            assert workers[-1].kwargs["session_id"] == runtime.get_runtime_id()
+            assert workers[-1].kwargs["runtime_id"] != first_runtime_id
+            assert workers[-1].start_calls == 1
+        finally:
+            writer.disable()
+
+
 def test_dd_api_key_app_key_telemetry_omitted(telemetry_writer, test_agent_session):
     """DD_API_KEY and DD_APP_KEY values are excluded from configuration telemetry.
 

--- a/tests/tracer/runtime/test_runtime_id.py
+++ b/tests/tracer/runtime/test_runtime_id.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 
@@ -395,6 +397,234 @@ runtime.refresh_identity()
 assert seen == [runtime.get_runtime_id()]
 """
     _, err, status, _ = run_python_code_in_subprocess(code)
+    assert status == 0, err
+
+
+@pytest.mark.parametrize("auto_enable_crashtracking", [False])
+def test_listen_for_identity_refresh_hooks_noop_does_not_import_core(monkeypatch, auto_enable_crashtracking):
+    import builtins
+
+    import ddtrace.internal.runtime as runtime
+
+    monkeypatch.setattr(runtime, "in_aws_lambda_microvm", lambda: False)
+
+    real_import = builtins.__import__
+
+    def fail_core_import(name, *args, **kwargs):
+        fromlist = kwargs.get("fromlist", ())
+        if len(args) >= 3:
+            fromlist = args[2]
+        if name == "ddtrace.internal" and "core" in fromlist:
+            raise AssertionError("listen_for_identity_refresh_hooks() imported core outside a MicroVM")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_core_import)
+
+    runtime.listen_for_identity_refresh_hooks(lambda _event, _callback: None)
+
+
+def test_web_request_starting_event_name_is_shared_with_contrib_event():
+    from ddtrace.contrib._events.web_framework import WebFrameworkEvents
+
+    assert "web.request.starting" == WebFrameworkEvents.WEB_REQUEST_STARTING.value
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12"}, err=None)
+def test_import_ddtrace_in_microvm_environment():
+    """MicroVM hook registration must not import contrib before ddtrace.config exists."""
+    import ddtrace
+
+    assert ddtrace.config is not None
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": None, "_DD_GLOBAL_TRACER_INIT": "false"}, err=None)
+def test_import_ddtrace_outside_microvm_does_not_import_core():
+    """Normal ddtrace imports do not load the event core needed only by MicroVM hooks."""
+    import sys
+
+    import ddtrace  # noqa: F401
+
+    assert "ddtrace.internal.core" not in sys.modules
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12"}, err=None)
+def test_maybe_refresh_identity_matches_microvm_run_hook():
+    """Only the exact AWS Lambda MicroVM /run hook request triggers a refresh."""
+    import ddtrace.internal.runtime as runtime
+
+    runtime_id = runtime.get_runtime_id()
+
+    runtime.maybe_refresh_identity(runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH)
+
+    refreshed_runtime_id = runtime.get_runtime_id()
+    assert refreshed_runtime_id != runtime_id
+
+    runtime.maybe_refresh_identity(runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH)
+
+    assert runtime.get_runtime_id() == refreshed_runtime_id
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12"}, err=None)
+def test_identity_refresh_hook_runs_before_root_span_creation():
+    """The pre-request hook must refresh runtime-id before a web root span reads it."""
+    from ddtrace import tracer
+    from ddtrace.contrib._events.web_framework import WebFrameworkEvents
+    from ddtrace.internal import core
+    import ddtrace.internal.runtime as runtime
+
+    runtime_id = runtime.get_runtime_id()
+    core.dispatch(
+        WebFrameworkEvents.WEB_REQUEST_STARTING.value, (runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH)
+    )
+
+    refreshed_runtime_id = runtime.get_runtime_id()
+    assert refreshed_runtime_id != runtime_id
+
+    with tracer.trace("web.request") as span:
+        assert span.get_tag("runtime-id") == refreshed_runtime_id
+
+    core.dispatch(
+        WebFrameworkEvents.WEB_REQUEST_STARTING.value, (runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH)
+    )
+
+    assert runtime.get_runtime_id() == refreshed_runtime_id
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12"}, err=None)
+def test_maybe_refresh_identity_is_thread_safe():
+    """Concurrent observations of the same /run hook refresh identity once."""
+    import threading
+    import time
+
+    import ddtrace.internal.runtime as runtime
+
+    calls = []
+
+    def refresh_identity():
+        calls.append(1)
+        time.sleep(0.01)
+
+    runtime.refresh_identity = refresh_identity
+
+    workers = 16
+    barrier = threading.Barrier(workers)
+    errors = []
+    threads = []
+
+    def refresh_from_request_layer():
+        try:
+            barrier.wait()
+            runtime.maybe_refresh_identity(runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH)
+        except Exception as e:
+            errors.append(e)
+
+    for _ in range(workers):
+        thread = threading.Thread(target=refresh_from_request_layer)
+        thread.start()
+        threads.append(thread)
+
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert len(calls) == 1
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12"}, err=None)
+def test_maybe_refresh_identity_retries_after_refresh_failure():
+    """A failed identity refresh must not make later /run hooks no-op."""
+    import pytest
+
+    import ddtrace.internal.runtime as runtime
+
+    calls = []
+
+    def refresh_identity():
+        calls.append(1)
+        if len(calls) == 1:
+            raise RuntimeError("identity refresh failed")
+
+    runtime.refresh_identity = refresh_identity
+
+    with pytest.raises(RuntimeError, match="identity refresh failed"):
+        runtime.maybe_refresh_identity(runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH)
+
+    runtime.maybe_refresh_identity(runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH)
+
+    assert len(calls) == 2
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12"}, err=None)
+def test_microvm_refresh_guard_resets_after_fork():
+    """A child process must not inherit a locked or already-refreshed MicroVM guard."""
+    from ddtrace.internal import forksafe
+    import ddtrace.internal.runtime as runtime
+
+    runtime._IDENTITY_REFRESH_HOOK_REFRESH_LOCK.acquire()
+    runtime._IDENTITY_REFRESH_HOOK_REFRESHED.set()
+
+    forksafe.ddtrace_after_in_child()
+
+    assert runtime._IDENTITY_REFRESH_HOOK_REFRESH_LOCK.acquire(False)
+    assert not runtime._IDENTITY_REFRESH_HOOK_REFRESHED.is_set()
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12"}, err=None)
+def test_maybe_refresh_identity_ignores_other_requests():
+    """A different method/path, or the /resume hook, must not trigger a refresh."""
+    import ddtrace.internal.runtime as runtime
+
+    runtime_id = runtime.get_runtime_id()
+
+    runtime.maybe_refresh_identity("GET", runtime.MICROVM_RUN_HOOK_PATH)
+    runtime.maybe_refresh_identity(runtime.MICROVM_RUN_HOOK_METHOD, "/aws/lambda-microvms/runtime/v1/resume")
+    runtime.maybe_refresh_identity(runtime.MICROVM_RUN_HOOK_METHOD, "/some/other/path")
+    runtime.maybe_refresh_identity(None, runtime.MICROVM_RUN_HOOK_PATH)
+    runtime.maybe_refresh_identity(runtime.MICROVM_RUN_HOOK_METHOD, None)
+
+    assert runtime.get_runtime_id() == runtime_id
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": None}, err=None)
+def test_listen_for_identity_refresh_hooks_noop_outside_microvm():
+    """Outside a MicroVM, do not register the request-event listener."""
+    from ddtrace.contrib._events.web_framework import WebFrameworkEvents
+    from ddtrace.internal import core
+    import ddtrace.internal.runtime as runtime
+
+    core.reset_listeners(WebFrameworkEvents.WEB_REQUEST_STARTING.value)
+    runtime.listen_for_identity_refresh_hooks(core.on)
+
+    runtime_id = runtime.get_runtime_id()
+
+    core.dispatch(
+        WebFrameworkEvents.WEB_REQUEST_STARTING.value, (runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH)
+    )
+
+    assert runtime.get_runtime_id() == runtime_id
+
+
+@pytest.mark.parametrize("microvm_image_arn", ["", "   "])
+def test_listen_for_identity_refresh_hooks_noop_for_blank_microvm_env(run_python_code_in_subprocess, microvm_image_arn):
+    """Blank MicroVM image ARN env values must not enable hook registration."""
+    code = """
+from ddtrace.contrib._events.web_framework import WebFrameworkEvents
+from ddtrace.internal import core
+import ddtrace.internal.runtime as runtime
+
+core.reset_listeners(WebFrameworkEvents.WEB_REQUEST_STARTING.value)
+runtime.listen_for_identity_refresh_hooks(core.on)
+
+runtime_id = runtime.get_runtime_id()
+core.dispatch(
+    WebFrameworkEvents.WEB_REQUEST_STARTING.value, (runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH)
+)
+
+assert runtime.get_runtime_id() == runtime_id
+"""
+    env = os.environ.copy()
+    env["AWS_LAMBDA_MICROVM_IMAGE_ARN"] = microvm_image_arn
+    _, err, status, _ = run_python_code_in_subprocess(code, env=env)
     assert status == 0, err
 
 

--- a/tests/tracer/runtime/test_runtime_id.py
+++ b/tests/tracer/runtime/test_runtime_id.py
@@ -41,6 +41,50 @@ def test_get_runtime_id_fork():
 
 
 @pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
+def test_fork_notifies_runtime_id_subscribers():
+    import os
+
+    from ddtrace.internal import runtime
+
+    seen = []
+
+    def on_change(new_id):
+        seen.append(new_id)
+
+    runtime.on_runtime_id_change(on_change)
+
+    child = os.fork()
+    if child == 0:
+        assert seen == [runtime.get_runtime_id()]
+        os._exit(42)
+
+    _, status = os.waitpid(child, 0)
+    assert os.WEXITSTATUS(status) == 42
+
+
+@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
+def test_fork_does_not_notify_runtime_identity_refresh_subscribers():
+    import os
+
+    from ddtrace.internal import runtime
+
+    seen = []
+
+    def on_refresh(new_id):
+        seen.append(new_id)
+
+    runtime.on_runtime_identity_refresh(on_refresh)
+
+    child = os.fork()
+    if child == 0:
+        assert seen == []
+        os._exit(42)
+
+    _, status = os.waitpid(child, 0)
+    assert os.WEXITSTATUS(status) == 42
+
+
+@pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})
 def test_get_runtime_id_double_fork():
     import os
 
@@ -210,3 +254,168 @@ def test_get_process_role_spawn_child() -> None:
     from ddtrace.internal.runtime import get_process_role
 
     assert get_process_role() == "worker", get_process_role()
+
+
+def test_refresh_identity_changes_runtime_id(run_python_code_in_subprocess):
+    """refresh_identity() is the non-fork trigger for a new logical process instance."""
+    code = """
+from ddtrace.internal import runtime
+
+runtime_id = runtime.get_runtime_id()
+runtime.refresh_identity()
+new_runtime_id = runtime.get_runtime_id()
+
+assert isinstance(new_runtime_id, str)
+assert new_runtime_id != runtime_id
+assert new_runtime_id == runtime.get_runtime_id()
+"""
+    _, err, status, _ = run_python_code_in_subprocess(code)
+    assert status == 0, err
+
+
+def test_refresh_identity_does_not_record_fork_lineage(run_python_code_in_subprocess):
+    """Unlike a fork, refresh_identity() must not make get_process_role() report a fake worker.
+
+    The previous runtime ID was not a real parent process, so recording it as one would
+    corrupt process-lineage telemetry.
+    """
+    import os
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "_DD_ROOT_PY_SESSION_ID": None,
+            "_DD_PARENT_PY_SESSION_ID": None,
+            "DD_TRACE_SUBPROCESS_ENABLED": "false",
+        }
+    )
+    code = """
+from ddtrace.internal import runtime
+
+assert runtime.get_process_role() is None
+assert runtime.get_parent_runtime_id() is None
+assert runtime.get_ancestor_runtime_id() is None
+
+runtime.refresh_identity()
+
+assert runtime.get_process_role() is None
+assert runtime.get_parent_runtime_id() is None
+assert runtime.get_ancestor_runtime_id() is None
+"""
+    _, err, status, _ = run_python_code_in_subprocess(code, env=env)
+    assert status == 0, err
+
+
+def test_refresh_identity_preserves_spawned_lineage(run_python_code_in_subprocess):
+    import os
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "_DD_ROOT_PY_SESSION_ID": "ancestor-session-id",
+            "_DD_PARENT_PY_SESSION_ID": "parent-session-id",
+            "DD_TRACE_SUBPROCESS_ENABLED": "false",
+        }
+    )
+    code = """
+from ddtrace.internal import runtime
+
+assert runtime.get_ancestor_runtime_id() == "ancestor-session-id"
+assert runtime.get_parent_runtime_id() == "parent-session-id"
+assert runtime.get_process_role() == "worker"
+
+runtime.refresh_identity()
+
+assert runtime.get_ancestor_runtime_id() == "ancestor-session-id"
+assert runtime.get_parent_runtime_id() == "parent-session-id"
+assert runtime.get_process_role() == "worker"
+"""
+    _, err, status, _ = run_python_code_in_subprocess(code, env=env)
+    assert status == 0, err
+
+
+def test_refresh_identity_preserves_fork_lineage(run_python_code_in_subprocess):
+    import os
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "_DD_ROOT_PY_SESSION_ID": None,
+            "_DD_PARENT_PY_SESSION_ID": None,
+            "DD_TRACE_SUBPROCESS_ENABLED": "false",
+        }
+    )
+    code = """
+import os
+
+from ddtrace.internal import runtime
+
+root_id = runtime.get_runtime_id()
+child = os.fork()
+
+if child == 0:
+    parent_id = runtime.get_parent_runtime_id()
+    ancestor_id = runtime.get_ancestor_runtime_id()
+
+    assert parent_id == root_id
+    assert ancestor_id == root_id
+    assert runtime.get_process_role() == "worker"
+
+    runtime.refresh_identity()
+
+    assert runtime.get_parent_runtime_id() == parent_id
+    assert runtime.get_ancestor_runtime_id() == ancestor_id
+    assert runtime.get_process_role() == "worker"
+    os._exit(42)
+
+_, status = os.waitpid(child, 0)
+assert os.WEXITSTATUS(status) == 42
+"""
+    _, err, status, _ = run_python_code_in_subprocess(code, env=env)
+    assert status == 0, err
+
+
+def test_refresh_identity_notifies_subscribers(run_python_code_in_subprocess):
+    code = """
+from ddtrace.internal import runtime
+
+seen = []
+
+
+class _Subscriber:
+    def on_change(self, new_id):
+        seen.append(new_id)
+
+
+subscriber = _Subscriber()
+runtime.on_runtime_id_change(subscriber.on_change)
+
+runtime.refresh_identity()
+
+assert seen == [runtime.get_runtime_id()]
+"""
+    _, err, status, _ = run_python_code_in_subprocess(code)
+    assert status == 0, err
+
+
+def test_refresh_identity_notifies_refresh_subscribers(run_python_code_in_subprocess):
+    code = """
+from ddtrace.internal import runtime
+
+seen = []
+
+
+class _Subscriber:
+    def on_refresh(self, new_id):
+        seen.append(new_id)
+
+
+subscriber = _Subscriber()
+runtime.on_runtime_identity_refresh(subscriber.on_refresh)
+
+runtime.refresh_identity()
+
+assert seen == [runtime.get_runtime_id()]
+"""
+    _, err, status, _ = run_python_code_in_subprocess(code)
+    assert status == 0, err

--- a/tests/tracer/runtime/test_runtime_id.py
+++ b/tests/tracer/runtime/test_runtime_id.py
@@ -649,3 +649,120 @@ assert seen == [runtime.get_runtime_id()]
 """
     _, err, status, _ = run_python_code_in_subprocess(code)
     assert status == 0, err
+
+
+def test_tracer_microvm_identity_refresh_recreates_exporter_without_fork_side_effects():
+    """Tracer MicroVM refresh must not reuse fork recreation semantics."""
+    from unittest import mock
+
+    from ddtrace._trace.tracer import Tracer
+    from ddtrace.internal import runtime
+
+    with mock.patch("ddtrace._trace.tracer.store_metadata"):
+        tracer = Tracer()
+
+    try:
+        tracer._new_process = False
+        with (
+            mock.patch.object(tracer, "_recreate") as recreate,
+            mock.patch.object(tracer, "_store_metadata") as store_metadata,
+        ):
+            tracer._refresh_runtime_identity(runtime.get_runtime_id())
+
+        recreate.assert_called_once_with(reset_buffer=True, drop_buffered_traces=True)
+        store_metadata.assert_called_once_with()
+        assert tracer._new_process is False
+    finally:
+        tracer.shutdown()
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12"}, err=None)
+def test_identity_refresh_hook_notifies_global_tracer():
+    """The global tracer must rebuild its identity-bound state on the MicroVM /run hook."""
+    from unittest import mock
+
+    from ddtrace import tracer
+    from ddtrace.contrib._events.web_framework import WebFrameworkEvents
+    from ddtrace.internal import core
+    import ddtrace.internal.runtime as runtime
+
+    with (
+        mock.patch.object(tracer, "_recreate") as recreate,
+        mock.patch.object(tracer, "_store_metadata") as store_metadata,
+    ):
+        core.dispatch(
+            WebFrameworkEvents.WEB_REQUEST_STARTING.value,
+            (runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH),
+        )
+
+    recreate.assert_called_once_with(reset_buffer=True, drop_buffered_traces=True)
+    store_metadata.assert_called_once_with()
+
+
+def test_tracer_microvm_identity_refresh_drops_direct_and_indirect_trace_buffers():
+    """Identity refresh drops queued spans and active traces carrying the old runtime ID."""
+    from unittest import mock
+
+    from ddtrace._trace.tracer import Tracer
+    from ddtrace.internal import runtime
+
+    class BufferedWriter:
+        def __init__(self):
+            self.traces = []
+            self.dropped = False
+
+        def write(self, spans):
+            self.traces.append(spans)
+
+        def drop_buffered_traces(self):
+            self.traces.clear()
+            self.dropped = True
+
+        def recreate(self, **kwargs):
+            self.recreate_kwargs = kwargs
+            return BufferedWriter()
+
+        def flush_queue(self):
+            raise AssertionError("identity refresh must drop buffered traces, not flush them")
+
+        def stop(self, timeout=None):
+            pass
+
+    writers = []
+
+    def create_writer(**kwargs):
+        writer = BufferedWriter()
+        writers.append(writer)
+        return writer
+
+    with (
+        mock.patch("ddtrace._trace.processor.create_trace_writer", side_effect=create_writer),
+        mock.patch("ddtrace._trace.tracer.store_metadata"),
+    ):
+        tracer = Tracer()
+
+    try:
+        old_writer = writers[-1]
+        queued_root = tracer.start_span("queued-root")
+        old_runtime_id = queued_root.get_tag("runtime-id")
+        queued_root.finish()
+
+        active_root = tracer.start_span("active-root")
+        active_child = tracer.start_span("active-child", child_of=active_root)
+        active_child.finish()
+        assert active_root.trace_id in tracer._span_aggregator._traces
+        assert tracer._span_aggregator._traces[active_root.trace_id].spans == [active_root, active_child]
+        assert old_writer.traces
+
+        runtime._refresh_runtime_id()
+        tracer._refresh_runtime_identity(runtime.get_runtime_id())
+
+        assert old_writer.dropped is True
+        assert old_writer.traces == []
+        assert tracer._span_aggregator._traces == {}
+
+        refreshed_root = tracer.start_span("refreshed-root")
+        assert refreshed_root.get_tag("runtime-id") != old_runtime_id
+        refreshed_root.finish()
+    finally:
+        tracer.shutdown()

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -1010,6 +1010,20 @@ def test_writer_recreate_keeps_response_callback():
     assert writer._response_cb is response_callback
 
 
+def test_native_writer_drops_buffered_traces():
+    writer = NativeWriter("http://dne:1234")
+    try:
+        span = Span("span")
+        writer._clients[0].encoder.put([span])
+        assert len(writer._clients[0].encoder) == 1
+
+        writer.drop_buffered_traces()
+
+        assert len(writer._clients[0].encoder) == 0
+    finally:
+        writer.shutdown_exporter()
+
+
 @pytest.mark.parametrize(
     "sys_platform, api_version, ddtrace_api_version, raises_error, expected",
     [
@@ -1171,6 +1185,7 @@ def test_writer_telemetry_enabled_on_linux(
         "set_tracer_version",
         "set_git_commit_sha",
         "set_client_computed_top_level",
+        "set_runtime_id",
         "set_input_format",
         "set_output_format",
         "enable_telemetry",
@@ -1181,6 +1196,7 @@ def test_writer_telemetry_enabled_on_linux(
         with override_global_config(dict(_telemetry_enabled=config_value)):
             _writer = NativeWriter("http://localhost:8126/v0.5/traces", sync_mode=True)
 
+            mock_builder.set_runtime_id.assert_called_once_with(get_runtime_id())
             if expected_enabled:
                 mock_builder.enable_telemetry.assert_called_once_with(60000, get_runtime_id(), config._debug_mode)
             else:
@@ -1209,6 +1225,7 @@ def test_otlp_metric_tags_configured():
         "set_tracer_version",
         "set_git_commit_sha",
         "set_client_computed_top_level",
+        "set_runtime_id",
     ]:
         getattr(mock_builder, method_name).return_value = mock_builder
 


### PR DESCRIPTION
Stacked PRs:
- #19778 — runtime identity foundation
  - #19898 — WSGI/ASGI request-start hook
    - #19939 — central MicroVM /run identity refresh
      - #19820 — tracer/writer identity refresh and stale-buffer reset
        - #19821 — telemetry worker refresh
          - 👉 This PR #19822 — runtime metrics runtime-id tags

## Description

Runtime metrics can build platform tags up front, including runtime-id when that option is enabled. After a MicroVM identity refresh, cached platform tags would otherwise continue reporting metrics under the previous runtime ID.

This change refreshes platform tags at flush time only when runtime-id tagging is enabled. When runtime-id tagging is disabled, static platform tags remain cached and no identity-refresh callback is registered.

## Testing

Added focused coverage for:

- replacing the old runtime-id tag after identity refresh
- retaining the current runtime-id on subsequent flushes
- keeping platform tags cached when runtime-id tagging is disabled
- preserving worker lifecycle behavior

Validation included lint, compile, and diff checks.

## Risks

Low. The change is limited to runtime metric tag collection and does not add another identity-refresh subscriber.
