### PR TITLE
chore(aiokafka): add instrumentation manifest

### DIFF
--- a/ddtrace/contrib/internal/aiokafka/aiokafka.manifest.yaml
+++ b/ddtrace/contrib/internal/aiokafka/aiokafka.manifest.yaml
@@ -1,8 +1,8 @@
 _v: 1
 name: aiokafka
 display_name: aiokafka
-description: Instruments aiokafka message sends, single and batch receives, and consumer offset commits with trace and data-stream
-  context propagation.
+description: Instruments aiokafka message publishing and consumption with distributed tracing and Data Streams Monitoring,
+  including consumer offset tracking.
 packages:
 - name: aiokafka
 category:

--- a/ddtrace/contrib/internal/aiokafka/aiokafka.manifest.yaml
+++ b/ddtrace/contrib/internal/aiokafka/aiokafka.manifest.yaml
@@ -1,0 +1,13 @@
+_v: 1
+name: aiokafka
+display_name: aiokafka
+description: Instruments aiokafka message sends, single and batch receives, and consumer offset commits with trace and data-stream
+  context propagation.
+packages:
+- name: aiokafka
+category:
+- messaging.consumer
+- messaging.producer
+systems:
+- kafka
+creation_date: '2025-11-18'


### PR DESCRIPTION
## Description

Adds an [instrumentation manifest](https://docs.google.com/document/d/18za_vEcA-hH4IEwRhebDhoQxQKSylCtwMeVDB3rYM4Y/edit?usp=sharing) for the aiokafka integration.

The manifest provides structured, machine-readable metadata describing the integration without requiring consumers such as the Integration Portal to parse tracer implementation code. It records:

- The `aiokafka` package and integration identity
- Kafka producer and consumer instrumentation categories
- Kafka as the instrumented system
- Message sends, single and batch receives, offset commits, and trace/Data Streams context propagation
- The integration creation date derived from Git history

This PR does not change runtime behavior or public APIs.

## Testing

- All 46 aiokafka tests passed.
- `scripts/lint checks` passed.

## Risks

There is no runtime instrumentation risk because this change adds only a declarative YAML file.

The metadata could become stale if the aiokafka instrumentation changes without updating its manifest.

`MANIFEST.in` currently grafts the `ddtrace` directory, so the manifest may be included in source distributions unless packaging excludes it separately. This PR intentionally does not change packaging behavior.
