### PR TITLE
test(iast): flaky test_packages_patched pyjwt

### DIFF
--- a/tests/appsec/iast_packages/test_packages.py
+++ b/tests/appsec/iast_packages/test_packages.py
@@ -1,3 +1,4 @@
+from contextlib import ExitStack
 from contextlib import contextmanager
 import fcntl
 import json
@@ -42,6 +43,7 @@ TEMPLATE_VENV_DIR = os.path.join(DDTRACE_PATH, "template_venv")
 CLONED_VENVS_DIR = os.path.join(DDTRACE_PATH, "cloned_venvs")
 PIP_EXECUTABLE = os.path.join(TEMPLATE_VENV_DIR, "bin", "pip")
 PIP_CACHE_SHARED_VENVS_DIR = os.path.join(DDTRACE_PATH, "pip_cache_shared_venvs")
+FLASK_SERVER_START_LOCK_PATH = os.path.join(CLONED_VENVS_DIR, "flask_server_start.lock")
 
 # Compute a per-worker port offset so parallel xdist workers don't collide on the flask server port.
 # PYTEST_XDIST_WORKER is e.g. "gw0", "gw1", ... — not set when running without xdist.
@@ -97,6 +99,16 @@ def set_pip_cache_dir():
             os.environ["PIP_CACHE_DIR"] = original_value
         else:
             del os.environ["PIP_CACHE_DIR"]
+
+
+@contextmanager
+def synchronized_flask_server(*args, **kwargs):
+    """Start one package Flask subprocess at a time across xdist workers."""
+    with ExitStack() as stack:
+        with open(FLASK_SERVER_START_LOCK_PATH, "w") as _lock:
+            fcntl.flock(_lock, fcntl.LOCK_EX)
+            context = stack.enter_context(flask_server(*args, **kwargs))
+        yield context
 
 
 class PackageForTesting:
@@ -1084,7 +1096,7 @@ def test_packages_not_patched(package):
         )
 
     if package.test_e2e:
-        with flask_server(
+        with synchronized_flask_server(
             python_cmd=python_bin,
             iast_enabled="false",
             tracer_enabled="true",
@@ -1144,7 +1156,7 @@ def test_packages_patched(package):
             )
 
     if package.test_e2e or package.test_propagation:
-        with flask_server(
+        with synchronized_flask_server(
             python_cmd=python_bin,
             iast_enabled="true",
             remote_configuration_enabled="false",


### PR DESCRIPTION
<!-- dd-meta {"pullId":"dd98a931-aa74-46bc-bb8d-e245e8dee5cb","source":"chat","resourceId":"aca90f3d-0e94-4f43-9d3f-9b890c76769b","workflowId":"e14760d9-5905-4cb2-9b93-6b35cd0b09e0","codeChangeId":"e14760d9-5905-4cb2-9b93-6b35cd0b09e0","sourceType":"test-optimization"} -->
## Description

Fixing `test_packages_patched[pyjwt][py3.13]` • **Questions?** Ask in #code-gen-flaky-tests

Motivation/Summary: `test_packages_patched[pyjwt][py3.13]` was reported failing during Flask server readiness. The failure showed the subprocess was still alive, the port was not bound, and the client saw connection refused on port 8012. That points to an xdist startup race in the test harness rather than PyJWT behavior.

Changes:
- Added a test-only `synchronized_flask_server` wrapper in `tests/appsec/iast_packages/test_packages.py`.
- The wrapper uses a file lock to allow only one package Flask subprocess to enter its startup/readiness phase at a time across xdist workers.
- Routed the patched and unpatched package E2E server call sites through that wrapper without changing package assertions.

## Testing

- Reproduction before fix: `scripts/run-tests --venv ac4b246 -- -s -- -k 'test_packages_patched and pyjwt'` passed 4/4 times, so I did not personally reproduce the flaky failure.
- Rebasing: fetched `origin/main` and rebased with autostash successfully.
- Validation: `scripts/run-tests --venv ac4b246 -- -s -- -k 'test_packages_patched and pyjwt'` passed.
- Validation: `scripts/run-tests --venv ac4b246 -- -s -- -k 'test_packages_patched and (pyjwt or requests or six or zipp)'` passed 6 selected tests under xdist.
- Validation: `git diff --check` passed.
- Lint note: `scripts/lint fmt tests/appsec/iast_packages/test_packages.py` could not run because the sandbox failed downloading a standalone Python from GitHub.

## Risks

Low. The change is test-only and serializes only Flask server startup/readiness for this suite, not the package assertions or import validation. It may slightly reduce startup concurrency in `appsec_iast_packages`, but it avoids nondeterministic concurrent server startup contention.

## Additional Notes

No release note is needed for this test-only flake fix.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/aca90f3d-0e94-4f43-9d3f-9b890c76769b)

Comment @datadog to request changes