### PR TITLE
chore: add module affinity analysis

### DIFF
--- a/.claude/skills/dependency-direction-analysis/SKILL.md
+++ b/.claude/skills/dependency-direction-analysis/SKILL.md
@@ -18,7 +18,7 @@ allowed-tools:
 # Dependency Direction Analysis Skill
 
 This skill runs the dependency direction detector locally and proposes sound
-architectural fixes for any violations found. It enforces two rules:
+architectural fixes for any violations found. It enforces three rules:
 
 1. **`ddtrace.internal` and `ddtrace.contrib` must not depend on product code.**
    They are shared foundation layers; every product depends on them, so a
@@ -29,6 +29,14 @@ architectural fixes for any violations found. It enforces two rules:
    Visibility, Error Tracking, OpenFeature, OpenTelemetry, and Runtime metrics
    are each isolated: none of them are mandatory for a given dd-trace-py
    install, so one product can't assume another is present.
+3. **Products must not depend on `ddtrace.contrib` directly** (config:
+   `rules.forbid_products_into_contrib` in `layers.json`, enabled by default).
+   Contrib exists to attach integration-specific behaviour to a product
+   (Pattern 1 below: dispatch events, let contrib listen), never the other
+   way round. A product module importing `ddtrace.contrib` directly means
+   integration-specific knowledge (a per-library constant, a per-library
+   helper) leaked into code every install runs, regardless of which
+   integrations are active.
 
 The guiding principle is the same as circular-import analysis: **Separation of
 Concerns**. Fixes must restructure ownership or add a decoupling layer, not
@@ -100,6 +108,107 @@ Clean up afterwards:
 ```bash
 rm violations.json violations-base.json violations-pr.json
 ```
+
+## Finding hidden per-product ownership in shared zones
+
+`layers.py` only catches internal-core/contrib code that *imports* a
+product. It can't catch the opposite smell: a module that lives in one of
+the zones supposed to serve every product but is, in practice, only ever
+*used by* one (e.g. `ddtrace.internal.writer` is only imported by tracing
+code) -- that module was never generic and belongs in that product's own
+namespace instead of the shared foundation layer.
+
+`affinity.py` looks the other direction across the same import graph: for
+every module in a zone under analysis, who imports it, and does that set of
+importers belong overwhelmingly to one product?
+
+```bash
+uv run --script scripts/import-analysis/affinity.py analyze affinity.json
+uv run --script scripts/import-analysis/affinity.py report affinity.json
+```
+
+By default it checks every zone in `layers.json`'s
+`rules.forbid_from_zones_into_products` -- the same list `layers.py` already
+uses to mean "must serve every product" -- rather than hardcoding a single
+zone name. Today that's `internal-core` and `contrib`. Pass `--zones
+internal-core` to narrow it if you only want one.
+
+`analyze` writes `affinity.json` with a `candidates` list, each entry giving
+the module, its resolved `dominant_zone`, a `confidence` tier, the breakdown
+of importer zones, a `confirmed_violations` list (see below), and (for the
+weaker tier) which importers don't fit the pattern:
+
+- **Confirmed** — `confirmed_violations` is non-empty: at least one direct
+  importer of this module already trips a `layers.py` rule (most often rule 3
+  above, a product importing straight into `contrib`). This isn't a
+  heuristic judgement call, it's the same exact-edge detection `layers.py`
+  uses for CI, just surfaced here alongside the affinity data, and it's
+  reported regardless of `dominant_ratio` -- a module used broadly enough
+  that no single product dominates (e.g. `ddtrace.contrib.trace_utils`,
+  `ratio` well under the dominant threshold) can still contain a confirmed
+  violation; breadth of use doesn't excuse one bad edge. Fix these the same
+  way you'd fix a `layers.py` violation (see the patterns below); `report`
+  lists these first, separately from the two heuristic tiers.
+- **`exclusive`** — every importer with a resolvable zone belongs to the same
+  product, and none of those imports are themselves confirmed violations.
+  Strongest heuristic signal; a good candidate to move into
+  `ddtrace.internal.<product>` (see Pattern 4/5 below) or reclassify in
+  `layers.json`.
+- **`dominant`** — one product accounts for most (≥60%) of the importers, but
+  not all, and none of those imports are confirmed violations. The
+  `minority_importers` field lists the outliers -- read those first: they're
+  either a legitimate shared use (leave the module where it is) or evidence
+  that *they* are the ones reaching into the wrong place (e.g. another
+  product borrowing this one's internals informally).
+
+`dominant_ratio` is votes for the top product divided by *all* importers with
+any resolvable zone, not just the ones that voted -- an importer with no
+usable signal (foundation code like `ddtrace.bootstrap.preload`, or a
+same-zone importer that hasn't itself resolved to a product) still counts
+against the denominator instead of being dropped. This matters: a module
+imported once by a product and once by generic bootstrap/plugin code isn't
+"100% exclusive" to that product just because the bootstrap caller doesn't
+vote for anyone -- its presence is itself evidence the module is more
+broadly used than the vote count alone would suggest.
+
+Detection propagates through same-zone chains: if module A is only imported
+by module B, and B itself resolved to product X, A inherits X's vote too.
+This lets it catch indirection (a low-level helper used only by a
+product-specific wrapper) that a single-hop check would miss. This makes the
+`exclusive`/`dominant` tiers heuristic rather than exact -- unlike
+`confirmed_violations`, they aren't wired into CI and shouldn't gate
+anything; treat them as a prioritized list of places to look, not a verdict.
+
+**Namespace buckets:** some packages are deliberately structured so each
+child module belongs to a different product by design -- e.g.
+`ddtrace.internal.settings` holds the generic `Config` aggregator
+(`_config.py`) plus one settings module per product (`settings.profiling`,
+`settings.aiguard`, ...), each contributed independently. Flagging
+`settings.profiling` as "exclusive to profiling" would be true but not
+actionable: it was never meant to be generic, so there's nothing to
+relocate. `layers.json`'s `affinity.namespace_buckets` lists such packages;
+`affinity.py` drops their direct children from the `exclusive`/`dominant`
+tiers (a `confirmed_violations` hit still surfaces regardless -- the bucket
+doesn't excuse an actual `layers.py` rule violation). Add a new prefix here
+when you hit the same shape elsewhere, rather than treating every
+single-product hit under it as a relocation candidate.
+
+**On contrib results:** most `ddtrace.contrib` modules come back `exclusive`
+by construction -- each integration patches one library for one product, so
+"this contrib module is only used by product X" is rarely surprising on its
+own, and that's expected (see the `contrib -> product:tracing` exception in
+`layers.json`). But don't dismiss every contrib entry as noise: check
+`confirmed_violations` first. A contrib module whose only importer is, say,
+`ddtrace._trace.trace_handlers` isn't "product-specific by design" -- it's
+evidence of rule 3 above being broken (integration-specific logic living in
+code the product runs unconditionally). Run with `--zones internal-core` only
+once you've looked at the confirmed section, if you want to drop the
+remaining structural contrib noise.
+
+Once you've picked a real candidate, apply Pattern 4 or 5 from "Architectural
+Patterns for Fixing Violations" below, then re-run `layers.py analyze` to
+confirm the move didn't introduce a `layers.json`-visible violation the other
+way.
 
 ## Zone Configuration
 

--- a/scripts/import-analysis/affinity.py
+++ b/scripts/import-analysis/affinity.py
@@ -1,0 +1,312 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "betsy @ git+https://github.com/p403n1x87/betsy.git",
+# ]
+# ///
+"""Find ddtrace.internal (or ddtrace.contrib) modules that are really product-specific.
+
+layers.py enforces that ddtrace.internal/ddtrace.contrib don't *import* product
+code. This script looks the other way: it inspects who *imports* each
+internal-core module, and flags modules that are, in practice, only used by a
+single product -- a sign the module was never generic and should live in that
+product's own namespace (e.g. ddtrace.internal.<product>) instead of the
+shared foundation layer.
+
+This is advisory: unlike layers.py it isn't meant to gate CI, since dominance
+is a judgement call (see "Confidence tiers" below), not a hard rule.
+"""
+
+import argparse
+from collections import Counter
+import json
+from pathlib import Path
+import sys
+from typing import TypedDict
+
+from betsy import DependencyGraph
+from betsy import compute_metrics
+
+
+sys.path.insert(0, str(Path(__file__).parent))
+from layers import _violates  # noqa: E402
+
+
+_Candidate = TypedDict(
+    "_Candidate",
+    {
+        "module": str,
+        "dominant_zone": str,
+        "confidence": str,
+        "dominant_ratio": float,
+        "importer_zones": dict[str, int],
+        "minority_importers": list[str],
+        "total_importers": int,
+        "score": int,
+        "confirmed_violations": list[str],
+    },
+)
+
+# Module prefixes we don't control and can't restructure.
+_EXCLUDED_PREFIXES = {"ddtrace.vendor"}
+
+_CONFIG_PATH = Path(__file__).with_name("layers.json")
+
+# A module used by exactly one product is "exclusive" evidence. A module used
+# by more than one, where one product still accounts for most of the
+# importers, is "dominant" -- weaker, worth a human look at the minority
+# importers before moving anything.
+_DOMINANT_RATIO = 0.6
+_MAX_ITERATIONS = 10
+
+
+def _load_config(config_path: Path) -> tuple[dict[str, str], set[str], set[tuple[str, str]], bool, set[str]]:
+    config = json.loads(config_path.read_text())
+    zones: dict[str, str] = config["zones"]
+    # The zones layers.py already treats as "must serve every product" --
+    # reused here as the default set to check for hidden per-product
+    # ownership, instead of hardcoding a single zone name.
+    forbid_from: set[str] = set(config["rules"]["forbid_from_zones_into_products"])
+    exceptions: set[tuple[str, str]] = {(e["from_zone"], e["to_zone"]) for e in config["rules"]["exceptions"]}
+    forbid_products_into_contrib: bool = config["rules"]["forbid_products_into_contrib"]["enabled"]
+    namespace_buckets: set[str] = set(config["affinity"]["namespace_buckets"])
+    return zones, forbid_from, exceptions, forbid_products_into_contrib, namespace_buckets
+
+
+def _in_namespace_bucket(module: str, namespace_buckets: set[str]) -> bool:
+    parent = module.rsplit(".", 1)[0]
+    return parent in namespace_buckets
+
+
+def _zone_of(module: str, zones: dict[str, str], prefixes: list[str]) -> str | None:
+    for prefix in prefixes:
+        if module == prefix or module.startswith(prefix + "."):
+            return zones[prefix]
+    return None
+
+
+def _reverse_graph(graph: DependencyGraph) -> dict[str, set[str]]:
+    reverse: dict[str, set[str]] = {name: set() for name in graph.data}
+    for importer, imports in graph.data.items():
+        for imported in imports:
+            if imported in reverse and imported != importer:
+                reverse[imported].add(importer)
+    return reverse
+
+
+def _classify(
+    importers: set[str],
+    zones: dict[str, str],
+    prefixes: list[str],
+    candidate_zones: set[str],
+    resolved: dict[str, tuple[str, float] | None],
+) -> tuple[dict[str, int], int]:
+    """Return (product -> importer count, total importers counted towards the ratio).
+
+    An importer casts a vote for a product when it's either a product itself,
+    or another module in one of the zones under analysis that has already
+    resolved to a product (propagating affinity through zone-internal
+    chains). Everything else -- foundation code, or a same-zone importer that
+    hasn't itself resolved to a product -- is neutral: it still counts
+    towards the denominator (diluting the ratio), it just doesn't vote for
+    anyone. Without this, a module imported by one product and by generic
+    bootstrap/plugin code (unclassified, so foundation) would read as "100%
+    exclusive" to that product -- the foundation caller is exactly the
+    evidence that it isn't.
+    """
+    votes: Counter[str] = Counter()
+    total = 0
+    for importer in importers:
+        zone = _zone_of(importer, zones, prefixes)
+        total += 1
+        if zone is None:
+            continue
+        if zone.startswith("product:"):
+            votes[zone] += 1
+        elif zone in candidate_zones:
+            prior = resolved.get(importer)
+            if prior is not None:
+                votes[prior[0]] += 1
+    return dict(votes), total
+
+
+def analyze(args: argparse.Namespace) -> None:
+    root = args.root if args.root is not None else Path(__file__).parents[2] / "ddtrace"
+    root = root.resolve()
+    graph = DependencyGraph(root=root, include={"ddtrace"}, exclude=_EXCLUDED_PREFIXES)
+    zones, forbid_from, exceptions, forbid_products_into_contrib, namespace_buckets = _load_config(_CONFIG_PATH)
+    candidate_zones = set(args.zones) if args.zones else forbid_from
+    prefixes = sorted(zones, key=len, reverse=True)
+    metrics = compute_metrics(graph)
+    reverse = _reverse_graph(graph)
+
+    candidate_modules = [m for m in graph.data if _zone_of(m, zones, prefixes) in candidate_zones]
+
+    # Fixed-point iteration: a module's dominant zone can feed into the
+    # dominance computation of the modules that import *it*, so resolving one
+    # module can change the answer for another. Not strictly monotonic (a
+    # newly-arriving vote can shift which product dominates), so we cap
+    # iterations rather than require true convergence -- this is an advisory
+    # tool, not a correctness-critical analysis.
+    resolved: dict[str, tuple[str, float] | None] = dict.fromkeys(candidate_modules)
+    for _ in range(_MAX_ITERATIONS):
+        changed = False
+        for module in candidate_modules:
+            votes, total = _classify(reverse.get(module, set()), zones, prefixes, candidate_zones, resolved)
+            if not votes:
+                new_value = None
+            else:
+                zone, count = max(votes.items(), key=lambda kv: kv[1])
+                ratio = count / total
+                new_value = (zone, ratio) if ratio >= _DOMINANT_RATIO else None
+            if resolved[module] != new_value:
+                resolved[module] = new_value
+                changed = True
+        if not changed:
+            break
+
+    candidates: list[_Candidate] = []
+    for module in candidate_modules:
+        # A confirmed violation is a hard fact -- layers.py's own rule already
+        # flags a direct importer -> module edge (e.g. a product importing
+        # straight into contrib) -- independent of whether this module's
+        # overall importer mix clears the heuristic dominance threshold
+        # below. It must not be gated behind that threshold, or a module
+        # diluted by unrelated neutral importers would hide a real violation.
+        own_zone = _zone_of(module, zones, prefixes)
+        confirmed_violations = sorted(
+            importer
+            for importer in reverse.get(module, set())
+            if own_zone is not None
+            and (importer_zone := _zone_of(importer, zones, prefixes)) is not None
+            and _violates(importer_zone, own_zone, forbid_from, exceptions, forbid_products_into_contrib)
+        )
+        votes, total = _classify(reverse.get(module, set()), zones, prefixes, candidate_zones, resolved)
+        if not votes:
+            continue
+        dominant_zone, count = max(votes.items(), key=lambda kv: kv[1])
+        ratio = count / total if total else 0.0
+        if ratio < _DOMINANT_RATIO and not confirmed_violations:
+            continue
+        # A namespace bucket (e.g. ddtrace.internal.settings) is intentionally
+        # structured with one child module per product; "exclusive to product
+        # X" is true but not a finding there, since the module was never
+        # meant to be generic. A confirmed violation still counts -- the
+        # bucket doesn't excuse an actual layers.py rule violation.
+        if not confirmed_violations and _in_namespace_bucket(module, namespace_buckets):
+            continue
+        confidence = "exclusive" if len(votes) == 1 else "dominant"
+        minority = sorted(
+            importer
+            for importer in reverse.get(module, set())
+            if (importer_zone := _zone_of(importer, zones, prefixes)) is not None
+            and importer_zone.startswith("product:")
+            and importer_zone != dominant_zone
+        )
+        target = metrics.get(module)
+        candidates.append(
+            {
+                "module": module,
+                "dominant_zone": dominant_zone,
+                "confidence": confidence,
+                "dominant_ratio": round(ratio, 3),
+                "importer_zones": votes,
+                "minority_importers": minority,
+                "total_importers": total,
+                "score": target.ca if target is not None else 0,
+                "confirmed_violations": confirmed_violations,
+            }
+        )
+
+    candidates.sort(
+        key=lambda c: (not c["confirmed_violations"], c["confidence"] != "exclusive", -c["score"], c["module"])
+    )
+
+    args.output.write_text(json.dumps({"candidates": candidates}, indent=2) + "\n")
+
+    confirmed = [c for c in candidates if c["confirmed_violations"]]
+    exclusive = [c for c in candidates if not c["confirmed_violations"] and c["confidence"] == "exclusive"]
+    dominant = [c for c in candidates if not c["confirmed_violations"] and c["confidence"] == "dominant"]
+    print(f"Found {len(confirmed)} module(s) with a direct import already flagged as a layers.py violation.")
+    print(f"Found {len(exclusive)} module(s) used exclusively by a single product.")
+    print(f"Found {len(dominant)} module(s) mostly used by a single product (review minority importers).")
+
+
+def _print_candidate(c: _Candidate) -> None:
+    zones_str = ", ".join(f"{z}={n}" for z, n in sorted(c["importer_zones"].items(), key=lambda kv: -kv[1]))
+    print(f"  {c['module']}  (score={c['score']}, ratio={c['dominant_ratio']})")
+    print(f"    -> {c['dominant_zone']}  [{zones_str}]")
+    if c["confirmed_violations"]:
+        print(f"    confirmed layers.py violation, imported directly by: {', '.join(c['confirmed_violations'])}")
+    if c["minority_importers"]:
+        print(f"    minority importers to review: {', '.join(c['minority_importers'])}")
+
+
+def report(args: argparse.Namespace) -> None:
+    data = json.loads(args.candidates.read_text())
+    candidates: list[_Candidate] = data["candidates"]
+    confirmed = [c for c in candidates if c["confirmed_violations"]]
+    exclusive = [c for c in candidates if not c["confirmed_violations"] and c["confidence"] == "exclusive"]
+    dominant = [c for c in candidates if not c["confirmed_violations"] and c["confidence"] == "dominant"]
+
+    if confirmed:
+        print(f"## Confirmed layering violations, also caught by layers.py ({len(confirmed)})")
+        print()
+        print(
+            "These aren't just heuristically dominated by one product -- at least one direct importer "
+            "already violates layers.py's rules (e.g. a product importing straight into contrib). "
+            "Fix these the way layers.py violations are fixed; see the dependency-direction-analysis skill."
+        )
+        print()
+        for c in confirmed:
+            _print_candidate(c)
+        print()
+
+    if exclusive:
+        print(f"## Exclusive to one product ({len(exclusive)})")
+        print()
+        for c in exclusive:
+            _print_candidate(c)
+        print()
+
+    if dominant:
+        print(f"## Dominated by one product, minority use elsewhere ({len(dominant)})")
+        print()
+        for c in dominant:
+            _print_candidate(c)
+
+
+def main() -> int:
+    argp = argparse.ArgumentParser()
+    subp = argp.add_subparsers(dest="command", required=True)
+
+    subp_analyze = subp.add_parser("analyze", help="Compute per-product affinity of internal-core/contrib modules")
+    subp_analyze.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Path to the ddtrace package root (default: auto-detected from __file__)",
+    )
+    subp_analyze.add_argument(
+        "--zones",
+        type=lambda s: [z.strip() for z in s.split(",")],
+        default=None,
+        help=(
+            "Comma-separated zones to check for hidden per-product ownership "
+            "(default: layers.json's rules.forbid_from_zones_into_products, "
+            "i.e. every zone that's supposed to serve every product)"
+        ),
+    )
+    subp_analyze.add_argument("output", type=Path)
+
+    subp_report = subp.add_parser("report", help="Pretty-print an affinity.py analyze output")
+    subp_report.add_argument("candidates", type=Path)
+
+    args = argp.parse_args()
+
+    globals()[args.command](args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/import-analysis/layers.json
+++ b/scripts/import-analysis/layers.json
@@ -70,15 +70,42 @@
     "//": [
       "A directed edge importer-zone -> imported-zone is a violation when:",
       "  - importer zone is 'internal-core' or 'contrib' and imported zone is any product, or",
-      "  - importer and imported zones are two different products.",
+      "  - importer and imported zones are two different products, or",
+      "  - importer zone is a product and imported zone is 'contrib' (see forbid_products_into_contrib).",
       "Same-zone edges, and edges into/out of unclassified (foundation) modules, are never flagged.",
       "'exceptions' lists zone-pairs that are exempt from the above -- e.g. if we later decide a",
       "product may import a security product directly, add {\"from_zone\": \"product:x\", \"to_zone\":",
       "\"product:appsec\"} here rather than changing the detection logic."
     ],
     "forbid_from_zones_into_products": ["internal-core", "contrib"],
+    "forbid_products_into_contrib": {
+      "//": [
+        "Contrib exists to attach integration-specific behaviour to a product (Pattern 1: dispatch",
+        "events, let contrib listen), never the other way round. A product module importing",
+        "ddtrace.contrib directly means integration-specific knowledge (a per-library constant, a",
+        "per-library helper) leaked into code every install runs regardless of which integrations are",
+        "active -- e.g. ddtrace._trace.trace_handlers importing per-integration constants from",
+        "ddtrace.contrib.internal.{botocore,mlflow,ray,azure_cosmos,google_cloud_pubsub}."
+      ],
+      "enabled": true
+    },
     "exceptions": [
       {"from_zone": "contrib", "to_zone": "product:tracing", "//": "contrib/* are tracer integrations; they attach to the Tracer/Pin/Span API by design"}
     ]
+  },
+  "affinity": {
+    "//": [
+      "Used only by affinity.py (the heuristic per-product-ownership finder), never by layers.py's",
+      "exact violation detection. A namespace bucket is a package that is intentionally structured so",
+      "each child module is owned by a single product -- e.g. ddtrace.internal.settings holds the",
+      "generic Config aggregator (_config.py) plus one settings module per product",
+      "(settings.profiling, settings.aiguard, ...), each contributed independently. affinity.py would",
+      "otherwise flag every such child as 'exclusive to one product' -- true, but not a finding: it was",
+      "never meant to be generic, so there's nothing to relocate. Modules directly under a listed prefix",
+      "are excluded from the exclusive/dominant tiers; a module still shows up if it has a",
+      "confirmed_violations entry, since a namespace bucket doesn't excuse an actual layers.py rule",
+      "violation."
+    ],
+    "namespace_buckets": ["ddtrace.internal.settings"]
   }
 }

--- a/scripts/import-analysis/layers.py
+++ b/scripts/import-analysis/layers.py
@@ -50,13 +50,14 @@ _PRODUCT_PRODUCT_WEIGHT = 1
 _CYCLE_BONUS = 5
 
 
-def _load_zones(config_path: Path) -> tuple[dict[str, str], set[str], set[tuple[str, str]], set[str]]:
+def _load_zones(config_path: Path) -> tuple[dict[str, str], set[str], set[tuple[str, str]], set[str], bool]:
     config = json.loads(config_path.read_text())
     zones: dict[str, str] = config["zones"]
     forbid_from: set[str] = set(config["rules"]["forbid_from_zones_into_products"])
     exceptions: set[tuple[str, str]] = {(e["from_zone"], e["to_zone"]) for e in config["rules"]["exceptions"]}
     foundation_top_level: set[str] = set(config["foundation"]["top_level"])
-    return zones, forbid_from, exceptions, foundation_top_level
+    forbid_products_into_contrib: bool = config["rules"]["forbid_products_into_contrib"]["enabled"]
+    return zones, forbid_from, exceptions, foundation_top_level, forbid_products_into_contrib
 
 
 def _uncovered_top_level(root: Path, zones: dict[str, str], foundation_top_level: set[str]) -> list[str]:
@@ -88,13 +89,25 @@ def _zone_of(module: str, zones: dict[str, str], prefixes: list[str]) -> str | N
     return None
 
 
-def _violates(from_zone: str, to_zone: str, forbid_from: set[str], exceptions: set[tuple[str, str]]) -> bool:
+def _violates(
+    from_zone: str,
+    to_zone: str,
+    forbid_from: set[str],
+    exceptions: set[tuple[str, str]],
+    forbid_products_into_contrib: bool,
+) -> bool:
     if from_zone == to_zone or (from_zone, to_zone) in exceptions:
         return False
     is_product = to_zone.startswith("product:")
     if from_zone in forbid_from:
         return is_product
-    return from_zone.startswith("product:") and is_product
+    if not from_zone.startswith("product:"):
+        return False
+    # Contrib is meant to depend on products (Pattern 1: dispatch events, let
+    # contrib listen), never the reverse -- a product importing contrib
+    # directly means integration-specific knowledge leaked into code every
+    # install runs, regardless of which integrations are active.
+    return is_product or (forbid_products_into_contrib and to_zone == "contrib")
 
 
 def _severity(from_zone: str, metrics: dict[str, ModuleMetrics], imported: str) -> int:
@@ -109,7 +122,7 @@ def analyze(args: argparse.Namespace) -> None:
     root = args.root if args.root is not None else Path(__file__).parents[2] / "ddtrace"
     root = root.resolve()
     graph = DependencyGraph(root=root, include={"ddtrace"}, exclude=_EXCLUDED_PREFIXES)
-    zones, forbid_from, exceptions, foundation_top_level = _load_zones(_CONFIG_PATH)
+    zones, forbid_from, exceptions, foundation_top_level, forbid_products_into_contrib = _load_zones(_CONFIG_PATH)
     prefixes = sorted(zones, key=len, reverse=True)
     metrics = compute_metrics(graph)
 
@@ -120,7 +133,9 @@ def analyze(args: argparse.Namespace) -> None:
             continue
         for imported in imports:
             to_zone = _zone_of(imported, zones, prefixes)
-            if to_zone is None or not _violates(from_zone, to_zone, forbid_from, exceptions):
+            if to_zone is None or not _violates(
+                from_zone, to_zone, forbid_from, exceptions, forbid_products_into_contrib
+            ):
                 continue
             target = metrics.get(imported)
             violations.append(


### PR DESCRIPTION
## Description

We add an import analysis script that determines the affinity of a module to a component. It keeps layering violations into account when working out if a module in a certain component is more likely to belong to a different component.