### PR TITLE
ci: bump wheel-builder IMAGE_TAGs after images (PROF-15844)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -175,7 +175,7 @@ microbenchmarks:
         matrix:
           - ARCH_TAG: "amd64"
             PYTHON_TAG: "cp39-cp39"
-            IMAGE_TAG: "v113741238-d2b8243-manylinux2014_x86_64"
+            IMAGE_TAG: "v133965508-8f84bce-manylinux2014_x86_64"
   rules:
     # Allow failures if explicitly asked
     - if: $RELEASE_ALLOW_BENCHMARK_FAILURES == "true"
@@ -216,7 +216,7 @@ macrobenchmarks:
         matrix:
           - ARCH_TAG: "amd64"
             PYTHON_TAG: "cp39-cp39"
-            IMAGE_TAG: "v113741238-d2b8243-manylinux2014_x86_64"
+            IMAGE_TAG: "v133965508-8f84bce-manylinux2014_x86_64"
   trigger:
     include: .gitlab/benchmarks/macrobenchmarks.yml
   variables:

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -27,7 +27,7 @@ candidate:
     - interruptible: true
   needs:
     - pipeline: $PARENT_PIPELINE_ID
-      job: "build linux: [amd64, cp39-cp39, v113741238-d2b8243-manylinux2014_x86_64]"
+      job: "build linux: [amd64, cp39-cp39, v133965508-8f84bce-manylinux2014_x86_64]"
       artifacts: true
   script: |
     cp pywheels/*-cp39-cp39-manylinux*_x86_64*.whl ./

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -167,7 +167,7 @@ candidate:
   tags: [ "arch:amd64" ]
   needs:
     - pipeline: $PARENT_PIPELINE_ID
-      job: "build linux: [amd64, cp39-cp39, v113741238-d2b8243-manylinux2014_x86_64]"
+      job: "build linux: [amd64, cp39-cp39, v133965508-8f84bce-manylinux2014_x86_64]"
       artifacts: true
   script: |
     mkdir -p candidate-wheel

--- a/.gitlab/debugging-exploration.yml
+++ b/.gitlab/debugging-exploration.yml
@@ -25,19 +25,19 @@
         matrix:
           - ARCH_TAG: "amd64"
             PYTHON_TAG: "cp310-cp310"
-            IMAGE_TAG: "v113741238-d2b8243-manylinux2014_x86_64"
+            IMAGE_TAG: "v133965508-8f84bce-manylinux2014_x86_64"
           - ARCH_TAG: "amd64"
             PYTHON_TAG: "cp311-cp311"
-            IMAGE_TAG: "v113741238-d2b8243-manylinux2014_x86_64"
+            IMAGE_TAG: "v133965508-8f84bce-manylinux2014_x86_64"
           - ARCH_TAG: "amd64"
             PYTHON_TAG: "cp312-cp312"
-            IMAGE_TAG: "v113741238-d2b8243-manylinux2014_x86_64"
+            IMAGE_TAG: "v133965508-8f84bce-manylinux2014_x86_64"
           - ARCH_TAG: "amd64"
             PYTHON_TAG: "cp313-cp313"
-            IMAGE_TAG: "v113741238-d2b8243-manylinux2014_x86_64"
+            IMAGE_TAG: "v133965508-8f84bce-manylinux2014_x86_64"
           - ARCH_TAG: "amd64"
             PYTHON_TAG: "cp314-cp314"
-            IMAGE_TAG: "v113741238-d2b8243-manylinux2014_x86_64"
+            IMAGE_TAG: "v133965508-8f84bce-manylinux2014_x86_64"
 
 ".debugging/exploration":
   stage: tests

--- a/.gitlab/multi-os-tests.yml
+++ b/.gitlab/multi-os-tests.yml
@@ -22,13 +22,13 @@ os tests ubuntu:
         matrix:
           - ARCH_TAG: "amd64"
             PYTHON_TAG: "cp310-cp310"
-            IMAGE_TAG: "v113741238-d2b8243-manylinux2014_x86_64"
+            IMAGE_TAG: "v133965508-8f84bce-manylinux2014_x86_64"
           - ARCH_TAG: "amd64"
             PYTHON_TAG: "cp312-cp312"
-            IMAGE_TAG: "v113741238-d2b8243-manylinux2014_x86_64"
+            IMAGE_TAG: "v133965508-8f84bce-manylinux2014_x86_64"
           - ARCH_TAG: "amd64"
             PYTHON_TAG: "cp314-cp314"
-            IMAGE_TAG: "v113741238-d2b8243-manylinux2014_x86_64"
+            IMAGE_TAG: "v133965508-8f84bce-manylinux2014_x86_64"
   variables:
     WHEEL_PATTERN: "manylinux2014*x86_64.whl"
     PLATFORM: "Ubuntu"

--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -1,6 +1,6 @@
 variables:
   IMAGE_BASE_URL: "registry.ddbuild.io/dd-trace-py"
-  MANYLINUX_AMD64_IMAGE_TAG: "v113741238-d2b8243-manylinux2014_x86_64"
+  MANYLINUX_AMD64_IMAGE_TAG: "v133965508-8f84bce-manylinux2014_x86_64"
   ALPINE_BUILD_IMAGE_TAG: "v126532003-233089d-alpine_build"
 
 .PYTHON_VERSIONS: &PYTHON_VERSIONS
@@ -22,12 +22,12 @@ variables:
   - "cp315-cp315"
 
 .AARCH64_IMAGES: &AARCH64_IMAGES
-  - "v113741357-d2b8243-manylinux2014_aarch64"
-  - "v126532182-233089d-musllinux_1_2_aarch64"
+  - "v133965501-8f84bce-manylinux2014_aarch64"
+  - "v133965516-8f84bce-musllinux_1_2_aarch64"
 
 .X86_64_IMAGES: &X86_64_IMAGES
-  - "v113741238-d2b8243-manylinux2014_x86_64"
-  - "v126532274-233089d-musllinux_1_2_x86_64"
+  - "v133965508-8f84bce-manylinux2014_x86_64"
+  - "v133965497-8f84bce-musllinux_1_2_x86_64"
 
 .build_base:
   stage: package
@@ -201,7 +201,7 @@ variables:
         matrix:
           - ARCH_TAG: "amd64"
             PYTHON_TAG: *PYTHON_TAGS
-            IMAGE_TAG: "v113741238-d2b8243-manylinux2014_x86_64"
+            IMAGE_TAG: "v133965508-8f84bce-manylinux2014_x86_64"
     - job: "package version"
   variables:
     UPLOAD_SUFFIX: "manylinux2014_x86_64"
@@ -251,10 +251,10 @@ variables:
         matrix:
           - ARCH_TAG: "amd64"
             PYTHON_TAG: *PYTHON_TAGS
-            IMAGE_TAG: "v113741238-d2b8243-manylinux2014_x86_64"
+            IMAGE_TAG: "v133965508-8f84bce-manylinux2014_x86_64"
           - ARCH_TAG: "arm64"
             PYTHON_TAG: *PYTHON_TAGS
-            IMAGE_TAG: "v113741357-d2b8243-manylinux2014_aarch64"
+            IMAGE_TAG: "v133965501-8f84bce-manylinux2014_aarch64"
     - job: "package version"
 
 "patch macos wheel versions":
@@ -276,10 +276,10 @@ variables:
         matrix:
           - ARCH_TAG: "amd64"
             PYTHON_TAG: *PYTHON_TAGS
-            IMAGE_TAG: "v113741238-d2b8243-manylinux2014_x86_64"
+            IMAGE_TAG: "v133965508-8f84bce-manylinux2014_x86_64"
           - ARCH_TAG: "arm64"
             PYTHON_TAG: *PYTHON_TAGS
-            IMAGE_TAG: "v113741357-d2b8243-manylinux2014_aarch64"
+            IMAGE_TAG: "v133965501-8f84bce-manylinux2014_aarch64"
     - job: "package version"
   variables:
     UPLOAD_SUFFIX: "manylinux2014"

--- a/.gitlab/system-tests.yml
+++ b/.gitlab/system-tests.yml
@@ -27,7 +27,7 @@
               - "cp312-cp312"
               - "cp313-cp313"
               - "cp314-cp314"
-            IMAGE_TAG: "v113741238-d2b8243-manylinux2014_x86_64"
+            IMAGE_TAG: "v133965508-8f84bce-manylinux2014_x86_64"
   before_script:
     - |
       echo -e "\e[0Ksection_start:`date +%s`:system_deps\r\e[0KInstalling system dependencies"


### PR DESCRIPTION
## Description

Point CI wheel-builder `IMAGE_TAG`s at the four tags from [DataDog/images#11356](https://github.com/DataDog/images/pull/11356): `v133965508-8f84bce-manylinux2014_x86_64`, `v133965501-8f84bce-manylinux2014_aarch64`, `v133965497-8f84bce-musllinux_1_2_x86_64`, `v133965516-8f84bce-musllinux_1_2_aarch64`. `ALPINE_BUILD_IMAGE_TAG` and `requires-python` (`>=3.9,<3.15`) are unchanged.

## Testing

GitLab wheel jobs pick up the new tags.

## Risks

Low. Immutable tag bump.
