### PR TITLE
feat(openfeature): add API key fingerprint header

### DIFF
--- a/ddtrace/internal/openfeature/_agentless.py
+++ b/ddtrace/internal/openfeature/_agentless.py
@@ -8,6 +8,7 @@ tested in isolation.
 """
 
 import gzip
+import hashlib
 import json
 from typing import Any
 from typing import Optional
@@ -19,6 +20,19 @@ from urllib.parse import urlunsplit
 # Canonical rules-based server path appended to the managed CDN host and to
 # custom base URLs that only supply an origin.
 DEFAULT_AGENTLESS_PATH = "/api/v2/feature-flagging/config/rules-based/server"
+
+BASE62_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+SHA256_BASE62_LENGTH = 43
+
+
+def api_key_fingerprint(api_key: str) -> str:
+    """Return the stable, non-secret identifier used for agentless authentication."""
+    value = int.from_bytes(hashlib.sha256(api_key.encode("utf-8")).digest(), "big")
+    encoded = ""
+    while value:
+        value, remainder = divmod(value, 62)
+        encoded = BASE62_ALPHABET[remainder] + encoded
+    return "rijn_" + encoded.rjust(SHA256_BASE62_LENGTH, "0")
 
 
 def build_agentless_endpoint(site: str, env: Optional[str] = None, base_url: Optional[str] = None) -> str:

--- a/ddtrace/internal/openfeature/_agentless_source.py
+++ b/ddtrace/internal/openfeature/_agentless_source.py
@@ -25,6 +25,7 @@ from urllib.parse import urlunsplit
 
 from ddtrace.internal.constants import _HTTPLIB_NO_TRACE_REQUEST
 from ddtrace.internal.logger import get_logger
+from ddtrace.internal.openfeature._agentless import api_key_fingerprint
 from ddtrace.internal.openfeature._agentless import decode_response_body
 from ddtrace.internal.openfeature._agentless import parse_ufc_configuration
 from ddtrace.internal.periodic import PeriodicService
@@ -267,6 +268,7 @@ class AgentlessConfigurationSource(PeriodicService):
         }
         if self._api_key:
             headers["DD-API-KEY"] = self._api_key
+            headers["DD-API-KEY-FINGERPRINT"] = api_key_fingerprint(self._api_key)
         if self._etag:
             headers["If-None-Match"] = self._etag
         return headers

--- a/releasenotes/notes/openfeature-api-key-fingerprint-13e8b61d9c0f4a27.yaml
+++ b/releasenotes/notes/openfeature-api-key-fingerprint-13e8b61d9c0f4a27.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    openfeature: Adds a privacy-preserving API key fingerprint header to managed
+    agentless Feature Flag configuration requests.

--- a/tests/openfeature/test_agentless_poller.py
+++ b/tests/openfeature/test_agentless_poller.py
@@ -216,10 +216,14 @@ def test_api_key_header_present_and_absent(harness):
     with_key = harness([_FakeResponse(304)], api_key="secret")
     with_key.periodic()
     assert with_key._requests[0]["headers"]["DD-API-KEY"] == "secret"
+    assert with_key._requests[0]["headers"]["DD-API-KEY-FINGERPRINT"] == (
+        "rijn_amLaG4Pd6h6t9VtJna81k744P1DYxGHzIJ6ECO3OOMj"
+    )
 
     without_key = harness([_FakeResponse(304)], api_key=None)
     without_key.periodic()
     assert "DD-API-KEY" not in without_key._requests[0]["headers"]
+    assert "DD-API-KEY-FINGERPRINT" not in without_key._requests[0]["headers"]
 
 
 def test_client_library_headers_and_gzip_accept(harness):

--- a/tests/openfeature/test_api_key_fingerprint.py
+++ b/tests/openfeature/test_api_key_fingerprint.py
@@ -1,0 +1,17 @@
+import pytest
+
+from ddtrace.internal.openfeature._agentless import api_key_fingerprint
+
+
+@pytest.mark.parametrize(
+    ("api_key", "expected"),
+    [
+        ("", "rijn_RZwTDmWjELXeEmMEb0eIIegKayGGUPNsuJweEPhlXi5"),
+        ("padding-171", "rijn_053ybBRXypQt9AC6UIlqH1YCFYSV1rQl8HCDIcBZs3D"),
+        ("!@#$%^𐍈한€हИ£", "rijn_eFLHeyLxwaiNs2hY16pjkjNjVSHWRgf2rlveKc8YA1K"),
+        ("secret", "rijn_amLaG4Pd6h6t9VtJna81k744P1DYxGHzIJ6ECO3OOMj"),
+    ],
+)
+def test_api_key_fingerprint_matches_clifford_v1(api_key, expected):
+    assert api_key_fingerprint(api_key) == expected
+    assert len(api_key_fingerprint(api_key)) == 48


### PR DESCRIPTION
## Motivation

Agentless Feature Flags configuration requests need a stable, non-secret API-key identifier so the backend can correlate authentication without logging the key itself.

## Changes

- Add the canonical SHA-256-to-base62 `rijn_` fingerprint helper.
- Attach `DD-API-KEY-FINGERPRINT` to authenticated agentless configuration requests.
- Cover the shared cross-language golden vectors and absent-key behavior.

## Decisions

- The raw API key remains the authentication credential; the fingerprint is supplemental metadata.
- The fingerprint has a fixed 48-character representation, including the `rijn_` prefix.

## Validation

- Canonical golden-vector tests cover empty, padding-sensitive, Unicode, and common fixture inputs.
- Focused agentless poller coverage verifies presence and absence with the API key.
