### PR TITLE
chore: exclude integration manifests yaml from source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ graft cmake
 graft ddtrace
 graft src
 
+recursive-exclude ddtrace *.manifest.yaml
 recursive-exclude * **/__pycache__/*
 prune .riot/
 prune benchmarks/


### PR DESCRIPTION
## Description

Excludes integration `*.manifest.yaml` files from source distributions to minimize package size.

The [Instrumentation Manifest RFC](https://docs.google.com/document/d/18za_vEcA-hH4IEwRhebDhoQxQKSylCtwMeVDB3rYM4Y/edit?usp=sharing) will introduce a colocated manifest for every tracer integration, as illustrated by [PR #19890](https://github.com/DataDog/dd-trace-py/pull/19890). These manifests are repository metadata and are not required at runtime.

Because `MANIFEST.in` grafts the entire `ddtrace` directory, the manifests would otherwise be included automatically in published sdists. Wheels already exclude them through the existing explicit package-data allowlist.

This change does not affect runtime behavior or public APIs.

## Testing

- Tested with `ddtrace/contrib/internal/aiokafka/aiokafka.manifest.yaml` file.
- Confirmed the previous `manifest.in` rules included the `*.manifest.yaml` file.
- Confirmed the new rule excludes it while retaining normal integration Python files.
- `scripts/run-tests --list MANIFEST.in` found no applicable test suites.
- `scripts/lint checks` passed.

## Risks

Low. The rule only excludes files ending in `.manifest.yaml` under `ddtrace` from source distributions. The files remain available in the repository.

## Additional Notes

No release note is required. Add the `changelog/no-changelog` label.
