### PR TITLE
ci: automatically retry os tests

### DIFF
--- a/.gitlab/multi-os-tests.yml
+++ b/.gitlab/multi-os-tests.yml
@@ -3,6 +3,8 @@
 
 .multi_os_test_base:
   stage: tests
+  # multi-OS runners (especially windows) are prone to flaky infra/test failures
+  retry: 2
   variables:
     DD_IAST_ENABLED: "false"
     DD_REMOTE_CONFIGURATION_ENABLED: "false"


### PR DESCRIPTION
## Description

I'm getting a lot of failures on OS tests recently (particularly Windows) so I'm adding an automatic retry since the failures are coming from flaky infra and not the tests themselves which I've never seen fail. 