### PR TITLE
fix(config): support OTel deployment environment name

### DIFF
--- a/ddtrace/internal/settings/_otel_remapper.py
+++ b/ddtrace/internal/settings/_otel_remapper.py
@@ -10,6 +10,7 @@ from ddtrace.internal.settings import env
 log = get_logger(__name__)
 
 OTEL_UNIFIED_TAG_MAPPINGS = {
+    "deployment.environment.name": ENV_KEY,
     "deployment.environment": ENV_KEY,
     "service.name": "service",
     "service.version": VERSION_KEY,
@@ -85,9 +86,13 @@ def _remap_otel_tags(otel_value: str) -> Optional[str]:
             key, value = tag.split("=")
             otel_user_tag_dict[key] = value
 
+        has_stable_environment = any(key.lower() == "deployment.environment.name" for key in otel_user_tag_dict)
         for key, value in otel_user_tag_dict.items():
-            if key.lower() in OTEL_UNIFIED_TAG_MAPPINGS:
-                dd_key = OTEL_UNIFIED_TAG_MAPPINGS[key.lower()]
+            normalized_key = key.lower()
+            if normalized_key == "deployment.environment" and has_stable_environment:
+                continue
+            if normalized_key in OTEL_UNIFIED_TAG_MAPPINGS:
+                dd_key = OTEL_UNIFIED_TAG_MAPPINGS[normalized_key]
                 dd_tags.insert(0, f"{dd_key}:{value}")
             else:
                 dd_tags.append(f"{key}:{value}")

--- a/releasenotes/notes/support-otel-deployment-environment-name-546fe8ea7b425364.yaml
+++ b/releasenotes/notes/support-otel-deployment-environment-name-546fe8ea7b425364.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    tracing: Fixes an issue where the Datadog environment is not set from the
+    ``deployment.environment.name`` attribute in ``OTEL_RESOURCE_ATTRIBUTES``.

--- a/tests/opentelemetry/test_config.py
+++ b/tests/opentelemetry/test_config.py
@@ -251,7 +251,7 @@ def test_otel_logs_exporter_configuration():
 
 
 @pytest.mark.subprocess(
-    env={"OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=prod,service.name=bleh,service.version=1.0"}
+    env={"OTEL_RESOURCE_ATTRIBUTES": "deployment.environment.name=prod,service.name=bleh,service.version=1.0"}
 )
 def test_otel_resource_attributes_unified_tags():
     from ddtrace import config
@@ -259,6 +259,15 @@ def test_otel_resource_attributes_unified_tags():
     assert config.service == "bleh"
     assert config.version == "1.0"
     assert config.env == "prod"
+
+
+@pytest.mark.subprocess(
+    env={"OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=legacy,deployment.environment.name=stable"}
+)
+def test_otel_resource_attributes_prefer_stable_environment():
+    from ddtrace import config
+
+    assert config.env == "stable"
 
 
 @pytest.mark.subprocess(


### PR DESCRIPTION
## Description

Maps the stable OpenTelemetry `deployment.environment.name` resource attribute to the Datadog environment. The deprecated `deployment.environment` attribute remains supported as a fallback.

This ensures applications using the current OpenTelemetry semantic convention receive the expected unified environment tag.

## Testing

- Focused OpenTelemetry configuration tests on Python 3.12
- `scripts/lint checks`
- Targeted style and type checks

## Risks

Low. The change adds an alias to the existing resource attribute remapping and preserves legacy behavior.

## Additional Notes

Includes a customer-facing release note under the `tracing` scope.
