### PR TITLE
fix(ci): drop --no-ddtrace from integration-snapshot suite

### DIFF
--- a/riotfile.py
+++ b/riotfile.py
@@ -506,7 +506,7 @@ venv = Venv(
             env={
                 "DDTEST_SUITE_PATH": "tests/integration",
                 "DDTEST_TESTS_LOCATION": "tests/integration/**/test*.py",
-                "DDTEST_PYTEST_ADDOPTS": "-vv --ignore-glob='*civisibility*' --no-ddtrace",
+                "DDTEST_PYTEST_ADDOPTS": "-vv --ignore-glob='*civisibility*'",
             },
             # Enabling coverage for integration tests breaks certain tests in CI
             # Also, running two separate pytest sessions, the ``civisibility`` one with --no-ddtrace


### PR DESCRIPTION
The --no-ddtrace workaround (1dc95f614a) was added because ddtest's PYTEST_ADDOPTS=--ddtrace leaked into test subprocesses, enabling CI Visibility whose CIVisibilityWriter doesn't respect the testagent's session token (cross-session contamination). That leak is now fixed at the source: tests/utils.py call_program strips PYTEST_ADDOPTS, and tests/conftest.py strips DD_CIVISIBILITY_ENABLED from subprocess env.

With the leak fixed, --ddtrace is safe again for the integration-snapshot suite (matching normal riot CI, which never passed --no-ddtrace here — the suite simply runs without --ddtrace in its command). Drop the workaround so the suite runs under CI Visibility as intended.

## Description

<!-- Provide an overview of the change and motivation for the change.
     Implementation detail and rationale belong here, not in the release note -
     release notes are customer-facing (see docs/releasenotes.rst). -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
