### PR TITLE
perf(packages): resolve file paths without pathlib containment

### DIFF
--- a/ddtrace/debugging/_probe/model.py
+++ b/ddtrace/debugging/_probe/model.py
@@ -42,8 +42,12 @@ def _resolve_source_file(_path: str) -> Optional[Path]:
     if path.is_file():
         return path.resolve()
 
-    for relpath in (path.relative_to(_) for _ in reversed(path.parents)):
-        if (resolved_path := _resolve(relpath)) is not None:
+    # Stripping successive leading components is just successive suffixes of the
+    # parts, and avoids building a path object per ancestor. The anchor is never a
+    # candidate, which is why an absolute path starts one component in.
+    parts = path.parts
+    for start in range(1 if path.anchor else 0, len(parts)):
+        if (resolved_path := _resolve(Path(*parts[start:]))) is not None:
             return resolved_path
 
     return None

--- a/ddtrace/internal/ci_visibility/api/_base.py
+++ b/ddtrace/internal/ci_visibility/api/_base.py
@@ -37,6 +37,7 @@ from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.test_visibility._atr_mixins import AutoTestRetriesSettings
 from ddtrace.internal.test_visibility.coverage_lines import CoverageLines
+from ddtrace.internal.utils.paths import relative_path
 from ddtrace.internal.utils.time import Time
 from ddtrace.trace import Span
 from ddtrace.trace import Tracer
@@ -268,12 +269,11 @@ class TestVisibilityItemBase(abc.ABC):
         if self._source_file_info is not None:
             if self._source_file_info.path:
                 # Set source file path to be relative to the root directory
-                try:
-                    relative_path = self._source_file_info.path.relative_to(self._session_settings.workspace_path)
-                except ValueError:
+                relative = relative_path(self._source_file_info.path, self._session_settings.workspace_path)
+                if relative is None:
                     log.debug("Source file path is not within the root directory, replacing with absolute path")
-                    relative_path = self._source_file_info.path
-                self.set_tag(test.SOURCE_FILE, str(relative_path))
+                    relative = str(self._source_file_info.path)
+                self.set_tag(test.SOURCE_FILE, relative)
             if self._source_file_info.start_line is not None:
                 self.set_tag(test.SOURCE_START, self._source_file_info.start_line)
             if self._source_file_info.end_line is not None:

--- a/ddtrace/internal/ci_visibility/api/_coverage_data.py
+++ b/ddtrace/internal/ci_visibility/api/_coverage_data.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import TypedDict  # noqa:F401
 
 from ddtrace.internal.test_visibility.coverage_lines import CoverageLines
+from ddtrace.internal.utils.paths import relative_path
 
 
 class CoverageFilePayload(TypedDict):
@@ -33,13 +34,10 @@ class TestVisibilityCoverageData:
         """Generate a Test Visibility coverage payload"""
         coverage_data = []
         for file_path, covered_lines in self._coverage_data.items():
-            try:
-                # Report relative path unless the file path is not relative to root_dir
-                # Paths are assumed to be absolute based on having been converted at instantiation / add time.
-                relative_path = file_path.relative_to(root_dir)
-            except ValueError:
-                relative_path = file_path
-            path_str = f"/{str(relative_path)}"
+            # Report relative path unless the file path is not relative to root_dir
+            # Paths are assumed to be absolute based on having been converted at instantiation / add time.
+            relative = relative_path(file_path, root_dir)
+            path_str = f"/{relative if relative is not None else file_path}"
             file_payload: CoverageFilePayload = {"filename": path_str, "bitmap": covered_lines.to_bytes()}
             coverage_data.append(file_payload)
         return coverage_data

--- a/ddtrace/internal/ci_visibility/api/_module.py
+++ b/ddtrace/internal/ci_visibility/api/_module.py
@@ -17,6 +17,7 @@ from ddtrace.internal.ci_visibility.telemetry.constants import EVENT_TYPES
 from ddtrace.internal.ci_visibility.telemetry.events import record_event_created
 from ddtrace.internal.ci_visibility.telemetry.events import record_event_finished
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.utils.paths import relative_path
 
 
 log = get_logger(__name__)
@@ -47,10 +48,9 @@ class TestVisibilityModule(
             if self._module_path == self._session_settings.workspace_path:
                 # '.' is not the desired relative path when the workspace and module path are the same
                 module_path = ""
-            elif self._module_path.is_relative_to(self._session_settings.workspace_path):
-                module_path = str(self._module_path.relative_to(self._session_settings.workspace_path))
             else:
-                module_path = str(self._module_path)
+                relative = relative_path(self._module_path, self._session_settings.workspace_path)
+                module_path = relative if relative is not None else str(self._module_path)
         else:
             module_path = ""
 

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -25,6 +25,8 @@ from ddtrace.internal.settings import env
 from ddtrace.internal.test_visibility.coverage_lines import CoverageLines
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.inspection import resolved_code_origin
+from ddtrace.internal.utils.paths import is_contained
+from ddtrace.internal.utils.paths import relative_path
 
 
 log = get_logger(__name__)
@@ -504,9 +506,8 @@ class ModuleCodeCollector(ModuleWatchdog):
 
         for abs_path_str, lines in covered.items():
             abs_path = Path(abs_path_str)
-            path_str = (
-                str(abs_path.relative_to(workspace_path)) if abs_path.is_relative_to(workspace_path) else abs_path_str
-            )
+            relative = relative_path(abs_path, workspace_path)
+            path_str = relative if relative is not None else abs_path_str
 
             sorted_lines = [i for i, v in enumerate(sorted(lines.to_sorted_list())) if v == 1]
 
@@ -528,11 +529,11 @@ class ModuleCodeCollector(ModuleWatchdog):
             # Do not instrument dependencies vendored or installed under the workspace.
             return code
 
-        if not any(code_path.is_relative_to(include_path) for include_path in self._include_paths):
+        if not any(is_contained(code_path, include_path) for include_path in self._include_paths):
             # Not a code object we want to instrument
             return code
 
-        if any(code_path.is_relative_to(exclude_path) for exclude_path in self._exclude_paths):
+        if any(is_contained(code_path, exclude_path) for exclude_path in self._exclude_paths):
             # Don't instrument code from standard library/site packages/etc.
             return code
 

--- a/ddtrace/internal/coverage/report.py
+++ b/ddtrace/internal/coverage/report.py
@@ -7,6 +7,7 @@ import re
 import typing as t
 
 from ddtrace.internal.coverage.util import collapse_ranges
+from ddtrace.internal.utils.paths import relative_path
 
 
 try:
@@ -24,8 +25,8 @@ def _get_relative_path_strings(executable_lines, workspace_path: Path) -> dict[s
 
     for path in executable_lines:
         path_obj = Path(path)
-        path_str = str(path_obj.relative_to(workspace_path) if path_obj.is_relative_to(workspace_path) else path_obj)
-        relative_path_strs[path] = path_str
+        relative = relative_path(path_obj, workspace_path)
+        relative_path_strs[path] = relative if relative is not None else str(path_obj)
 
     return relative_path_strs
 

--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -12,6 +12,9 @@ import typing as t
 from ddtrace.internal.module import origin
 from ddtrace.internal.settings.third_party import config as tp_config
 from ddtrace.internal.utils.cache import callonce
+from ddtrace.internal.utils.paths import deepest_containing_root
+from ddtrace.internal.utils.paths import is_contained
+from ddtrace.internal.utils.paths import relative_parts
 
 
 LOG = logging.getLogger(__name__)
@@ -127,10 +130,20 @@ def get_version_for_package(name: str) -> str:
         return ""
 
 
-def _effective_root(rel_path: Path, parent: Path) -> str:
-    base = rel_path.parts[0]
+@cached(maxsize=256)
+def _is_regular_package(parent: Path, base: str) -> bool:
+    """Whether ``parent/base`` is a regular package (it ships an ``__init__.py``).
+
+    Keyed on the top-level name, not the caller's full relative path, which would
+    spend a cache entry per source file and almost never hit.
+    """
     root = parent / base
-    return base if root.is_dir() and (root / "__init__.py").exists() else "/".join(rel_path.parts[:2])
+    return root.is_dir() and (root / "__init__.py").exists()
+
+
+def _effective_root(rel_parts: tuple[str, ...], parent: Path) -> str:
+    base = rel_parts[0]
+    return base if _is_regular_package(parent, base) else "/".join(rel_parts[:2])
 
 
 # DEV: Since we can't lock on sys.path, these operations can be racy.
@@ -148,32 +161,21 @@ def resolve_sys_path() -> list[Path]:
     return _RESOLVED_SYS_PATH
 
 
-def _root_module(path: Path) -> str:
-    # Try the most likely prefixes first
+def _root_module(path: Path, resolved: Path) -> str:
+    # Most likely prefixes first, and against the resolved path to get the
+    # shortest relative one. The sys.path probe below keeps the path as given.
     for parent_path in (purelib_path, platlib_path):
-        try:
-            # Resolve the path to use the shortest relative path.
-            return _effective_root(path.resolve().relative_to(parent_path), parent_path)
-        except ValueError:
-            # Not relative to this path
-            pass
+        parts = relative_parts(resolved, parent_path)
+        if parts:
+            return _effective_root(parts, parent_path)
 
     # Try to resolve the root module using sys.path. We keep the shortest
     # relative path as the one more likely to give us the root module.
-    min_relative_path = max_parent_path = None
-    for parent_path in resolve_sys_path():
-        try:
-            relative = path.relative_to(parent_path)
-            if min_relative_path is None or len(relative.parents) < len(min_relative_path.parents):
-                min_relative_path, max_parent_path = relative, parent_path
-        except ValueError:
-            pass
-
-    if min_relative_path is not None:
-        try:
-            return _effective_root(min_relative_path, t.cast(Path, max_parent_path))
-        except IndexError:
-            pass
+    hit = deepest_containing_root(path, resolve_sys_path())
+    if hit is not None:
+        parent_path, parts = hit
+        if parts:
+            return _effective_root(parts, parent_path)
 
     # Bazel runfiles support: we assume that these paths look like
     # /some/path.runfiles/<distribution_name>/site-packages/<root_module>/...
@@ -186,7 +188,37 @@ def _root_module(path: Path) -> str:
     raise ValueError(msg)
 
 
+def _normalized_dist_name(name: str) -> str:
+    """Normalize a distribution name for comparison (PEP 503-ish).
+
+    ``.dist-info`` / ``.egg-info`` directories escape the project name (dashes
+    become underscores), so fold ``-``, ``_`` and ``.`` to a single form and
+    lowercase before comparing (``google-cloud-storage`` == ``google_cloud_storage``).
+    """
+    return name.replace("-", "_").replace(".", "_").lower()
+
+
 @cached(maxsize=256)
+def _shipped_distributions(directory: Path) -> frozenset[str]:
+    """Normalized names of the distributions whose metadata ``directory`` ships.
+
+    One cached listing serves both callers below. Keying on the directory alone
+    is what allows that, and an install root is routinely large enough that
+    re-walking it per probe is worth avoiding.
+    """
+    try:
+        return frozenset(
+            # ``{name}-{version}.dist-info`` / ``{name}.egg-info``: the name part
+            # (escaped, so it never contains a dash) precedes the first dash.
+            _normalized_dist_name(child.name[: -len(child.suffix)].split("-", 1)[0])
+            for child in directory.iterdir()
+            if child.suffix in (".dist-info", ".egg-info")
+        )
+    except OSError:
+        # Not a directory, missing, or unreadable: ships nothing.
+        return frozenset()
+
+
 def _is_install_root(directory: Path) -> bool:
     """Whether ``directory`` ships any distribution metadata.
 
@@ -199,25 +231,7 @@ def _is_install_root(directory: Path) -> bool:
     unrelated dependency namespaces living in the same tree, so the match is
     additionally gated on distribution ownership in _install_root_owner.
     """
-    try:
-        if not directory.is_dir():
-            return False
-        for child in directory.iterdir():
-            if child.suffix in (".dist-info", ".egg-info"):
-                return True
-    except OSError:
-        return False
-    return False
-
-
-def _normalized_dist_name(name: str) -> str:
-    """Normalize a distribution name for comparison (PEP 503-ish).
-
-    ``.dist-info`` / ``.egg-info`` directories escape the project name (dashes
-    become underscores), so fold ``-``, ``_`` and ``.`` to a single form and
-    lowercase before comparing (``google-cloud-storage`` == ``google_cloud_storage``).
-    """
-    return name.replace("-", "_").replace(".", "_").lower()
+    return bool(_shipped_distributions(directory))
 
 
 def _root_ships_distribution(directory: Path, dist_name: str) -> bool:
@@ -227,20 +241,7 @@ def _root_ships_distribution(directory: Path, dist_name: str) -> bool:
     ``*.dist-info`` / ``*.egg-info`` is present) from an unrelated directory
     that merely happens to carry some other distribution's metadata.
     """
-    target = _normalized_dist_name(dist_name)
-    try:
-        children = list(directory.iterdir())
-    except OSError:
-        return False
-    for child in children:
-        if child.suffix not in (".dist-info", ".egg-info"):
-            continue
-        # ``{name}-{version}.dist-info`` / ``{name}.egg-info``: the name part
-        # (escaped, so it never contains a dash) precedes the first dash.
-        candidate = child.name[: -len(child.suffix)].split("-", 1)[0]
-        if _normalized_dist_name(candidate) == target:
-            return True
-    return False
+    return _normalized_dist_name(dist_name) in _shipped_distributions(directory)
 
 
 def _install_root_owner(path: Path, mapping: dict[str, Distribution]) -> t.Optional[Distribution]:
@@ -256,11 +257,9 @@ def _install_root_owner(path: Path, mapping: dict[str, Distribution]) -> t.Optio
     for parent_path in resolve_sys_path():
         if parent_path.name == "site-packages" or not _is_install_root(parent_path):
             continue
-        try:
-            relative = path.relative_to(parent_path)
-        except ValueError:
+        parts = relative_parts(path, parent_path)
+        if parts is None:
             continue
-        parts = relative.parts
         for end in range(len(parts), 0, -1):
             hit = mapping.get("/".join(parts[:end]))
             if hit is not None:
@@ -270,38 +269,27 @@ def _install_root_owner(path: Path, mapping: dict[str, Distribution]) -> t.Optio
     return None
 
 
-def _relative_to_known_root(path: Path) -> t.Optional[Path]:
-    """Return path relative to the site-packages-like root that contains it.
+def _relative_to_known_root(path: Path, resolved: Path) -> t.Optional[tuple[str, ...]]:
+    """Return path's components relative to the site-packages-like root containing it.
     Only trusted dependency roots are considered (purelib/platlib and
     site-packages dirs). Install roots outside site-packages are handled by
     _install_root_owner, which additionally verifies distribution ownership.
     Returns None when path is not under such a root.
     """
     for parent_path in (purelib_path, platlib_path):
-        try:
-            return path.resolve().relative_to(parent_path)
-        except ValueError:
-            pass
+        parts = relative_parts(resolved, parent_path)
+        if parts is not None:
+            return parts
 
-    min_relative_path: t.Optional[Path] = None
-    for parent_path in resolve_sys_path():
-        if parent_path.name != "site-packages":
-            continue
-        try:
-            relative = path.relative_to(parent_path)
-        except ValueError:
-            continue
-        if min_relative_path is None or len(relative.parents) < len(min_relative_path.parents):
-            min_relative_path = relative
-    if min_relative_path is not None:
-        return min_relative_path
+    hit = deepest_containing_root(path, (p for p in resolve_sys_path() if p.name == "site-packages"))
+    if hit is not None:
+        return hit[1]
 
     for s in path.parents:
         if s.parent.name == "site-packages":
-            try:
-                return path.relative_to(s.parent)
-            except ValueError:
-                pass
+            parts = relative_parts(path, s.parent)
+            if parts is not None:
+                return parts
     return None
 
 
@@ -405,6 +393,12 @@ def filename_to_package(filename: t.Union[str, Path]) -> t.Optional[Distribution
     try:
         path = Path(filename) if isinstance(filename, str) else filename
 
+        # Resolved once and threaded through both probes below, which used to
+        # resolve it each: this dominates the cost of a cache miss. Passed
+        # alongside the original rather than replacing it, because the sys.path
+        # probes must match on the path as given or symlinked entries are missed.
+        resolved = path.resolve()
+
         # Longest-prefix match against the mapping. Namespace distributions can
         # share an intermediate level (google/cloud/storage vs
         # google/cloud/bigquery), so the most specific (deepest) mapped prefix
@@ -412,9 +406,8 @@ def filename_to_package(filename: t.Union[str, Path]) -> t.Optional[Distribution
         # the siblings apart. The probe is anchored at the site-packages-relative
         # root, so a subpackage that happens to share a name with another
         # top-level dist cannot mismatch.
-        relative = _relative_to_known_root(path)
-        if relative is not None:
-            parts = relative.parts
+        parts = _relative_to_known_root(path, resolved)
+        if parts is not None:
             for end in range(len(parts), 0, -1):
                 hit = mapping.get("/".join(parts[:end]))
                 if hit is not None:
@@ -428,8 +421,7 @@ def filename_to_package(filename: t.Union[str, Path]) -> t.Optional[Distribution
         if owner is not None:
             return owner
 
-        # Avoid calling .resolve() on the path here to prevent breaking symlink matching in `_root_module`.
-        root_module_path = _root_module(path)
+        root_module_path = _root_module(path, resolved)
         if root_module_path in mapping:
             return mapping[root_module_path]
 
@@ -463,8 +455,8 @@ def is_stdlib(path: Path) -> bool:
     if not rpath.is_absolute() or rpath.is_symlink():
         rpath = rpath.resolve()
 
-    return (rpath.is_relative_to(stdlib_path) or rpath.is_relative_to(platstdlib_path)) and not (
-        rpath.is_relative_to(purelib_path) or rpath.is_relative_to(platlib_path)
+    return (is_contained(rpath, stdlib_path) or is_contained(rpath, platstdlib_path)) and not (
+        is_contained(rpath, purelib_path) or is_contained(rpath, platlib_path)
     )
 
 

--- a/ddtrace/internal/utils/paths.py
+++ b/ddtrace/internal/utils/paths.py
@@ -1,0 +1,150 @@
+r"""Cheap replacements for the pathlib containment operations.
+
+``PurePath.relative_to`` and ``PurePath.is_relative_to`` are the natural way to
+ask "is this file inside that directory, and where relative to it", but on
+Python 3.12 a single call costs path allocations and case-folded comparisons
+proportional to the depth of *both* operands, whether it succeeds or fails. Code
+that probes one file against every entry of ``sys.path`` then spends most of its
+time building throwaway path objects, which is what ``ddtrace.internal.packages``
+was doing in production allocation profiles.
+
+These helpers answer the same questions by comparing ``PurePath.parts``, which
+pathlib has already parsed: containment becomes a prefix check on a tuple of
+strings, with no intermediate objects and no exceptions on the miss path.
+
+Contract, and where it differs from pathlib:
+
+- Arguments must be ``PurePath`` instances; a string raises ``AttributeError``
+  rather than quietly answering. Comparing parsed components is what guarantees
+  that ``.`` and repeated separators are already collapsed, and that anchors
+  match only as whole units -- ``/`` and POSIX's separate ``//``, or Windows'
+  ``C:`` and ``C:\``, are distinct, as pathlib also has it. (pathlib agreed on
+  that last one only from 3.12, where anchors became strict; no caller here
+  passes a non-absolute root.)
+- ``..`` is not resolved and nothing here touches the filesystem, so resolve
+  first if symlinks matter. Comparing a resolved path against an unresolved root
+  is as meaningless here as it is in pathlib.
+- Case sensitivity follows the host rather than the flavour of the path passed
+  in. That matches pathlib for the native paths every caller uses, but a
+  ``PureWindowsPath`` compared on POSIX will not fold case.
+- A path is relative to itself, giving an empty tuple of components, matching
+  the empty ``.parts`` of the ``"."`` pathlib returns.
+"""
+
+import os
+from pathlib import PurePath
+import typing as t
+
+
+# Roots are given back to the caller unchanged, so a caller passing concrete
+# Path objects keeps getting Path objects (and their I/O methods) back.
+AnyPurePath = t.TypeVar("AnyPurePath", bound=PurePath)
+
+# Module globals so the tests can force Windows rules on a POSIX host, which is
+# the only coverage the Windows behaviour gets: CI here is POSIX-only.
+_CASE_INSENSITIVE = os.path.normcase("A") != "A"
+_SEP = os.sep
+
+
+def _starts_with(path_parts: tuple[str, ...], root_parts: tuple[str, ...], n: int) -> bool:
+    """Whether the first n components of path_parts are root_parts.
+
+    Callers must have checked ``n == len(root_parts) <= len(path_parts)``, which
+    is what bounds the zip below.
+
+    Folding per component, rather than folding the joined path and indexing into
+    it, because case folding does not preserve length: the lowercase of U+0130 is
+    two characters, and an offset-based version silently truncated components.
+    """
+    if _CASE_INSENSITIVE:
+        return all(a.lower() == b.lower() for a, b in zip(path_parts, root_parts))
+    return path_parts[:n] == root_parts
+
+
+def relative_parts(path: PurePath, root: PurePath) -> t.Optional[tuple[str, ...]]:
+    """Components of path relative to root, or None if not contained.
+
+    The fast equivalent of ``path.relative_to(root).parts`` guarded by a
+    ``try/except ValueError``. Returns an empty tuple when path is root itself.
+    """
+    path_parts = path.parts
+    root_parts = root.parts
+    n = len(root_parts)
+
+    if not n:
+        # A root of "." has no components at all. pathlib makes only another
+        # anchorless path relative to it, since the anchors have to agree.
+        return None if path.anchor else path_parts
+
+    if n > len(path_parts) or not _starts_with(path_parts, root_parts, n):
+        return None
+
+    return path_parts[n:]
+
+
+def is_contained(path: PurePath, root: PurePath) -> bool:
+    """Whether path is root or lives under it.
+
+    The fast equivalent of ``path.is_relative_to(root)``. Prefer
+    ``relative_parts`` when the relative components are needed too, so the
+    containment test is not paid twice.
+    """
+    path_parts = path.parts
+    root_parts = root.parts
+    n = len(root_parts)
+
+    if not n:
+        return not path.anchor
+
+    return n <= len(path_parts) and _starts_with(path_parts, root_parts, n)
+
+
+def relative_path(path: PurePath, root: PurePath) -> t.Optional[str]:
+    """path relative to root as a string, or None if not contained.
+
+    The fast equivalent of ``str(path.relative_to(root))``, using the native
+    separator. Yields ``""`` rather than pathlib's ``"."`` when path is root.
+    """
+    parts = relative_parts(path, root)
+    return None if parts is None else _SEP.join(parts)
+
+
+def deepest_containing_root(
+    path: PurePath, roots: t.Iterable[AnyPurePath]
+) -> t.Optional[tuple[AnyPurePath, tuple[str, ...]]]:
+    """The most specific root containing path, with path relative to it.
+
+    Returns the (root, relative_parts) pair for the deepest root that contains
+    path, or None if none does. The root is returned as it was passed in, so
+    callers keep working with their own path objects.
+
+    Deepest root and shortest relative path are the same criterion, the path
+    being fixed. It is the one that identifies which package a file belongs to:
+    with a virtualenv and its site-packages both on sys.path, only the latter
+    anchors the module name correctly.
+    """
+    path_parts = path.parts
+    depth = len(path_parts)
+    best: t.Optional[AnyPurePath] = None
+    best_n = -1
+
+    for root in roots:
+        root_parts = root.parts
+        n = len(root_parts)
+
+        # Any two roots containing the same path are prefixes of one another, so
+        # component count orders them by depth and a shallower one cannot win.
+        if n <= best_n or n > depth:
+            continue
+
+        if not n:
+            if not path.anchor and best is None:
+                best, best_n = root, 0
+            continue
+
+        if not _starts_with(path_parts, root_parts, n):
+            continue
+
+        best, best_n = root, n
+
+    return None if best is None else (best, path_parts[best_n:])

--- a/ddtrace/testing/internal/pytest/_discovery.py
+++ b/ddtrace/testing/internal/pytest/_discovery.py
@@ -8,6 +8,7 @@ import typing as t
 import pytest
 
 from ddtrace.internal.settings import env
+from ddtrace.internal.utils.paths import relative_parts
 from ddtrace.testing.internal.constants import DD_TEST_OPTIMIZATION_DISCOVERY_ENABLED
 from ddtrace.testing.internal.constants import DD_TEST_OPTIMIZATION_DISCOVERY_FILE
 from ddtrace.testing.internal.git import get_workspace_path
@@ -57,10 +58,10 @@ def _is_item_skipped(item: pytest.Item) -> bool:
 def _get_suite_source_file(item: pytest.Item, workspace_path: t.Optional[Path]) -> str:
     item_path = Path(item.path if hasattr(item, "path") else getattr(item, "fspath", "")).absolute()
     if workspace_path is not None:
-        try:
-            return item_path.relative_to(workspace_path).as_posix()
-        except ValueError:
-            pass
+        relative = relative_parts(item_path, workspace_path)
+        if relative is not None:
+            # as_posix() of a relative path is its components joined by "/".
+            return "/".join(relative) if relative else "."
     return str(item_path)
 
 

--- a/ddtrace/testing/internal/pytest/plugin.py
+++ b/ddtrace/testing/internal/pytest/plugin.py
@@ -25,6 +25,8 @@ from ddtrace.contrib.internal.coverage.utils import handle_coverage_report
 from ddtrace.internal.ci_visibility.utils import get_source_lines_for_test_method
 from ddtrace.internal.settings import env
 from ddtrace.internal.utils.inspection import undecorated
+from ddtrace.internal.utils.paths import relative_parts
+from ddtrace.internal.utils.paths import relative_path
 from ddtrace.testing.internal.ci import CITag
 from ddtrace.testing.internal.constants import TAG_TRUE
 from ddtrace.testing.internal.constants import ITRSkippingLevel
@@ -207,10 +209,7 @@ def _get_relative_module_path_from_item(item: pytest.Item, workspace_path: Path)
 @lru_cache(maxsize=512)
 def _cached_relative_path(item_path: Path, workspace_path: Path) -> t.Optional[str]:
     """Return item_path relative to workspace_path as a string, or None if not under workspace."""
-    try:
-        return str(item_path.relative_to(workspace_path))
-    except ValueError:
-        return None
+    return relative_path(item_path, workspace_path)
 
 
 def _get_test_location_info(item: pytest.Item, workspace_path: Path) -> tuple[t.Optional[str], int, int]:
@@ -603,11 +602,10 @@ class TestOptPlugin(TestOptPluginProtocol):
 
         ignored_by_module: dict[str, list[Path]] = defaultdict(list)
         for path in self._itr_ignored_suite_paths:
-            try:
-                relative = path.relative_to(root_path)
-            except ValueError:
+            relative = relative_parts(path, root_path)
+            if relative is None:
                 continue
-            module_name = ".".join(relative.parent.parts) if relative.parent.parts else ""
+            module_name = ".".join(relative[:-1])
             ignored_by_module[module_name].append(path)
 
         for module_name, paths in ignored_by_module.items():
@@ -620,8 +618,9 @@ class TestOptPlugin(TestOptPluginProtocol):
                 TelemetryAPI.get().record_module_created(test_framework=TEST_FRAMEWORK)
 
             for path in paths:
-                relative = path.relative_to(root_path)
-                suite_name = relative.name
+                # Making a path relative only strips leading components, so the
+                # last one is unchanged.
+                suite_name = path.name
                 test_suite, _ = test_module.get_or_create_child(suite_name)
                 if not test_suite.is_started():
                     test_suite.start()

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -18,6 +18,8 @@ except ImportError:  # pragma: no cover — Windows / restricted environments
     _FCNTL_AVAILABLE = False
 
 from ddtrace.internal.settings import env
+from ddtrace.internal.utils.paths import relative_parts
+from ddtrace.internal.utils.paths import relative_path
 from ddtrace.testing.internal.api_client import APIClient
 from ddtrace.testing.internal.cached_file_provider import CachedFileDataProvider
 from ddtrace.testing.internal.cached_file_provider import TestOptDataProvider
@@ -449,9 +451,8 @@ class SessionManager:
             log.debug("Could not get source file for test %s", test)
             return
 
-        try:
-            repo_relative_path = str(Path(source_file).relative_to(self.workspace_path))
-        except ValueError:
+        repo_relative_path = relative_path(Path(source_file), self.workspace_path)
+        if repo_relative_path is None:
             log.debug("Could not get repo relative path for %r", source_file)
             repo_relative_path = source_file
 
@@ -819,15 +820,15 @@ class SessionManager:
         if self.itr_skipping_level != ITRSkippingLevel.SUITE:
             return False
         base = root_path or self.workspace_path
-        try:
-            relative = collection_path.relative_to(base)
-        except ValueError:
+        relative = relative_parts(collection_path, base)
+        if relative is None:
             return False
         # Mirror the module/suite decomposition used by item_to_test_ref / nodeid_to_names:
         # everything up to the last path component becomes the dot-separated module name,
         # and the filename itself is the suite name.
-        module_name = ".".join(relative.parent.parts) if relative.parent.parts else ""
-        suite_ref = SuiteRef(ModuleRef(module_name), relative.name)
+        module_name = ".".join(relative[:-1])
+        # No components means collection_path is base itself, whose name is "".
+        suite_ref = SuiteRef(ModuleRef(module_name), relative[-1] if relative else "")
         if suite_ref not in self.skippable_items:
             return False
         # Do not skip suites that contain attempt-to-fix tests — those must run regardless of ITR.

--- a/ddtrace/testing/internal/tracer_api/coverage.py
+++ b/ddtrace/testing/internal/tracer_api/coverage.py
@@ -20,6 +20,7 @@ from ddtrace.contrib.internal.coverage.utils import _is_coverage_patched
 from ddtrace.internal.coverage.code import ModuleCodeCollector
 import ddtrace.internal.coverage.installer
 from ddtrace.internal.test_visibility.coverage_lines import CoverageLines
+from ddtrace.internal.utils.paths import relative_path
 from ddtrace.testing.internal.logging import catch_and_log_exceptions
 
 
@@ -44,10 +45,11 @@ def uninstall_coverage() -> None:
 
 @functools.lru_cache(maxsize=65536)
 def _relative_coverage_path(absolute_path: str, relative_to: str) -> t.Optional[str]:
-    try:
-        return f"/{Path(absolute_path).relative_to(relative_to)}"
-    except ValueError:
+    # Both sides go through Path, which is the normalization relative_path needs.
+    relative = relative_path(Path(absolute_path), Path(relative_to))
+    if relative is None:
         return None  # covered file does not belong to current repo
+    return f"/{relative}"
 
 
 _FILE_LEVEL_BITMAP = bytes(CoverageLines.from_list([0]).to_bytes())

--- a/tests/internal/test_packages_resilience.py
+++ b/tests/internal/test_packages_resilience.py
@@ -23,9 +23,9 @@ import pytest
 # in Python 3.10; on 3.9 the strict-future regression we exercise here
 # cannot be reproduced via that hook, so the tests below are skipped.
 try:
-    import importlib.metadata._adapters as _meta_adapters  # type: ignore[import-not-found]
+    import importlib.metadata._adapters as _meta_adapters  # type: ignore[import-not-found, unused-ignore]
 except ImportError:  # Python 3.9
-    _meta_adapters = None  # type: ignore[assignment]
+    _meta_adapters = None  # type: ignore[assignment, unused-ignore]
 
 
 @pytest.fixture
@@ -41,6 +41,11 @@ def reset_packages_caches():
             inner = getattr(fn, "__wrapped__", None) or (fn.__closure__[0].cell_contents if fn.__closure__ else None)
             if inner is not None and hasattr(inner, "__callonce_result__"):
                 del inner.__callonce_result__
+        # Filesystem-backed caches: these tests build fixture trees under
+        # tmp_path, so a stale directory listing would leak between tests.
+        _p._shipped_distributions.cache_clear()
+        _p._is_regular_package.cache_clear()
+        _p.filename_to_package.cache_clear()
         _p._BAD_DISTS_WARNED.clear()
 
     _clear()
@@ -195,14 +200,14 @@ def test_filename_to_package_resolves_namespace_on_non_site_packages_install_roo
     mapping = {"google/cloud/storage": _p.Distribution(name="google-cloud-storage", version="1.0")}
     monkeypatch.setattr(_p, "_package_for_root_module_mapping", lambda: mapping)
     monkeypatch.setattr(_p, "resolve_sys_path", lambda: [vendor])
-    _p._is_install_root.cache_clear()
+    _p._shipped_distributions.cache_clear()
     _p.filename_to_package.cache_clear()
 
     pkg = _p.filename_to_package(vendor / "google" / "cloud" / "storage" / "blob.py")
 
     assert pkg is not None and pkg.name == "google-cloud-storage"
 
-    _p._is_install_root.cache_clear()
+    _p._shipped_distributions.cache_clear()
     _p.filename_to_package.cache_clear()
 
 
@@ -379,12 +384,96 @@ def test_filename_to_package_does_not_attribute_editable_source_root_to_dependen
     mapping = {"google/cloud/storage": _p.Distribution(name="google-cloud-storage", version="1.0")}
     monkeypatch.setattr(_p, "_package_for_root_module_mapping", lambda: mapping)
     monkeypatch.setattr(_p, "resolve_sys_path", lambda: [repo])
-    _p._is_install_root.cache_clear()
+    _p._shipped_distributions.cache_clear()
     _p.filename_to_package.cache_clear()
 
     pkg = _p.filename_to_package(repo / "google" / "cloud" / "storage" / "app.py")
 
     assert pkg is None
 
-    _p._is_install_root.cache_clear()
+    _p._shipped_distributions.cache_clear()
     _p.filename_to_package.cache_clear()
+
+
+def test_filename_to_package_on_a_sys_path_root_itself(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A path that *is* a sys.path entry must resolve to None, not raise.
+
+    Such a path is relative to the root by zero components, so the root-module
+    lookup has no first component to inspect. _effective_root used to index
+    parts[0] unguarded, raising IndexError -- which filename_to_package does not
+    catch (it only handles ValueError/OSError), so it escaped to the caller.
+    """
+    from ddtrace.internal import packages as _p
+
+    root = tmp_path / "root"
+    root.mkdir()
+
+    mapping = {"something": _p.Distribution(name="something", version="1.0")}
+    monkeypatch.setattr(_p, "_package_for_root_module_mapping", lambda: mapping)
+    monkeypatch.setattr(_p, "resolve_sys_path", lambda: [root])
+    _p.filename_to_package.cache_clear()
+
+    assert _p.filename_to_package(root) is None
+
+    _p.filename_to_package.cache_clear()
+
+
+def test_shipped_distributions_lists_each_directory_once(
+    tmp_path: Path,
+    reset_packages_caches,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both install-root probes share one cached directory listing.
+
+    _is_install_root and _root_ships_distribution used to walk the same
+    directory independently and uncached, on every probe -- and an install root
+    is routinely a site-packages tree with thousands of entries.
+    """
+    from ddtrace.internal import packages as _p
+
+    vendor = tmp_path / "vendor"
+    vendor.mkdir()
+    _write_dist_info(vendor, "google-cloud-storage", "1.0")
+
+    listed: list[Path] = []
+    real_iterdir = Path.iterdir
+
+    def counting_iterdir(self):
+        listed.append(self)
+        return real_iterdir(self)
+
+    monkeypatch.setattr(Path, "iterdir", counting_iterdir)
+
+    assert _p._is_install_root(vendor) is True
+    assert _p._root_ships_distribution(vendor, "google-cloud-storage") is True
+    assert _p._root_ships_distribution(vendor, "some-other-dist") is False
+    assert _p._is_install_root(vendor) is True
+
+    assert listed.count(vendor) == 1
+
+
+def test_effective_root_reuses_the_package_probe_across_files(
+    tmp_path: Path,
+    reset_packages_caches,
+) -> None:
+    """The __init__.py probe is keyed on the package, not the source file.
+
+    It depends only on (parent, top-level name), so keying it on the caller's
+    full relative path would spend an entry per file and never hit.
+    """
+    from ddtrace.internal import packages as _p
+
+    site = tmp_path / "site-packages"
+    (site / "pkg").mkdir(parents=True)
+    (site / "pkg" / "__init__.py").write_text("")
+
+    assert _p._effective_root(("pkg", "a.py"), site) == "pkg"
+    assert _p._effective_root(("pkg", "sub", "b.py"), site) == "pkg"
+    assert _p._effective_root(("pkg", "sub", "c.py"), site) == "pkg"
+
+    info = _p._is_regular_package.cache_info()
+    assert (info.misses, info.hits) == (1, 2)

--- a/tests/internal/test_utils_paths.py
+++ b/tests/internal/test_utils_paths.py
@@ -1,0 +1,277 @@
+import itertools
+import os
+from pathlib import Path
+from pathlib import PurePosixPath
+from pathlib import PureWindowsPath
+
+import pytest
+
+from ddtrace.internal.utils import paths
+from ddtrace.internal.utils.paths import deepest_containing_root
+from ddtrace.internal.utils.paths import is_contained
+from ddtrace.internal.utils.paths import relative_parts
+from ddtrace.internal.utils.paths import relative_path
+
+
+# Deliberately includes near-misses a naive string prefix test gets wrong
+# (/a/bb under /a/b, /ab under /a), the degenerate filesystem root, POSIX's
+# separate '//' anchor, relative paths, and '.'.
+POSIX_PATHS = [
+    "/",
+    "//",
+    "//a",
+    "//a/b",
+    "/a",
+    "/a/b",
+    "/a/b/c",
+    "/a/b/c/d.py",
+    "/a/b.py",
+    "/a/bb",
+    "/ab",
+    "/x/y",
+    ".",
+    "a",
+    "a/b",
+    "a/b/c.py",
+]
+
+POSIX_ROOTS = ["/", "//", "/a", "/a/b", "/a/bb", "/x/y", "."]
+
+
+def _reference_relative_parts(path, root):
+    """What relative_to would return, or None where it raises."""
+    try:
+        return path.relative_to(root).parts
+    except ValueError:
+        return None
+
+
+@pytest.mark.parametrize("path_str,root_str", itertools.product(POSIX_PATHS, repeat=2))
+def test_matches_pathlib(path_str, root_str):
+    """relative_parts/is_contained agree with pathlib on every pair.
+
+    pathlib is the specification here, so this is the test that matters: the
+    helpers exist only to be a cheaper way of computing the same answer.
+    """
+    path, root = Path(path_str), Path(root_str)
+    expected = _reference_relative_parts(path, root)
+
+    assert relative_parts(path, root) == expected
+    assert is_contained(path, root) is (expected is not None)
+
+
+@pytest.mark.parametrize("path_str,root_str", itertools.product(POSIX_PATHS, repeat=2))
+def test_relative_path_matches_pathlib(path_str, root_str):
+    path, root = Path(path_str), Path(root_str)
+    if _reference_relative_parts(path, root) is None:
+        assert relative_path(path, root) is None
+        return
+
+    expected = str(path.relative_to(root))
+    # A path relative to itself is "" here rather than pathlib's "."
+    assert relative_path(path, root) == ("" if expected == "." else expected)
+
+
+@pytest.mark.parametrize("path_str", POSIX_PATHS)
+def test_deepest_containing_root_matches_pathlib(path_str):
+    """The deepest root wins, matching a shortest-relative-path search."""
+    path = Path(path_str)
+    roots = [Path(_) for _ in POSIX_ROOTS]
+
+    best = None
+    for root in roots:
+        relative = _reference_relative_parts(path, root)
+        if relative is None:
+            continue
+        if best is None or len(relative) < len(best[1]):
+            best = (root, relative)
+
+    assert deepest_containing_root(path, roots) == best
+
+
+def test_deepest_containing_root_prefers_site_packages():
+    """The motivating case: venv and its site-packages both on sys.path."""
+    venv = Path("/app/.venv")
+    site_packages = Path("/app/.venv/lib/python3.12/site-packages")
+    path = Path("/app/.venv/lib/python3.12/site-packages/google/cloud/storage/blob.py")
+
+    root, parts = deepest_containing_root(path, [venv, site_packages, Path("/app")])
+
+    assert root == site_packages
+    assert parts == ("google", "cloud", "storage", "blob.py")
+
+
+def test_deepest_containing_root_no_match():
+    assert deepest_containing_root(Path("/somewhere/else.py"), [Path("/a"), Path("/b")]) is None
+
+
+def test_deepest_containing_root_empty_roots():
+    assert deepest_containing_root(Path("/a/b"), []) is None
+
+
+def test_deepest_containing_root_accepts_a_generator():
+    """packages.py filters sys.path inline, so roots is often a generator."""
+    roots = (Path(_) for _ in ("/a", "/a/b"))
+
+    assert deepest_containing_root(Path("/a/b/c.py"), roots) == (Path("/a/b"), ("c.py",))
+
+
+def test_root_returned_unchanged():
+    """The caller's own object comes back, so its I/O methods stay available."""
+    root = Path("/a/b")
+    returned, _ = deepest_containing_root(Path("/a/b/c.py"), [root])
+    assert returned is root
+
+
+def test_path_relative_to_itself_is_empty():
+    assert relative_parts(Path("/a/b"), Path("/a/b")) == ()
+    assert is_contained(Path("/a/b"), Path("/a/b")) is True
+
+
+@pytest.mark.parametrize(
+    "path_str,root_str",
+    [
+        ("/a/bb", "/a/b"),  # sibling sharing a prefix
+        ("/ab", "/a"),
+        ("/a/bcd", "/a/b"),
+    ],
+)
+def test_prefix_must_land_on_a_component_boundary(path_str, root_str):
+    assert relative_parts(Path(path_str), Path(root_str)) is None
+    assert is_contained(Path(path_str), Path(root_str)) is False
+
+
+def test_strings_are_rejected_rather_than_silently_mishandled():
+    """The contract is PurePath, and comparing parts enforces it.
+
+    An earlier string-prefix implementation accepted str and quietly got
+    unnormalized input wrong ("/a/./b" reported as not contained). Comparing
+    .parts means a str fails loudly instead, and normalization is guaranteed
+    because PurePath construction has already done it.
+    """
+    with pytest.raises(AttributeError):
+        relative_parts("/a/b/c.py", "/a/b")
+
+    # The same path through PurePath is normalized, so it matches.
+    assert relative_parts(Path("/a/./b/c.py"), Path("/a/b")) == ("c.py",)
+    assert relative_parts(Path("/a//b/c.py"), Path("/a/b")) == ("c.py",)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX is case-sensitive")
+def test_posix_is_case_sensitive():
+    assert relative_parts(PurePosixPath("/A/b"), PurePosixPath("/a")) is None
+    assert is_contained(PurePosixPath("/A/b"), PurePosixPath("/a")) is False
+
+
+@pytest.mark.skipif(os.name == "nt", reason="'//' anchor is POSIX-specific")
+def test_double_slash_is_a_separate_posix_anchor():
+    """Matches pathlib, which keeps '//a' distinct from '/a'."""
+    assert relative_parts(Path("//a"), Path("/")) is None
+    assert relative_parts(Path("//a/b"), Path("//")) == ("a", "b")
+    assert relative_parts(Path("/a/b"), Path("//")) is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="'//' anchor is POSIX-specific")
+def test_deepest_containing_root_handles_the_double_slash_anchor():
+    roots = [Path("/"), Path("//"), Path("//a")]
+
+    assert deepest_containing_root(Path("//a/b"), roots) == (Path("//a"), ("b",))
+    assert deepest_containing_root(Path("//x"), [Path("/")]) is None
+    assert deepest_containing_root(Path("//x"), [Path("//")]) == (Path("//"), ("x",))
+    assert deepest_containing_root(Path("/x/y"), [Path("/")]) == (Path("/"), ("x", "y"))
+    assert deepest_containing_root(Path("/x/y"), [Path("//")]) is None
+
+
+# ---------------------------------------------------------------------------
+# Windows. Development and CI here are POSIX-only, so the native test below
+# never runs; _force_windows_rules makes the same pathlib comparison runnable
+# on any host, which is the only coverage this behaviour actually gets.
+# ---------------------------------------------------------------------------
+
+# Drive roots, UNC shares, drive-relative paths, mixed separators, the
+# C:\ab-under-C:\a near-miss, differing case, and 'İ' (U+0130), whose lowercase
+# is two codepoints -- the case that broke an offset-based implementation.
+WINDOWS_PATHS = [
+    "C:\\",
+    r"C:\a",
+    r"C:\A",
+    r"C:\a\b",
+    r"C:\a\b\c.py",
+    r"C:\ab",
+    r"C:a",
+    r"C:a\b",
+    r"D:\a",
+    r"\\server\share",
+    r"\\server\share\a",
+    r"\\server\share\a\b.py",
+    r"\\other\share\a",
+    r"\a",
+    r"\a\b",
+    "C:/a/b",
+    ".",
+    r"C:\İstanbul",
+    r"C:\İstanbul\site-packages",
+    r"C:\İstanbul\site-packages\google\cloud\storage\blob.py",
+    r"C:\İ",
+    r"C:\İ\x",
+    r"C:\i\x",
+    r"C:\Users\İb\proj",
+    r"C:\Users\İb\proj\test_a.py",
+]
+
+
+@pytest.fixture
+def _force_windows_rules(monkeypatch):
+    monkeypatch.setattr(paths, "_CASE_INSENSITIVE", True)
+    monkeypatch.setattr(paths, "_SEP", "\\")
+
+
+@pytest.mark.parametrize("path_str,root_str", itertools.product(WINDOWS_PATHS, repeat=2))
+def test_windows_semantics_match_pathlib(path_str, root_str, _force_windows_rules):
+    path, root = PureWindowsPath(path_str), PureWindowsPath(root_str)
+    expected = _reference_relative_parts(path, root)
+
+    assert paths.relative_parts(path, root) == expected
+    assert paths.is_contained(path, root) is (expected is not None)
+
+    if expected is not None:
+        reference = str(path.relative_to(root))
+        assert paths.relative_path(path, root) == ("" if reference == "." else reference)
+
+
+def test_windows_case_folding_is_length_safe(_force_windows_rules):
+    r"""Regression: 'İ'.lower() is two codepoints, so offsets cannot be reused.
+
+    Folding the whole path and then slicing the original string at an offset
+    found in the folded copy truncated the first relative component whenever a
+    root contained U+0130 -- silently, since containment still reported True.
+    Turkish directory names ('C:\\Users\\İbrahim') hit this in normal use.
+    """
+    path = PureWindowsPath(r"C:\Users\İb\proj\test_a.py")
+
+    assert paths.relative_parts(path, PureWindowsPath(r"C:\Users\İb\proj")) == ("test_a.py",)
+    assert paths.relative_parts(PureWindowsPath(r"C:\İ\x"), PureWindowsPath(r"C:\İ")) == ("x",)
+    assert paths.relative_path(path, PureWindowsPath(r"C:\Users\İb")) == "proj\\test_a.py"
+    # Case folding still applies to the rest of the path.
+    assert paths.is_contained(path, PureWindowsPath(r"c:\users\İb")) is True
+
+
+def test_windows_distinguishes_drive_and_unc_anchors(_force_windows_rules):
+    """Anchors are compared as whole components, so they cannot be confused."""
+    assert paths.relative_parts(PureWindowsPath(r"C:\a"), PureWindowsPath(r"D:\a")) is None
+    assert paths.relative_parts(PureWindowsPath(r"\\server\share\a"), PureWindowsPath(r"\\other\share")) is None
+    assert paths.relative_parts(PureWindowsPath(r"\\server\share\a\b"), PureWindowsPath(r"\\server\share")) == (
+        "a",
+        "b",
+    )
+    # A drive-relative root ('C:', no root) is a different anchor from 'C:\'.
+    # pathlib agreed only from 3.12 on, where anchors became strict; before that
+    # it allowed the match. No caller passes a non-absolute root.
+    assert paths.relative_parts(PureWindowsPath(r"C:\a"), PureWindowsPath("C:")) is None
+
+
+@pytest.mark.skipif(os.name != "nt", reason="native Windows only")
+def test_windows_native_case_insensitivity():
+    """The one thing the simulation cannot check: the platform probe itself."""
+    assert paths._CASE_INSENSITIVE is True
+    assert paths.is_contained(Path(r"C:\a\b"), Path(r"C:\A")) is True


### PR DESCRIPTION
## Description

`filename_to_package` and the `is_user_code` / `is_third_party` / `is_stdlib` predicates built on it are called per stack frame by the profiler and Dynamic Instrumentation. A production alloc-size profile attributed a large share of allocations to them, with `PurePath._str_normcase` and `Path.__new__` at the top of the flame graph.

The cause is `PurePath.relative_to` / `is_relative_to`. On Python 3.12 a single call allocates path objects and performs case-folded comparisons proportional to the depth of *both* operands, whether it succeeds or fails. `packages.py` probed one filename against every `sys.path` entry across three separate fallback helpers, so almost all of that work was thrown away on the miss path.

Add `ddtrace/internal/utils/paths.py`, which answers the same questions by comparing the `PurePath.parts` pathlib has already parsed: containment becomes a prefix check over a tuple of strings, with no intermediate objects and no exceptions when the answer is no. `relative_parts`, `is_contained`, `relative_path` and `deepest_containing_root` replace the ad-hoc probing here and at eleven call sites in `coverage/`, `ci_visibility/`, `testing/` and `debugging/` that were open-coding the same patterns -- several of them paying for containment twice by calling `is_relative_to` and then `relative_to`.

Comparing parsed components rather than strings is also what makes the anchor handling correct: `/` and POSIX's separate `//`, or `C:` and `C:\`, no longer match each other, and normalization is guaranteed by `PurePath` construction rather than assumed.

Also cut redundant filesystem work the profile exposed:

* `_relative_to_known_root` and `_root_module` each called `path.resolve()` on the same path. It is now resolved once in `filename_to_package` and passed alongside the original, which the `sys.path` probes still need unresolved or symlinked entries stop matching.
* `_is_install_root` and `_root_ships_distribution` walked the same directory independently, the latter uncached on every probe. One cached `_shipped_distributions` listing now serves both.
* The `__init__.py` probe behind `_effective_root` is cached on the package name instead of being repeated per source file.

Measured on 3.12. `filename_to_package` on a cache miss, against the real distribution mapping:

    before   1198 us / 6634 B
    after     284 us / 3138 B      4.2x faster, 53% less allocated

An Austin profile of the miss path (262k misses, 15.7 kHz, wall) confirms where the remaining cost sits and that containment is no longer part of it:

    Path.resolve()                 89.3% of the miss path
    parents-walk fallback           3.8%
    containment helpers             1.3%

Removing the duplicate resolve took the miss from 57.1 us to 49.5 us, 13% end to end, and the follow-up profile shows `resolve()` at a single call site with the two helpers down from 23.4%/9.5% to 2.1%/1.6%.

The helpers are verified against pathlib itself rather than by construction: an exhaustive differential test over every path/root pair asserts they agree with `relative_to`, on 3.9 through 3.14. Because CI here is POSIX-only, the Windows rules are forced on and differentially tested too -- that is what caught a case folding bug, since the lowercase of U+0130 is two characters and an earlier offset-based implementation silently truncated components under a Turkish directory name.

No behaviour change is intended. Two latent bugs are fixed incidentally: an `IndexError` escaping `filename_to_package` when a path was itself a `sys.path` entry, and the `PurePath.parents` walk in `_resolve_source_file` no longer being quadratic in path depth.