### PR TITLE
fix(iast): resolve flakiness in fork tests

### DIFF
--- a/tests/appsec/iast/test_fork_handler_regression.py
+++ b/tests/appsec/iast/test_fork_handler_regression.py
@@ -370,7 +370,8 @@ def test_early_fork_keeps_iast_enabled():
     from ddtrace.internal.settings.asm import config as asm_config
 
     # Ensure IAST is enabled but NO context is active (simulating early fork)
-    # Don't call _start_iast_context_and_oce() - this simulates pre-fork state
+    # Don't call _start_iast_context_and_oce() - this simulates pre-fork state.
+    # A leaked context would make the handler see a late fork and disable IAST, so reset state.
     reset_native_state()
     original_state = asm_config._iast_enabled
     try:

--- a/tests/appsec/iast/test_fork_handler_regression.py
+++ b/tests/appsec/iast/test_fork_handler_regression.py
@@ -35,16 +35,15 @@ def test_fork_handler_callable(iast_context_defaults):
     from ddtrace.internal.settings.asm import config as asm_config
 
     # Should not raise any exception
+    original_state = asm_config._iast_enabled
     try:
-        original_state = asm_config._iast_enabled
         _disable_iast_after_fork()
         # Fork handler should disable IAST
         assert asm_config._iast_enabled is False, "IAST should be disabled after fork"
+    finally:
         # Restore for other tests - reinitialize native state for clean slate
         asm_config._iast_enabled = original_state
         reset_native_state()  # Reinitialize to clean state for next test
-    except Exception as e:
-        pytest.fail(f"Fork handler raised unexpected exception: {e}")
 
 
 def test_fork_handler_with_active_context(iast_context_defaults):
@@ -62,17 +61,18 @@ def test_fork_handler_with_active_context(iast_context_defaults):
 
     # Reset simulates what happens after fork - IAST is disabled
     original_state = asm_config._iast_enabled
-    _disable_iast_after_fork()
+    try:
+        _disable_iast_after_fork()
 
-    # IAST should now be disabled
-    assert asm_config._iast_enabled is False, "IAST should be disabled after fork"
+        # IAST should now be disabled
+        assert asm_config._iast_enabled is False, "IAST should be disabled after fork"
 
-    # After reset, we should be able to call these safely (they're no-ops now)
-    _end_iast_context_and_oce()
-
-    # Restore for other tests - reinitialize native state for clean slate
-    asm_config._iast_enabled = original_state
-    reset_native_state()  # Reinitialize to clean state for next test
+        # After reset, we should be able to call these safely (they're no-ops now)
+        _end_iast_context_and_oce()
+    finally:
+        # Restore for other tests - reinitialize native state for clean slate
+        asm_config._iast_enabled = original_state
+        reset_native_state()  # Reinitialize to clean state for next test
 
 
 @pytest.mark.skip(reason="multiprocessing fork doesn't work correctly in ddtrace-py 4.0")
@@ -264,33 +264,36 @@ def test_fork_handler_clears_state(iast_context_defaults):
     """
     from ddtrace.appsec._iast import _disable_iast_after_fork
     from ddtrace.appsec._iast._taint_tracking import is_tainted
+    from ddtrace.appsec._iast._taint_tracking import reset_native_state
     from ddtrace.internal.settings.asm import config as asm_config
 
     _start_iast_context_and_oce()
-    tainted = taint_pyobject("test", "source", "value", OriginType.PARAMETER)
-    assert is_tainted(tainted), "Should be tainted before fork"
-
-    # Manually call the fork handler (simulating what happens after fork)
     original_state = asm_config._iast_enabled
-    _disable_iast_after_fork()
+    try:
+        tainted = taint_pyobject("test", "source", "value", OriginType.PARAMETER)
+        assert is_tainted(tainted), "Should be tainted before fork"
 
-    # IAST should now be disabled
-    assert asm_config._iast_enabled is False, "IAST should be disabled after fork"
+        # Manually call the fork handler (simulating what happens after fork)
+        _disable_iast_after_fork()
 
-    # After reset, these should be safe no-ops
-    _end_iast_context_and_oce()
-    _start_iast_context_and_oce()
+        # IAST should now be disabled
+        assert asm_config._iast_enabled is False, "IAST should be disabled after fork"
 
-    # taint_pyobject should be a no-op (IAST disabled)
-    tainted2 = taint_pyobject("test2", "source2", "value2", OriginType.PARAMETER)
-    count = _num_objects_tainted_in_request()
-    assert count == 0, "Should have 0 tainted objects (IAST disabled)"
-    assert not is_tainted(tainted2), "Should not be tainted (IAST disabled)"
+        # After reset, these should be safe no-ops
+        _end_iast_context_and_oce()
+        _start_iast_context_and_oce()
 
-    _end_iast_context_and_oce()
+        # taint_pyobject should be a no-op (IAST disabled)
+        tainted2 = taint_pyobject("test2", "source2", "value2", OriginType.PARAMETER)
+        count = _num_objects_tainted_in_request()
+        assert count == 0, "Should have 0 tainted objects (IAST disabled)"
+        assert not is_tainted(tainted2), "Should not be tainted (IAST disabled)"
 
-    # Restore for other tests
-    asm_config._iast_enabled = original_state
+        _end_iast_context_and_oce()
+    finally:
+        # Restore for other tests
+        asm_config._iast_enabled = original_state
+        reset_native_state()
 
 
 @pytest.mark.skip(reason="multiprocessing fork doesn't work correctly in ddtrace-py 4.0")
@@ -362,34 +365,37 @@ def test_early_fork_keeps_iast_enabled():
     remain enabled in the child and work normally.
     """
     from ddtrace.appsec._iast import _disable_iast_after_fork
-    from ddtrace.appsec._iast._taint_tracking import initialize_native_state
     from ddtrace.appsec._iast._taint_tracking import is_tainted
+    from ddtrace.appsec._iast._taint_tracking import reset_native_state
     from ddtrace.internal.settings.asm import config as asm_config
 
     # Ensure IAST is enabled but NO context is active (simulating early fork)
     # Don't call _start_iast_context_and_oce() - this simulates pre-fork state
-    initialize_native_state()
+    reset_native_state()
     original_state = asm_config._iast_enabled
-    asm_config._iast_enabled = True
+    try:
+        asm_config._iast_enabled = True
 
-    # Call the fork handler - should detect no active context and keep IAST enabled
-    _disable_iast_after_fork()
+        # Call the fork handler - should detect no active context and keep IAST enabled
+        _disable_iast_after_fork()
 
-    # IAST should still be enabled (early fork scenario)
-    assert asm_config._iast_enabled is True, "IAST should remain enabled for early forks"
+        # IAST should still be enabled (early fork scenario)
+        assert asm_config._iast_enabled is True, "IAST should remain enabled for early forks"
 
-    # Now we can initialize IAST fresh in this "worker"
-    _start_iast_context_and_oce()
+        # Now we can initialize IAST fresh in this "worker"
+        _start_iast_context_and_oce()
 
-    # IAST should work normally
-    tainted = taint_pyobject("worker_data", "source", "value", OriginType.PARAMETER)
-    assert is_tainted(tainted), "IAST should work in early fork (web worker)"
+        # IAST should work normally
+        tainted = taint_pyobject("worker_data", "source", "value", OriginType.PARAMETER)
+        assert is_tainted(tainted), "IAST should work in early fork (web worker)"
 
-    count = _num_objects_tainted_in_request()
-    assert count > 0, "Should have tainted objects in early fork"
+        count = _num_objects_tainted_in_request()
+        assert count > 0, "Should have tainted objects in early fork"
 
-    _end_iast_context_and_oce()
-    asm_config._iast_enabled = original_state
+        _end_iast_context_and_oce()
+    finally:
+        asm_config._iast_enabled = original_state
+        reset_native_state()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- dd-meta {"pullId":"00000000-0000-0000-0000-000000000000","source":"chat","resourceId":"c014785d-1b56-4e97-9a0e-291a44af672e","workflowId":"1bcb6697-fb3d-43e0-98a0-b1bc19ba156d","codeChangeId":"1bcb6697-fb3d-43e0-98a0-b1bc19ba156d","sourceType":"test-optimization"} -->
## Description

Fixing `test_early_fork_keeps_iast_enabled[py3.11]` • [View in Test Optimization](https://app.datadoghq.com/ci/test/flaky?query=%40git.repository.id_v2%3A%22github.com%2Fdatadog%2Fdd-trace-py%22+%40test.name%3A%22test_early_fork_keeps_iast_enabled%5Bpy3.11%5D%22&sp=%5B%7B%22p%22%3A%7B%22fingerprintFqn%22%3A%22f39b976b860483ed%22%7D%2C%22i%22%3A%22test-optimization-flaky-management-history%22%7D%5D) • **Questions?** Ask in #code-gen-flaky-tests

Fixes flakiness in `test_early_fork_keeps_iast_enabled[py3.11]` by ensuring proper native state cleanup in `tests/appsec/iast/test_fork_handler_regression.py`.

The flakiness was caused by several tests manually calling `_disable_iast_after_fork()` to simulate fork behavior without an actual process fork. This resulted in the Python `IAST_CONTEXT` being cleared while the native context remained active, leaking slots in the limited-size native context array. Eventually, subsequent tests would fail to start a new native context, causing `is_tainted` to return `False` erroneously.

## Changes

- Added `reset_native_state()` to tests that manually simulate fork behavior.
- Wrapped these simulations in `try...finally` blocks to ensure `asm_config._iast_enabled` restoration and native state cleanup even on test failures.
- Changed `initialize_native_state()` to `reset_native_state()` in `test_early_fork_keeps_iast_enabled` to guarantee a clean slate before simulation.

## Testing

- Code verified for syntax and style using `ruff`.
- Analysis confirmed that manual `_disable_iast_after_fork()` calls were leaking native context slots, explaining the observed failure mode.

## Risks

None (test-only changes).

## Additional Notes

HIGH IMPACT FLAKY TEST: 6.4% flake rate, 5 hours of CI time wasted, 2 failed pipelines.
This fix improves CI reliability by preventing state leakage between IAST fork regression tests.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/c014785d-1b56-4e97-9a0e-291a44af672e)

Comment @datadog to request changes