### PR TITLE
feat(runtime): refresh MicroVM identity

### DIFF
--- a/ddtrace/__init__.py
+++ b/ddtrace/__init__.py
@@ -12,7 +12,9 @@ from ._logger import configure_ddtrace_logger  # noqa: E402
 configure_ddtrace_logger()  # noqa: E402
 
 # Enable telemetry writer and excepthook as early as possible to ensure we capture any exceptions from initialization
-import ddtrace.internal.telemetry  # noqa: E402, F401
+from ddtrace.internal.runtime import listen_for_identity_refresh_hooks  # noqa: E402,I001
+from ddtrace.internal.serverless import in_aws_lambda_microvm  # noqa: E402
+import ddtrace.internal.telemetry  # noqa: F401,E402
 
 from ._monkey import patch  # noqa: E402
 from ._monkey import patch_all  # noqa: E402
@@ -23,6 +25,12 @@ from .internal.utils.deprecations import DDTraceDeprecationWarning  # noqa: E402
 from .internal.utils.deprecations import deprecate  # noqa: E402
 from .version import __version__  # noqa: E402
 
+
+# Register import-time hooks that depend on ddtrace.config being exported.
+if in_aws_lambda_microvm():
+    from .internal import core as _core  # noqa: E402
+
+    listen_for_identity_refresh_hooks(_core.on)
 
 # TODO: Deprecate accessing tracer from ddtrace.__init__ module in v4.0
 if env.get("_DD_GLOBAL_TRACER_INIT", "true").lower() in ("1", "true"):

--- a/ddtrace/contrib/internal/web.py
+++ b/ddtrace/contrib/internal/web.py
@@ -2,12 +2,11 @@ from typing import Optional
 
 from ddtrace.contrib._events.web_framework import WebFrameworkEvents
 from ddtrace.internal import core
+from ddtrace.internal.serverless import MICROVM_RUN_HOOK_METHOD
+from ddtrace.internal.serverless import MICROVM_RUN_HOOK_PATH
 from ddtrace.internal.serverless import in_aws_lambda_microvm
 
 
-_LAMBDA_MICROVM_RUN_PATH = "/aws/lambda-microvms/runtime/v1/run"
-
-
 def dispatch_web_request_starting(method: Optional[str], path: str) -> None:
-    if method == "POST" and path == _LAMBDA_MICROVM_RUN_PATH and in_aws_lambda_microvm():
+    if method == MICROVM_RUN_HOOK_METHOD and path == MICROVM_RUN_HOOK_PATH and in_aws_lambda_microvm():
         core.dispatch(WebFrameworkEvents.WEB_REQUEST_STARTING.value, (method, path))

--- a/ddtrace/internal/runtime/__init__.py
+++ b/ddtrace/internal/runtime/__init__.py
@@ -1,6 +1,9 @@
 import typing as t
 import uuid
 
+from ddtrace.internal.serverless import MICROVM_RUN_HOOK_METHOD
+from ddtrace.internal.serverless import MICROVM_RUN_HOOK_PATH
+from ddtrace.internal.serverless import in_aws_lambda_microvm
 from ddtrace.internal.settings import env
 
 from .. import forksafe
@@ -12,6 +15,8 @@ __all__ = [
     "get_runtime_id",
     "get_parent_runtime_id",
     "get_runtime_propagation_envs",
+    "listen_for_identity_refresh_hooks",
+    "maybe_refresh_identity",
     "refresh_identity",
 ]
 
@@ -89,6 +94,36 @@ def refresh_identity() -> None:
     _refresh_runtime_id()
     for cb in _ON_RUNTIME_IDENTITY_REFRESH:
         cb(_RUNTIME_ID)
+
+
+# Multiple request layers can observe the same /run hook. Refresh identity once per
+# process so a single logical MicroVM instance gets one runtime-id rotation.
+_IDENTITY_REFRESH_HOOK_REFRESHED = forksafe.Event()
+_IDENTITY_REFRESH_HOOK_REFRESH_LOCK = forksafe.Lock()
+
+
+def listen_for_identity_refresh_hooks(
+    on_event: t.Callable[[str, t.Callable[[t.Optional[str], t.Optional[str]], None]], None],
+) -> None:
+    """Refresh MicroVM identity from request events emitted before root span creation."""
+    if not in_aws_lambda_microvm():
+        return
+
+    on_event("web.request.starting", maybe_refresh_identity)
+
+
+def maybe_refresh_identity(method: t.Optional[str], path: t.Optional[str]) -> None:
+    """Call refresh_identity() if this request is the AWS Lambda MicroVM /run hook."""
+    if not method or not path:
+        return
+    if method != MICROVM_RUN_HOOK_METHOD or path != MICROVM_RUN_HOOK_PATH:
+        return
+
+    with _IDENTITY_REFRESH_HOOK_REFRESH_LOCK:
+        if _IDENTITY_REFRESH_HOOK_REFRESHED.is_set():
+            return
+        refresh_identity()
+        _IDENTITY_REFRESH_HOOK_REFRESHED.set()
 
 
 def get_runtime_id() -> str:

--- a/ddtrace/internal/serverless/__init__.py
+++ b/ddtrace/internal/serverless/__init__.py
@@ -3,6 +3,11 @@ from os import path
 from ddtrace.internal.settings import env
 
 
+# Fixed platform request details for the AWS Lambda MicroVM /run lifecycle hook.
+MICROVM_RUN_HOOK_METHOD = "POST"
+MICROVM_RUN_HOOK_PATH = "/aws/lambda-microvms/runtime/v1/run"
+
+
 def in_aws_lambda():
     # type: () -> bool
     """Returns whether the environment is an AWS Lambda.

--- a/releasenotes/notes/aws-lambda-microvm-identity-refresh-3a672cd6bcbad16d.yaml
+++ b/releasenotes/notes/aws-lambda-microvm-identity-refresh-3a672cd6bcbad16d.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    wsgi,asgi: Adds support for refreshing the runtime ID when applications
+    start in AWS Lambda MicroVM environments.

--- a/tests/contrib/asgi/test_asgi.py
+++ b/tests/contrib/asgi/test_asgi.py
@@ -216,6 +216,42 @@ async def test_web_request_starting_dispatch_precedes_span_creation(scope):
     assert events.index("request_starting") < events.index("span")
 
 
+async def test_microvm_run_hook_refreshes_identity(scope):
+    from ddtrace.internal import runtime
+
+    event_name = WebFrameworkEvents.WEB_REQUEST_STARTING.value
+    app = TraceMiddleware(basic_app)
+    scope.update({"method": "POST", "path": "/run", "root_path": "/aws/lambda-microvms/runtime/v1"})
+    runtime._IDENTITY_REFRESH_HOOK_REFRESHED.clear()
+    web.core.reset_listeners(event_name, runtime.maybe_refresh_identity)
+
+    try:
+        with (
+            mock.patch.object(web, "in_aws_lambda_microvm", return_value=True),
+            mock.patch.object(runtime, "in_aws_lambda_microvm", return_value=True),
+        ):
+            runtime.listen_for_identity_refresh_hooks(web.core.on)
+            runtime_id = runtime.get_runtime_id()
+
+            instance = ApplicationCommunicator(app, scope)
+            await instance.send_input({"type": "http.request", "body": b""})
+            await instance.receive_output(1)
+            await instance.receive_output(1)
+
+            refreshed_runtime_id = runtime.get_runtime_id()
+            assert refreshed_runtime_id != runtime_id
+
+            instance = ApplicationCommunicator(app, scope)
+            await instance.send_input({"type": "http.request", "body": b""})
+            await instance.receive_output(1)
+            await instance.receive_output(1)
+
+            assert runtime.get_runtime_id() == refreshed_runtime_id
+    finally:
+        web.core.reset_listeners(event_name, runtime.maybe_refresh_identity)
+        runtime._IDENTITY_REFRESH_HOOK_REFRESHED.clear()
+
+
 @pytest.mark.asyncio
 async def test_basic_asgi(scope, test_spans):
     app = TraceMiddleware(basic_app)

--- a/tests/contrib/wsgi/test_wsgi.py
+++ b/tests/contrib/wsgi/test_wsgi.py
@@ -118,6 +118,37 @@ def test_microvm_dispatches_web_request_starting(tracer, method, path, script_na
         assert request_starting_calls == []
 
 
+def test_microvm_run_hook_refreshes_identity(tracer):
+    from ddtrace.internal import runtime
+
+    event_name = WebFrameworkEvents.WEB_REQUEST_STARTING.value
+    app = TestApp(DDWSGIMiddleware(application, tracer=tracer))
+    runtime._IDENTITY_REFRESH_HOOK_REFRESHED.clear()
+    web.core.reset_listeners(event_name, runtime.maybe_refresh_identity)
+
+    try:
+        with (
+            mock.patch.object(web, "in_aws_lambda_microvm", return_value=True),
+            mock.patch.object(runtime, "in_aws_lambda_microvm", return_value=True),
+        ):
+            runtime.listen_for_identity_refresh_hooks(web.core.on)
+            runtime_id = runtime.get_runtime_id()
+
+            resp = app.post("/run", extra_environ={"SCRIPT_NAME": "/aws/lambda-microvms/runtime/v1"})
+
+            assert resp.status == "200 OK"
+            refreshed_runtime_id = runtime.get_runtime_id()
+            assert refreshed_runtime_id != runtime_id
+
+            resp = app.post("/run", extra_environ={"SCRIPT_NAME": "/aws/lambda-microvms/runtime/v1"})
+
+            assert resp.status == "200 OK"
+            assert runtime.get_runtime_id() == refreshed_runtime_id
+    finally:
+        web.core.reset_listeners(event_name, runtime.maybe_refresh_identity)
+        runtime._IDENTITY_REFRESH_HOOK_REFRESHED.clear()
+
+
 def test_middleware(tracer, test_spans):
     app = TestApp(DDWSGIMiddleware(application, tracer=tracer))
     resp = app.get("/")

--- a/tests/tracer/runtime/test_runtime_id.py
+++ b/tests/tracer/runtime/test_runtime_id.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 
@@ -395,6 +397,234 @@ runtime.refresh_identity()
 assert seen == [runtime.get_runtime_id()]
 """
     _, err, status, _ = run_python_code_in_subprocess(code)
+    assert status == 0, err
+
+
+@pytest.mark.parametrize("auto_enable_crashtracking", [False])
+def test_listen_for_identity_refresh_hooks_noop_does_not_import_core(monkeypatch, auto_enable_crashtracking):
+    import builtins
+
+    import ddtrace.internal.runtime as runtime
+
+    monkeypatch.setattr(runtime, "in_aws_lambda_microvm", lambda: False)
+
+    real_import = builtins.__import__
+
+    def fail_core_import(name, *args, **kwargs):
+        fromlist = kwargs.get("fromlist", ())
+        if len(args) >= 3:
+            fromlist = args[2]
+        if name == "ddtrace.internal" and "core" in fromlist:
+            raise AssertionError("listen_for_identity_refresh_hooks() imported core outside a MicroVM")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_core_import)
+
+    runtime.listen_for_identity_refresh_hooks(lambda _event, _callback: None)
+
+
+def test_web_request_starting_event_name_is_shared_with_contrib_event():
+    from ddtrace.contrib._events.web_framework import WebFrameworkEvents
+
+    assert "web.request.starting" == WebFrameworkEvents.WEB_REQUEST_STARTING.value
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12"}, err=None)
+def test_import_ddtrace_in_microvm_environment():
+    """MicroVM hook registration must not import contrib before ddtrace.config exists."""
+    import ddtrace
+
+    assert ddtrace.config is not None
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": None, "_DD_GLOBAL_TRACER_INIT": "false"}, err=None)
+def test_import_ddtrace_outside_microvm_does_not_import_core():
+    """Normal ddtrace imports do not load the event core needed only by MicroVM hooks."""
+    import sys
+
+    import ddtrace  # noqa: F401
+
+    assert "ddtrace.internal.core" not in sys.modules
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12"}, err=None)
+def test_maybe_refresh_identity_matches_microvm_run_hook():
+    """Only the exact AWS Lambda MicroVM /run hook request triggers a refresh."""
+    import ddtrace.internal.runtime as runtime
+
+    runtime_id = runtime.get_runtime_id()
+
+    runtime.maybe_refresh_identity(runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH)
+
+    refreshed_runtime_id = runtime.get_runtime_id()
+    assert refreshed_runtime_id != runtime_id
+
+    runtime.maybe_refresh_identity(runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH)
+
+    assert runtime.get_runtime_id() == refreshed_runtime_id
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12"}, err=None)
+def test_identity_refresh_hook_runs_before_root_span_creation():
+    """The pre-request hook must refresh runtime-id before a web root span reads it."""
+    from ddtrace import tracer
+    from ddtrace.contrib._events.web_framework import WebFrameworkEvents
+    from ddtrace.internal import core
+    import ddtrace.internal.runtime as runtime
+
+    runtime_id = runtime.get_runtime_id()
+    core.dispatch(
+        WebFrameworkEvents.WEB_REQUEST_STARTING.value, (runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH)
+    )
+
+    refreshed_runtime_id = runtime.get_runtime_id()
+    assert refreshed_runtime_id != runtime_id
+
+    with tracer.trace("web.request") as span:
+        assert span.get_tag("runtime-id") == refreshed_runtime_id
+
+    core.dispatch(
+        WebFrameworkEvents.WEB_REQUEST_STARTING.value, (runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH)
+    )
+
+    assert runtime.get_runtime_id() == refreshed_runtime_id
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12"}, err=None)
+def test_maybe_refresh_identity_is_thread_safe():
+    """Concurrent observations of the same /run hook refresh identity once."""
+    import threading
+    import time
+
+    import ddtrace.internal.runtime as runtime
+
+    calls = []
+
+    def refresh_identity():
+        calls.append(1)
+        time.sleep(0.01)
+
+    runtime.refresh_identity = refresh_identity
+
+    workers = 16
+    barrier = threading.Barrier(workers)
+    errors = []
+    threads = []
+
+    def refresh_from_request_layer():
+        try:
+            barrier.wait()
+            runtime.maybe_refresh_identity(runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH)
+        except Exception as e:
+            errors.append(e)
+
+    for _ in range(workers):
+        thread = threading.Thread(target=refresh_from_request_layer)
+        thread.start()
+        threads.append(thread)
+
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert len(calls) == 1
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12"}, err=None)
+def test_maybe_refresh_identity_retries_after_refresh_failure():
+    """A failed identity refresh must not make later /run hooks no-op."""
+    import pytest
+
+    import ddtrace.internal.runtime as runtime
+
+    calls = []
+
+    def refresh_identity():
+        calls.append(1)
+        if len(calls) == 1:
+            raise RuntimeError("identity refresh failed")
+
+    runtime.refresh_identity = refresh_identity
+
+    with pytest.raises(RuntimeError, match="identity refresh failed"):
+        runtime.maybe_refresh_identity(runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH)
+
+    runtime.maybe_refresh_identity(runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH)
+
+    assert len(calls) == 2
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12"}, err=None)
+def test_microvm_refresh_guard_resets_after_fork():
+    """A child process must not inherit a locked or already-refreshed MicroVM guard."""
+    from ddtrace.internal import forksafe
+    import ddtrace.internal.runtime as runtime
+
+    runtime._IDENTITY_REFRESH_HOOK_REFRESH_LOCK.acquire()
+    runtime._IDENTITY_REFRESH_HOOK_REFRESHED.set()
+
+    forksafe.ddtrace_after_in_child()
+
+    assert runtime._IDENTITY_REFRESH_HOOK_REFRESH_LOCK.acquire(False)
+    assert not runtime._IDENTITY_REFRESH_HOOK_REFRESHED.is_set()
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12"}, err=None)
+def test_maybe_refresh_identity_ignores_other_requests():
+    """A different method/path, or the /resume hook, must not trigger a refresh."""
+    import ddtrace.internal.runtime as runtime
+
+    runtime_id = runtime.get_runtime_id()
+
+    runtime.maybe_refresh_identity("GET", runtime.MICROVM_RUN_HOOK_PATH)
+    runtime.maybe_refresh_identity(runtime.MICROVM_RUN_HOOK_METHOD, "/aws/lambda-microvms/runtime/v1/resume")
+    runtime.maybe_refresh_identity(runtime.MICROVM_RUN_HOOK_METHOD, "/some/other/path")
+    runtime.maybe_refresh_identity(None, runtime.MICROVM_RUN_HOOK_PATH)
+    runtime.maybe_refresh_identity(runtime.MICROVM_RUN_HOOK_METHOD, None)
+
+    assert runtime.get_runtime_id() == runtime_id
+
+
+@pytest.mark.subprocess(env={"AWS_LAMBDA_MICROVM_IMAGE_ARN": None}, err=None)
+def test_listen_for_identity_refresh_hooks_noop_outside_microvm():
+    """Outside a MicroVM, do not register the request-event listener."""
+    from ddtrace.contrib._events.web_framework import WebFrameworkEvents
+    from ddtrace.internal import core
+    import ddtrace.internal.runtime as runtime
+
+    core.reset_listeners(WebFrameworkEvents.WEB_REQUEST_STARTING.value)
+    runtime.listen_for_identity_refresh_hooks(core.on)
+
+    runtime_id = runtime.get_runtime_id()
+
+    core.dispatch(
+        WebFrameworkEvents.WEB_REQUEST_STARTING.value, (runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH)
+    )
+
+    assert runtime.get_runtime_id() == runtime_id
+
+
+@pytest.mark.parametrize("microvm_image_arn", ["", "   "])
+def test_listen_for_identity_refresh_hooks_noop_for_blank_microvm_env(run_python_code_in_subprocess, microvm_image_arn):
+    """Blank MicroVM image ARN env values must not enable hook registration."""
+    code = """
+from ddtrace.contrib._events.web_framework import WebFrameworkEvents
+from ddtrace.internal import core
+import ddtrace.internal.runtime as runtime
+
+core.reset_listeners(WebFrameworkEvents.WEB_REQUEST_STARTING.value)
+runtime.listen_for_identity_refresh_hooks(core.on)
+
+runtime_id = runtime.get_runtime_id()
+core.dispatch(
+    WebFrameworkEvents.WEB_REQUEST_STARTING.value, (runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH)
+)
+
+assert runtime.get_runtime_id() == runtime_id
+"""
+    env = os.environ.copy()
+    env["AWS_LAMBDA_MICROVM_IMAGE_ARN"] = microvm_image_arn
+    _, err, status, _ = run_python_code_in_subprocess(code, env=env)
     assert status == 0, err
 
 


### PR DESCRIPTION
Stacked PRs:
- #19778 — runtime identity foundation
  - #19898 — WSGI/ASGI request-start hook
    - 👉 This PR #19939 — central MicroVM /run identity refresh
      - #19820 — tracer/native writer exporter refresh
        - #19821 — telemetry worker refresh
          - #19822 — runtime metrics runtime-id tags

## Description

The runtime ID is created when ddtrace imports. In Lambda MicroVMs, the same Python process can be reused for a fresh logical runtime after the platform sends the /run request, so import-time identity is not enough.

This change registers a guarded listener for web.request.starting, matches the exact POST /aws/lambda-microvms/runtime/v1/run request, and refreshes identity once per process. The refresh does not record fork lineage and notifies the explicit identity-refresh subscribers used by downstream consumers.

## Testing

Added coverage for:

- exact MicroVM /run request matching and one-shot refresh behavior
- non-MicroVM import and listener behavior
- refresh ordering before root span creation
- WSGI and ASGI request-hook integration
- preserving fork lineage semantics

Validation included lint, compile, and focused MicroVM identity tests.

## Risks

Runtime identity refresh timing changes only in the AWS Lambda MicroVM /run path; regular non-MicroVM paths remain unchanged.
