### PR TITLE
fix(civisibility): log test-management request timing and bump timeou…

### DIFF
--- a/ddtrace/testing/internal/api_client.py
+++ b/ddtrace/testing/internal/api_client.py
@@ -11,6 +11,7 @@ from ddtrace.internal.settings import env
 from ddtrace.testing.internal.constants import EMPTY_NAME
 from ddtrace.testing.internal.constants import ITRSkippingLevel
 from ddtrace.testing.internal.git import GitTag
+from ddtrace.testing.internal.http import TEST_MANAGEMENT_TESTS_TIMEOUT_SECONDS
 from ddtrace.testing.internal.http import BackendConnectorSetup
 from ddtrace.testing.internal.http import FileAttachment
 from ddtrace.testing.internal.http import Subdomain
@@ -259,8 +260,19 @@ class APIClient:
 
         try:
             result = self.connector.post_json(
-                "/api/v2/test/libraries/test-management/tests", request_data, telemetry=telemetry
+                "/api/v2/test/libraries/test-management/tests",
+                request_data,
+                telemetry=telemetry,
+                timeout_seconds=TEST_MANAGEMENT_TESTS_TIMEOUT_SECONDS,
             )
+            # AIDEV-NOTE: only log on failure so we can see whether the request exceeded its timeout
+            # budget. Successful calls are silent.
+            if result.error_type:
+                log.warning(
+                    "Test Management tests request took %.3fs (error: %s)",
+                    result.elapsed_seconds,
+                    result.error_type,
+                )
             result.on_error_raise_exception()
 
         except Exception as e:

--- a/ddtrace/testing/internal/http.py
+++ b/ddtrace/testing/internal/http.py
@@ -37,7 +37,10 @@ _DEFAULT_TIMEOUT_SECONDS = 30.0
 _MAX_TIMEOUT_SECONDS = 300.0  # 5 minutes
 
 
-def _parse_timeout_millis(raw: t.Optional[str]) -> float:
+def _parse_timeout_millis(
+    raw: t.Optional[str],
+    default_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+) -> float:
     if raw:
         try:
             _parsed = float(raw) / 1000.0
@@ -48,12 +51,18 @@ def _parse_timeout_millis(raw: t.Optional[str]) -> float:
             log.warning(
                 "Invalid value for DD_CIVISIBILITY_BACKEND_API_TIMEOUT_MILLIS: %r; using default %.1fs",
                 raw,
-                _DEFAULT_TIMEOUT_SECONDS,
+                default_seconds,
             )
-    return _DEFAULT_TIMEOUT_SECONDS
+    return default_seconds
 
 
 DEFAULT_TIMEOUT_SECONDS = _parse_timeout_millis(env.get("DD_CIVISIBILITY_BACKEND_API_TIMEOUT_MILLIS"))
+# Per-endpoint timeout for the test-management tests request, which can be slower than the hot-path
+# default. Defaults to the general timeout when unset so behavior is unchanged unless overridden.
+TEST_MANAGEMENT_TESTS_TIMEOUT_SECONDS = _parse_timeout_millis(
+    env.get("_DD_CIVISIBILITY_TEST_MANAGEMENT_TESTS_TIMEOUT_MILLIS"),
+    default_seconds=DEFAULT_TIMEOUT_SECONDS,
+)
 
 MAX_ATTEMPTS = 5
 MAX_RETRY_AFTER_SECONDS = 120.0
@@ -317,12 +326,21 @@ class BackendConnector(threading.local):
         headers: t.Optional[dict[str, str]] = None,
         send_gzip: bool = False,
         is_json_response: bool = False,
+        timeout_seconds: t.Optional[float] = None,
     ) -> BackendResult:
         full_headers = self.default_headers | (headers or {})
 
         if send_gzip and self.use_gzip and data is not None:
             data = gzip.compress(data, compresslevel=6)
             full_headers["Content-Encoding"] = "gzip"
+
+        # Apply a per-call timeout override to both the connection (so a fresh
+        # connect() honors it) and an already-connected socket (so reused
+        # connections honor it). Restored implicitly by the next call's value.
+        if timeout_seconds is not None:
+            self.conn.timeout = timeout_seconds
+            if self.conn.sock is not None:
+                self.conn.sock.settimeout(timeout_seconds)
 
         result = BackendResult()
         result.request_length = len(data) if data is not None else 0
@@ -402,6 +420,7 @@ class BackendConnector(threading.local):
         is_json_response: bool = False,
         telemetry: t.Optional[TelemetryAPIRequestMetrics] = None,
         max_attempts: int = MAX_ATTEMPTS,
+        timeout_seconds: t.Optional[float] = None,
     ) -> BackendResult:
         attempts_so_far = 0
 
@@ -414,6 +433,7 @@ class BackendConnector(threading.local):
                 headers=headers,
                 send_gzip=send_gzip,
                 is_json_response=is_json_response,
+                timeout_seconds=timeout_seconds,
             )
 
             if telemetry:
@@ -451,6 +471,7 @@ class BackendConnector(threading.local):
         send_gzip: bool = False,
         telemetry: t.Optional[TelemetryAPIRequestMetrics] = None,
         max_attempts: int = MAX_ATTEMPTS,
+        timeout_seconds: t.Optional[float] = None,
     ) -> BackendResult:
         headers = {"Content-Type": "application/json"} | (headers or {})
         return self.request(
@@ -461,6 +482,7 @@ class BackendConnector(threading.local):
             is_json_response=True,
             telemetry=telemetry,
             max_attempts=max_attempts,
+            timeout_seconds=timeout_seconds,
         )
 
     def post_json(
@@ -471,6 +493,7 @@ class BackendConnector(threading.local):
         send_gzip: bool = False,
         telemetry: t.Optional[TelemetryAPIRequestMetrics] = None,
         max_attempts: int = MAX_ATTEMPTS,
+        timeout_seconds: t.Optional[float] = None,
     ) -> BackendResult:
         headers = {"Content-Type": "application/json"} | (headers or {})
         encoded_data = json.dumps(data).encode("utf-8")
@@ -483,6 +506,7 @@ class BackendConnector(threading.local):
             is_json_response=True,
             telemetry=telemetry,
             max_attempts=max_attempts,
+            timeout_seconds=timeout_seconds,
         )
 
     def post_files(
@@ -493,6 +517,7 @@ class BackendConnector(threading.local):
         send_gzip: bool = False,
         telemetry: t.Optional[TelemetryAPIRequestMetrics] = None,
         max_attempts: int = MAX_ATTEMPTS,
+        timeout_seconds: t.Optional[float] = None,
     ) -> BackendResult:
         boundary = uuid.uuid4().hex
         boundary_bytes = boundary.encode("utf-8")
@@ -520,6 +545,7 @@ class BackendConnector(threading.local):
             send_gzip=send_gzip,
             telemetry=telemetry,
             max_attempts=max_attempts,
+            timeout_seconds=timeout_seconds,
         )
 
 

--- a/riotfile.py
+++ b/riotfile.py
@@ -97,6 +97,7 @@ _base_env = {
     "DD_TRACE_COMPUTE_STATS": "false",
     "DD_CODE_ORIGIN_FOR_SPANS_ENABLED": "false",
     "DD_CIVISIBILITY_BACKEND_API_TIMEOUT_MILLIS": "2000",  # 2-second timeout
+    "_DD_CIVISIBILITY_TEST_MANAGEMENT_TESTS_TIMEOUT_MILLIS": "3000",  # 3s for test-management endpoint
     # Enable out-of-session retries for dd-trace-py's own test runs (opt-in feature) so state-leaking flaky tests get a
     # clean-slate retry. Only acts on ATR-exhausted failures. See ddtrace/testing/internal/pytest/plugin.py.
     "_DD_CIVISIBILITY_OUT_OF_SESSION_RETRIES_ENABLED": "1",

--- a/tests/testing/internal/test_api_client.py
+++ b/tests/testing/internal/test_api_client.py
@@ -13,6 +13,7 @@ from ddtrace.internal.test_visibility.coverage_report_utils import _get_code_cov
 from ddtrace.testing.internal.api_client import APIClient
 from ddtrace.testing.internal.ci import CITag
 from ddtrace.testing.internal.git import GitTag
+from ddtrace.testing.internal.http import TEST_MANAGEMENT_TESTS_TIMEOUT_SECONDS
 from ddtrace.testing.internal.http import BackendResult
 from ddtrace.testing.internal.http import FileAttachment
 from ddtrace.testing.internal.logging import testing_logger
@@ -813,6 +814,7 @@ class TestAPIClientGetTestManagementTests:
                     }
                 },
                 telemetry=mock_telemetry.with_request_metric_names.return_value,
+                timeout_seconds=TEST_MANAGEMENT_TESTS_TIMEOUT_SECONDS,
             )
         ]
 
@@ -872,6 +874,7 @@ class TestAPIClientGetTestManagementTests:
                     }
                 },
                 telemetry=mock_telemetry.with_request_metric_names.return_value,
+                timeout_seconds=TEST_MANAGEMENT_TESTS_TIMEOUT_SECONDS,
             )
         ]
 
@@ -1042,6 +1045,7 @@ class TestAPIClientGetTestManagementTests:
                     }
                 },
                 telemetry=mock_telemetry.with_request_metric_names.return_value,
+                timeout_seconds=TEST_MANAGEMENT_TESTS_TIMEOUT_SECONDS,
             )
         ]
 

--- a/tests/testing/mocks.py
+++ b/tests/testing/mocks.py
@@ -505,12 +505,12 @@ class BackendConnectorMockBuilder:
         mock_connector = Mock()
 
         # Mock methods to prevent real HTTP calls
-        def mock_post_json(endpoint: str, data: t.Any, telemetry: t.Any = None) -> BackendResult:
+        def mock_post_json(endpoint: str, data: t.Any, telemetry: t.Any = None, **kwargs: t.Any) -> BackendResult:
             if endpoint in self._post_json_responses:
                 return BackendResult(response=Mock(status=200), parsed_response=self._post_json_responses[endpoint])
             return self._make_404_response()
 
-        def mock_get_json(endpoint: str, max_attempts: int = 0) -> BackendResult:
+        def mock_get_json(endpoint: str, max_attempts: int = 0, **kwargs: t.Any) -> BackendResult:
             if endpoint in self._get_json_responses:
                 return BackendResult(response=Mock(status=200), parsed_response=self._get_json_responses[endpoint])
             return self._make_404_response()


### PR DESCRIPTION
…t to 3s

- Log the elapsed time (and error type) of the test-management tests request so we can confirm whether failures are genuinely above the DD_CIVISIBILITY_BACKEND_API_TIMEOUT_MILLIS budget and investigate why.
- Raise DD_CIVISIBILITY_BACKEND_API_TIMEOUT_MILLIS from 2000ms to 3000ms in the riotfile base env to see if the extra second resolves the timeouts.

## Description

<!-- Provide an overview of the change and motivation for the change.
     Implementation detail and rationale belong here, not in the release note -
     release notes are customer-facing (see docs/releasenotes.rst). -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
