### PR TITLE
fix(tracing): preserve valid W3C tracestate elements

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -95,11 +95,11 @@ jobs:
   serverless-system-tests:
     needs: [serverless-system-tests-build-layer]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@72ed6ee7d6b33d2d3a080b939c10a6d3d9077746
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@fe7159979b0265543bbd76210a7e120446e66642
     secrets: inherit
     with:
       library: python_lambda
-      ref: '72ed6ee7d6b33d2d3a080b939c10a6d3d9077746'
+      ref: 'fe7159979b0265543bbd76210a7e120446e66642'
       binaries_artifact: serverless_system_tests_binaries
       scenarios_groups: lambda_end_to_end
       skip_empty_scenarios: true
@@ -126,11 +126,11 @@ jobs:
     if: github.event_name != 'schedule' || github.event.repository.fork == false
     needs: [integration-frameworks-combine-wheels]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@72ed6ee7d6b33d2d3a080b939c10a6d3d9077746
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@fe7159979b0265543bbd76210a7e120446e66642
     secrets: inherit
     with:
       library: python
-      ref: '72ed6ee7d6b33d2d3a080b939c10a6d3d9077746'
+      ref: 'fe7159979b0265543bbd76210a7e120446e66642'
       scenarios: INTEGRATION_FRAMEWORKS
       binaries_artifact: integration-frameworks-wheels
       push_to_test_optimization: true
@@ -138,10 +138,10 @@ jobs:
   tracer-release:
     needs:
       - download-s3-wheels
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@72ed6ee7d6b33d2d3a080b939c10a6d3d9077746
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@fe7159979b0265543bbd76210a7e120446e66642
     with:
       library: python
-      ref: '72ed6ee7d6b33d2d3a080b939c10a6d3d9077746'
+      ref: 'fe7159979b0265543bbd76210a7e120446e66642'
       binaries_artifact: wheels-manylinux_x86_64
       desired_execution_time: 900
       scenarios_groups: tracer-release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "72ed6ee7d6b33d2d3a080b939c10a6d3d9077746"
+  SYSTEM_TESTS_REF: "fe7159979b0265543bbd76210a7e120446e66642"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
   PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v103334885-be1888c-profiling_native"

--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -755,7 +755,11 @@ class _TraceContext:
                 # cut out dd= before turning into dict
                 list_mem = list_mem[3:]
                 # since tags can have a value with a :, we need to only split on the first instance of :
-                dd = dict(item.split(":", 1) for item in list_mem.split(";"))
+                dd = {}
+                for item in list_mem.split(";"):
+                    key, separator, value = item.partition(":")
+                    if separator:
+                        dd[key] = value
 
         # parse out values
         if dd:

--- a/releasenotes/notes/fix-w3c-tracestate-parsing-90f37b6cdb0492b0.yaml
+++ b/releasenotes/notes/fix-w3c-tracestate-parsing-90f37b6cdb0492b0.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    tracing: Fixes an issue where W3C ``tracestate`` propagation loses valid Datadog sampling and origin
+    information when an adjacent entry is empty or malformed.

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -1480,9 +1480,9 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
         ),
         (
             "dd=invalid,congo=123",
+            (None, {}, None, None),
             None,
-            ["received invalid dd header value in tracestate: 'dd=invalid,congo=123'"],
-            ValueError,
+            None,
         ),
         (  # "ts_string,expected_tuple,expected_logging,expected_exception",
             "dd=foo|bar:hi|l¢¢¢¢¢¢:",
@@ -1531,7 +1531,7 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
         "tracestate_with_unknown_t._values",
         "tracestate_with_no_dd_list_member",
         "tracestate_no_origin",
-        "tracestate_invalid_dd_list_member",
+        "tracestate_with_only_malformed_dd_element",
         "tracestate_invalid_tracestate_char_outside_ascii_range_20-70",
         "tracestate_tilda_replaced_with_equals",
         "tracestate_colon_acceptable_char_in_value",
@@ -1549,6 +1549,26 @@ def test_extract_tracestate(caplog, ts_string, expected_tuple, expected_logging,
             if caplog.text or expected_logging:
                 for expected_log in expected_logging:
                     assert expected_log in caplog.text
+
+
+@pytest.mark.parametrize(
+    "tracestate",
+    [
+        "dd=s:2;o:some;",
+        "dd=s:2;o:some; \t",
+        "dd=s:2;o:some;;",
+        "dd=s:2;o:some;,other=x",
+        "dd=;s:2;o:some",
+        "dd=s:2;;o:some",
+        "dd=s:2;;;o:some",
+        "dd=s:2;flag;o:some",
+        "dd=flag;s:2;o:some",
+        "dd=s:2;o:some;flag",
+        "dd=s:2; z:w;o:some",
+    ],
+)
+def test_extract_tracestate_skips_empty_and_malformed_dd_elements(tracestate):
+    assert _TraceContext._get_tracestate_values(tracestate.split(",")) == (2, {}, "some", None)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Parse semicolon-delimited Datadog W3C `tracestate` elements independently so empty or malformed elements no longer discard valid sampling priority and origin data.

Fixes [APMAPI-2294](https://datadoghq.atlassian.net/browse/APMAPI-2294). This addresses the Python failures documented in [DataDog/system-tests#7569](https://github.com/DataDog/system-tests/pull/7569).

## Testing

- `scripts/run-tests --venv ed437ab -- tests/tracer/test_propagation.py -k 'not 128bit'` (1,831 passed)
- `scripts/lint checks`
- Local system-tests run of the three affected parametric tests from DataDog/system-tests#7569 (3 passed)

## Risks

Low. The change only makes malformed sub-element handling more lenient; known valid fields retain their existing parsing and validation.

## Additional Notes

The regression test covers every malformed or empty `dd` element variant added by the system-tests PR.


[APMAPI-2294]: https://datadoghq.atlassian.net/browse/APMAPI-2294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ