### PR TITLE
chore(aiguard): move telemetry metrics to the ai_guard namespace

### DIFF
--- a/ddtrace/aiguard/_api_client.py
+++ b/ddtrace/aiguard/_api_client.py
@@ -133,14 +133,20 @@ class AIGuardClient:
 
     @staticmethod
     def _add_request_to_telemetry(tags: MetricTagType) -> None:
-        telemetry.telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.APPSEC, AI_GUARD.REQUESTS_METRIC, 1, tags)
+        telemetry.telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.AI_GUARD, AI_GUARD.REQUESTS_METRIC, 1, tags)
+
+    @staticmethod
+    def _add_error_to_telemetry(error_type: str) -> None:
+        telemetry.telemetry_writer.add_count_metric(
+            TELEMETRY_NAMESPACE.AI_GUARD, AI_GUARD.ERROR_METRIC, 1, (("type", error_type),)
+        )
 
     @staticmethod
     def _messages_for_meta_struct(messages: list[Message]) -> list[Message]:
         max_messages_length = aiguard_config._ai_guard_max_messages_length
         if len(messages) > max_messages_length:
             telemetry.telemetry_writer.add_count_metric(
-                TELEMETRY_NAMESPACE.APPSEC, AI_GUARD.TRUNCATED_METRIC, 1, (("type", "messages"),)
+                TELEMETRY_NAMESPACE.AI_GUARD, AI_GUARD.TRUNCATED_METRIC, 1, (("type", "messages"),)
             )
         messages = messages[-max_messages_length:]
 
@@ -169,7 +175,7 @@ class AIGuardClient:
         result = [truncate_message(message) for message in messages]
         if content_truncated:
             telemetry.telemetry_writer.add_count_metric(
-                TELEMETRY_NAMESPACE.APPSEC, AI_GUARD.TRUNCATED_METRIC, 1, (("type", "content"),)
+                TELEMETRY_NAMESPACE.AI_GUARD, AI_GUARD.TRUNCATED_METRIC, 1, (("type", "content"),)
             )
         return result
 
@@ -242,6 +248,10 @@ class AIGuardClient:
 
         from ddtrace.trace import tracer
 
+        # Classifies the error metric when a raise below escapes. Transport failures and
+        # unexpected internal errors keep the default; response-driven raises narrow it.
+        error_type: str = AI_GUARD.ERROR_CLIENT
+
         with tracer.trace(AI_GUARD.RESOURCE_TYPE) as span:
             try:
                 payload = {"data": {"attributes": {"messages": messages, "meta": self._meta}}}
@@ -274,6 +284,7 @@ class AIGuardClient:
                         # detection metadata only and never drive redaction.
                         redaction_replacements = attributes.get("redaction_replacements")
                     except Exception as e:
+                        error_type = AI_GUARD.ERROR_BAD_RESPONSE
                         value = json.dumps(result, indent=2)[:500]
                         raise AIGuardClientError(
                             message=f"AI Guard service returned unexpected response format: {value}",
@@ -281,6 +292,7 @@ class AIGuardClient:
                         ) from e
 
                     if action not in ACTIONS:
+                        error_type = AI_GUARD.ERROR_BAD_RESPONSE
                         raise AIGuardClientError(
                             f"AI Guard service returned unrecognized action: '{action}'. Expected {ACTIONS}",
                             status=response.status,
@@ -308,6 +320,7 @@ class AIGuardClient:
                     if tag_probs is not None:
                         meta_struct.update({"tag_probs": tag_probs})
                 else:
+                    error_type = AI_GUARD.ERROR_BAD_STATUS
                     raise AIGuardClientError(
                         message=f"AI Guard service call failed, status: {response.status}",
                         status=response.status,
@@ -369,6 +382,7 @@ class AIGuardClient:
 
             except Exception:
                 self._add_request_to_telemetry((("error", "true"),))
+                self._add_error_to_telemetry(error_type)
                 # Log the size only: the messages may carry sensitive data that redaction would have
                 # removed, and this runs before any redaction decision is known.
                 logger.debug("AI Guard evaluation failed for %d messages", len(messages), exc_info=True)

--- a/ddtrace/aiguard/_api_client.py
+++ b/ddtrace/aiguard/_api_client.py
@@ -265,9 +265,19 @@ class AIGuardClient:
 
                 try:
                     response = self._execute_request(f"{self._endpoint}/evaluate", payload)
-                    result = response.get_json() or {}  # type: ignore[no-untyped-call]
                 except Exception as e:
                     raise AIGuardClientError(message=f"Unexpected error calling AI Guard service: {e}") from e
+
+                try:
+                    result = response.get_json() or {}  # type: ignore[no-untyped-call]
+                except Exception as e:
+                    # A body we cannot decode is a response problem, not a transport one, unless
+                    # the status code already explains the failure.
+                    error_type = AI_GUARD.ERROR_BAD_RESPONSE if response.status == 200 else AI_GUARD.ERROR_BAD_STATUS
+                    raise AIGuardClientError(
+                        message=f"AI Guard service returned an undecodable response body: {e}",
+                        status=response.status,
+                    ) from e
 
                 if response.status == 200:
                     try:

--- a/ddtrace/aiguard/_constants.py
+++ b/ddtrace/aiguard/_constants.py
@@ -39,9 +39,16 @@ class AI_GUARD(metaclass=Constant_Class):
     STRUCT: Literal["ai_guard"] = "ai_guard"
 
     # metrics
-    METRIC_PREFIX: Literal["ai_guard"] = "ai_guard"
-    REQUESTS_METRIC: str = METRIC_PREFIX + ".requests"
-    TRUNCATED_METRIC: str = METRIC_PREFIX + ".truncated"
+    # Reported under the dedicated ai_guard telemetry namespace, so the full metric ids are
+    # ai_guard.<name>. Spec: https://datadoghq.atlassian.net/wiki/spaces/AIGuard/pages/6600426215
+    REQUESTS_METRIC: Literal["requests"] = "requests"
+    TRUNCATED_METRIC: Literal["truncated"] = "truncated"
+    ERROR_METRIC: Literal["error"] = "error"
+
+    # Values of the "type" tag on the error metric.
+    ERROR_CLIENT: Literal["client_error"] = "client_error"
+    ERROR_BAD_STATUS: Literal["bad_status"] = "bad_status"
+    ERROR_BAD_RESPONSE: Literal["bad_response"] = "bad_response"
 
     # environment variables
     ENV_ENABLED: Literal["DD_AI_GUARD_ENABLED"] = "DD_AI_GUARD_ENABLED"

--- a/ddtrace/internal/telemetry/constants.py
+++ b/ddtrace/internal/telemetry/constants.py
@@ -17,6 +17,7 @@ class TELEMETRY_NAMESPACE(Enum):
     IAST = "iast"
     CIVISIBILITY = "civisibility"
     MLOBS = "mlobs"
+    AI_GUARD = "ai_guard"
     DD_TRACE_API = "ddtraceapi"
     PROFILER = "profilers"
     DEBUGGER = "live_debugger"

--- a/tests/aiguard/api/test_api_client.py
+++ b/tests/aiguard/api/test_api_client.py
@@ -94,7 +94,7 @@ def _build_test_params():
 
 def assert_telemetry(mocked, metric, tags):
     metrics = [(args[0].value,) + args[1:] for args, kwargs in mocked.call_args_list]
-    assert ("appsec", metric, 1, tags) in metrics
+    assert ("ai_guard", metric, 1, tags) in metrics
 
 
 @pytest.mark.parametrize("action,reason,tags,blocking,suite,target,messages", _build_test_params())
@@ -147,7 +147,7 @@ def test_evaluate_method(
     )
     assert_telemetry(
         telemetry_mock,
-        "ai_guard.requests",
+        "requests",
         (
             ("action", action),
             ("block", "true" if should_block else "false"),
@@ -197,7 +197,8 @@ def test_evaluate_http_error(mock_execute_request, telemetry_mock, ai_guard_clie
 
     assert exc_info.value.status == 500
     assert exc_info.value.errors == errors
-    assert_telemetry(telemetry_mock, "ai_guard.requests", (("error", "true"),))
+    assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
+    assert_telemetry(telemetry_mock, "error", (("type", "bad_status"),))
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
@@ -215,7 +216,8 @@ def test_evaluate_http_error_empty_json_body(mock_execute_request, telemetry_moc
     assert str(exc_info.value) == "AI Guard service call failed, status: 500"
     assert exc_info.value.status == 500
     assert exc_info.value.errors == []
-    assert_telemetry(telemetry_mock, "ai_guard.requests", (("error", "true"),))
+    assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
+    assert_telemetry(telemetry_mock, "error", (("type", "bad_status"),))
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
@@ -231,7 +233,8 @@ def test_evaluate_invalid_json(mock_execute_request, telemetry_mock, ai_guard_cl
         ai_guard_client.evaluate(TOOL_CALL)
 
     assert str(exc_info.value) == "Unexpected error calling AI Guard service: Invalid JSON"
-    assert_telemetry(telemetry_mock, "ai_guard.requests", (("error", "true"),))
+    assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
+    assert_telemetry(telemetry_mock, "error", (("type", "client_error"),))
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
@@ -247,7 +250,8 @@ def test_evaluate_malformed_response(mock_execute_request, telemetry_mock, ai_gu
         ai_guard_client.evaluate(TOOL_CALL)
 
     assert str(exc_info.value).startswith("AI Guard service returned unexpected response format")
-    assert_telemetry(telemetry_mock, "ai_guard.requests", (("error", "true"),))
+    assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
+    assert_telemetry(telemetry_mock, "error", (("type", "bad_response"),))
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
@@ -263,7 +267,8 @@ def test_evaluate_invalid_action(mock_execute_request, telemetry_mock, ai_guard_
         str(exc_info.value)
         == "AI Guard service returned unrecognized action: 'GO_TO_SLEEP'. Expected ['ALLOW', 'DENY', 'ABORT']"
     )
-    assert_telemetry(telemetry_mock, "ai_guard.requests", (("error", "true"),))
+    assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
+    assert_telemetry(telemetry_mock, "error", (("type", "bad_response"),))
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
@@ -279,7 +284,7 @@ def test_span_meta_messages_truncation(mock_execute_request, telemetry_mock, ai_
     span = find_ai_guard_span(test_spans)
     meta = span._get_struct_tag(AI_GUARD.TAG)
     assert len(meta["messages"]) == aiguard_config._ai_guard_max_messages_length
-    assert_telemetry(telemetry_mock, "ai_guard.truncated", (("type", "messages"),))
+    assert_telemetry(telemetry_mock, "truncated", (("type", "messages"),))
 
 
 @pytest.mark.parametrize("content_part", [True, False])
@@ -302,7 +307,7 @@ def test_span_meta_content_truncation(mock_execute_request, telemetry_mock, ai_g
     if content_part:
         content = content[0]["text"]
     assert len(content) == aiguard_config._ai_guard_max_content_size
-    assert_telemetry(telemetry_mock, "ai_guard.truncated", (("type", "content"),))
+    assert_telemetry(telemetry_mock, "truncated", (("type", "content"),))
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")

--- a/tests/aiguard/api/test_api_client.py
+++ b/tests/aiguard/api/test_api_client.py
@@ -232,7 +232,39 @@ def test_evaluate_invalid_json(mock_execute_request, telemetry_mock, ai_guard_cl
     with pytest.raises(AIGuardClientError) as exc_info:
         ai_guard_client.evaluate(TOOL_CALL)
 
-    assert str(exc_info.value) == "Unexpected error calling AI Guard service: Invalid JSON"
+    assert str(exc_info.value) == "AI Guard service returned an undecodable response body: Invalid JSON"
+    assert exc_info.value.status == 200
+    assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
+    assert_telemetry(telemetry_mock, "error", (("type", "bad_response"),))
+
+
+@patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
+@patch("ddtrace.aiguard._api_client.AIGuardClient._execute_request")
+def test_evaluate_invalid_json_error_status(mock_execute_request, telemetry_mock, ai_guard_client):
+    """An undecodable body on a failing status is reported as bad_status, not bad_response."""
+    mock_response = Mock()
+    mock_response.status = 502
+    mock_response.get_json.side_effect = Exception("Invalid JSON")
+    mock_execute_request.return_value = mock_response
+
+    with pytest.raises(AIGuardClientError) as exc_info:
+        ai_guard_client.evaluate(TOOL_CALL)
+
+    assert exc_info.value.status == 502
+    assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
+    assert_telemetry(telemetry_mock, "error", (("type", "bad_status"),))
+
+
+@patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
+@patch("ddtrace.aiguard._api_client.AIGuardClient._execute_request")
+def test_evaluate_transport_failure(mock_execute_request, telemetry_mock, ai_guard_client):
+    """A failure reaching the service is a client_error."""
+    mock_execute_request.side_effect = Exception("Connection refused")
+
+    with pytest.raises(AIGuardClientError) as exc_info:
+        ai_guard_client.evaluate(TOOL_CALL)
+
+    assert str(exc_info.value) == "Unexpected error calling AI Guard service: Connection refused"
     assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
     assert_telemetry(telemetry_mock, "error", (("type", "client_error"),))
 

--- a/tests/aiguard/api/test_redaction.py
+++ b/tests/aiguard/api/test_redaction.py
@@ -51,7 +51,7 @@ def _metrics(add_count_metric: Mock, metric: str) -> list[tuple[Any, Any]]:
     return [
         (args[2], args[3])
         for args, _ in add_count_metric.call_args_list
-        if args[0].value == "appsec" and args[1] == metric
+        if args[0].value == "ai_guard" and args[1] == metric
     ]
 
 


### PR DESCRIPTION
## Description

Implements [APPSEC-62466](https://datadoghq.atlassian.net/browse/APPSEC-62466), following the
[AI Guard telemetry metrics](https://datadoghq.atlassian.net/wiki/spaces/AIGuard/pages/6600426215) spec.

**Namespace move.** AI Guard metrics leave the shared `appsec` telemetry namespace for their own
`ai_guard` namespace. libdatadog `v41.0.0` — the rev currently pinned in `src/native/Cargo.toml` —
added the `AiGuard` variant to `MetricNamespace`, so this needs no Rust change, only a new
`TELEMETRY_NAMESPACE` member whose value maps onto it. Worth verifying rather than assuming, because
`ddtrace/internal/telemetry/metrics.py` builds its native mapping with
`getattr(MetricNamespace, ns.value)` over *every* enum member: a member with no matching native
attribute would raise on the first metric of any product, not just AI Guard.

Since the namespace now carries the prefix, the metric ids drop it. `METRIC_PREFIX` only ever built
these names, so it is removed:

| | before | after |
|---|---|---|
| namespace | `appsec` | `ai_guard` |
| names | `ai_guard.requests`, `ai_guard.truncated` | `requests`, `truncated`, `error` |
| full ids | `appsec.ai_guard.requests` | `ai_guard.requests` |

**New `ai_guard.error` count metric**, with a `type` tag classified inside `evaluate()`:

- `bad_status` — response status was not 200
- `bad_response` — body could not be parsed, or the action was unrecognized
- `client_error` — transport failure or unexpected internal error (the default)

It is emitted alongside the existing `requests{error:true}`, and never on a block, since
`AIGuardAbortError` re-raises before the failure handler — a block is not a failure.

**Not included.** `ai_guard.duration` is a distribution metric and the tracers do not support
ddsketch yet, so it stays unimplemented as the ticket directs. The spec's `source` and `integration`
tags are also deliberately out of scope here — a first pass derived a shallow per-provider client
view to carry them, which was rejected as too heavy a mechanism for one tag. They are tracked for
both Python and Node.js in [APPSEC-69866](https://datadoghq.atlassian.net/browse/APPSEC-69866),
since Node.js shipped without them too.

Note the ticket's "rename the metrics" item turned out to be the namespace move, not a change to the
metric names: the ids were already `appsec.ai_guard.*` once the namespace prefix is accounted for.

## Testing

- `aiguard::ai_guard_api` — 276 passed (py3.12). The five existing error-path tests now assert their
  specific `error` metric type, and the namespace/name assertions were updated.
- `telemetry` — 174 passed (py3.12). Run because `ddtrace/internal/telemetry/constants.py` is shared
  across products.
- Verified against the real writer (not just the mocked `add_count_metric`) that all 9 namespaces
  still map to the native enum and that contexts register as `('ai_guard', 'requests', 'count')` and
  `('ai_guard', 'error', 'count')` — i.e. the new namespace is accepted natively rather than
  silently dropped.
- `scripts/lint fmt` / `style` / `typing` / `spelling` clean.

## Risks

**This is a hard switch, not a dual-emit**, matching the spec's "old AI Guard metrics inside appsec
namespace will be removed as soon as tracers implement new changes". Two consequences:

- Anything keying off `appsec.ai_guard.*` needs updating — dashboards, monitors, and the system tests
  from APPSEC-62497.
- Customers only get the new ids once they upgrade the tracer; there is a gap where neither namespace
  has continuous history for a given customer.

The `TELEMETRY_NAMESPACE` addition touches a module shared by all products. It is additive and the
mapping is verified for every existing member, so the blast radius is contained, but it is the one
change here that is not AI Guard-local.

## Additional Notes

No release note: internal telemetry only, no customer-visible behavior change — hence
`changelog/no-changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APPSEC-62466]: https://datadoghq.atlassian.net/browse/APPSEC-62466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPSEC-69866]: https://datadoghq.atlassian.net/browse/APPSEC-69866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ