### PR TITLE
fix(tracing): prevent agentless uWSGI worker stalls

### DIFF
--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -924,11 +924,11 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
             _safelog(log.warning, "failed to shutdown exporter", exc_info=True)
 
     def shutdown_exporter(self) -> None:
-        """Tear down the native exporter without going through ``stop()``."""
+        """Discard an unstarted native exporter without activating its runtime."""
         try:
-            self._exporter.shutdown(3_000_000_000)
+            self._exporter.drop()
         except Exception:
-            _safelog(log.warning, "failed to shutdown exporter", exc_info=True)
+            _safelog(log.warning, "failed to discard exporter", exc_info=True)
 
     def recreate(
         self,

--- a/releasenotes/notes/fix-agentless-uwsgi-startup-latency-ae931df9575e0133.yaml
+++ b/releasenotes/notes/fix-agentless-uwsgi-startup-latency-ae931df9575e0133.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    tracing: Fixes an issue where uWSGI worker processes can stall for up to 60 seconds when
+    agentless tracing is enabled.

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -419,6 +419,15 @@ class NativeWriterTests(BaseTestCase):
         # Call shutdown without ever calling start()
         writer.on_shutdown()
 
+    def test_shutdown_exporter_drops_unstarted_exporter(self):
+        writer = NativeWriter("http://dne:1234")
+        writer._exporter = exporter = mock.Mock()
+
+        writer.shutdown_exporter()
+
+        exporter.drop.assert_called_once_with()
+        exporter.shutdown.assert_not_called()
+
     # Http related metrics are sent by the native code
     def test_drop_reason_bad_endpoint(self):
         pytest.skip()


### PR DESCRIPTION
## Description
Agentless tracing creates a native trace exporter when ddtrace starts. When replacing an exporter that had never been started, ddtrace called its normal shutdown method.

That shutdown method starts the exporter’s background runtime. With pre-fork servers such as uWSGI, this can happen before workers are forked. Workers then inherit an invalid runtime state and requests can stall for about 60 seconds.

This change drops unstarted exporters directly instead of shutting them down. This releases their resources without starting the background runtime. Normal shutdown behavior for exporters that have started remains unchanged.

Fixes a regression introduced by #19761.

## Testing
Added a regression test confirming unstarted exporters are dropped without invoking shutdown.
Targeted writer tests pass.

