### PR TITLE
chore(appsec): remove internal _dd.appsec.usr.id and _dd.appsec.usr.login tags

### DIFF
--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -60,8 +60,6 @@ class APPSEC(metaclass=Constant_Class):
     CUSTOM_EVENT_PREFIX: Literal["appsec.events"] = "appsec.events"
     USER_LOGIN_EVENT_PREFIX: Literal["_dd.appsec.events.users.login"] = "_dd.appsec.events.users.login"
     USER_LOGIN_EVENT_PREFIX_PUBLIC: Literal["appsec.events.users.login"] = "appsec.events.users.login"
-    USER_LOGIN_USERID: Literal["_dd.appsec.usr.id"] = "_dd.appsec.usr.id"
-    USER_LOGIN_USERNAME: Literal["_dd.appsec.usr.login"] = "_dd.appsec.usr.login"
     USER_LOGIN_EVENT_SUCCESS_TRACK: Literal["appsec.events.users.login.success.track"] = (
         "appsec.events.users.login.success.track"
     )

--- a/ddtrace/appsec/_contrib/django/__init__.py
+++ b/ddtrace/appsec/_contrib/django/__init__.py
@@ -183,17 +183,9 @@ def _on_django_process(
             hash_id = ""
             if isinstance(user_id, str):
                 hash_id = _hash_user_id(user_id)
-                span._set_attribute(APPSEC.USER_LOGIN_USERID, hash_id)
-            if isinstance(user_login, str):
-                hash_login = _hash_user_id(user_login)
-                span._set_attribute(APPSEC.USER_LOGIN_USERNAME, hash_login)
             span._set_attribute(APPSEC.AUTO_LOGIN_EVENTS_COLLECTION_MODE, mode)
             set_user(None, hash_id, propagate=True, session_id=session_key, may_block=False, span=span)
         elif mode == LOGIN_EVENTS_MODE.IDENT:
-            if user_id:
-                span._set_attribute(APPSEC.USER_LOGIN_USERID, str(user_id))
-            if user_login:
-                span._set_attribute(APPSEC.USER_LOGIN_USERNAME, user_login)
             span._set_attribute(APPSEC.AUTO_LOGIN_EVENTS_COLLECTION_MODE, mode)
             set_user(
                 None,
@@ -252,13 +244,11 @@ def _on_django_signup_user(
             if asm_config._user_event_mode == LOGIN_EVENTS_MODE.ANON:
                 login = _hash_user_id(login)
             span._set_attribute(APPSEC.USER_SIGNUP_EVENT_USERNAME, login)
-            span._set_attribute(APPSEC.USER_LOGIN_USERNAME, login)
         if user_id:
             user_id = str(user_id)
             if asm_config._user_event_mode == LOGIN_EVENTS_MODE.ANON:
                 user_id = _hash_user_id(user_id)
             span._set_attribute(APPSEC.USER_SIGNUP_EVENT_USERID, user_id)
-            span._set_attribute(APPSEC.USER_LOGIN_USERID, user_id)
 
 
 def _on_traced_get_response_pre(

--- a/ddtrace/appsec/_trace_utils.py
+++ b/ddtrace/appsec/_trace_utils.py
@@ -118,8 +118,6 @@ def _track_user_login_common(
 
         if login:
             span._set_attribute(f"{APPSEC.USER_LOGIN_EVENT_PREFIX_PUBLIC}.{success_str}.usr.login", login)
-            if login_events_mode != LOGIN_EVENTS_MODE.SDK:
-                span._set_attribute(APPSEC.USER_LOGIN_USERNAME, login)
             span._set_attribute(f"{tag_prefix}.login", login)
 
         if email:
@@ -175,9 +173,7 @@ def track_user_login_success_event(
     session_id = _maybe_hash(session_id, real_mode)
     span._set_attribute(APPSEC.AUTO_LOGIN_EVENTS_COLLECTION_MODE, real_mode)
     if user_id:
-        if login_events_mode != LOGIN_EVENTS_MODE.SDK:
-            span._set_attribute(APPSEC.USER_LOGIN_USERID, str(user_id))
-        else:
+        if login_events_mode == LOGIN_EVENTS_MODE.SDK:
             span._set_attribute(f"{APPSEC.USER_LOGIN_EVENT_PREFIX_PUBLIC}.success.usr.id", str(user_id))
     set_user(
         None,
@@ -237,8 +233,6 @@ def track_user_login_failure_event(
         span._set_attribute(f"{APPSEC.USER_LOGIN_EVENT_PREFIX_PUBLIC}.failure.{user.EXISTS}", exists_str)
     if user_id:
         user_id = _maybe_hash(user_id, real_mode)
-        if login_events_mode != LOGIN_EVENTS_MODE.SDK:
-            span._set_attribute(APPSEC.USER_LOGIN_USERID, str(user_id))
         span._set_attribute(f"{APPSEC.USER_LOGIN_EVENT_PREFIX_PUBLIC}.failure.{user.ID}", str(user_id))
     span._set_attribute(APPSEC.AUTO_LOGIN_EVENTS_COLLECTION_MODE, real_mode)
     # if called from the SDK, set the login, email and name
@@ -273,11 +267,9 @@ def track_user_signup_event(
             user_id = _maybe_hash(user_id, login_events_mode)
             span._set_attribute(user.ID, str(user_id))
             span._set_attribute(APPSEC.USER_SIGNUP_EVENT_USERID, str(user_id))
-            span._set_attribute(APPSEC.USER_LOGIN_USERID, str(user_id))
         if login:
             login = _maybe_hash(login, login_events_mode)
             span._set_attribute(APPSEC.USER_SIGNUP_EVENT_USERNAME, str(login))
-            span._set_attribute(APPSEC.USER_LOGIN_USERNAME, str(login))
         _asm_manual_keep(span)
 
         # This is used to mark if the call was done from the SDK of the automatic login events
@@ -383,8 +375,6 @@ def block_request_if_user_blocked(userid: str, mode: str = "sdk", session_id: Op
         if userid:
             if mode == LOGIN_EVENTS_MODE.ANON:
                 userid = _hash_user_id(str(userid))
-            if mode != LOGIN_EVENTS_MODE.SDK:
-                entry_span._set_attribute(APPSEC.USER_LOGIN_USERID, str(userid))
             entry_span._set_attribute(user.ID, str(userid))
     if should_block_user(None, userid, session_id):
         _asm_request_context.block_request()

--- a/ddtrace/appsec/track_user_sdk.py
+++ b/ddtrace/appsec/track_user_sdk.py
@@ -88,10 +88,6 @@ def track_user(
     span = _asm_request_context.get_entry_span()
     if span is None:
         return
-    if user_id:
-        span._set_attribute(_constants.APPSEC.USER_LOGIN_USERID, str(user_id))
-    if login:
-        span._set_attribute(_constants.APPSEC.USER_LOGIN_USERNAME, str(login))
     meta = metadata or {}
     usr_name = meta.pop("name", None) or meta.pop("usr.name", None)
     usr_email = meta.pop("email", None) or meta.pop("usr.email", None)
@@ -142,8 +138,6 @@ def track_user_id(
     span = _asm_request_context.get_entry_span()
     if span is None:
         return
-    if user_id:
-        span._set_attribute(_constants.APPSEC.USER_LOGIN_USERID, str(user_id))
     meta = metadata or {}
     usr_name = meta.pop("name", None) or meta.pop("usr.name", None)
     usr_email = meta.pop("email", None) or meta.pop("usr.email", None)

--- a/docs/rfc-addendum-remove-appsec-usr-tags.md
+++ b/docs/rfc-addendum-remove-appsec-usr-tags.md
@@ -1,0 +1,133 @@
+# [RFC Addendum] Removal of `_dd.appsec.usr.id` and `_dd.appsec.usr.login` tags
+
+**Amends:** [RFC] Automated user lifecycle tracking (Accepted, Oct 21, 2024)
+**Author:** Florentin Labelle
+**Status:** Proposed
+**Date:** 2025
+
+## Context & Motivation
+
+The original RFC introduced two internal, write-only span tags to support
+*accuracy analysis* of automated user ID/login collection:
+
+- `_dd.appsec.usr.id` — a duplicate of `usr.id` emitted only on
+  auto-collected (non-SDK) requests, so the backend could compare the
+  auto-instrumented value against the SDK-provided one.
+- `_dd.appsec.usr.login` — a duplicate of the public
+`appsec.events.users.{login,signup}.*.usr.login` event tags, emitted only
+on auto-collected events, for the same correlation purpose.
+
+An audit of the Python tracer (and cross-check against the RFC's own
+examples) shows that these tags are **redundant in every collection mode**:
+
+| Scenario | `_dd.appsec.usr.id` vs `usr.id` | `_dd.appsec.usr.login` vs public event tag |
+|----------|--------------------------------|--------------------------------------------|
+| Pure-auto, identification | identical value, identical value | identical value |
+| Pure-auto, anonymization | identical (both hashed) | identical (both hashed) |
+| SDK + auto, identification, auto accurate | identical | identical |
+| SDK + auto, anonymization | **differ** (raw vs hashed) | **differ** (raw vs hashed) |
+| SDK + auto, identification, auto inaccurate | **differ** | **differ** |
+
+The only cases where the internal tags carry information not already
+available elsewhere are the last two rows — both require the **SDK to be
+in use simultaneously with auto-instrumentation**, and the divergence is
+fully derivable from the existing `_dd.appsec.user.collection_mode` /
+`_dd.appsec.events.*.auto.mode` tags together with `usr.id` and the
+public `*.usr.login` event tags.
+
+For the (majority) case of customers using **only** auto-instrumentation
+(no SDK), the internal tags are a verbatim duplicate of `usr.id` and the
+public event tags in both identification and anonymization modes, and
+carry zero additional information.
+
+No tracer code reads these tags; they are emitted exclusively for
+backend consumption.
+
+## Proposed Change
+
+Remove the `_dd.appsec.usr.id` and `_dd.appsec.usr.login` span tags from
+the specification and from all library implementations. Specifically:
+
+1. **Authenticated user tracking** — remove the `_dd.appsec.usr.id`
+   requirement. The `usr.id` and `_dd.appsec.user.collection_mode` tags
+   remain sufficient to identify that the user ID was collected
+   automatically and in which mode.
+
+2. **Login success / failure / signup events** — remove both
+   `_dd.appsec.usr.id` and `_dd.appsec.usr.login`. The public event tags
+   (`appsec.events.users.{login,signup}.*.usr.{login,id}`) and `usr.id`
+   remain the authoritative carriers of user identity for business logic
+   events.
+
+3. **Backend accuracy analysis** — the backend must derive the
+   auto-vs-SDK comparison from `_dd.appsec.user.collection_mode`
+   (value `sdk` vs `identification`/`anonymization`) and the
+   `_dd.appsec.events.*.sdk` tag, comparing `usr.id` against the public
+   event tags where both are present. No dedicated duplicate tag is
+   required.
+
+## Scope of removal (per library)
+
+Each library implementation may remove:
+
+- The constant definitions for the two tags.
+- All `set_attribute` write sites.
+- The `if mode != SDK` conditionals that existed solely to gate emission
+  of these tags (the surrounding mode logic, hashing, `set_user`, and
+  public event tags are unaffected).
+- Any dead locals computed only for these tags (e.g. a hashed login
+  computed solely to populate `_dd.appsec.usr.login`).
+- Test assertions on the removed tags.
+
+No public API, customer-facing tag, libddwaf address, telemetry metric,
+or configuration setting is affected.
+
+## Backward compatibility
+
+- **No customer-facing tag is removed.** `usr.id`, `usr.login`, and the
+  `appsec.events.*` event tags are unchanged.
+- **Backend ingestion** must stop relying on `_dd.appsec.usr.id` /
+  `_dd.appsec.usr.login` as the source of auto-collected user identity.
+  Because the values were always duplicates of `usr.id` / the public event
+  tags (except in the SDK+auto divergence cases, which are derivable from
+  `collection_mode`), no data loss occurs if the backend reads the
+  remaining tags instead.
+- Libraries may ship the removal in a minor release; no major-version
+  bump is required since the removed tags are internal (`_dd.`-prefixed)
+  and were never part of the documented public contract.
+
+## Rollout
+
+1. Backend confirms it no longer consumes `_dd.appsec.usr.id` /
+   `_dd.appsec.usr.login` (or derives the same signal from
+   `collection_mode` + `usr.id` + public event tags).
+2. Libraries remove the tags and update tests.
+3. This addendum is merged, retiring the tags from the RFC specification.
+
+## Appendix: Examples after removal
+
+The RFC's Appendix B examples are updated by deleting the two internal
+tag lines from each example. For instance, authenticated user tracking
+in identification mode becomes:
+
+```json
+{
+  "_dd.appsec.user.collection_mode": "identification",
+  "usr.id": "1023712892"
+}
+```
+
+And an automated login success event in identification mode with user ID
+becomes:
+
+```json
+{
+  "appsec.events.users.login.success.track": "true",
+  "_dd.appsec.events.users.login.success.auto.mode": "identification",
+  "appsec.events.users.login.success.usr.login": "zouzou@sansgluten.com",
+  "usr.id": "1023712892",
+  "manual.keep": "true"
+}
+```
+
+All other tags in every example are unchanged.

--- a/tests/appsec/contrib_appsec/utils.py
+++ b/tests/appsec/contrib_appsec/utils.py
@@ -1979,16 +1979,9 @@ class Contrib_TestClass_For_Threats(_Contrib_TestClass_Base):
                         assert get_entry_span_tag("_dd.appsec.events.users.login.failure.sdk") == "true"
                     else:
                         assert get_entry_span_tag("_dd.appsec.events.users.login.success.sdk") is None
-                    if mode == "identification":
-                        assert get_entry_span_tag("_dd.appsec.usr.login") == user
-                    elif mode == "anonymization":
-                        assert get_entry_span_tag("_dd.appsec.usr.login") == _hash_user_id(user)
                 else:
                     assert get_entry_span_tag("appsec.events.users.login.success.track") == "true"
                     assert get_entry_span_tag("usr.id") == user_id_hash
-                    assert get_entry_span_tag("_dd.appsec.usr.id") == user_id_hash
-                    if mode == "identification":
-                        assert get_entry_span_tag("_dd.appsec.usr.login") == user
                     # check for manual instrumentation tag in manual instrumented frameworks
                     if interface.name in ["flask", "fastapi", "tornado"]:
                         assert get_entry_span_tag("_dd.appsec.events.users.login.success.sdk") == "true"

--- a/tests/appsec/integrations/django_tests/test_appsec_django.py
+++ b/tests/appsec/integrations/django_tests/test_appsec_django.py
@@ -94,13 +94,11 @@ def test_create_new_user(client, test_spans, tracer):
         if hasattr(result, "headers"):
             assert result.headers["content-type"].startswith("text/html")
         assert root.get_tag("appsec.events.users.signup.usr.login") == "john"
-        assert root.get_tag("_dd.appsec.usr.login") == "john"
         assert root.get_tag("_dd.appsec.events.users.signup.auto.mode") == "identification", root.get_tag(
             "_dd.appsec.events.users.signup.auto.mode"
         )
         assert root.get_tag("appsec.events.users.signup.track") == "true"
         assert root.get_tag("appsec.events.users.signup.usr.id")
-        assert root.get_tag("_dd.appsec.usr.id")
 
 
 _BLOCKED_USER = "123456"


### PR DESCRIPTION
## Description

Removes the internal `_dd.appsec.usr.id` and `_dd.appsec.usr.login` span tags, along with the `USER_LOGIN_USERID` / `USER_LOGIN_USERNAME` constants and the now-dead conditionals / locals that only existed to populate them.

### Context

These tags were introduced by the **Automated user lifecycle tracking** RFC for *accuracy analysis* of automated user ID collection — i.e. comparing the SDK-provided `usr.id` against the auto-instrumented value. An audit of every write/read site shows:

- **Outside anonymization mode**, `_dd.appsec.usr.id` is always a verbatim duplicate of `usr.id` (both derived from the same `user_id` variable after the same `_maybe_hash` step). It carries no additional information for pure-auto customers.
- The user **login** value is already carried by the public event tags `appsec.events.users.login.{success,failure}.usr.login` and `appsec.events.users.signup.usr.login`.
- The user **id** value is already carried by `usr.id` (set via `set_user`) and, for login-failure / signup / SDK-success events, by the public event tags `appsec.events.users.{login,signup}.*.usr.id`.
- The only remaining non-redundant signal (SDK+auto in anonymization mode, where `usr.id` is raw and `_dd.appsec.usr.id` is hashed) can be derived from `_dd.appsec.user.collection_mode` together with `usr.id`.

The tracer never reads these tags; they are write-only. **This is a behavior change for the AppSec backend's accuracy-analysis pipeline**, which is why this opens as a draft — backend sign-off is required before merging.

### What is removed
- `ddtrace/appsec/_constants.py` — `USER_LOGIN_USERID` / `USER_LOGIN_USERNAME` constant definitions.
- `ddtrace/appsec/_trace_utils.py` — 5 write sites + 4 collapsing `if … != SDK` conditionals.
- `ddtrace/appsec/track_user_sdk.py` — 3 write sites.
- `ddtrace/appsec/_contrib/django/__init__.py` — 4 write sites + the dead `hash_login` local in the ANON auth branch.
- Tests — 6 assertions on the removed tags.

### What is preserved (unchanged)
- `usr.id` (set via `set_user`).
- The public event tags: `appsec.events.users.login.{success,failure}.usr.{login,id}`, `appsec.events.users.signup.usr.{login,id}`.
- `_dd.appsec.user.collection_mode`, `_dd.appsec.events.*.auto.mode`, `_dd.appsec.events.*.sdk`, `manual.keep`, and all libddwaf addresses.

## Testing

- `python3 -m py_compile` on all modified files.
- `scripts/lint ruff-fix` + `scripts/lint format_check` pass on the changed files.
- Existing AppSec login/signup/auth-tracking tests updated to drop assertions on the removed tags; the assertions on `usr.id` and the public event tags remain and continue to validate the user-identity data path.

**TODO before merging:** run the relevant AppSec test suites via the `run-tests` skill (django appsec, contrib appsec login/signup events) to confirm no regressions.

## Risks

- **Backend accuracy analysis:** the AppSec backend may currently consume `_dd.appsec.usr.id` / `_dd.appsec.usr.login` specifically (rather than `usr.id` or the public event tags) to populate user-identity fields or run accuracy comparisons. If so, removing them is a breaking change for that pipeline. **Requires sign-off from the ASM Respond/Monitor backend team.**
- **RFC compliance:** these tags are mandated by the accepted *Automated user lifecycle tracking* RFC. Removing them technically deviates from the spec; an RFC update (or explicit waiver) should accompany the merge.
- No public API is affected. No customer-facing tag is removed (`usr.id`, `usr.login`, and the `appsec.events.*` tags are untouched).

## Additional Notes

- Suggested PR label: `changelog/no-changelog` (removal of internal `_dd.*` tags; no customer-facing API change).
- Net diff: 6 files changed, 1 insertion, 38 deletions.
- Follow-up: if the backend confirms the tags are unused, an RFC update should retire them from the spec.
