### PR TITLE
ci(testrunner): rebuild 3.15-dev against current CPython

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -119,8 +119,11 @@ COPY .python-version /home/bits/
 # Allow running datadog-ci in CI with npx
 RUN npm install -g @datadog/datadog-ci
 
-# Install pyenv and necessary Python versions
-RUN git clone --depth 1 --branch "v2.6.31" https://github.com/pyenv/pyenv "${PYENV_ROOT}" \
+# Install pyenv and necessary Python versions.
+# 3.15-dev is a rolling CPython 3.15 branch clone. Bumping pyenv retriggers
+# .github/workflows/testrunner.yml so the image is not stuck on 3.15.0b3+dev
+# (Jun 30 2026); rc1-built cp315 wheels fail to import on that interpreter.
+RUN git clone --depth 1 --branch "v2.8.4" https://github.com/pyenv/pyenv "${PYENV_ROOT}" \
   && pyenv local | xargs -L 1 pyenv install \
   && cd -
 


### PR DESCRIPTION
## Description

The pinned testrunner still ships pyenv `3.15-dev` = CPython **3.15.0b3+dev** (Jun 30).
rc1-built cp315 wheels fail to import on that interpreter (`SystemError: unknown slot ID
84/85`). Test jobs use `TESTRUNNER_IMAGE`, not DataDog/images.

This PR bumps pyenv `v2.6.31` → `v2.8.4` in `docker/Dockerfile`. A `docker/**` push to
`main` retriggers `.github/workflows/testrunner.yml`, which recompiles `3.15-dev`. It
does not pin 3.15.0.

_Impact:_ the next testrunner image rebuilds. GitLab jobs
keep the old digest until a follow-up pins it.

## Testing

Image rebuild runs after merge to `main` (workflow is `push` to `main` on `docker/**`, not
PR branches). After publish, check `python3.15 -VV` on the new image, then pin
`.gitlab/testrunner.yml`.

## Risks

Pyenv 2.8.4 also reinstalls 3.8–3.14 from current definitions (patch-level bumps possible).
3.8.20 still exists in 2.8.4.

## Additional Notes

* Base: #19903. Next: #19907 (Cython pin on the 3.15 venv cache).
