### PR TITLE
fix(fastapi): resource name in subapps should include mount path

### DIFF
--- a/tests/contrib/fastapi/test_fastapi.py
+++ b/tests/contrib/fastapi/test_fastapi.py
@@ -483,6 +483,10 @@ def test_nested_include_router_resource_names(fastapi_tracer, test_spans):
     app = FastAPI()
     app.include_router(v1, prefix="/v1")
 
+    sub_app = FastAPI()
+    sub_app.include_router(items, prefix="/items")
+    app.mount("/v2", sub_app)
+
     with TestClient(app) as client:
         r = client.get("/v1/items")
         assert r.status_code == 200
@@ -495,6 +499,18 @@ def test_nested_include_router_resource_names(fastapi_tracer, test_spans):
         request_span = test_spans.pop_traces()[0][0]
         assert request_span.resource == "GET /v1/items/{item_id}"
         assert request_span.get_tag("http.route") == "/v1/items/{item_id}"
+
+        r = client.get("/v2/items")
+        assert r.status_code == 200
+        request_span = test_spans.pop_traces()[0][0]
+        assert request_span.resource == "GET /v2/items"
+        assert request_span.get_tag("http.route") == "/v2/items"
+
+        r = client.get("/v2/items/42")
+        assert r.status_code == 200
+        request_span = test_spans.pop_traces()[0][0]
+        assert request_span.resource == "GET /v2/items/{item_id}"
+        assert request_span.get_tag("http.route") == "/v2/items/{item_id}"
 
 
 def test_distributed_tracing(client, tracer, test_spans):


### PR DESCRIPTION
## Description

I use sub-apps in my FastAPI app, and with dd-trace-py 4.13.1 (and fastapi 0.141.1) the mount path is not included in the resource name.

Draft: reproduce the issue in CI before fixing it

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
