### PR TITLE
chore: internal dogfooding build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.15.0rc1"
+version = "4.15.0rc1+internal-dogfooding"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"50fda0e7-7353-42fd-83b6-5ed9e8214062","source":"chat","resourceId":"61da1417-5c03-4b77-93c9-fd595f0259bb","workflowId":"f2d9d226-1662-476a-89d0-5a4918cef2c6","codeChangeId":"f2d9d226-1662-476a-89d0-5a4918cef2c6","sourceType":"scheduled_task"} -->
## Description

Internal dogfooding build: bumps the version in `pyproject.toml` to `4.15.0rc1+internal-dogfooding` to trigger the CI "patch wheels" pipeline for manylinux packages.

This is a temporary branch cut from `main` (2026-08-25) for internal testing. **Do not merge.**

## Testing

CI will automatically trigger the package/patch-wheels jobs on GitLab, which produce the dogfooding wheel artifacts.

## Risks

None — version-only change, no code changes.

## Additional Notes

Branch: `kowalski/internal-dogfooding-20260825`

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/61da1417-5c03-4b77-93c9-fd595f0259bb)

Comment @datadog to request changes