### PR TITLE
refactor: use a protocol type to avoid Span imports throughout appsec

### DIFF
--- a/ddtrace/appsec/_asm_request_context.py
+++ b/ddtrace/appsec/_asm_request_context.py
@@ -12,7 +12,6 @@ from typing import Protocol
 from typing import Union
 from urllib import parse
 
-from ddtrace._trace.span import Span
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import EXPLOIT_PREVENTION
 from ddtrace.appsec._constants import SPAN_DATA_NAMES
@@ -29,6 +28,7 @@ from ddtrace.internal import core
 from ddtrace.internal import span_bus
 from ddtrace.internal import telemetry
 from ddtrace.internal._exceptions import BlockingException
+from ddtrace.internal.appsec.prototypes import SpanProtocol
 from ddtrace.internal.constants import Constant_Class
 from ddtrace.internal.core.events import Event
 import ddtrace.internal.logger as ddlogger
@@ -98,7 +98,7 @@ class ASM_Environment:
     def __init__(
         self,
         waf_callable: Optional[WafCallable],
-        span: Optional[Span] = None,
+        span: Optional[SpanProtocol] = None,
         rc_products: str = "",
     ):
         self.root = not in_asm_context()
@@ -109,8 +109,8 @@ class ASM_Environment:
         if context_span is None:
             logger.warning(WARNING_TAGS.ASM_ENV_NO_SPAN, extra=log_extra, stack_info=True)
             raise TypeError("ASM_Environment requires a span")
-        self.span: Span = context_span
-        self.entry_span: Span = self.span._service_entry_span
+        self.span: SpanProtocol = context_span
+        self.entry_span: SpanProtocol = self.span._service_entry_span
         if self.span.name.endswith(".request"):
             self.framework = self.span.name[:-8]
         else:
@@ -163,7 +163,7 @@ def get_blocked() -> Optional[Block_config]:
     return env.blocked or None
 
 
-def get_entry_span() -> Optional[Span]:
+def get_entry_span() -> Optional[SpanProtocol]:
     env = _get_asm_context()
     if env is None:
         span = span_bus.get_span()
@@ -310,7 +310,7 @@ def set_blocked_dict(block: Union[dict[str, Any], Block_config, None]) -> None:
     set_blocked(blocked)
 
 
-def update_span_metrics(span: Span, name: str, value: Union[float, int]) -> None:
+def update_span_metrics(span: SpanProtocol, name: str, value: Union[float, int]) -> None:
     span._set_attribute(name, value + (span.get_metric(name) or 0.0))
 
 
@@ -651,7 +651,7 @@ def store_waf_results_data(data: "list[WafEvent]") -> None:
     env.waf_triggers.extend(data)
 
 
-def start_context(waf_callable: Optional[WafCallable], span: Span, rc_products: str) -> None:
+def start_context(waf_callable: Optional[WafCallable], span: SpanProtocol, rc_products: str) -> None:
     if asm_config._asm_enabled:
         core.set_item(
             _ASM_CONTEXT,
@@ -674,7 +674,7 @@ def start_context(waf_callable: Optional[WafCallable], span: Span, rc_products: 
         )
 
 
-def end_context(span: Span) -> None:
+def end_context(span: SpanProtocol) -> None:
     env = _get_asm_context()
     if env is not None and env.span is span:
         finalize_asm_env(env)
@@ -767,7 +767,7 @@ _COLLECTED_REQUEST_HEADERS = {
 _COLLECTED_REQUEST_HEADERS.update(_COLLECTED_REQUEST_HEADERS_ASM_ENABLED)
 
 
-def _set_headers(span: Span, headers: Any, kind: str, only_asm_enabled: bool = False) -> None:
+def _set_headers(span: SpanProtocol, headers: Any, kind: str, only_asm_enabled: bool = False) -> None:
     for k in headers:
         if isinstance(k, tuple):
             key, value = k

--- a/ddtrace/appsec/_contrib/aws_lambda/__init__.py
+++ b/ddtrace/appsec/_contrib/aws_lambda/__init__.py
@@ -3,7 +3,6 @@ from typing import Any
 from typing import Optional
 from typing import Union
 
-from ddtrace._trace.span import Span
 from ddtrace.appsec._asm_request_context import _call_waf
 from ddtrace.appsec._asm_request_context import _call_waf_first
 from ddtrace.appsec._asm_request_context import set_body_response
@@ -12,11 +11,12 @@ from ddtrace.appsec._http_utils import extract_cookies_from_headers
 from ddtrace.appsec._http_utils import normalize_headers
 from ddtrace.appsec._http_utils import parse_http_body
 from ddtrace.internal import core
+from ddtrace.internal.appsec.prototypes import SpanProtocol
 from ddtrace.internal.settings.asm import config as asm_config
 
 
 def _on_lambda_start_request(
-    span: Span,
+    span: SpanProtocol,
     request_headers: dict[str, str],
     request_ip: Optional[str],
     body: Optional[str],
@@ -54,7 +54,7 @@ def _on_lambda_start_request(
 
 
 def _on_lambda_start_response(
-    span: Span,
+    span: SpanProtocol,
     status_code: str,
     response_headers: Mapping[str, object],
 ) -> None:

--- a/ddtrace/appsec/_contrib/django/__init__.py
+++ b/ddtrace/appsec/_contrib/django/__init__.py
@@ -1,6 +1,8 @@
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Optional
+from typing import cast
 
 from ddtrace._trace.pin import Pin
 from ddtrace.appsec import _asm_request_context
@@ -34,6 +36,9 @@ from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.settings.integration import IntegrationConfig
 from ddtrace.trace import tracer
 
+
+if TYPE_CHECKING:
+    from ddtrace._trace.span import Span
 
 log = get_logger(__name__)
 
@@ -188,7 +193,7 @@ def _on_django_process(
                 hash_login = _hash_user_id(user_login)
                 span._set_attribute(APPSEC.USER_LOGIN_USERNAME, hash_login)
             span._set_attribute(APPSEC.AUTO_LOGIN_EVENTS_COLLECTION_MODE, mode)
-            set_user(None, hash_id, propagate=True, session_id=session_key, may_block=False, span=span)
+            set_user(None, hash_id, propagate=True, session_id=session_key, may_block=False, span=cast("Span", span))
         elif mode == LOGIN_EVENTS_MODE.IDENT:
             if user_id:
                 span._set_attribute(APPSEC.USER_LOGIN_USERID, str(user_id))
@@ -203,7 +208,7 @@ def _on_django_process(
                 name=user_extra.get("name"),
                 session_id=session_key,
                 may_block=False,
-                span=span,
+                span=cast("Span", span),
             )
         if in_asm_context():
             custom_data = {

--- a/ddtrace/appsec/_exploit_prevention/stack_traces.py
+++ b/ddtrace/appsec/_exploit_prevention/stack_traces.py
@@ -5,10 +5,10 @@ from typing import Any
 from typing import Iterable
 from typing import Optional
 
-from ddtrace._trace.span import Span
 from ddtrace.appsec import _asm_request_context
 from ddtrace.appsec._constants import STACK_TRACE
 from ddtrace.internal import span_bus
+from ddtrace.internal.appsec.prototypes import SpanProtocol
 from ddtrace.internal.settings.asm import config as asm_config
 
 
@@ -19,7 +19,7 @@ _INTERNAL_FRAMES = tuple(
 
 def report_stack(
     message: Optional[str] = None,
-    span: Optional[Span] = None,
+    span: Optional[SpanProtocol] = None,
     crop_stack: Optional[str] = None,
     stack_id: Optional[str] = None,
     namespace: str = STACK_TRACE.RASP,

--- a/ddtrace/appsec/_handlers.py
+++ b/ddtrace/appsec/_handlers.py
@@ -4,7 +4,6 @@ from typing import Any
 from typing import Optional
 from typing import Union
 
-from ddtrace._trace.span import Span
 from ddtrace.appsec._api_security._normalized_route import normalize_route
 from ddtrace.appsec._api_security._normalized_route import normalize_route_django
 from ddtrace.appsec._api_security._normalized_route import normalize_route_flask
@@ -13,6 +12,7 @@ from ddtrace.appsec._asm_request_context import get_active_asm_context
 from ddtrace.appsec._constants import API_SECURITY
 from ddtrace.appsec._constants import SPAN_DATA_NAMES
 from ddtrace.internal import core
+from ddtrace.internal.appsec.prototypes import SpanProtocol
 from ddtrace.internal.constants import FLASK_RESOURCE_FULL
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings.asm import config as asm_config
@@ -25,7 +25,7 @@ logger = get_logger(__name__)
 
 
 def _on_set_http_meta(
-    span: Span,
+    span: SpanProtocol,
     request_ip: Optional[str],
     raw_uri: Optional[str],
     route: Optional[str],
@@ -77,7 +77,7 @@ _NORMALIZED_ROUTE_BY_INTEGRATION = {
 
 
 def _on_set_http_meta_for_normalized_route(
-    span: Span,
+    span: SpanProtocol,
     request_ip: Optional[str],
     raw_uri: Optional[str],
     route: Optional[str],

--- a/ddtrace/appsec/_iast/_iast_env.py
+++ b/ddtrace/appsec/_iast/_iast_env.py
@@ -1,10 +1,10 @@
 from typing import TYPE_CHECKING
 from typing import Optional
 
-from ddtrace._trace.span import Span
 from ddtrace.appsec._constants import IAST
 from ddtrace.internal import core
 from ddtrace.internal import span_bus
+from ddtrace.internal.appsec.prototypes import SpanProtocol
 
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
@@ -18,7 +18,7 @@ class IASTEnvironment:
     It is contained into a ContextVar.
     """
 
-    def __init__(self, span: Optional[Span] = None):
+    def __init__(self, span: Optional[SpanProtocol] = None):
         self.span = span or span_bus.get_span()
 
         self.iast_reporter: Optional["IastSpanReporter"] = None

--- a/ddtrace/appsec/_iast/_iast_request_context.py
+++ b/ddtrace/appsec/_iast/_iast_request_context.py
@@ -2,7 +2,6 @@ from typing import Any
 from typing import Optional
 from typing import Union
 
-from ddtrace._trace.span import Span
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import IAST
 from ddtrace.appsec._iast._iast_env import _get_iast_env
@@ -15,6 +14,7 @@ from ddtrace.appsec._iast.reporter import IastSpanReporter
 from ddtrace.appsec._iast.sampling.vulnerability_detection import reset_request_vulnerabilities
 from ddtrace.constants import _ORIGIN_KEY
 from ddtrace.internal import span_bus
+from ddtrace.internal.appsec.prototypes import SpanProtocol
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings.asm import config as asm_config
 
@@ -38,7 +38,7 @@ def get_iast_reporter() -> Optional[IastSpanReporter]:
 
 
 def _create_and_attach_iast_report_to_span(
-    req_span: "Span", existing_data: Optional[Union[str, dict[str, Any]]], merge: bool = False
+    req_span: SpanProtocol, existing_data: Optional[Union[str, dict[str, Any]]], merge: bool = False
 ):
     report_data: Optional[IastSpanReporter] = get_iast_reporter()
     if merge and existing_data is not None and report_data is not None:

--- a/ddtrace/appsec/_iast/_overhead_control_engine.py
+++ b/ddtrace/appsec/_iast/_overhead_control_engine.py
@@ -4,13 +4,19 @@ limit. It will measure operations being executed in a request and it will deacti
 (and therefore reduce the overhead to nearly 0) if a certain threshold is reached.
 """
 
+from typing import TYPE_CHECKING
+from typing import cast
+
 from ddtrace._trace.sampler import RateSampler
-from ddtrace._trace.span import Span
 from ddtrace.appsec._iast._utils import _is_iast_debug_enabled
 from ddtrace.internal._unpatched import _threading as threading
+from ddtrace.internal.appsec.prototypes import SpanProtocol
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings.asm import config as asm_config
 
+
+if TYPE_CHECKING:
+    from ddtrace._trace.span import Span
 
 log = get_logger(__name__)
 
@@ -31,11 +37,11 @@ class OverheadControl(object):
     def reconfigure(self):
         self._sampler = RateSampler(sample_rate=get_request_sampling_value() / 100.0)
 
-    def acquire_request(self, span: Span) -> bool:
+    def acquire_request(self, span: "SpanProtocol") -> bool:
         """Decide whether if IAST analysis will be done for this request.
         - Use sample rating to analyze only a percentage of the total requests (30% by default).
         """
-        if span and not self._sampler.sample(span):
+        if span and not self._sampler.sample(cast("Span", span)):
             if _is_iast_debug_enabled():
                 log.debug("iast::propagation::context::Skip request by sampling rate")
             return False

--- a/ddtrace/appsec/_iast/processor.py
+++ b/ddtrace/appsec/_iast/processor.py
@@ -3,8 +3,8 @@ from typing import ClassVar
 from typing import Optional
 
 from ddtrace._trace.processor import SpanProcessor
-from ddtrace._trace.span import Span
 from ddtrace.ext import SpanTypes
+from ddtrace.internal.appsec.prototypes import SpanProtocol
 from ddtrace.internal.logger import get_logger
 
 from ._iast_request_context import _iast_end_request
@@ -37,13 +37,13 @@ class AppSecIastSpanProcessor(SpanProcessor):
 
         load_iast()
 
-    def on_span_start(self, span: Span):
+    def on_span_start(self, span: SpanProtocol):
         if span.span_type != SpanTypes.WEB:
             return
 
         _iast_start_request(span)
 
-    def on_span_finish(self, span: Span):
+    def on_span_finish(self, span: SpanProtocol):
         """Report reported vulnerabilities.
 
         Span Tags:

--- a/ddtrace/appsec/_processor.py
+++ b/ddtrace/appsec/_processor.py
@@ -9,7 +9,6 @@ from typing import Sequence
 from typing import Union
 
 from ddtrace._trace.processor import SpanProcessor
-from ddtrace._trace.span import Span
 from ddtrace.appsec import _asm_request_context
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import DEFAULT
@@ -33,6 +32,7 @@ from ddtrace.constants import _RUNTIME_FAMILY
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
 from ddtrace.internal._unpatched import unpatched_open as open  # noqa: A004
+from ddtrace.internal.appsec.prototypes import SpanProtocol
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.rate_limiter import RateLimiter
 from ddtrace.internal.remoteconfig import PayloadType
@@ -197,7 +197,7 @@ class AppSecSpanProcessor(SpanProcessor):
     def rasp_sqli_enabled(self) -> bool:
         return WAF_DATA_NAMES.SQLI_ADDRESS in self._addresses_to_keep
 
-    def on_span_start(self, span: Span) -> None:
+    def on_span_start(self, span: SpanProtocol) -> None:
         from ddtrace.contrib.internal import trace_utils
 
         if isinstance(self._ddwaf, _DDWafNotInitialized):
@@ -260,7 +260,7 @@ class AppSecSpanProcessor(SpanProcessor):
 
     def _waf_action(
         self,
-        entry_span: Span,
+        entry_span: SpanProtocol,
         ctx: DDWafContext,
         custom_data: Optional[dict[str, Any]] = None,
         crop_trace: Optional[str] = None,
@@ -420,7 +420,7 @@ class AppSecSpanProcessor(SpanProcessor):
     def _is_needed(self, address: str) -> bool:
         return address in self._addresses_to_keep
 
-    def on_span_finish(self, span: Span) -> None:
+    def on_span_finish(self, span: SpanProtocol) -> None:
         if not isinstance(self._ddwaf, DDWaf):
             return
         if span.span_type not in asm_config._asm_processed_span_types:

--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -1,10 +1,11 @@
 from collections.abc import Mapping
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Optional
 from typing import TypeVar
 from typing import Union
+from typing import cast
 
-from ddtrace._trace.span import Span
 from ddtrace.appsec import _asm_request_context
 from ddtrace.appsec._asm_request_context import call_waf_callback
 from ddtrace.appsec._asm_request_context import get_blocked
@@ -20,9 +21,13 @@ from ddtrace.ext import user
 from ddtrace.internal import core
 from ddtrace.internal import span_bus
 from ddtrace.internal._exceptions import BlockingException
+from ddtrace.internal.appsec.prototypes import SpanProtocol
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings.asm import config as asm_config
 
+
+if TYPE_CHECKING:
+    from ddtrace._trace.span import Span
 
 log = get_logger(__name__)
 
@@ -46,7 +51,7 @@ def _maybe_hash(value: Optional[_T], mode: str) -> Optional[Union[_T, str]]:
     return value
 
 
-def _asm_manual_keep(span: Span) -> None:
+def _asm_manual_keep(span: SpanProtocol) -> None:
     from ddtrace.internal.constants import SAMPLING_DECISION_TRACE_TAG_KEY
     from ddtrace.internal.constants import TraceSource
     from ddtrace.internal.sampling import SamplingMechanism
@@ -57,10 +62,10 @@ def _asm_manual_keep(span: Span) -> None:
     span._set_attribute(SAMPLING_DECISION_TRACE_TAG_KEY, f"-{SamplingMechanism.APPSEC}")
 
     # set trace source propagation tag (_dd.p.ts) with the ASM bit
-    add_trace_source(span, TraceSource.ASM)
+    add_trace_source(cast("Span", span), TraceSource.ASM)
 
 
-def _handle_metadata(entry_span: Span, prefix: str, metadata: Mapping[str, object]) -> None:
+def _handle_metadata(entry_span: SpanProtocol, prefix: str, metadata: Mapping[str, object]) -> None:
     MAX_DEPTH = 6
     stack: list[tuple[str, Any, int]] = [(prefix, metadata, 1)]
     while stack:
@@ -87,8 +92,8 @@ def _track_user_login_common(
     login: Optional[str] = None,
     name: Optional[str] = None,
     email: Optional[str] = None,
-    span: Optional[Span] = None,
-) -> Optional[Span]:
+    span: Optional[SpanProtocol] = None,
+) -> Optional[SpanProtocol]:
     if span is None:
         span = _asm_request_context.get_entry_span()
     if not span and (current_span := span_bus.get_span()):
@@ -147,7 +152,7 @@ def track_user_login_success_event(
     session_id: Optional[str] = None,
     propagate: bool = False,
     login_events_mode: str = LOGIN_EVENTS_MODE.SDK,
-    span: Optional[Span] = None,
+    span: Optional[SpanProtocol] = None,
 ) -> None:
     """
     Add a new login success tracking event. The parameters after metadata (name, email,
@@ -188,7 +193,7 @@ def track_user_login_success_event(
         role,
         session_id,
         propagate,
-        span,
+        cast("Span", span),
         may_block=False,
     )
     if in_asm_context():

--- a/ddtrace/appsec/_utils.py
+++ b/ddtrace/appsec/_utils.py
@@ -11,11 +11,11 @@ from typing import TypedDict
 from typing import Union
 
 from ddtrace._trace._inferred_proxy import INFERRED_SPAN_NAMES
-from ddtrace._trace.span import Span
 from ddtrace.appsec._constants import API_SECURITY
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.contrib.internal.trace_utils_base import _get_header_value_case_insensitive
 from ddtrace.internal._unpatched import unpatched_json_loads
+from ddtrace.internal.appsec.prototypes import SpanProtocol
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.settings.asm import config as asm_config
 
@@ -393,13 +393,13 @@ class _UserInfoRetriever:
         return user_id, user_extra_info
 
 
-def has_triggers(span: Span) -> bool:
+def has_triggers(span: SpanProtocol) -> bool:
     if asm_config._use_metastruct_for_triggers:
         return (span._get_struct_tag(APPSEC.STRUCT) or {}).get("triggers", None) is not None
     return span.get_tag(APPSEC.JSON) is not None
 
 
-def get_triggers(span: Span) -> Any:
+def get_triggers(span: SpanProtocol) -> Any:
     if asm_config._use_metastruct_for_triggers:
         return (span._get_struct_tag(APPSEC.STRUCT) or {}).get("triggers", None)
     json_payload = span.get_tag(APPSEC.JSON)
@@ -450,5 +450,5 @@ def unpatching_popen() -> typing.Iterator[None]:
             asm_config._bypass_instrumentation_for_waf = False
 
 
-def is_inferred_span(span: Span) -> bool:
+def is_inferred_span(span: SpanProtocol) -> bool:
     return span.name in INFERRED_SPAN_NAMES

--- a/ddtrace/appsec/track_user_sdk.py
+++ b/ddtrace/appsec/track_user_sdk.py
@@ -7,6 +7,8 @@ Implementation can change in the future, but the interface will remain compatibl
 """
 
 import typing as t
+from typing import TYPE_CHECKING
+from typing import cast
 
 from ddtrace.appsec import _asm_request_context
 from ddtrace.appsec import _constants
@@ -17,6 +19,10 @@ from ddtrace.appsec._constants import WAF_ACTIONS as _WAF_ACTIONS
 import ddtrace.appsec.trace_utils  # noqa: F401
 from ddtrace.contrib.internal.trace_utils_base import set_user
 from ddtrace.internal._exceptions import BlockingException
+
+
+if TYPE_CHECKING:
+    from ddtrace._trace.span import Span
 
 
 def track_login_success(
@@ -105,7 +111,7 @@ def track_user(
         scope=usr_scope if isinstance(usr_scope, str) else None,
         role=usr_role if isinstance(usr_role, str) else None,
         session_id=session_id,
-        span=span,
+        span=cast("Span", span),
         may_block=_auto,
         mode=_constants.LOGIN_EVENTS_MODE.AUTO if _auto else _constants.LOGIN_EVENTS_MODE.SDK,
     )
@@ -157,7 +163,7 @@ def track_user_id(
         scope=usr_scope if isinstance(usr_scope, str) else None,
         role=usr_role if isinstance(usr_role, str) else None,
         session_id=session_id,
-        span=span,
+        span=cast("Span", span),
         may_block=_auto,
         mode=_constants.LOGIN_EVENTS_MODE.AUTO if _auto else _constants.LOGIN_EVENTS_MODE.SDK,
     )

--- a/ddtrace/internal/appsec/prototypes.py
+++ b/ddtrace/internal/appsec/prototypes.py
@@ -1,5 +1,6 @@
 import typing as t
 
+from ddtrace._trace.context import Context
 from ddtrace.internal.compat import NumericType
 
 
@@ -20,11 +21,16 @@ class SpanProtocol(t.Protocol):
     @property
     def _service_entry_span(self) -> "SpanProtocol": ...
 
+    @property
+    def context(self) -> Context: ...
+
     def get_tag(self, key: str) -> t.Optional[str]: ...
 
     def get_metric(self, key: str) -> t.Optional[NumericType]: ...
 
     def set_tag(self, key: str, value: t.Optional[str] = None) -> None: ...
+
+    def _has_attribute(self, key: str) -> bool: ...
 
     def _set_attribute(self, key: str, value: t.Union[str, int, float]) -> None: ...
 

--- a/ddtrace/internal/appsec/prototypes.py
+++ b/ddtrace/internal/appsec/prototypes.py
@@ -1,5 +1,39 @@
 import typing as t
 
+from ddtrace.internal.compat import NumericType
+
+
+class SpanProtocol(t.Protocol):
+    """Structural interface for the span members ``ddtrace.appsec.*`` relies on.
+
+    Lets appsec code type-annotate spans without a runtime dependency on the concrete
+    ``ddtrace._trace.span.Span`` class.
+    """
+
+    name: str
+    span_id: int
+    span_type: t.Optional[str]
+
+    @property
+    def _parent(self) -> t.Optional["SpanProtocol"]: ...
+
+    @property
+    def _service_entry_span(self) -> "SpanProtocol": ...
+
+    def get_tag(self, key: str) -> t.Optional[str]: ...
+
+    def get_metric(self, key: str) -> t.Optional[NumericType]: ...
+
+    def set_tag(self, key: str, value: t.Optional[str] = None) -> None: ...
+
+    def _set_attribute(self, key: str, value: t.Union[str, int, float]) -> None: ...
+
+    def _set_struct_tag(self, key: str, value: dict[str, t.Any]) -> None: ...
+
+    def _get_struct_tag(self, key: str) -> t.Optional[dict[str, t.Any]]: ...
+
+    def _override_sampling_decision(self, decision: t.Optional[NumericType]) -> None: ...
+
 
 class AppsecSpanProcessorProto(t.Protocol):
     def _update_rules(


### PR DESCRIPTION
This change removes many `Span` imports from the appsec module via the use of a protocol type.