### PR TITLE
chore(config): update Pub/Sub span links registry implementation

### DIFF
--- a/supported-configurations.json
+++ b/supported-configurations.json
@@ -1927,7 +1927,7 @@
     ],
     "DD_GOOGLE_CLOUD_PUBSUB_PROPAGATION_AS_SPAN_LINKS": [
       {
-        "implementation": "A",
+        "implementation": "B",
         "type": "string",
         "default": null
       }


### PR DESCRIPTION
## Description

Updates the local configuration registry to reference implementation B for DD_GOOGLE_CLOUD_PUBSUB_PROPAGATION_AS_SPAN_LINKS, matching the central Configuration Registry implementation.

I added a new implementation in the config registry because of https://github.com/DataDog/dd-trace-py/pull/19858
## Testing

python3 scripts/supported_configurations.py --check

git diff --check

## Risks

None. This changes registry metadata only and does not alter runtime behavior.

## Additional Notes

No release note is required; the changelog/no-changelog label is applied.