### PR TITLE
feat(serverless): emit MicroVM request start for WSGI & ASGI-based applications

### DIFF
--- a/ddtrace/contrib/_events/web_framework.py
+++ b/ddtrace/contrib/_events/web_framework.py
@@ -13,7 +13,7 @@ from ddtrace.internal.schema import schematize_url_operation
 
 class WebFrameworkEvents(str, Enum):
     WEB_REQUEST = "web.request"
-
+    WEB_REQUEST_STARTING = "web.request.starting"
 
 @dataclass
 class WebFrameworkRequestEvent(HttpRequestBaseEvent, TracingEvent):

--- a/ddtrace/contrib/internal/asgi/middleware.py
+++ b/ddtrace/contrib/internal/asgi/middleware.py
@@ -12,6 +12,7 @@ from ddtrace.contrib import trace_utils
 from ddtrace.contrib.internal.asgi.utils import bytes_to_str
 from ddtrace.contrib.internal.asgi.utils import extract_headers
 from ddtrace.contrib.internal.asgi.utils import guarantee_single_callable
+from ddtrace.contrib.internal.web import dispatch_web_request_starting
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import http
@@ -231,6 +232,9 @@ class TraceMiddleware:
         operation_name = self.integration_config.get("request_span_name", "asgi.request")
         if scope["type"] == "http":
             operation_name = schematize_url_operation(operation_name, direction=SpanDirection.INBOUND, protocol="http")
+            if not is_subapp:
+                path = (scope.get("root_path") or "").rstrip("/") + (scope.get("path") or "")
+                dispatch_web_request_starting(method, path)
 
         with (
             core.context_with_data(

--- a/ddtrace/contrib/internal/web.py
+++ b/ddtrace/contrib/internal/web.py
@@ -1,0 +1,13 @@
+from typing import Optional
+
+from ddtrace.contrib._events.web_framework import WebFrameworkEvents
+from ddtrace.internal import core
+from ddtrace.internal.serverless import in_aws_lambda_microvm
+
+
+_LAMBDA_MICROVM_RUN_PATH = "/aws/lambda-microvms/runtime/v1/run"
+
+
+def dispatch_web_request_starting(method: Optional[str], path: str) -> None:
+    if method == "POST" and path == _LAMBDA_MICROVM_RUN_PATH and in_aws_lambda_microvm():
+        core.dispatch(WebFrameworkEvents.WEB_REQUEST_STARTING.value, (method, path))

--- a/ddtrace/contrib/internal/wsgi/wsgi.py
+++ b/ddtrace/contrib/internal/wsgi/wsgi.py
@@ -22,6 +22,7 @@ import wrapt
 from ddtrace import config
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
+from ddtrace.contrib.internal.web import dispatch_web_request_starting
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
@@ -102,6 +103,10 @@ class _DDWSGIMiddlewareBase(object):
         raise NotImplementedError
 
     def __call__(self, environ: Iterable, start_response: Callable) -> wrapt.ObjectProxy:
+        method = environ.get("REQUEST_METHOD")
+        path = (environ.get("SCRIPT_NAME") or "").rstrip("/") + (environ.get("PATH_INFO") or "")
+        dispatch_web_request_starting(method, path)
+
         headers = get_request_headers(environ)
         closing_iterable = ()
         not_blocked = True

--- a/ddtrace/internal/serverless/__init__.py
+++ b/ddtrace/internal/serverless/__init__.py
@@ -35,3 +35,9 @@ def in_azure_function():
     # type: () -> bool
     """Returns whether the environment is an Azure Function."""
     return env.get("FUNCTIONS_WORKER_RUNTIME", "") != "" and env.get("FUNCTIONS_EXTENSION_VERSION", "") != ""
+
+
+def in_aws_lambda_microvm():
+    # type: () -> bool
+    """Returns whether the environment is an AWS Lambda MicroVM."""
+    return bool(env.get("AWS_LAMBDA_MICROVM_IMAGE_ARN", "").strip())

--- a/tests/contrib/asgi/test_asgi.py
+++ b/tests/contrib/asgi/test_asgi.py
@@ -3,6 +3,7 @@ from functools import partial
 import logging
 import os
 import random
+from unittest import mock
 
 from asgiref.testing import ApplicationCommunicator
 import httpx
@@ -11,6 +12,9 @@ import pytest
 from ddtrace.constants import _SAMPLING_PRIORITY_KEY
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import USER_KEEP
+from ddtrace.contrib._events.web_framework import WebFrameworkEvents
+from ddtrace.contrib.internal import web
+from ddtrace.contrib.internal.asgi import middleware as asgi_middleware
 from ddtrace.contrib.internal.asgi.middleware import TraceMiddleware
 from ddtrace.contrib.internal.asgi.middleware import _parse_response_cookies
 from ddtrace.contrib.internal.asgi.middleware import span_from_scope
@@ -150,6 +154,66 @@ def _check_span_tags(scope, span):
         or scope["asgi"].get("spec_version") is None
         or span.get_tag("asgi.spec_version") == scope["asgi"]["spec_version"]
     )
+
+
+@pytest.mark.parametrize(
+    "method,path,root_path,in_microvm,dispatches",
+    [
+        ("POST", "/run", "/aws/lambda-microvms/runtime/v1", True, True),
+        ("GET", "/run", "/aws/lambda-microvms/runtime/v1", True, False),
+        ("POST", "/other", "/aws/lambda-microvms/runtime/v1", True, False),
+        ("POST", "/run", "/aws/lambda-microvms/runtime/v1", False, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_microvm_dispatches_web_request_starting(scope, method, path, root_path, in_microvm, dispatches):
+    scope.update({"method": method, "path": path, "root_path": root_path})
+    app = TraceMiddleware(basic_app)
+    instance = ApplicationCommunicator(app, scope)
+
+    with (
+        mock.patch.object(web, "in_aws_lambda_microvm", return_value=in_microvm),
+        mock.patch.object(web.core, "dispatch", wraps=web.core.dispatch) as dispatch,
+    ):
+        await instance.send_input({"type": "http.request", "body": b""})
+        await instance.receive_output(1)
+        await instance.receive_output(1)
+
+    request_starting_calls = [
+        call.args for call in dispatch.call_args_list if call.args[0] == WebFrameworkEvents.WEB_REQUEST_STARTING.value
+    ]
+    if dispatches:
+        assert request_starting_calls == [
+            (WebFrameworkEvents.WEB_REQUEST_STARTING.value, ("POST", "/aws/lambda-microvms/runtime/v1/run"))
+        ]
+    else:
+        assert request_starting_calls == []
+
+
+@pytest.mark.asyncio
+async def test_web_request_starting_dispatch_precedes_span_creation(scope):
+    events = []
+    original_span_from_context = asgi_middleware.span_from_context
+
+    def record_request_starting(*args, **kwargs):
+        events.append("request_starting")
+
+    def record_span_from_context(*args, **kwargs):
+        events.append("span")
+        return original_span_from_context(*args, **kwargs)
+
+    app = TraceMiddleware(basic_app)
+    instance = ApplicationCommunicator(app, scope)
+
+    with (
+        mock.patch.object(asgi_middleware, "dispatch_web_request_starting", side_effect=record_request_starting),
+        mock.patch.object(asgi_middleware, "span_from_context", side_effect=record_span_from_context),
+    ):
+        await instance.send_input({"type": "http.request", "body": b""})
+        await instance.receive_output(1)
+        await instance.receive_output(1)
+
+    assert events.index("request_starting") < events.index("span")
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/wsgi/test_wsgi.py
+++ b/tests/contrib/wsgi/test_wsgi.py
@@ -1,9 +1,12 @@
 import os
+from unittest import mock
 
 import pytest
 from webtest import TestApp
 
 from ddtrace import config
+from ddtrace.contrib._events.web_framework import WebFrameworkEvents
+from ddtrace.contrib.internal import web
 from ddtrace.contrib.internal.wsgi.wsgi import DDWSGIMiddleware
 from ddtrace.contrib.internal.wsgi.wsgi import _DDWSGIMiddlewareBase
 from ddtrace.contrib.internal.wsgi.wsgi import construct_url
@@ -83,6 +86,36 @@ class WsgiCustomMiddleware(_DDWSGIMiddlewareBase):
         resp_span.set_tag("response_tag", "resp test tag set")
         resp_span._set_attribute("response_metric", 3)
         resp_span.resource = "response resource was modified"
+
+
+@pytest.mark.parametrize(
+    "method,path,script_name,in_microvm,dispatches",
+    [
+        ("post", "/run", "/aws/lambda-microvms/runtime/v1", True, True),
+        ("get", "/run", "/aws/lambda-microvms/runtime/v1", True, False),
+        ("post", "/other", "/aws/lambda-microvms/runtime/v1", True, False),
+        ("post", "/run", "/aws/lambda-microvms/runtime/v1", False, False),
+    ],
+)
+def test_microvm_dispatches_web_request_starting(tracer, method, path, script_name, in_microvm, dispatches):
+    app = TestApp(DDWSGIMiddleware(application, tracer=tracer))
+
+    with (
+        mock.patch.object(web, "in_aws_lambda_microvm", return_value=in_microvm),
+        mock.patch.object(web.core, "dispatch", wraps=web.core.dispatch) as dispatch,
+    ):
+        resp = getattr(app, method)(path, extra_environ={"SCRIPT_NAME": script_name})
+
+    assert resp.status == "200 OK"
+    request_starting_calls = [
+        call.args for call in dispatch.call_args_list if call.args[0] == WebFrameworkEvents.WEB_REQUEST_STARTING.value
+    ]
+    if dispatches:
+        assert request_starting_calls == [
+            (WebFrameworkEvents.WEB_REQUEST_STARTING.value, ("POST", "/aws/lambda-microvms/runtime/v1/run"))
+        ]
+    else:
+        assert request_starting_calls == []
 
 
 def test_middleware(tracer, test_spans):

--- a/tests/internal/test_serverless.py
+++ b/tests/internal/test_serverless.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ddtrace.internal.serverless import in_aws_lambda_microvm
 from ddtrace.internal.serverless import in_azure_function
 from ddtrace.internal.serverless import in_gcp_function
 from tests.utils import override_env
@@ -26,6 +27,19 @@ def test_is_azure_function():
 
 def test_not_azure_function():
     assert in_azure_function() is False
+
+
+@pytest.mark.parametrize(
+    "environment,expected",
+    [
+        ({"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1:123456789012:image:test"}, True),
+        ({}, False),
+        ({"AWS_LAMBDA_MICROVM_IMAGE_ARN": "   "}, False),
+    ],
+)
+def test_is_aws_lambda_microvm(environment, expected):
+    with override_env(environment, replace_os_env=True):
+        assert in_aws_lambda_microvm() is expected
 
 
 standard_blocklist = [


### PR DESCRIPTION
Stacked PRs:
- #19778 — runtime identity foundation
  - 👉 This PR #19898 — WSGI/ASGI request-start hook
    - #19939 — central MicroVM /run identity refresh
      - #19820 — tracer/native writer exporter refresh
        - #19821 — telemetry worker refresh
          - #19822 — runtime metrics runtime-id tags

## Description

MicroVMs call the language runtime through a local /run endpoint before the user request is served. The identity refresh stack needs a request-start signal before the framework root span is created; otherwise the first span for a fresh MicroVM run can still pick up the previous runtime ID.

The WSGI and ASGI entry points now recognize the AWS Lambda MicroVM runtime request and emit the existing web.request.starting event before root-span creation. Normal application requests, non-MicroVM environments, and non-matching paths keep the old behavior.

## Testing

Added focused WSGI and ASGI coverage for:

- dispatching web.request.starting for the MicroVM runtime request
- preserving normal request behavior
- dispatching the request event before span creation
- ASGI-based Django [test](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda-microvms$252Fsample-django-asgi-app/log-events/2026$252F09$252F04$255B10.0$255Dmicrovm-02a00af9-fdcd-397e-9e2a-9cf1ce87bb11$3FfilterPattern$3DMicroVM$26start$3D1788494400000$26end$3D1788580799000) shows the run event can be intercepted
<img width="1132" height="564" alt="image" src="https://github.com/user-attachments/assets/c231cf70-683b-4daa-a9ca-563f9bfb2883" />
- WSGI-based Flask [test](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda-microvms$252Fsample-flask-app/log-events/2026$252F09$252F04$255B18.0$255Dmicrovm-672def42-7c09-3b3d-a1cf-a6bff1be0e64$3FfilterPattern$3DMicroVM$26start$3D1788494400000$26end$3D1788580799000) shows the run event can be intercepted
<img width="1215" height="572" alt="image" src="https://github.com/user-attachments/assets/cd9604a5-bfea-412c-b63b-1a4d0aadf2c9" />

Validation included lint and diff checks.

## Risks

Low. The new event is limited to AWS Lambda MicroVM runtime request metadata and leaves non-matching ASGI/WSGI requests unchanged.
