### PR TITLE
chore: set pyproject version to internal-dogfooding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ddtrace"
-version = "4.15.0rc1"
+version = "4.15.0rc1+internal-dogfooding"
 description = "Datadog APM client library"
 readme = "README.md"
 license = { text = "LICENSE.BSD3" }


### PR DESCRIPTION
https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1993854839