### PR TITLE
chore(wrapping): run wrap() trampoline on Python 3.15 (PROF-15852)

### DIFF
--- a/ddtrace/internal/compat.py
+++ b/ddtrace/internal/compat.py
@@ -20,7 +20,7 @@ __all__ = [
 PYTHON_VERSION_INFO = sys.version_info
 
 # First CPython version that wrapping / bytecode injection do not support yet.
-NEXT_PY_VERSION: str = "3.15"
+NEXT_PY_VERSION: str = "3.16"
 _next_py_parts = NEXT_PY_VERSION.split(".")[:2]
 NEXT_PY_VERSION_INFO: tuple[int, int] = (int(_next_py_parts[0]), int(_next_py_parts[1]))
 NEXT_PY_UNSUPPORTED_MSG: str = "This version of CPython is not supported yet (Python %s and later)" % NEXT_PY_VERSION

--- a/ddtrace/internal/wrapping/__init__.py
+++ b/ddtrace/internal/wrapping/__init__.py
@@ -21,9 +21,6 @@ from ddtrace.internal.wrapping.generators import wrap_generator
 
 
 PY = sys.version_info[:2]
-# wrap() is enabled on NEXT_PY_VERSION (3.15). Fail closed on the next CPython.
-# TODO(py-315): drop the +1 when NEXT_PY_VERSION is bumped to 3.16
-_WRAP_UNSUPPORTED_FROM = (NEXT_PY_VERSION_INFO[0], NEXT_PY_VERSION_INFO[1] + 1)
 
 # Maps each wrapped function to its inner copy (the singly-linked list of
 # wrapping layers). WeakKeyDictionary so functions are not kept alive by the
@@ -303,7 +300,7 @@ def wrap_bytecode(wrapper: Wrapper, wrapped: FunctionType) -> bc.Bytecode:
     return a coroutine function, and so on. The signature is also preserved to
     avoid breaking, e.g., usages of the ``inspect`` module.
     """
-    if PY >= _WRAP_UNSUPPORTED_FROM:
+    if PY >= NEXT_PY_VERSION_INFO:
         raise NotImplementedError(NEXT_PY_UNSUPPORTED_MSG)
 
     code = wrapped.__code__
@@ -352,9 +349,8 @@ def wrap(f: FunctionType, wrapper: Wrapper) -> WrappedFunction:
     Note that this changes the behavior of the original function with the
     wrapper function, instead of creating a new function object.
     """
-    if PY >= _WRAP_UNSUPPORTED_FROM:
+    if PY >= NEXT_PY_VERSION_INFO:
         raise NotImplementedError(NEXT_PY_UNSUPPORTED_MSG)
-
     wrapped = FunctionType(
         code := f.__code__,
         f.__globals__,

--- a/ddtrace/internal/wrapping/__init__.py
+++ b/ddtrace/internal/wrapping/__init__.py
@@ -13,8 +13,6 @@ import bytecode as bc
 from bytecode import Instr
 
 from ddtrace.internal.assembly import Assembly
-from ddtrace.internal.compat import NEXT_PY_UNSUPPORTED_MSG
-from ddtrace.internal.compat import NEXT_PY_VERSION_INFO
 from ddtrace.internal.threads import Lock
 from ddtrace.internal.wrapping.asyncs import wrap_async
 from ddtrace.internal.wrapping.generators import wrap_generator
@@ -300,9 +298,6 @@ def wrap_bytecode(wrapper: Wrapper, wrapped: FunctionType) -> bc.Bytecode:
     return a coroutine function, and so on. The signature is also preserved to
     avoid breaking, e.g., usages of the ``inspect`` module.
     """
-    if PY >= NEXT_PY_VERSION_INFO:
-        raise NotImplementedError(NEXT_PY_UNSUPPORTED_MSG)
-
     code = wrapped.__code__
     lineno = code.co_firstlineno + FIRSTLINENO_OFFSET
 
@@ -349,8 +344,6 @@ def wrap(f: FunctionType, wrapper: Wrapper) -> WrappedFunction:
     Note that this changes the behavior of the original function with the
     wrapper function, instead of creating a new function object.
     """
-    if PY >= NEXT_PY_VERSION_INFO:
-        raise NotImplementedError(NEXT_PY_UNSUPPORTED_MSG)
     wrapped = FunctionType(
         code := f.__code__,
         f.__globals__,

--- a/ddtrace/internal/wrapping/__init__.py
+++ b/ddtrace/internal/wrapping/__init__.py
@@ -13,12 +13,17 @@ import bytecode as bc
 from bytecode import Instr
 
 from ddtrace.internal.assembly import Assembly
+from ddtrace.internal.compat import NEXT_PY_UNSUPPORTED_MSG
+from ddtrace.internal.compat import NEXT_PY_VERSION_INFO
 from ddtrace.internal.threads import Lock
 from ddtrace.internal.wrapping.asyncs import wrap_async
 from ddtrace.internal.wrapping.generators import wrap_generator
 
 
 PY = sys.version_info[:2]
+# wrap() is enabled on NEXT_PY_VERSION (3.15). Fail closed on the next CPython.
+# TODO(py-315): drop the +1 when NEXT_PY_VERSION is bumped to 3.16
+_WRAP_UNSUPPORTED_FROM = (NEXT_PY_VERSION_INFO[0], NEXT_PY_VERSION_INFO[1] + 1)
 
 # Maps each wrapped function to its inner copy (the singly-linked list of
 # wrapping layers). WeakKeyDictionary so functions are not kept alive by the
@@ -298,6 +303,9 @@ def wrap_bytecode(wrapper: Wrapper, wrapped: FunctionType) -> bc.Bytecode:
     return a coroutine function, and so on. The signature is also preserved to
     avoid breaking, e.g., usages of the ``inspect`` module.
     """
+    if PY >= _WRAP_UNSUPPORTED_FROM:
+        raise NotImplementedError(NEXT_PY_UNSUPPORTED_MSG)
+
     code = wrapped.__code__
     lineno = code.co_firstlineno + FIRSTLINENO_OFFSET
 
@@ -344,6 +352,9 @@ def wrap(f: FunctionType, wrapper: Wrapper) -> WrappedFunction:
     Note that this changes the behavior of the original function with the
     wrapper function, instead of creating a new function object.
     """
+    if PY >= _WRAP_UNSUPPORTED_FROM:
+        raise NotImplementedError(NEXT_PY_UNSUPPORTED_MSG)
+
     wrapped = FunctionType(
         code := f.__code__,
         f.__globals__,

--- a/tests/internal/test_py315_import_degrade.py
+++ b/tests/internal/test_py315_import_degrade.py
@@ -41,6 +41,7 @@ def test_wrap_runs_on_315():
     assert seen == ["sync"]
 
     def gen_wrapper(wrapped, args, kwargs):  # noqa: ANN001, ANN202
+        seen.append("gen")
         for value in wrapped(*args, **kwargs):
             yield value
 
@@ -50,6 +51,7 @@ def test_wrap_runs_on_315():
 
     wrap(g, gen_wrapper)
     assert list(g()) == [1, 2]
+    assert seen == ["sync", "gen"]
 
 
 @pytest.mark.skipif(PYTHON_VERSION_INFO < NEXT_PY_VERSION_INFO, reason=f"{NEXT_PY_VERSION} wrap() coroutine")

--- a/tests/internal/test_py315_import_degrade.py
+++ b/tests/internal/test_py315_import_degrade.py
@@ -1,8 +1,9 @@
 """Python 3.15 import-time degrade: wrapping modules must load.
 
 wrap() runs the existing trampoline plus the 3.15 generator/coroutine
-assemblies. Remaining NEXT_PY_VERSION gates (lazy wrapping) still degrade
-instead of crashing import. inject_hook is monitoring-based on 3.15.
+assemblies, and fails closed on the next CPython. Remaining NEXT_PY_VERSION
+gates (lazy wrapping) still degrade instead of crashing import. inject_hook
+is monitoring-based on 3.15.
 """
 
 from types import CoroutineType
@@ -77,6 +78,28 @@ async def test_wrap_coroutine_on_315():
     wrap(c, wrapper)
     assert await c() == 42
     assert seen == [42]
+
+
+def test_wrap_raises_not_implemented_on_future_py(monkeypatch):
+    """wrap() must fail closed on the CPython after NEXT_PY_VERSION."""
+    import ddtrace.internal.wrapping as wrapping
+
+    monkeypatch.setattr(
+        wrapping,
+        "PY",
+        (NEXT_PY_VERSION_INFO[0], NEXT_PY_VERSION_INFO[1] + 1),
+    )
+
+    def f() -> None:
+        return None
+
+    def wrapper(wrapped, args, kwargs):  # noqa: ANN001, ANN202
+        return wrapped(*args, **kwargs)
+
+    with pytest.raises(NotImplementedError, match="not supported yet"):
+        wrapping.wrap(f, wrapper)
+    with pytest.raises(NotImplementedError, match="not supported yet"):
+        wrapping.wrap_bytecode(wrapper, f)
 
 
 @pytest.mark.skipif(PYTHON_VERSION_INFO < NEXT_PY_VERSION_INFO, reason=f"{NEXT_PY_VERSION} lazy module degrade")

--- a/tests/internal/test_py315_import_degrade.py
+++ b/tests/internal/test_py315_import_degrade.py
@@ -1,9 +1,11 @@
-"""Python 3.15 import-time degrade: wrapping must load, wrap() still raises.
+"""Python 3.15 import-time degrade: wrapping modules must load.
 
-Until #17849 lands bytecode wrapping for 3.15, products that import wrapping
-(e.g. ModuleWatchdog) must not crash the process. wrap()/inject_hook still
-raise NotImplementedError when actually used.
+wrap() runs the existing trampoline plus the 3.15 generator/coroutine
+assemblies. Remaining NEXT_PY_VERSION gates (lazy wrapping) still degrade
+instead of crashing import. inject_hook is monitoring-based on 3.15.
 """
+
+from types import CoroutineType
 
 import pytest
 
@@ -20,18 +22,61 @@ def test_wrapping_modules_import():
     import ddtrace.internal.wrapping.generators  # noqa: F401
 
 
-@pytest.mark.skipif(PYTHON_VERSION_INFO < NEXT_PY_VERSION_INFO, reason=f"{NEXT_PY_VERSION} wrap() degrade")
-def test_wrap_raises_not_implemented_on_315():
+@pytest.mark.skipif(PYTHON_VERSION_INFO < NEXT_PY_VERSION_INFO, reason=f"{NEXT_PY_VERSION} wrap() trampoline")
+def test_wrap_runs_on_315():
     from ddtrace.internal.wrapping import wrap
 
-    def f() -> None:
-        return None
+    seen: list[object] = []
 
     def wrapper(wrapped, args, kwargs):  # noqa: ANN001, ANN202
+        seen.append("sync")
         return wrapped(*args, **kwargs)
 
-    with pytest.raises(NotImplementedError, match="3.15"):
-        wrap(f, wrapper)
+    def f() -> int:
+        return 7
+
+    wrap(f, wrapper)
+    assert f() == 7
+    assert seen == ["sync"]
+
+    def gen_wrapper(wrapped, args, kwargs):  # noqa: ANN001, ANN202
+        for value in wrapped(*args, **kwargs):
+            yield value
+
+    def g():  # noqa: ANN202
+        yield 1
+        yield 2
+
+    wrap(g, gen_wrapper)
+    assert list(g()) == [1, 2]
+
+
+@pytest.mark.skipif(PYTHON_VERSION_INFO < NEXT_PY_VERSION_INFO, reason=f"{NEXT_PY_VERSION} wrap() coroutine")
+@pytest.mark.asyncio
+async def test_wrap_coroutine_on_315():
+    from ddtrace.internal.wrapping import wrap
+
+    seen: list[object] = []
+
+    def wrapper(wrapped, args, kwargs):  # noqa: ANN001, ANN202
+        result = wrapped(*args, **kwargs)
+        if isinstance(result, CoroutineType):
+
+            async def _await(coro):  # noqa: ANN001, ANN202
+                value = await coro
+                seen.append(value)
+                return value
+
+            return _await(result)
+        seen.append(result)
+        return result
+
+    async def c() -> int:
+        return 42
+
+    wrap(c, wrapper)
+    assert await c() == 42
+    assert seen == [42]
 
 
 @pytest.mark.skipif(PYTHON_VERSION_INFO < NEXT_PY_VERSION_INFO, reason=f"{NEXT_PY_VERSION} lazy module degrade")
@@ -66,9 +111,10 @@ def test_debugging_products_load_without_failure():
         assert product_name not in product_manager._failed
 
 
-@pytest.mark.skipif(PYTHON_VERSION_INFO < NEXT_PY_VERSION_INFO, reason=f"{NEXT_PY_VERSION} inject_hook degrade")
-def test_inject_hook_raises_not_implemented_on_315():
+@pytest.mark.skipif(PYTHON_VERSION_INFO < NEXT_PY_VERSION_INFO, reason=f"{NEXT_PY_VERSION} inject_hook")
+def test_inject_hook_does_not_raise_on_315():
     from ddtrace.internal.bytecode_injection import inject_hook
+    from ddtrace.internal.utils.inspection import linenos
 
     def f() -> None:
         return None
@@ -76,5 +122,4 @@ def test_inject_hook_raises_not_implemented_on_315():
     def hook(_arg: object) -> None:
         return None
 
-    with pytest.raises(NotImplementedError, match="3.15"):
-        inject_hook(f, hook, f.__code__.co_firstlineno, None)
+    inject_hook(f, hook, min(linenos(f)), None)

--- a/tests/internal/test_py315_import_degrade.py
+++ b/tests/internal/test_py315_import_degrade.py
@@ -1,18 +1,21 @@
-"""Python 3.15 import-time degrade: wrapping modules must load.
+"""Python 3.15 wrapping: trampoline plus 3.15 generator/coroutine assemblies.
 
-wrap() runs the existing trampoline plus the 3.15 generator/coroutine
-assemblies, and fails closed on the next CPython. Remaining NEXT_PY_VERSION
-gates (lazy wrapping) still degrade instead of crashing import. inject_hook
-is monitoring-based on 3.15.
+wrap() / wrap_bytecode() run on 3.15 and fail closed from NEXT_PY_VERSION.
+@lazy uses WrappingContext.wrap() (sys.monitoring) on 3.15. inject_hook is
+monitoring-based on 3.15.
 """
 
 from types import CoroutineType
 
 import pytest
 
-from ddtrace.internal.compat import NEXT_PY_VERSION
 from ddtrace.internal.compat import NEXT_PY_VERSION_INFO
 from ddtrace.internal.compat import PYTHON_VERSION_INFO
+
+
+# wrap() is live on 3.15 until NEXT_PY. A skipif of version < NEXT_PY would
+# skip 3.15 once NEXT_PY is 3.16.
+_WRAP_ON_315 = (3, 15) <= PYTHON_VERSION_INFO[:2] < NEXT_PY_VERSION_INFO
 
 
 def test_wrapping_modules_import():
@@ -23,7 +26,7 @@ def test_wrapping_modules_import():
     import ddtrace.internal.wrapping.generators  # noqa: F401
 
 
-@pytest.mark.skipif(PYTHON_VERSION_INFO < NEXT_PY_VERSION_INFO, reason=f"{NEXT_PY_VERSION} wrap() trampoline")
+@pytest.mark.skipif(not _WRAP_ON_315, reason="wrap() trampoline on 3.15")
 def test_wrap_runs_on_315():
     from ddtrace.internal.wrapping import wrap
 
@@ -54,7 +57,7 @@ def test_wrap_runs_on_315():
     assert seen == ["sync", "gen"]
 
 
-@pytest.mark.skipif(PYTHON_VERSION_INFO < NEXT_PY_VERSION_INFO, reason=f"{NEXT_PY_VERSION} wrap() coroutine")
+@pytest.mark.skipif(not _WRAP_ON_315, reason="wrap() coroutine on 3.15")
 @pytest.mark.asyncio
 async def test_wrap_coroutine_on_315():
     from ddtrace.internal.wrapping import wrap
@@ -83,14 +86,10 @@ async def test_wrap_coroutine_on_315():
 
 
 def test_wrap_raises_not_implemented_on_future_py(monkeypatch):
-    """wrap() must fail closed on the CPython after NEXT_PY_VERSION."""
+    """wrap() must fail closed from NEXT_PY_VERSION on."""
     import ddtrace.internal.wrapping as wrapping
 
-    monkeypatch.setattr(
-        wrapping,
-        "PY",
-        (NEXT_PY_VERSION_INFO[0], NEXT_PY_VERSION_INFO[1] + 1),
-    )
+    monkeypatch.setattr(wrapping, "PY", NEXT_PY_VERSION_INFO)
 
     def f() -> None:
         return None
@@ -104,7 +103,7 @@ def test_wrap_raises_not_implemented_on_future_py(monkeypatch):
         wrapping.wrap_bytecode(wrapper, f)
 
 
-@pytest.mark.skipif(PYTHON_VERSION_INFO < NEXT_PY_VERSION_INFO, reason=f"{NEXT_PY_VERSION} lazy module degrade")
+@pytest.mark.skipif(not _WRAP_ON_315, reason="lazy module wrap on 3.15")
 def test_lazy_module_decorator_without_bytecode_wrap():
     import tests.internal.lazy as lazy_module
 
@@ -121,7 +120,7 @@ def test_exec_lazy_init_without_source():
     assert module_globals["exported"] == 123
 
 
-@pytest.mark.skipif(PYTHON_VERSION_INFO < NEXT_PY_VERSION_INFO, reason=f"{NEXT_PY_VERSION} debugging products degrade")
+@pytest.mark.skipif(not _WRAP_ON_315, reason="debugging products load on 3.15")
 def test_debugging_products_load_without_failure():
     from ddtrace.internal.products import ProductManager
 
@@ -136,7 +135,7 @@ def test_debugging_products_load_without_failure():
         assert product_name not in product_manager._failed
 
 
-@pytest.mark.skipif(PYTHON_VERSION_INFO < NEXT_PY_VERSION_INFO, reason=f"{NEXT_PY_VERSION} inject_hook")
+@pytest.mark.skipif(not _WRAP_ON_315, reason="inject_hook on 3.15")
 def test_inject_hook_does_not_raise_on_315():
     from ddtrace.internal.bytecode_injection import inject_hook
     from ddtrace.internal.utils.inspection import linenos


### PR DESCRIPTION
## Description

[#17849](https://github.com/DataDog/dd-trace-py/pull/17849) is on main: 3.15 generator/coroutine assemblies and sys.monitoring WrappingContext / inject_hook. wrap() / wrap_bytecode() still gate on `NEXT_PY_VERSION_INFO` (was 3.15), so they raised on 3.15.

This PR sets `NEXT_PY_VERSION` to 3.16. The wrap() comparison is unchanged, so wrap() runs the existing trampoline on 3.15 and fail-closes from 3.16. Not a sys.monitoring port of wrap(). `requires-python` stays `>=3.9,<3.15`.

Side effect: `@lazy` on 3.15 takes the `PYTHON_VERSION_INFO < NEXT` branch (`LazyWrappingContext.wrap()`). inject_hook is already monitoring-based on 3.15 (`PY >= (3, 15)`); this PR does not change that gate.

| Layer | Meaning | Which PR |
| --- | --- | --- |
| Compiled into artifact | 3.15 assemblies | #17849 (on main) |
| Armed at runtime | wrap() no longer raises on 3.15 | this PR |
| Observable in product/Python | wrap() / wrap_bytecode() run on 3.15 | this PR |

## Testing

Sync, generator, and coroutine trampoline tests pinned to 3.15 (`>= (3, 15)` and `< NEXT_PY`). A monkeypatch pins fail-closed from 3.16.

## Risks

3.15 is still unsupported (`requires-python <3.15`).

## Additional Notes

Part of #17810. No release note: internal wrapping, 3.15 unsupported; `changelog/no-changelog`.
