### PR TITLE
refactor(profiling): make fallback profiler class match real interface

### DIFF
--- a/ddtrace/profiling/__init__.py
+++ b/ddtrace/profiling/__init__.py
@@ -1,4 +1,5 @@
 from typing import Any
+from typing import Optional
 
 
 # Native profiling extensions may be absent on some Python versions (e.g. 3.15
@@ -7,18 +8,42 @@ from typing import Any
 is_available: bool = False
 failure_msg: str = ""
 
+
+class _UnavailableProfiler:
+    """Stub Profiler class used when native profiling extensions are not available.
+
+    Interface matches the public interface of ``ddtrace.profiling.profiler.Profiler``
+    so static type checking and introspection stay consistent whether or not the
+    Profiler is actually available.
+    """
+
+    _import_error: Optional[BaseException] = None
+    _msg: str = (
+        "ddtrace.profiling is not available on this Python version "
+        "(native extensions are not built). "
+        "Import ddtrace.profiling and check is_available/failure_msg for details."
+    )
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        raise ImportError(self._msg) from type(self)._import_error
+
+    def start(self) -> None:
+        raise ImportError(self._msg) from type(self)._import_error
+
+    def stop(self, flush: bool = True) -> None:
+        raise ImportError(self._msg) from type(self)._import_error
+
+    def __getattr__(self, key: str) -> Any:
+        raise ImportError(self._msg) from type(self)._import_error
+
+
 try:
     from .profiler import Profiler  # noqa: F401
 
     is_available = True
 except Exception as e:
     failure_msg = str(e)
-    _profiler_import_error: BaseException = e
+    _UnavailableProfiler._import_error = e
 
-    class Profiler:  # type: ignore[no-redef]
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            raise ImportError(
-                "ddtrace.profiling is not available on this Python version "
-                "(native extensions are not built). "
-                "Import ddtrace.profiling and check is_available/failure_msg for details."
-            ) from _profiler_import_error
+    class Profiler(_UnavailableProfiler):  # type: ignore[no-redef]
+        pass

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -716,3 +716,68 @@ def test_profiler_atexit_no_assertion_error_with_gevent():
 
     # We don't need to assert anything here, we only want to make sure the subprocess
     # runs (and exits) without raising an exception/crashing.
+
+
+def test_unavailable_profiler_matches_real_interface() -> None:
+    import inspect
+
+    from ddtrace.profiling import _UnavailableProfiler
+    from ddtrace.profiling.profiler import Profiler as RealProfiler
+
+    # __init__ and __getattr__ are part of the callable contract callers rely
+    # on (construction and attribute delegation), so include them alongside
+    # public methods when comparing interfaces.
+    interesting_dunders: set[str] = {"__init__", "__getattr__"}
+
+    def _relevant_methods(cls: type) -> set[str]:
+        return {
+            name
+            for name, _ in inspect.getmembers(cls, predicate=inspect.isfunction)
+            if not name.startswith("_") or name in interesting_dunders
+        }
+
+    real_methods: set[str] = _relevant_methods(RealProfiler)
+    stub_methods: set[str] = _relevant_methods(_UnavailableProfiler)
+    assert real_methods == stub_methods, (
+        f"Interface drift between Profiler and _UnavailableProfiler: "
+        f"missing on stub={real_methods - stub_methods}, extra on stub={stub_methods - real_methods}"
+    )
+
+    for name in real_methods:
+        real_sig: inspect.Signature = inspect.signature(getattr(RealProfiler, name))
+        stub_sig: inspect.Signature = inspect.signature(getattr(_UnavailableProfiler, name))
+        assert real_sig == stub_sig, f"Signature mismatch on {name}: real={real_sig}, stub={stub_sig}"
+
+
+def test_unavailable_profiler_preserves_public_name() -> None:
+    from ddtrace.profiling import _UnavailableProfiler
+    from ddtrace.profiling.profiler import Profiler as RealProfiler
+
+    Profiler: type[_UnavailableProfiler] = type("Profiler", (_UnavailableProfiler,), {})
+
+    assert Profiler.__name__ == RealProfiler.__name__
+    assert Profiler.__qualname__ == RealProfiler.__qualname__
+
+
+def test_unavailable_profiler_raises_import_error() -> None:
+    from ddtrace.profiling import _UnavailableProfiler
+
+    _UnavailableProfiler._import_error = RuntimeError("native ext missing")
+    try:
+        with pytest.raises(ImportError) as excinfo:
+            _UnavailableProfiler()
+        assert isinstance(excinfo.value.__cause__, RuntimeError)
+
+        # __init__ raises, so drive start/stop/__getattr__ against the class
+        # using a bare instance created without calling __init__.
+        bare: _UnavailableProfiler = _UnavailableProfiler.__new__(_UnavailableProfiler)
+        with pytest.raises(ImportError):
+            bare.start()
+        with pytest.raises(ImportError):
+            bare.stop()
+        with pytest.raises(ImportError):
+            bare.stop(flush=False)
+        with pytest.raises(ImportError):
+            _ = bare.status  # delegated attribute on the real Profiler
+    finally:
+        _UnavailableProfiler._import_error = None


### PR DESCRIPTION
## Description

This fixes an issue discovered while trying to dogfood the latest `main` version of `ddtrace` in dd-source. 

The problem was that `ty` (the static type checker) detects that `Profiler` can be the _real_ `Profiler` class or the fake stub class; if it is the fake stub class, it doesn't have a `start` method, so static type checking fails even though the Profiler class would work at runtime.

The workaround is to make the interface of the fake `Profiler` match that of the real `Profiler` -- this hides the error at static type checking time (which is especially important because it is not possible to know whether the error will happen without actually running the code).

**Note** this is marked as `refactor` to avoid having to introduce a changelog entry for a change that was never released. 