### PR TITLE
fix(debugging): support probes on declarations

### DIFF
--- a/ddtrace/debugging/_debugger.py
+++ b/ddtrace/debugging/_debugger.py
@@ -370,13 +370,14 @@ class Debugger(Service):
 
         # Group probes by function so that we decompile each function once and
         # bulk-inject the probes.
-        probes_for_function: dict[FullyNamedContextWrappedFunction, list[Probe]] = defaultdict(list)
+        probes_for_function: dict[FullyNamedContextWrappedFunction, list[LineProbe]] = defaultdict(list)
+        discovery = FunctionDiscovery.from_module(module)
         for probe in self._probe_registry.get_pending(str(origin(module))):
             if not isinstance(probe, LineLocationMixin):
                 continue
             line = probe.line
             assert line is not None  # nosec
-            functions = FunctionDiscovery.from_module(module).at_line(line)
+            functions = discovery.at_line(line)
             if not functions:
                 module_origin = str(origin(module))
                 if linecache.getline(module_origin, line):
@@ -394,12 +395,12 @@ class Debugger(Service):
                 log.error(message, extra={"send_to_telemetry": False})
                 self._probe_registry.set_error(probe, "NoFunctionsAtLine", message)
                 continue
-            for function in (cast(FullyNamedContextWrappedFunction, _) for _ in functions):
-                probes_for_function[function].append(cast(LineProbe, probe))
+            for target_function in (cast(FullyNamedContextWrappedFunction, _) for _ in functions):
+                probes_for_function[target_function].append(cast(LineProbe, probe))
 
-        for function, probes in probes_for_function.items():
+        for target_function, probes in probes_for_function.items():
             failed = self._function_store.inject_hooks(
-                function, [(self._dd_debugger_hook, cast(LineProbe, probe).line, probe) for probe in probes]
+                target_function, [(self._dd_debugger_hook, probe.line, probe) for probe in probes]
             )
 
             for probe in probes:
@@ -416,7 +417,7 @@ class Debugger(Service):
                 os.getpid(),
                 os.getppid(),
                 [probe.probe_id for probe in probes if probe.probe_id not in failed],
-                function,
+                target_function,
             )
 
     def _inject_probes(self, probes: list[LineProbe]) -> None:
@@ -467,19 +468,18 @@ class Debugger(Service):
             if module is not None:
                 # The module is still loaded, so we can try to eject the hooks
                 probes_for_function: dict[FullyNamedContextWrappedFunction, list[LineProbe]] = defaultdict(list)
+                discovery = FunctionDiscovery.from_module(module)
                 for probe in probes:
                     if not isinstance(probe, LineLocationMixin):
                         continue  # type: ignore[unreachable]
-                    line = probe.line
-                    assert line is not None, probe  # nosec
-                    functions = FunctionDiscovery.from_module(module).at_line(line)
+                    functions = discovery.at_line(probe.line)
                     for function in (cast(FullyNamedContextWrappedFunction, _) for _ in functions):
                         probes_for_function[function].append(probe)
 
                 for function, ps in probes_for_function.items():
                     failed = self._function_store.eject_hooks(
                         cast(FunctionType, function),
-                        [(self._dd_debugger_hook, probe.line, probe) for probe in ps if probe.line is not None],
+                        [(self._dd_debugger_hook, probe.line, probe) for probe in ps],
                     )
                     for probe in ps:
                         if probe.probe_id in failed:

--- a/ddtrace/debugging/_function/discovery.py
+++ b/ddtrace/debugging/_function/discovery.py
@@ -257,6 +257,7 @@ class FunctionDiscovery(defaultdict[Any, Any]):
         if PYTHON_VERSION_INFO < (3, 11):
             self._name_index: dict[str, list[_FunctionCodePair]] = defaultdict(list)
         self._cached: dict[int, list[FullyNamedFunction]] = {}
+        self._function_header_index: list[tuple[int, int, _FunctionCodePair]] = []
 
         # Create the line to function mapping
         if hasattr(module, "__dd_code__"):
@@ -272,8 +273,7 @@ class FunctionDiscovery(defaultdict[Any, Any]):
                 else:
                     self._name_index[code.co_name].append(fcp)
 
-                for lineno in linenos(code):
-                    self[lineno].append(fcp)
+                self._index_code(fcp)
         else:
             self._fullname_index = _collect_functions(module)
             # If the module was already loaded we don't have its code object
@@ -290,9 +290,21 @@ class FunctionDiscovery(defaultdict[Any, Any]):
                 ):
                     # We only map line numbers for functions that actually belong to
                     # the module.
-                    for lineno in linenos(cast(FunctionType, code)):
-                        self[lineno].append(_FunctionCodePair(function=cast(FunctionType, function)))
+                    self._index_code(_FunctionCodePair(function=cast(FunctionType, function)), cast(CodeType, code))
                 seen_functions.add(function)
+
+    def _index_code(self, pair: _FunctionCodePair, code: Optional[CodeType] = None) -> None:
+        code = pair.code if code is None else code
+        assert code is not None  # nosec
+        executable_lines = linenos(code)
+        for lineno in executable_lines:
+            self[lineno].append(pair)
+
+        # A function's first line is its declaration, or its first decorator.
+        # AIDEV-NOTE: Keep this as an interval rather than indexing every line so
+        # multiline signatures cannot cause memory usage to grow with source size.
+        first_executable_line = min(executable_lines, default=code.co_firstlineno)
+        self._function_header_index.append((code.co_firstlineno, first_executable_line, pair))
 
     def at_line(self, line: int) -> list[FullyNamedFunction]:
         """Get the functions at the given line.
@@ -305,16 +317,23 @@ class FunctionDiscovery(defaultdict[Any, Any]):
         if line in self._cached:
             return self._cached[line]
 
-        if line in self:
+        pairs = list(self[line]) if line in self else []
+        pairs.extend(
+            pair
+            for start, first_executable_line, pair in self._function_header_index
+            if start <= line < first_executable_line or start == first_executable_line == line
+        )
+        if pairs:
             functions = []
-            for fcp in self[line]:
+            for fcp in pairs:
                 try:
                     functions.append(fcp.resolve())
                 except ValueError:
                     pass
 
             if not functions:
-                del self[line]
+                if line in self:
+                    del self[line]
             else:
                 self._cached[line] = functions
 

--- a/ddtrace/internal/bytecode_injection/__init__.py
+++ b/ddtrace/internal/bytecode_injection/__init__.py
@@ -25,6 +25,12 @@ class InvalidLine(Exception):
     """
 
 
+def _effective_line(first_line: int, executable_lines: set[int], line: int) -> int:
+    """Redirect a function header line to its first executable line."""
+    first_executable_line = min(executable_lines, default=first_line)
+    return first_executable_line if first_line <= line < first_executable_line else line
+
+
 if PY >= (3, 15):
     from ddtrace.internal import monitoring as _monitoring
     from ddtrace.internal.threads import Lock
@@ -79,6 +85,8 @@ if PY >= (3, 15):
         """
         code: CodeType = get_function_code(f)
         valid_lines: set[int] = linenos(code)
+        if not valid_lines:
+            valid_lines.add(code.co_firstlineno)
         failed: list[HookInfoType] = []
 
         with _line_hook_lock:
@@ -90,10 +98,11 @@ if PY >= (3, 15):
                 new_handler = False
 
             for hook, line, arg in hooks:
-                if line not in valid_lines:
+                effective_line = _effective_line(code.co_firstlineno, valid_lines, line)
+                if effective_line not in valid_lines:
                     failed.append((hook, line, arg))
                     continue
-                handler.add(line, hook, arg)
+                handler.add(effective_line, hook, arg)
 
             if not handler.is_empty:
                 if new_handler:
@@ -146,10 +155,14 @@ if PY >= (3, 15):
             if handler is None:
                 return list(hooks)
 
+            valid_lines: set[int] = linenos(code)
+            if not valid_lines:
+                valid_lines.add(code.co_firstlineno)
             for hook, line, arg in hooks:
-                before: int = len(handler._hooks.get(line, ()))
-                handler.remove(line, hook, arg)
-                if len(handler._hooks.get(line, ())) == before:
+                effective_line = _effective_line(code.co_firstlineno, valid_lines, line)
+                before: int = len(handler._hooks.get(effective_line, ()))
+                handler.remove(effective_line, hook, arg)
+                if len(handler._hooks.get(effective_line, ())) == before:
                     failed.append((hook, line, arg))
 
             if handler.is_empty:
@@ -229,6 +242,13 @@ else:
         identifier for the hook itself. This should be kept in case the hook needs
         to be removed.
         """
+        executable_lines = {
+            item.lineno
+            for item in code
+            if isinstance(item, Instr) and item.lineno is not None and item.lineno != code.first_lineno
+        }
+        lineno = _effective_line(code.first_lineno, executable_lines, lineno)
+
         # DEV: In general there are no guarantees for bytecode to be "linear",
         # meaning that a line number can occur multiple times. We need to find all
         # occurrences and inject the hook at each of them. An example of when this
@@ -281,6 +301,13 @@ else:
         The hook is identified by its argument. This ensures that only the right
         hook is ejected.
         """
+        executable_lines = {
+            item.lineno
+            for item in code
+            if isinstance(item, Instr) and item.lineno is not None and item.lineno != code.first_lineno
+        }
+        line = _effective_line(code.first_lineno, executable_lines, line)
+
         locs: deque[int] = deque()
         for i, item in enumerate(code):
             if not isinstance(item, Instr):

--- a/releasenotes/notes/fix-di-line-probe-method-declaration-e13fdd953806edc3.yaml
+++ b/releasenotes/notes/fix-di-line-probe-method-declaration-e13fdd953806edc3.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    dynamic instrumentation: Fixes an issue where line probes placed on function or
+    method declarations fail to install.

--- a/tests/debugging/function/test_discovery.py
+++ b/tests/debugging/function/test_discovery.py
@@ -1,4 +1,5 @@
 import sys
+from types import ModuleType
 
 import pytest
 
@@ -33,7 +34,7 @@ def test_abs_stuff():
 
 def test_function_discovery(stuff_discovery):
     assert len(stuff_discovery.at_line(11)) == 3
-    assert not stuff_discovery.at_line(69)
+    assert len(stuff_discovery.at_line(69)) == 1
     assert len(stuff_discovery.at_line(71)) == 1
     assert not stuff_discovery.at_line(72)
     assert len(stuff_discovery.at_line(86)) == 1
@@ -102,6 +103,41 @@ def test_function_instance_method(stuff_discovery):
     cls = stuff.Stuff
     (original_func,) = stuff_discovery.at_line(36)
     assert cls.instancestuff is original_func
+
+
+def test_function_header(stuff_discovery):
+    (function,) = stuff_discovery.at_line(35)
+    assert function is stuff.Stuff.instancestuff
+
+    (function,) = stuff_discovery.at_line(28)
+    assert function is stuff.Stuff.staticstuff
+
+
+def test_nested_function_header():
+    module = ModuleType("nested_header")
+    module.__file__ = "nested_header.py"
+    exec(
+        compile(
+            "def outer():\n    def inner():\n        return 42\n    return inner\nretained = outer()\n",
+            module.__file__,
+            "exec",
+        ),
+        vars(module),
+    )
+
+    functions = FunctionDiscovery(module).at_line(2)
+    assert set(functions) == {module.outer, module.retained}
+
+
+def test_unresolved_nested_function_header():
+    module = ModuleType("unresolved_nested_header")
+    module.__file__ = "unresolved_nested_header.py"
+    code = compile("def outer():\n    def inner():\n        return 42\n    return inner\n", module.__file__, "exec")
+    FunctionDiscovery.transformer(code, module)
+    exec(code, vars(module))
+
+    (function,) = FunctionDiscovery(module).at_line(2)
+    assert function is module.outer
 
 
 def test_function_decorated_method(stuff_discovery):

--- a/tests/debugging/test_debugger.py
+++ b/tests/debugging/test_debugger.py
@@ -98,6 +98,23 @@ def test_debugger_line_probe_on_instance_method(stuff):
     assert snapshot["debugger"]["snapshot"]["duration"] is None
 
 
+def test_debugger_line_probe_on_method_declaration(stuff):
+    snapshots = simple_debugger_test(
+        create_snapshot_line_probe(
+            probe_id="probe-method-declaration",
+            source_file="tests/submod/stuff.py",
+            line=35,
+            condition=None,
+        ),
+        stuff.Stuff().instancestuff,
+    )
+
+    (snapshot,) = snapshots
+    captures = snapshot["debugger"]["snapshot"]["captures"]["lines"]["35"]
+    assert set(captures["arguments"].keys()) == {"self", "bar"}
+    assert captures["locals"] == {}
+
+
 def test_debugger_line_probe_on_imported_module_function(stuff):
     lineno = min(linenos(stuff.modulestuff))
     snapshots = simple_debugger_test(
@@ -130,7 +147,7 @@ def test_debugger_line_probe_on_imported_module_function(stuff):
             create_snapshot_line_probe(
                 probe_id="probe-instance-method",
                 source_file="tests/submod/stuff.py",
-                line=36,
+                line=35,
                 rate=1000,
             )
         ),

--- a/tests/internal/bytecode_injection/test_injection.py
+++ b/tests/internal/bytecode_injection/test_injection.py
@@ -100,6 +100,35 @@ def test_eject_hook():
     hook.assert_not_called()
 
 
+def test_inject_hook_on_function_declaration():
+    hook = mock.Mock()
+    line = injection_target.__code__.co_firstlineno
+
+    inject_hook(injection_target, hook, line, 42)
+    injection_target(1, 2)
+    hook.assert_called_once_with(42)
+
+    eject_hook(injection_target, hook, line, 42)
+    injection_target(1, 2)
+    hook.assert_called_once_with(42)
+
+
+def test_inject_hook_on_one_line_function():
+    namespace = {}
+    exec("def target(): return 42\n", namespace)
+    target = namespace["target"]
+    hook = mock.Mock()
+    line = target.__code__.co_firstlineno
+
+    inject_hook(target, hook, line, 42)
+    assert target() == 42
+    hook.assert_called_once_with(42)
+
+    eject_hook(target, hook, line, 42)
+    assert target() == 42
+    hook.assert_called_once_with(42)
+
+
 def test_inject_hooks():
     n = 2
     hooks = [mock.Mock("hook%d" % _) for _ in range(n)]


### PR DESCRIPTION
## Description

Allow Dynamic Instrumentation line probes placed on function or method declarations to install successfully. When a probe targets a declaration, it runs at the beginning of that function while continuing to report the source line selected by the user.

This works for regular, decorated, nested, and one-line functions without reading or parsing application source files.

## Testing

- Dynamic Instrumentation debugging suite on Python 3.12: 529 passed, 4 skipped
- Bytecode injection suite on Python 3.12: 18 passed, 3 skipped
- `scripts/lint checks`
- Targeted formatting and type checks

## Risks

Python line information can differ between versions. The change is limited to probes placed on function declarations, while probes on ordinary executable lines retain their existing behavior.
