### PR TITLE
ci(testrunner): rebuild 3.15-dev and pin Cython<3.3 on the 3.15 cache (PROF-14439)

### DIFF
--- a/.codespellignorelines
+++ b/.codespellignorelines
@@ -1,3 +1,6 @@
                 input="thsi si a spelilgn imstkae.",
             input="thsi si a spelilgn imstkae.",
                     "input": "thsi si a spelilgn imstkae.",
+       | grep -qi "^fpr:.*:177F4010FE56CA3336300305F1656F24C74CD1D8:$" \
+         | grep -qi "^fpr:.*:BC528686B50D79E339D3721CEB3E94ADBE1229CF:$" \
+         | grep -qi "^fpr:.*:EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796:$" \

--- a/.codespellignorelines
+++ b/.codespellignorelines
@@ -1,6 +1,3 @@
                 input="thsi si a spelilgn imstkae.",
             input="thsi si a spelilgn imstkae.",
                     "input": "thsi si a spelilgn imstkae.",
-       | grep -qi "^fpr:.*:177F4010FE56CA3336300305F1656F24C74CD1D8:$" \
-         | grep -qi "^fpr:.*:BC528686B50D79E339D3721CEB3E94ADBE1229CF:$" \
-         | grep -qi "^fpr:.*:EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796:$" \

--- a/.gitlab/templates/cached-testrunner.yml
+++ b/.gitlab/templates/cached-testrunner.yml
@@ -18,7 +18,13 @@
     fi
 
     source $EXT_CACHE_VENV/bin/activate
-    python -m pip install cmake setuptools_rust Cython
+    # Cython 3.3 cp315 wheels SIGSEGV on pre-rc1 3.15; pyproject.toml pin does not apply here.
+    # TODO(py-315): drop this pin once testrunner 3.15 is 3.15.0rc1+.
+    if [ "$PYTHON_VERSION" = "3.15" ]; then
+        python -m pip install cmake setuptools_rust 'Cython<3.3'
+    else
+        python -m pip install cmake setuptools_rust Cython
+    fi
     python scripts/ext_cache.py restore
     deactivate
   after_script: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -126,8 +126,11 @@ COPY .python-version /home/bits/
 # Allow running datadog-ci in CI with npx
 RUN npm install -g @datadog/datadog-ci
 
-# Install pyenv and necessary Python versions
-RUN git clone --depth 1 --branch "v2.6.31" https://github.com/pyenv/pyenv "${PYENV_ROOT}" \
+# Install pyenv and necessary Python versions.
+# 3.15-dev is a rolling CPython 3.15 branch clone. Bumping pyenv retriggers
+# .github/workflows/testrunner.yml so the image is not stuck on 3.15.0b3+dev
+# (Jun 30 2026); rc1-built cp315 wheels fail to import on that interpreter.
+RUN git clone --depth 1 --branch "v2.8.4" https://github.com/pyenv/pyenv "${PYENV_ROOT}" \
   && pyenv local | xargs -L 1 pyenv install \
   && cd -
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [codespell]
 skip = *.json,*.h,*.cpp,*.c,.riot,.tox,.mypy_cache,.git,*ddtrace/vendor,tests/contrib/openai/cassettes/*,tests/contrib/langchain/cassettes/*,ddtrace/appsec/_iast/_taint_tracking/_vendor/*
 exclude-file = .codespellignorelines
-ignore-words-list = asend,dne,fo,medias,ment,nin,ot,setttings,statics,ba,spawnve,doas,numer
+ignore-words-list = asend,dne,fo,fpr,medias,ment,nin,ot,setttings,statics,ba,spawnve,doas,numer
 
 # DEV: We use `conftest.py` as a local pytest plugin to configure hooks for collection
 [tool:pytest]


### PR DESCRIPTION
## Description

Delta vs #19903.

`docker/Dockerfile`: pyenv `v2.6.31` → `v2.8.4`. A `docker/**` push to `main` retriggers `.github/workflows/testrunner.yml` and recompiles `3.15-dev`. Does not pin a 3.15.0 interpreter or the GitLab `TESTRUNNER_IMAGE` digest.

`.cached_testrunner` EXT_CACHE_VENV: `pip install … 'Cython<3.3'` when `PYTHON_VERSION=3.15`; other versions stay unpinned `Cython`.

If this merges and nothing else new lands: the next testrunner image rebuilds with pyenv 2.8.4, and the 3.15 cache venv gets Cython 3.2.x. GitLab jobs keep the old digest until a follow-up pins it.

## Testing

Image rebuild is the testrunner workflow after merge to `main`. After publish, pin `.gitlab/testrunner.yml`. Confirm the generated 3.15 `build_base_venvs` `before_script` installs `Cython<3.3`.

## Risks

Pyenv 2.8.4 also reinstalls 3.8–3.14 (patch-level bumps possible). Cython pin is 3.15-only.

## Additional Notes

Does not duplicate #19861 (`pyproject.toml` unchanged). No release note: CI chore, `changelog/no-changelog`.

Base: #19903. Next: #19904.
