### PR TITLE
fix(tracing): APMS-20291 parse tracestate

### DIFF
--- a/ddtrace/propagation/http.py
+++ b/ddtrace/propagation/http.py
@@ -700,6 +700,31 @@ class _TraceContext:
         return tag_val.replace("~", "=")
 
     @staticmethod
+    def _get_datadog_tracestate_value(list_mem: str) -> dict[str, str]:
+        dd = {}
+        has_invalid_item = False
+        for item in list_mem.split(";"):
+            item_stripped = item.strip()
+            if not item_stripped:
+                continue
+            if item_stripped != item:
+                raise ValueError("Invalid whitespace in dd tracestate member")
+            if ":" not in item:
+                has_invalid_item = True
+                continue
+
+            key, value = item.split(":", 1)
+            if not key:
+                has_invalid_item = True
+                continue
+            dd[key] = value
+
+        if has_invalid_item and not dd:
+            raise ValueError("Invalid dd tracestate member")
+
+        return dd
+
+    @staticmethod
     def _get_traceparent_values(tp: str) -> tuple[int, int, Literal[0, 1]]:
         """If there is no traceparent, or if the traceparent value is invalid raise a ValueError.
         Otherwise we extract the trace-id, span-id, and sampling priority from the
@@ -753,9 +778,8 @@ class _TraceContext:
         for list_mem in ts_l:
             if list_mem.startswith("dd="):
                 # cut out dd= before turning into dict
-                list_mem = list_mem[3:]
-                # since tags can have a value with a :, we need to only split on the first instance of :
-                dd = dict(item.split(":", 1) for item in list_mem.split(";"))
+                # since tags can have a value with a :, split only on the first instance of :
+                dd = _TraceContext._get_datadog_tracestate_value(list_mem[3:])
 
         # parse out values
         if dd:

--- a/releasenotes/notes/fix-w3c-tracestate-extra-separators-9f3b1a7c2d6e4a80.yaml
+++ b/releasenotes/notes/fix-w3c-tracestate-extra-separators-9f3b1a7c2d6e4a80.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    tracing: Fixes W3C ``tracestate`` extraction for Datadog entries that contain extra
+    semicolon separators, preserving sampling priority and origin propagation when the
+    rest of the trace context is valid.

--- a/tests/tracer/test_propagation.py
+++ b/tests/tracer/test_propagation.py
@@ -1479,6 +1479,48 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
             None,
         ),
         (
+            "dd=s:2;o:rum;",
+            (2, {}, "rum", None),
+            None,
+            None,
+        ),
+        (
+            "dd=s:2;o:rum; \t",
+            (2, {}, "rum", None),
+            None,
+            None,
+        ),
+        (
+            "dd=s:2;o:rum;  ,congo=t61rcWkgMzE",
+            (2, {}, "rum", None),
+            None,
+            None,
+        ),
+        (
+            "dd=;s:2;o:rum",
+            (2, {}, "rum", None),
+            None,
+            None,
+        ),
+        (
+            "dd=s:2;;o:rum",
+            (2, {}, "rum", None),
+            None,
+            None,
+        ),
+        (
+            "dd=s:0;t.dm:934086a686-4;  t.x:y",
+            None,
+            None,
+            ValueError,
+        ),
+        (
+            "dd=s:0; t.dm:934086a686-4",
+            None,
+            None,
+            ValueError,
+        ),
+        (
             "dd=invalid,congo=123",
             None,
             ["received invalid dd header value in tracestate: 'dd=invalid,congo=123'"],
@@ -1531,6 +1573,13 @@ def test_extract_traceparent(caplog, headers, expected_tuple, expected_logging, 
         "tracestate_with_unknown_t._values",
         "tracestate_with_no_dd_list_member",
         "tracestate_no_origin",
+        "tracestate_trailing_empty_dd_submember",
+        "tracestate_trailing_empty_dd_submember_ows",
+        "tracestate_trailing_empty_dd_submember_before_next_member",
+        "tracestate_leading_empty_dd_submember",
+        "tracestate_interior_empty_dd_submember",
+        "tracestate_invalid_interior_ows_dd_submember",
+        "tracestate_invalid_interior_ows_after_first_dd_submember",
         "tracestate_invalid_dd_list_member",
         "tracestate_invalid_tracestate_char_outside_ascii_range_20-70",
         "tracestate_tilda_replaced_with_equals",
@@ -1549,6 +1598,44 @@ def test_extract_tracestate(caplog, ts_string, expected_tuple, expected_logging,
             if caplog.text or expected_logging:
                 for expected_log in expected_logging:
                     assert expected_log in caplog.text
+
+
+@pytest.mark.parametrize(
+    "tracestate",
+    [
+        "foo=1,dd=s:2;o:some;",
+        "foo=1,dd=s:2;o:some; \t",
+        "dd=s:2;o:some;  ,x=y",
+        "foo=1,dd=;s:2;o:some",
+        "foo=1,dd=s:2;;o:some",
+    ],
+)
+def test_tracecontext_get_context_allows_empty_dd_tracestate_submembers(tracestate):
+    ctx = _TraceContext._get_context(TRACE_ID, 67667974448284343, 1, tracestate, {})
+
+    assert ctx.sampling_priority == 2
+    assert ctx.dd_origin == "some"
+
+
+@pytest.mark.parametrize(
+    "tracestate",
+    [
+        "foo=1,dd=s:0;t.dm:934086a686-4;  t.x:y",
+        "foo=1,dd=s:0; t.dm:934086a686-4",
+    ],
+)
+def test_tracecontext_get_context_skips_dd_tracestate_with_interior_ows(tracestate):
+    ctx = _TraceContext._get_context(
+        TRACE_ID,
+        67667974448284343,
+        1,
+        tracestate,
+        {},
+    )
+
+    assert ctx.sampling_priority == 1
+    assert ctx.dd_origin is None
+    assert "_dd.p.dm" not in ctx._meta
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- dd-meta {"pullId":"05888cf1-cc2a-4bea-b52f-f22b062be97e","source":"chat","resourceId":"ae3df51a-1281-4a6c-911f-1009465a9472","workflowId":"f3a16324-9a4e-4951-b9be-d05af2354a03","codeChangeId":"f3a16324-9a4e-4951-b9be-d05af2354a03","sourceType":"slack"} -->
## Description

Motivation:
Fixes APMS-20291 handling for W3C tracestate values where Datadog entries contain empty semicolon-separated submembers. The new system-tests branch showed Python dropping otherwise valid dd tracestate values for leading, trailing, and doubled separators, and applying partial propagated tags for invalid interior OWS.

Changes:
- Parse dd tracestate submembers explicitly instead of relying on a dict comprehension.
- Ignore empty dd submembers created by extra semicolon separators.
- Reject non-empty dd submembers with surrounding OWS so invalid dd entries are skipped consistently.
- Add focused propagation tests and a release note.

## Testing

- `scripts/run-tests --venv c48b0f7 tests/tracer/test_propagation.py -- -- -k 'tracestate and (empty_dd_tracestate_submembers or skips_dd_tracestate_with_interior_ows or extract_tracestate)'`
- `PYENV_VERSION=3.10.20 scripts/lint pre-commit-python ddtrace/propagation/http.py tests/tracer/test_propagation.py`
- `PYENV_VERSION=3.10.20 scripts/lint format_check ddtrace/propagation/http.py tests/tracer/test_propagation.py`
- `PYENV_VERSION=3.10.20 scripts/lint ruff check --no-cache ddtrace/propagation/http.py tests/tracer/test_propagation.py`
- `PYENV_VERSION=3.10.20 scripts/lint cython-lint ddtrace/propagation/http.py tests/tracer/test_propagation.py`
- `PYENV_VERSION=3.10.20 scripts/lint spelling releasenotes/notes/fix-w3c-tracestate-extra-separators-9f3b1a7c2d6e4a80.yaml`
- Built `ddtrace-4.15.0rc1-cp311-cp311-linux_x86_64.whl` from this checkout and installed it into the Python parametric system-tests image from branch `mcculls/extra-w3c-tracestate-tests`.
- Ran manual parametric checks through the shared `/trace/span/extract_headers` and `/trace/span/inject_headers` endpoints for all 11 new tracestate cases from that branch; all passed.

The full `./run.sh PARAMETRIC` path was also attempted with the locally built wheel, but this sandbox's Podman bridge network failed before tracer assertions with `netavark: Sysctl error: IO Error: Read-only file system`. The manual parametric run used host networking to avoid that local infrastructure blocker while still exercising the locally built Python tracer image and shared parametric API.

## Risks

Low. The change is scoped to parsing the Datadog W3C tracestate member during extraction. Empty separator-generated submembers are ignored, while invalid non-empty submembers with interior OWS continue to cause the dd member to be skipped.

## Additional Notes

The repository `releasenote` skill was not available in this environment, so the release note was added manually following the existing `releasenotes/notes` format.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/ae3df51a-1281-4a6c-911f-1009465a9472)

Comment @datadog to request changes