### PR TITLE
ci(hooks): block partially staged Python files from committing unformatted (PROF-15836)

### DIFF
--- a/hooks/scripts/run-fmt.sh
+++ b/hooks/scripts/run-fmt.sh
@@ -10,7 +10,18 @@ if [ -n "$staged_files" ]; then
     # ruff runs on .py and .pyi files only — ruff does not support Cython syntax in .pyx files
     # (see https://github.com/astral-sh/ruff/issues/10250)
     staged_ruff=$(echo "$staged_files" | tr ' ' '\n' | grep -E '\.(py|pyi)$' | grep -v '^$' | tr '\n' ' ')
+    # Partial staging: we skip re-add of dirty files, so ruff would format the
+    # working tree and leave the index unformatted. Fail before running ruff so
+    # we do not mutate unstaged hunks on this path.
     if [ -n "$(printf '%s' "$staged_ruff" | tr -d ' \t\n')" ]; then
+        for f in $staged_ruff; do
+            if echo "$unstaged_before" | grep -qFx "$f"; then
+                printf '\nFormat/lint error: %s is partially staged.\n' "$f" >&2
+                printf 'The hook will not format a partially staged file (index would stay unformatted).\n' >&2
+                printf 'Fix: git add %s   (or unstage, run scripts/lint fmt, then re-stage)\n\n' "$f" >&2
+                exit 1
+            fi
+        done
         "$LINT_CMD" ruff format --no-cache $staged_ruff || exit $?
         "$LINT_CMD" ruff check --fix --show-fixes --no-cache $staged_ruff || exit $?
     fi
@@ -21,17 +32,8 @@ if [ -n "$staged_files" ]; then
         echo "$unstaged_before" | grep -qFx "$f" || git add "$f"
     done
 
-    # Partial staging: ruff formats the working tree but we skip re-add above, so the
-    # index can still commit unformatted content. Block that explicitly.
+    # Verify staged .py/.pyi content is formatted after ruff + re-add
     if [ -n "$(printf '%s' "$staged_ruff" | tr -d ' \t\n')" ]; then
-        for f in $staged_ruff; do
-            if echo "$unstaged_before" | grep -qFx "$f"; then
-                printf '\nFormat/lint error: %s is partially staged.\n' "$f" >&2
-                printf 'ruff formatted the working tree, but the staged index was not updated.\n' >&2
-                printf 'Fix: git add %s   (or unstage, run scripts/lint fmt, then re-stage)\n\n' "$f" >&2
-                exit 1
-            fi
-        done
         staged_ruff_now=$(git diff --staged --name-only HEAD --diff-filter=ACMR | tr ' ' '\n' | grep -E '\.(py|pyi)$' | grep -v '^$' | tr '\n' ' ')
         if [ -n "$(printf '%s' "$staged_ruff_now" | tr -d ' \t\n')" ]; then
             ruff_staged_output=$("$LINT_CMD" ruff format --check --no-cache $staged_ruff_now 2>&1)

--- a/hooks/scripts/run-fmt.sh
+++ b/hooks/scripts/run-fmt.sh
@@ -32,7 +32,7 @@ if [ -n "$staged_files" ]; then
                 exit 1
             fi
         done
-        staged_ruff_now=$(git diff --staged --name-only HEAD | tr ' ' '\n' | grep -E '\.(py|pyi)$' | grep -v '^$' | tr '\n' ' ')
+        staged_ruff_now=$(git diff --staged --name-only HEAD --diff-filter=ACMR | tr ' ' '\n' | grep -E '\.(py|pyi)$' | grep -v '^$' | tr '\n' ' ')
         if [ -n "$(printf '%s' "$staged_ruff_now" | tr -d ' \t\n')" ]; then
             ruff_staged_output=$("$LINT_CMD" ruff format --check --no-cache $staged_ruff_now 2>&1)
             if [ $? -ne 0 ]; then

--- a/hooks/scripts/run-fmt.sh
+++ b/hooks/scripts/run-fmt.sh
@@ -21,6 +21,37 @@ if [ -n "$staged_files" ]; then
         echo "$unstaged_before" | grep -qFx "$f" || git add "$f"
     done
 
+    # Partial staging: ruff formats the working tree but we skip re-add above, so the
+    # index can still commit unformatted content. Block that explicitly.
+    if [ -n "$(printf '%s' "$staged_ruff" | tr -d ' \t\n')" ]; then
+        for f in $staged_ruff; do
+            if echo "$unstaged_before" | grep -qFx "$f"; then
+                printf '\nFormat/lint error: %s is partially staged.\n' "$f" >&2
+                printf 'ruff formatted the working tree, but the staged index was not updated.\n' >&2
+                printf 'Fix: git add %s   (or unstage, run scripts/lint fmt, then re-stage)\n\n' "$f" >&2
+                exit 1
+            fi
+        done
+        staged_ruff_now=$(git diff --staged --name-only HEAD | tr ' ' '\n' | grep -E '\.(py|pyi)$' | grep -v '^$' | tr '\n' ' ')
+        if [ -n "$(printf '%s' "$staged_ruff_now" | tr -d ' \t\n')" ]; then
+            ruff_staged_output=$("$LINT_CMD" ruff format --check --no-cache $staged_ruff_now 2>&1)
+            if [ $? -ne 0 ]; then
+                RED='\033[0;31m'
+                BOLD='\033[1m'
+                RESET='\033[0m'
+                printf "\n${BOLD}${RED}╔══ FORMAT ERROR ═══════════════════════════════════════════╗${RESET}\n"
+                printf "${BOLD}${RED}║  Staged file(s) are still unformatted after ruff format:${RESET}\n"
+                echo "$ruff_staged_output" | grep -E "^Would reformat" | while IFS= read -r line; do
+                    printf "${RED}║    • %s${RESET}\n" "$line"
+                done
+                printf "${BOLD}${RED}║${RESET}\n"
+                printf "${BOLD}${RED}║  Fix: scripts/lint fmt && git add <files>${RESET}\n"
+                printf "${BOLD}${RED}╚═══════════════════════════════════════════════════════════╝${RESET}\n\n"
+                exit 1
+            fi
+        fi
+    fi
+
     # cython-lint runs on .pyx files only; ruff covers .py/.pyi, and cython-lint's
     # pycodestyle checks would be redundant on .py files
     staged_cython_lint=$(echo "$staged_files" | tr ' ' '\n' | grep '\.pyx$' | grep -v '^$' | tr '\n' ' ')

--- a/hooks/tests/test-run-fmt.sh
+++ b/hooks/tests/test-run-fmt.sh
@@ -126,10 +126,10 @@ output=$(run_hook)
 check "no staged files: lint not called"      "! [ -s '$LINT_CALLS' ]"
 check "no staged files: skip message printed" "printf '%s' '$output' | grep -q 'skipped'"
 
-# Partial staging: ruff may format the working tree but must not commit an unformatted index
-cat > "$TMPDIR_TEST/git" << 'EOF'
+# Partial staging: fail before ruff so the working tree is not mutated
+cat > "$TMPDIR_TEST/git" << EOF
 #!/usr/bin/env sh
-case "$*" in
+case "\$*" in
     "diff --staged --name-only HEAD --diff-filter=ACMR")
         printf '%s\n' foo.py ;;
     "diff --name-only")
@@ -137,17 +137,20 @@ case "$*" in
     "diff --name-only --diff-filter=ACMR")
         printf '%s\n' foo.py ;;
     add\ *)
-        echo "$*" >> "$GIT_ADD_CALLS" ;;
+        echo "\$*" >> "$GIT_ADD_CALLS" ;;
     *)
-        exec "$(command -v git)" "$@" ;;
+        exec "$(command -v git)" "\$@" ;;
 esac
 EOF
 chmod +x "$TMPDIR_TEST/git"
 : > "$LINT_CALLS"
+: > "$GIT_ADD_CALLS"
 partial_out=$(run_hook 2>&1) || partial_rc=$?
 partial_rc="${partial_rc:-0}"
 check "partial staging: hook fails" "[ '${partial_rc}' -ne 0 ]"
 check "partial staging: mentions partially staged" "printf '%s' '$partial_out' | grep -qi 'partially staged'"
+check "partial staging: ruff not run" "! [ -s '$LINT_CALLS' ]"
+check "partial staging: git add not called" "! [ -s '$GIT_ADD_CALLS' ]"
 
 # ── summary ──────────────────────────────────────────────────────────────────
 

--- a/hooks/tests/test-run-fmt.sh
+++ b/hooks/tests/test-run-fmt.sh
@@ -126,6 +126,29 @@ output=$(run_hook)
 check "no staged files: lint not called"      "! [ -s '$LINT_CALLS' ]"
 check "no staged files: skip message printed" "printf '%s' '$output' | grep -q 'skipped'"
 
+# Partial staging: ruff may format the working tree but must not commit an unformatted index
+cat > "$TMPDIR_TEST/git" << 'EOF'
+#!/usr/bin/env sh
+case "$*" in
+    "diff --staged --name-only HEAD --diff-filter=ACMR")
+        printf '%s\n' foo.py ;;
+    "diff --name-only")
+        printf '%s\n' foo.py ;;
+    "diff --name-only --diff-filter=ACMR")
+        printf '%s\n' foo.py ;;
+    add\ *)
+        echo "$*" >> "$GIT_ADD_CALLS" ;;
+    *)
+        exec "$(command -v git)" "$@" ;;
+esac
+EOF
+chmod +x "$TMPDIR_TEST/git"
+: > "$LINT_CALLS"
+partial_out=$(run_hook 2>&1) || partial_rc=$?
+partial_rc="${partial_rc:-0}"
+check "partial staging: hook fails" "[ '${partial_rc}' -ne 0 ]"
+check "partial staging: mentions partially staged" "printf '%s' '$partial_out' | grep -qi 'partially staged'"
+
 # ── summary ──────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Description

This [style issue](https://github.com/DataDog/dd-trace-py/pull/19267/changes/3f2e26aebf2b83622ee63c74a893f0143ad37b3c) got through our hooks.

* Pre-commit `run-fmt.sh` fails fast when a staged `.py/.pyi` file is partially staged — ruff formats the working tree but skips re-add, so the index can still commit unformatted content.
* After ruff finishes, runs `ruff format --check` on staged `.py/.pyi` files to verify the index is formatted.

## Testing

* New unit test for the partial-staging failure path.