### PR TITLE
test(profiling): unflake `gevent_greenlet_switch_not_blocked_by_profiler`

### DIFF
--- a/tests/profiling/collector/test_stack.py
+++ b/tests/profiling/collector/test_stack.py
@@ -1125,7 +1125,8 @@ def test_gevent_greenlet_switch_not_blocked_by_profiler() -> None:
     SWITCHES = 200
     N_IDLE_HIGH = 2000
     STACK_DEPTH = 50
-    MAX_SCALING_RATIO = 3.0
+    MAX_SCALING_RATIO = 6.0
+    N_MEASUREMENTS = 5
     MEASURE_TIMEOUT = 30  # generous timeout to prevent CI hangs
 
     def active_worker() -> None:
@@ -1163,8 +1164,8 @@ def test_gevent_greenlet_switch_not_blocked_by_profiler() -> None:
     stack.set_adaptive_sampling(False)
     try:
         measure(0)  # warm up
-        t_low = min(measure(0) for _ in range(3))
-        t_high = min(measure(N_IDLE_HIGH) for _ in range(3))
+        t_low = min(measure(0) for _ in range(N_MEASUREMENTS))
+        t_high = min(measure(N_IDLE_HIGH) for _ in range(N_MEASUREMENTS))
     finally:
         p.stop()
 


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-15927

This is an attempt to unflake the `gevent_greenlet_switch_not_blocked_by_profiler` test which has been failing 2% of the time in CI recently. 

The fix is simply:
- Taking more measurements to reduce chances for noise to make the test fail 
- Adapt the expected numbers; the regression we expect to see is at 10x, so bumping even at 6x is OK (even though not ideal); tests are useless if they don't consistently pass when things are fine anyway, so better this than flaky. 

Fixes DD_5KBPQ7 DD_8IWYLY DD_STK0ST DD_69L6UC DD_T3OJLQ