### PR TITLE
ci(build_base_venvs): let riot install the dev package on Python 3.15 (PROF-14439)

### DIFF
--- a/.gitlab/templates/build-base-venvs.yml
+++ b/.gitlab/templates/build-base-venvs.yml
@@ -37,6 +37,13 @@ build_base_venvs:
       python scripts/allow_prerelease_dependencies.py
       export PIP_PRE=true
     fi
+    # PIP_IGNORE_REQUIRES_PYTHON lets riot's `pip install -e .` install the
+    # dev package despite requires-python = ">=3.9,<3.15". 3.15 only: other
+    # matrix versions already satisfy the bound.
+    # TODO(py-315): drop this once requires-python includes 3.15
+    case "$PYTHON_VERSION" in
+      3.15) export PIP_IGNORE_REQUIRES_PYTHON=1 ;;
+    esac
     riot -P -v generate --python=$PYTHON_VERSION
     .riot/venv_py3*/bin/pip freeze
     echo "Running smoke tests"


### PR DESCRIPTION
## Description

Delta vs #19907.

riot's `install_dev_pkg` runs `pip install -e .`, so pip enforces `requires-python = ">=3.9,<3.15"` and refuses the dev package on 3.15. This PR sets `PIP_IGNORE_REQUIRES_PYTHON=1` only for the `PYTHON_VERSION=3.15` arm of `build_base_venvs`. Published metadata stays `<3.15`.

## Testing

Inspect the generated `build_base_venvs` `before_script` for `PYTHON_VERSION=3.15` and confirm the ignore is set only on that arm.

## Risks

None. 3.15-only env var; other matrix versions unchanged.

## Additional Notes

No release note: CI chore, `changelog/no-changelog`. Base: #19907. Next: #19906.
