### PR TITLE
chore(ci): djangosimple-tracer-dont-create-db-spans slo bump

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -98,7 +98,7 @@ experiments:
               - execution_time < 21.40 ms
           - name: djangosimple-tracer-dont-create-db-spans
             thresholds:
-              - execution_time < 21.50 ms
+              - execution_time < 22.50 ms
           - name: djangosimple-tracer-no-middleware
             thresholds:
               - execution_time < 21.50 ms


### PR DESCRIPTION
## Description

Bumping the slo from 21.50ms to 22.50ms, as there have been some incremental breaches: https://mosaic.us1.ddbuild.io/change-request/15766187541058407751?owner=datadog&repository=dd-trace-py&taskExecutionId=1990758829&taskId=gitlab&utm_content=gitlab_task_check&utm_source=github_pr_page

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
