### PR TITLE
chore(tests): bump gevent to 26.8.0 to stop the flaky django IAST shutdown test

### DIFF
--- a/.riot/requirements/127d33e.txt
+++ b/.riot/requirements/127d33e.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==5.2.17
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/1376d8e.txt
+++ b/.riot/requirements/1376d8e.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==6.1
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/1503753.txt
+++ b/.riot/requirements/1503753.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==4.0.10
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/16baf4f.txt
+++ b/.riot/requirements/16baf4f.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==4.2.30
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/189e923.txt
+++ b/.riot/requirements/189e923.txt
@@ -14,7 +14,7 @@ dill==0.4.1
 django==4.2.30
 django-configurations==2.5.1
 exceptiongroup==1.3.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/1915800.txt
+++ b/.riot/requirements/1915800.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==6.1
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/19c11d3.txt
+++ b/.riot/requirements/19c11d3.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==5.2.17
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/19e3b6e.txt
+++ b/.riot/requirements/19e3b6e.txt
@@ -14,7 +14,7 @@ dill==0.4.1
 django==5.2.17
 django-configurations==2.5.1
 exceptiongroup==1.3.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/1a9a3f9.txt
+++ b/.riot/requirements/1a9a3f9.txt
@@ -14,7 +14,7 @@ dill==0.4.1
 django==4.2.30
 django-configurations==2.5.1
 exceptiongroup==1.3.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/1b618aa.txt
+++ b/.riot/requirements/1b618aa.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==6.1
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/1cedcf1.txt
+++ b/.riot/requirements/1cedcf1.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==4.2.30
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/1cff003.txt
+++ b/.riot/requirements/1cff003.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==4.2.30
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/1e48f3c.txt
+++ b/.riot/requirements/1e48f3c.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==5.2.17
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/1f1a6f3.txt
+++ b/.riot/requirements/1f1a6f3.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==6.1
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/1fc222e.txt
+++ b/.riot/requirements/1fc222e.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==3.2.25
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/48d5c6c.txt
+++ b/.riot/requirements/48d5c6c.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==3.2.25
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/5a0bcdf.txt
+++ b/.riot/requirements/5a0bcdf.txt
@@ -14,7 +14,7 @@ dill==0.4.1
 django==3.2.25
 django-configurations==2.5.1
 exceptiongroup==1.3.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/683e4d5.txt
+++ b/.riot/requirements/683e4d5.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==5.2.17
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/6db2d50.txt
+++ b/.riot/requirements/6db2d50.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==5.2.17
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/6ff806c.txt
+++ b/.riot/requirements/6ff806c.txt
@@ -14,7 +14,7 @@ dill==0.4.1
 django==5.2.17
 django-configurations==2.5.1
 exceptiongroup==1.3.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/7604751.txt
+++ b/.riot/requirements/7604751.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==6.1
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/7b08a74.txt
+++ b/.riot/requirements/7b08a74.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==4.0.10
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/a5417d6.txt
+++ b/.riot/requirements/a5417d6.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==4.0.10
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/a8b25c6.txt
+++ b/.riot/requirements/a8b25c6.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==4.2.30
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/adc21ad.txt
+++ b/.riot/requirements/adc21ad.txt
@@ -14,7 +14,7 @@ dill==0.4.1
 django==5.2.17
 django-configurations==2.5.1
 exceptiongroup==1.3.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/b88fb25.txt
+++ b/.riot/requirements/b88fb25.txt
@@ -14,7 +14,7 @@ dill==0.4.1
 django==4.0.10
 django-configurations==2.5.1
 exceptiongroup==1.3.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/c9be24d.txt
+++ b/.riot/requirements/c9be24d.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==4.2.30
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/cd15a87.txt
+++ b/.riot/requirements/cd15a87.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==4.2.30
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/e4cbe78.txt
+++ b/.riot/requirements/e4cbe78.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==6.1
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/f55d196.txt
+++ b/.riot/requirements/f55d196.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==3.2.25
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0

--- a/.riot/requirements/fe98215.txt
+++ b/.riot/requirements/fe98215.txt
@@ -13,7 +13,7 @@ coverage[toml]==7.15.4
 dill==0.4.1
 django==5.2.17
 django-configurations==2.5.1
-gevent==26.7.0
+gevent==26.8.0
 greenlet==3.5.4
 gunicorn==26.0.0
 hypothesis==6.45.0


### PR DESCRIPTION
APPSEC-69718

## Problem

`test_iast_vulnerable_request_downstream_django` fails in teardown: the `/shutdown` request never gets a response and the client gives up at its 10s read timeout.

The request greenlet parks permanently in `logging.Handler.acquire()`. Under monkey-patching a logging handler lock is a gevent semaphore, and a hubless native thread — the tracer's writer thread, or anything else logging off-hub — can release one without waking a greenlet waiting on the semaphore's owning hub. The greenlet then waits on a lock nobody holds: dumps taken during the failure show it blocked in `BoundedSemaphore.acquire` while every handler reports `owner=None count=0`. The event loop stays healthy throughout, which is why the worker looks idle and the response simply never goes out.

That is [gevent#2013](https://github.com/gevent/gevent/issues/2013), "Logging lock not released when held by OS threads".

## Why this is the right fix

The lost wakeup happens inside gevent's semaphore. It was fixed upstream in [gevent#2199](https://github.com/gevent/gevent/pull/2199) and shipped in 26.8.0:

> Fixed a semaphore acquired and released by a hubless native thread failing to wake greenlets waiting on the semaphore's owning hub.

Nothing in ddtrace or in the test can repair a missed notification inside that primitive. The only alternative is to stop logging from the paths that hit it — which would hide an already-fixed upstream bug, cost a genuine diagnostic, and leave every other log call from a greenlet exposed. Taking the fixed release removes the cause instead of the symptom, and the pin bump is the smallest change that does it.

Confirmed causal rather than assumed: with the endpoint configured to reproduce as often as possible, over 2000 full-suite passes per run —

| gevent | Failures | Passes |
|---|---|---|
| 26.7.0 | **28** | 363,085 |
| 26.8.0 | **0** | 363,848 |

Zero has probability ~7e-13 under the 26.7.0 rate.

## Scope

Only the `gevent` pin changes — 31 lockfiles, one line each.

The five py3.9 venvs stay on 26.7.0, since 26.8.0 requires Python >= 3.10. No py3.9 exposure is known: none of the flaky records below is py3.9, and the only py3.9 failures of this test come from an unrelated branch reworking the HTTP client. That is absence of evidence rather than proof.

Other suites using gevent remain on 26.7.0 and would need the same bump if they show these symptoms.

## Flaky tests fixed

| attempt_to_fix_id | fingerprint_fqn | parametrization |
|---|---|---|
| WQNXQ5 | c79c73db4fa90628 | config3, py3.14 |
| JU041J | 18caca56545ffa20 | config3, py3.11 |
| KUBWIR | 137269568180c6f2 | config3, py3.10 |
| F20P7M | 760e4fab124fc55c | config3, py3.13 |
| FQAL2Q | 8f5634e2f4389aa9 | config3, py3.12 |
| 4FSP2S | 510713355a313fd0 | config5, py3.14 |
| D07T24 | 8ac683d25efa1f5d | config5, py3.11 |
| SNBL4W | 4466dfe657be66b9 | config5, py3.10 |
| U55XLN | 50244629d266fe01 | config5, py3.13 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
