### PR TITLE
chore(iast): drop the unreleased 3.15 support note and retarget its gate comment

### DIFF
--- a/ddtrace/internal/settings/asm.py
+++ b/ddtrace/internal/settings/asm.py
@@ -264,8 +264,8 @@ class ASMConfig(DDConfig):
     _is_testing_instrumentation_for_waf = False
 
     # TODO(py-315): Only runtime gate for IAST version support; the native extensions are not
-    # version-gated in setup.py. This bound intentionally leads requires-python in pyproject.toml:
-    # IAST already works on 3.15, so do not "resync" it downwards until 3.15 ships in the matrix.
+    # version-gated in setup.py. This bound intentionally leads requires-python in pyproject.toml, so
+    # do not "resync" it downwards; 3.15 itself is still untested for IAST, tracked by issue #17843.
     # IAST supported on python 3.6 to 3.15 and never on windows
     _iast_supported: bool = ((3, 6, 0) <= sys.version_info < (3, 16, 0)) and not (
         sys.platform.startswith("win") or sys.platform.startswith("cygwin")

--- a/ddtrace/internal/settings/asm.py
+++ b/ddtrace/internal/settings/asm.py
@@ -263,8 +263,8 @@ class ASMConfig(DDConfig):
     _bypass_instrumentation_for_waf = False
     _is_testing_instrumentation_for_waf = False
 
-    # AIDEV-NOTE: Only runtime gate for IAST version support; the native extensions are not
-    # version-gated in setup.py. This bound intentionally leads requires-python (currently <3.15):
+    # TODO(py-315): Only runtime gate for IAST version support; the native extensions are not
+    # version-gated in setup.py. This bound intentionally leads requires-python in pyproject.toml:
     # IAST already works on 3.15, so do not "resync" it downwards until 3.15 ships in the matrix.
     # IAST supported on python 3.6 to 3.15 and never on windows
     _iast_supported: bool = ((3, 6, 0) <= sys.version_info < (3, 16, 0)) and not (

--- a/releasenotes/notes/iast-python-315-support-62b7d764f5b5b5b0.yaml
+++ b/releasenotes/notes/iast-python-315-support-62b7d764f5b5b5b0.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    Code Security (IAST): Adds support for Python 3.15. Setting ``DD_IAST_ENABLED=true`` now
-    enables Code Security on Python 3.15; previously it was silently ignored on that version.


### PR DESCRIPTION
## Description

Cleans up the two Python 3.15 leftovers from #19698: release note plus one comment.

1. Deletes the `features:` release note that read 
> Code Security (IAST): Adds support for Python 3.15. Setting `DD_IAST_ENABLED=true` now enables Code Security on Python 3.15.

_(Python 3.15 is not a supported runtime, so that advertises something we do not ship)_

2. Retargets the gate comment's `AIDEV-NOTE` marker to `TODO(py-315)` and drops its claim that IAST "already works on 3.15", pointing at #17843 for the real status.

_(Nothing validated that claim — `84ad6c9f2b` is a two-line change to this file alone, and `riotfile.py` caps `SUPPORTED_PYTHON_VERSIONS` at `(3, 14)`.)_

## Additional Notes

- Contributes to #17843
