### PR TITLE
refactor: encapsulate ddtest code for easy removal

### DIFF
--- a/scripts/ddtest_jobs.py
+++ b/scripts/ddtest_jobs.py
@@ -1,0 +1,241 @@
+"""ddtest job emission for gen_gitlab_config.py.
+
+All ddtest-specific logic is encapsulated here so that removing ddtest support
+is a simple matter of deleting this file and reverting the import + call sites
+in gen_gitlab_config.py, the ddtest templates in .gitlab/tests.yml, and the
+ddtest: true flags in suitespec.yml.
+
+Functions:
+  - validate_ddtest_venv_test_locations: reject suites without DDTEST_TESTS_LOCATION
+  - ddtest_k: read per-venv CI node count from suitespec
+  - emit_ddtest_jobs: emit plan + run jobs for one ddtest suite
+"""
+
+import typing as t
+
+
+def _get_bool_env(name: str) -> str:
+    """Return "true"/"false" for a boolean environment variable."""
+    import logging
+    import os
+
+    LOGGER = logging.getLogger(__name__)
+    value = os.getenv(name, "").lower()
+    if value not in ("", "true", "false"):
+        LOGGER.warning("Ignoring unexpected value for %s, treating it as false", name)
+    return "true" if value == "true" else "false"
+
+
+def validate_ddtest_venv_test_locations(suite: str, info) -> None:
+    """Reject ddtest suites whose matched venvs do not declare a test location."""
+    missing = [h for h, _py in (info.venvs or []) if not (info.venv_test_locations or {}).get(h)]
+    if missing:
+        raise ValueError(f"ddtest suite {suite} has venvs without DDTEST_TESTS_LOCATION: {', '.join(missing)}")
+
+
+def ddtest_k(config: dict) -> int:
+    """Per-venv CI node count K for a ddtest suite.
+
+    K controls file splitting WITHIN a venv (a different axis from the
+    legacy parallelism/venvs_per_job, which controlled venv PACKING — how
+    many venvs per CI job). ddtest already fans out one job per venv via the
+    parallel matrix; K further splits each venv's files across K CI
+    nodes.
+
+    K=1 (default): each venv runs all its files in one job (closest to
+    legacy semantics, where each job ran all files for its venv). K=2:
+    each venv's files split into 2 groups → 2x jobs per venv.
+
+    A suite can override K with a `ddtest_nodes` suitespec key. If not
+    set, K defaults to 1 (no file splitting). The legacy `parallelism`/
+    `venvs_per_job` knobs are NOT used for K — they controlled venv packing,
+    a different axis.
+    """
+    k = config.get("ddtest_nodes")
+    if k is None or k < 1:
+        k = 1
+    return int(k)
+
+
+def _ddtest_base(snapshot: bool, gpu: bool) -> str:
+    """Return the hidden base template a ddtest suite's before_script references."""
+    base = ".ddtest_base"
+    if gpu:
+        base += "_gpu"
+    if snapshot:
+        base += "_snapshot"
+    return base
+
+
+def _ddtest_plan_template(gpu: bool) -> str:
+    """Plan template. Plan only collects (glob + Datadog API); it sends
+    no traces, so it never needs the testagent and has no snapshot
+    variant — snapshot suites and non-snapshot suites plan the same way.
+    """
+    tpl = ".ddtest_plan"
+    if gpu:
+        tpl += "_gpu"
+    return tpl
+
+
+def _ddtest_run_template(snapshot: bool, gpu: bool) -> str:
+    tpl = ".ddtest_run"
+    if gpu:
+        tpl += "_gpu"
+    if snapshot:
+        tpl += "_snapshot"
+    return tpl
+
+
+def emit_ddtest_jobs(
+    f,
+    suite: str,
+    stage: str,
+    clean_name: str,
+    config: dict,
+    venvs: list[tuple[str, str]],
+    k: int,
+) -> None:
+    """Emit ddtest-plan and ddtest-run jobs for one suite.
+
+    One plan job loops over all suite venvs. Run jobs are emitted per Python
+    version, with a parallel matrix over that version's hashes and
+    CI_NODE_INDEX. The plan partitions its artifact by hash so run jobs can
+    restore only their own plan.
+    """
+    snapshot = config.get("snapshot", False)
+    gpu = config.get("gpu", False)
+    services = list(dict.fromkeys(config.get("services") or []))
+    env = dict(config.get("env") or {})
+    retry = config.get("retry")
+    timeout = config.get("timeout")
+    allow_failure = config.get("allow_failure", False)
+    base = _ddtest_base(snapshot, gpu)
+    plan_base = _ddtest_base(False, gpu)  # plan never needs the testagent
+    plan_tpl = _ddtest_plan_template(gpu)
+    run_tpl = _ddtest_run_template(snapshot, gpu)
+    job_prefix = f"{stage}/{clean_name.replace('::', '/')}"
+    plan_name = f"{job_prefix}::ddtest-plan"
+    run_name = f"{job_prefix}::ddtest-run"
+    suite_name = config.get("pattern") or clean_name
+    wait_for = list(services)
+    if snapshot:
+        wait_for.append("testagent")
+
+    def emit_services(plan: bool) -> None:
+        if not services:
+            return
+        print("  services:", file=f)
+        svc_base = plan_base if plan else base
+        _svc = [f"!reference [.services, {s}]" for s in services]
+        if snapshot and not plan:
+            _svc.insert(0, f"!reference [{svc_base}, services]")
+        for s in _svc:
+            print(f"    - {s}", file=f)
+
+    def emit_before_script(plan: bool) -> None:
+        print("  before_script:", file=f)
+        ref_base = plan_base if plan else base
+        print(f"    - !reference [{ref_base}, before_script]", file=f)
+        print("    - pip cache info", file=f)
+        print(f'    - export NIGHTLY_BUILD="{_get_bool_env("NIGHTLY_BUILD")}"', file=f)
+        # Plan only collects; it sends no traces, so it never waits for the
+        # testagent even for snapshot suites.
+        if wait_for and not plan:
+            print(f"    - riot -v run -s --pass-env wait -- {' '.join(wait_for)}", file=f)
+
+    def emit_variables(extra: t.Optional[dict[str, str]] = None) -> None:
+        print("  variables:", file=f)
+        print(f"    SUITE_NAME: {suite_name}", file=f)
+        for key, value in env.items():
+            print(f"    {key}: {value}", file=f)
+        if extra:
+            for key, value in extra.items():
+                print(f"    {key}: {value}", file=f)
+
+    def emit_needs_ddtest_build() -> None:
+        print("    - job: ddtest-build", file=f)
+        print("      artifacts: true", file=f)
+
+    def emit_needs_build_base_venvs(needed_venvs: list[tuple[str, str]]) -> None:
+        print("    - job: build_base_venvs", file=f)
+        print("      artifacts: true", file=f)
+        print("      parallel:", file=f)
+        print("        matrix:", file=f)
+        # Dedup PYTHON_VERSIONs: several hashes share a Python version, but
+        # build_base_venvs only needs to be downloaded once per version.
+        seen_py: set[str] = set()
+        for _h, py in needed_venvs:
+            if py in seen_py:
+                continue
+            seen_py.add(py)
+            print(f'          - PYTHON_VERSION: "{py}"', file=f)
+
+    # ---- plan job: single job per suite (groups hashes by Python version) ----
+    # One plan job per suite (not per venv) to reduce CI runner contention.
+    # The job prepares and plans hashes in parallel across Python versions,
+    # partitioning the plan artifact by hash.
+    print(f"{plan_name}:", file=f)
+    print(f"  extends: {plan_tpl}", file=f)
+    print(f"  stage: {stage}", file=f)
+    print("  needs:", file=f)
+    print("    - prechecks", file=f)
+    emit_needs_build_base_venvs(venvs)
+    emit_needs_ddtest_build()
+    emit_services(plan=True)
+    emit_before_script(plan=True)
+    riot_hashes = " ".join(h for h, _ in venvs)
+    emit_variables(
+        {
+            "DDTEST_NODES": str(k),
+            "RIOT_HASHES": riot_hashes,
+            "RIOT_HASH_PYTHON": " ".join(f"{h}:{py}" for h, py in venvs),
+            "DD_TEST_OPTIMIZATION_RUNNER_COMMAND": "pytest",
+        }
+    )
+    if retry is not None:
+        print(f"  retry: {retry}", file=f)
+    if timeout is not None:
+        print(f"  timeout: {timeout}", file=f)
+    if allow_failure:
+        print("  allow_failure: true", file=f)
+    # artifacts (.testoptimization-*/) are declared on the .ddtest_plan template.
+
+    # ---- run jobs: K instances per venv, grouped by Python version ----
+    # Matrix expressions are not available on all GitLab versions used by CI,
+    # so emit one run job per Python version instead of dynamically matching a
+    # need from the run matrix. This keeps each run job's artifact download
+    # limited to its own build_base_venvs matrix entry.
+    venvs_by_py: dict[str, list[tuple[str, str]]] = {}
+    for venv in venvs:
+        venvs_by_py.setdefault(venv[1], []).append(venv)
+
+    for py, py_venvs in venvs_by_py.items():
+        py_run_name = f"{run_name}-{py}"
+        print(f"{py_run_name}:", file=f)
+        print(f"  extends: {run_tpl}", file=f)
+        print(f"  stage: {stage}", file=f)
+        print("  needs:", file=f)
+        print("    - prechecks", file=f)
+        emit_needs_build_base_venvs(py_venvs)
+        emit_needs_ddtest_build()
+        # Each run downloads the single plan artifact (which contains all
+        # hashes' plans, partitioned by hash) and restores its own hash's plan.
+        print("    - job: " + plan_name, file=f)
+        print("      artifacts: true", file=f)
+        emit_services(plan=False)
+        emit_before_script(plan=False)
+        emit_variables({"DD_TEST_OPTIMIZATION_RUNNER_COMMAND": "pytest"})
+        print("  parallel:", file=f)
+        print("    matrix:", file=f)
+        for h, _py in py_venvs:
+            for node in range(k):
+                print(f'      - RIOT_HASH: "{h}"', file=f)
+                print(f'        PYTHON_VERSION: "{py}"', file=f)
+                print(f"        CI_NODE_INDEX: {node}", file=f)
+        if retry is not None:
+            print(f"  retry: {retry}", file=f)
+        if timeout is not None:
+            print(f"  timeout: {timeout}", file=f)
+        if allow_failure:
+            print("  allow_failure: true", file=f)

--- a/scripts/gen_gitlab_config.py
+++ b/scripts/gen_gitlab_config.py
@@ -21,14 +21,19 @@ from collections import defaultdict
 from dataclasses import dataclass
 import datetime
 import hashlib
+
+# ddtest job emission is encapsulated in ddtest_jobs.py (same directory).
+# This script runs via uv-run-script; scripts/ is added to sys.path later
+# (line 884), so use a deferred import to avoid ModuleNotFoundError at top level.
+import importlib as _importlib
 import os
 import re
 import subprocess
 import typing as t
 
-from scripts.ddtest_jobs import ddtest_k
-from scripts.ddtest_jobs import emit_ddtest_jobs
-from scripts.ddtest_jobs import validate_ddtest_venv_test_locations
+
+def _ddtest_module():
+    return _importlib.import_module("ddtest_jobs")
 
 
 MAX_BENCHMARKS_PER_GROUP = 2
@@ -522,7 +527,7 @@ def _gen_tests(suites: dict, required_suites: list[str]) -> None:
     for suite in non_skipped:
         if not suites[suite].get("ddtest") or suite not in suite_venv_info:
             continue
-        validate_ddtest_venv_test_locations(suite, suite_venv_info[suite])
+        _ddtest_module().validate_ddtest_venv_test_locations(suite, suite_venv_info[suite])
 
     # Populate the module-level global so gen_build_base_venvs can use it
     _global_python_versions = set()
@@ -586,9 +591,9 @@ def _gen_tests(suites: dict, required_suites: list[str]) -> None:
                 if not venvs:
                     LOGGER.warning("Suite %s opted into ddtest but has no riot venvs; skipping", suite)
                     continue
-                k = ddtest_k(suite_config)
+                k = _ddtest_module().ddtest_k(suite_config)
                 LOGGER.info("Suite %s: ddtest (venvs=%d, nodes/venv=%d)", suite, len(venvs), k)
-                emit_ddtest_jobs(f, suite, stage, clean_name, suite_config, venvs, k)
+                _ddtest_module().emit_ddtest_jobs(f, suite, stage, clean_name, suite_config, venvs, k)
                 continue
 
             jobspec = JobSpec(clean_name, stage=stage, python_versions=py_versions, **suite_config)

--- a/scripts/gen_gitlab_config.py
+++ b/scripts/gen_gitlab_config.py
@@ -26,6 +26,10 @@ import re
 import subprocess
 import typing as t
 
+from scripts.ddtest_jobs import ddtest_k
+from scripts.ddtest_jobs import emit_ddtest_jobs
+from scripts.ddtest_jobs import validate_ddtest_venv_test_locations
+
 
 MAX_BENCHMARKS_PER_GROUP = 2
 BENCHMARK_CLASS_REGEX = r"class ([A-Za-z]+)\((bm\.)?Scenario(.+)?\)\:"
@@ -255,13 +259,6 @@ def collect_all_suite_venv_info(suite_patterns: dict[str, str]) -> dict[str, Sui
     return result
 
 
-def _validate_ddtest_venv_test_locations(suite: str, info: SuiteVenvInfo) -> None:
-    """Reject ddtest suites whose matched venvs do not declare a test location."""
-    missing = [h for h, _py in (info.venvs or []) if not (info.venv_test_locations or {}).get(h)]
-    if missing:
-        raise ValueError(f"ddtest suite {suite} has venvs without DDTEST_TESTS_LOCATION: {', '.join(missing)}")
-
-
 def calculate_parallelism_from_venvs(venv_count: int, venvs_per_job: int, max_parallelism: int = 25) -> int:
     """Calculate parallelism given a venv count and venvs_per_job packing density."""
     import math
@@ -479,214 +476,6 @@ def _filter_benchmarks_slos_file(classnames: list) -> None:
     MICROBENCHMARKS_SLOS.write_text("\n".join(new_contents))
 
 
-def _ddtest_base(snapshot: bool, gpu: bool) -> str:
-    """Return the hidden base template a ddtest suite's before_script references."""
-    base = ".ddtest_base"
-    if gpu:
-        base += "_gpu"
-    if snapshot:
-        base += "_snapshot"
-    return base
-
-
-def _ddtest_plan_template(gpu: bool) -> str:
-    """Plan template. Plan only collects (glob + Datadog API); it sends
-    no traces, so it never needs the testagent and has no snapshot
-    variant — snapshot suites and non-snapshot suites plan the same way.
-    """
-    tpl = ".ddtest_plan"
-    if gpu:
-        tpl += "_gpu"
-    return tpl
-
-
-def _ddtest_run_template(snapshot: bool, gpu: bool) -> str:
-    tpl = ".ddtest_run"
-    if gpu:
-        tpl += "_gpu"
-    if snapshot:
-        tpl += "_snapshot"
-    return tpl
-
-
-def _ddtest_k(config: dict) -> int:
-    """Per-venv CI node count K for a ddtest suite.
-
-    K controls file splitting WITHIN a venv (a different axis from the
-    legacy parallelism/venvs_per_job, which controlled venv PACKING — how
-    many venvs per CI job). ddtest already fans out one job per venv via the
-    parallel matrix; K further splits each venv's files across K CI
-    nodes.
-
-    K=1 (default): each venv runs all its files in one job (closest to
-    legacy semantics, where each job ran all files for its venv). K=2:
-    each venv's files split into 2 groups → 2x jobs per venv.
-
-    A suite can override K with a `ddtest_nodes` suitespec key. If not
-    set, K defaults to 1 (no file splitting). The legacy `parallelism`/
-    `venvs_per_job` knobs are NOT used for K — they controlled venv packing,
-    a different axis.
-    """
-    k = config.get("ddtest_nodes")
-    if k is None or k < 1:
-        k = 1
-    return int(k)
-
-
-def _emit_ddtest_jobs(
-    f,
-    suite: str,
-    stage: str,
-    clean_name: str,
-    config: dict,
-    venvs: list[tuple[str, str]],
-    k: int,
-) -> None:
-    """Emit ddtest-plan and ddtest-run jobs for one suite.
-
-    One plan job loops over all suite venvs. Run jobs are emitted per Python
-    version, with a parallel matrix over that version's hashes and
-    CI_NODE_INDEX. The plan partitions its artifact by hash so run jobs can
-    restore only their own plan.
-    """
-    snapshot = config.get("snapshot", False)
-    gpu = config.get("gpu", False)
-    services = list(dict.fromkeys(config.get("services") or []))
-    env = dict(config.get("env") or {})
-    retry = config.get("retry")
-    timeout = config.get("timeout")
-    allow_failure = config.get("allow_failure", False)
-    base = _ddtest_base(snapshot, gpu)
-    plan_base = _ddtest_base(False, gpu)  # plan never needs the testagent
-    plan_tpl = _ddtest_plan_template(gpu)
-    run_tpl = _ddtest_run_template(snapshot, gpu)
-    job_prefix = f"{stage}/{clean_name.replace('::', '/')}"
-    plan_name = f"{job_prefix}::ddtest-plan"
-    run_name = f"{job_prefix}::ddtest-run"
-    suite_name = config.get("pattern") or clean_name
-    wait_for = list(services)
-    if snapshot:
-        wait_for.append("testagent")
-
-    def emit_services(plan: bool) -> None:
-        if not services:
-            return
-        print("  services:", file=f)
-        svc_base = plan_base if plan else base
-        _svc = [f"!reference [.services, {s}]" for s in services]
-        if snapshot and not plan:
-            _svc.insert(0, f"!reference [{svc_base}, services]")
-        for s in _svc:
-            print(f"    - {s}", file=f)
-
-    def emit_before_script(plan: bool) -> None:
-        print("  before_script:", file=f)
-        ref_base = plan_base if plan else base
-        print(f"    - !reference [{ref_base}, before_script]", file=f)
-        print("    - pip cache info", file=f)
-        print(f'    - export NIGHTLY_BUILD="{_get_bool_env("NIGHTLY_BUILD")}"', file=f)
-        # Plan only collects; it sends no traces, so it never waits for the
-        # testagent even for snapshot suites.
-        if wait_for and not plan:
-            print(f"    - riot -v run -s --pass-env wait -- {' '.join(wait_for)}", file=f)
-
-    def emit_variables(extra: t.Optional[dict[str, str]] = None) -> None:
-        print("  variables:", file=f)
-        print(f"    SUITE_NAME: {suite_name}", file=f)
-        for key, value in env.items():
-            print(f"    {key}: {value}", file=f)
-        if extra:
-            for key, value in extra.items():
-                print(f"    {key}: {value}", file=f)
-
-    def emit_needs_ddtest_build() -> None:
-        print("    - job: ddtest-build", file=f)
-        print("      artifacts: true", file=f)
-
-    def emit_needs_build_base_venvs(needed_venvs: list[tuple[str, str]]) -> None:
-        print("    - job: build_base_venvs", file=f)
-        print("      artifacts: true", file=f)
-        print("      parallel:", file=f)
-        print("        matrix:", file=f)
-        # Dedup PYTHON_VERSIONs: several hashes share a Python version, but
-        # build_base_venvs only needs to be downloaded once per version.
-        seen_py: set[str] = set()
-        for _h, py in needed_venvs:
-            if py in seen_py:
-                continue
-            seen_py.add(py)
-            print(f'          - PYTHON_VERSION: "{py}"', file=f)
-
-    # ---- plan job: single job per suite (groups hashes by Python version) ----
-    # One plan job per suite (not per venv) to reduce CI runner contention.
-    # The job prepares and plans hashes in parallel across Python versions,
-    # partitioning the plan artifact by hash.
-    print(f"{plan_name}:", file=f)
-    print(f"  extends: {plan_tpl}", file=f)
-    print(f"  stage: {stage}", file=f)
-    print("  needs:", file=f)
-    print("    - prechecks", file=f)
-    emit_needs_build_base_venvs(venvs)
-    emit_needs_ddtest_build()
-    emit_services(plan=True)
-    emit_before_script(plan=True)
-    riot_hashes = " ".join(h for h, _ in venvs)
-    emit_variables(
-        {
-            "DDTEST_NODES": str(k),
-            "RIOT_HASHES": riot_hashes,
-            "RIOT_HASH_PYTHON": " ".join(f"{h}:{py}" for h, py in venvs),
-            "DD_TEST_OPTIMIZATION_RUNNER_COMMAND": "pytest",
-        }
-    )
-    if retry is not None:
-        print(f"  retry: {retry}", file=f)
-    if timeout is not None:
-        print(f"  timeout: {timeout}", file=f)
-    if allow_failure:
-        print("  allow_failure: true", file=f)
-    # artifacts (.testoptimization-*/) are declared on the .ddtest_plan template.
-
-    # ---- run jobs: K instances per venv, grouped by Python version ----
-    # Matrix expressions are not available on all GitLab versions used by CI,
-    # so emit one run job per Python version instead of dynamically matching a
-    # need from the run matrix. This keeps each run job's artifact download
-    # limited to its own build_base_venvs matrix entry.
-    venvs_by_py: dict[str, list[tuple[str, str]]] = {}
-    for venv in venvs:
-        venvs_by_py.setdefault(venv[1], []).append(venv)
-
-    for py, py_venvs in venvs_by_py.items():
-        py_run_name = f"{run_name}-{py}"
-        print(f"{py_run_name}:", file=f)
-        print(f"  extends: {run_tpl}", file=f)
-        print(f"  stage: {stage}", file=f)
-        print("  needs:", file=f)
-        print("    - prechecks", file=f)
-        emit_needs_build_base_venvs(py_venvs)
-        emit_needs_ddtest_build()
-        # Each run downloads the single plan artifact (which contains all
-        # hashes' plans, partitioned by hash) and restores its own hash's plan.
-        print("    - job: " + plan_name, file=f)
-        print("      artifacts: true", file=f)
-        emit_services(plan=False)
-        emit_before_script(plan=False)
-        emit_variables({"DD_TEST_OPTIMIZATION_RUNNER_COMMAND": "pytest"})
-        print("  parallel:", file=f)
-        print("    matrix:", file=f)
-        for h, _py in py_venvs:
-            for node in range(k):
-                print(f'      - RIOT_HASH: "{h}"', file=f)
-                print(f'        PYTHON_VERSION: "{py}"', file=f)
-                print(f"        CI_NODE_INDEX: {node}", file=f)
-        if retry is not None:
-            print(f"  retry: {retry}", file=f)
-        if timeout is not None:
-            print(f"  timeout: {timeout}", file=f)
-        if allow_failure:
-            print("  allow_failure: true", file=f)
-
-
 def _gen_tests(suites: dict, required_suites: list[str]) -> None:
     global _global_python_versions
 
@@ -733,7 +522,7 @@ def _gen_tests(suites: dict, required_suites: list[str]) -> None:
     for suite in non_skipped:
         if not suites[suite].get("ddtest") or suite not in suite_venv_info:
             continue
-        _validate_ddtest_venv_test_locations(suite, suite_venv_info[suite])
+        validate_ddtest_venv_test_locations(suite, suite_venv_info[suite])
 
     # Populate the module-level global so gen_build_base_venvs can use it
     _global_python_versions = set()
@@ -797,9 +586,9 @@ def _gen_tests(suites: dict, required_suites: list[str]) -> None:
                 if not venvs:
                     LOGGER.warning("Suite %s opted into ddtest but has no riot venvs; skipping", suite)
                     continue
-                k = _ddtest_k(suite_config)
+                k = ddtest_k(suite_config)
                 LOGGER.info("Suite %s: ddtest (venvs=%d, nodes/venv=%d)", suite, len(venvs), k)
-                _emit_ddtest_jobs(f, suite, stage, clean_name, suite_config, venvs, k)
+                emit_ddtest_jobs(f, suite, stage, clean_name, suite_config, venvs, k)
                 continue
 
             jobspec = JobSpec(clean_name, stage=stage, python_versions=py_versions, **suite_config)

--- a/tests/_ddtest_conftest_helpers.py
+++ b/tests/_ddtest_conftest_helpers.py
@@ -1,0 +1,38 @@
+"""ddtest-specific conftest helpers.
+
+Encapsulates the _DD_PYTEST_XDIST_INFERRED_SERVICE handling so that
+removing ddtest support is a simple matter of deleting this file and
+reverting the import + call site in tests/conftest.py.
+"""
+
+import os
+import sys
+
+
+def pop_and_seed_inferred_service():
+    """Pop _DD_PYTEST_XDIST_INFERRED_SERVICE and seed the detect_service cache.
+
+    Consumed by detect_service() during ddtrace import; unset now so
+    it doesn't leak into tests (e.g. unit tests that call detect_service directly).
+
+    Save it so pytest_configure can propagate the correct value to xdist workers
+    (the suitespec may set this to the suite-level service, e.g. tests.tracer;
+    detect_service(sys.argv) under ddtest would pick the first file's subpackage).
+
+    Seed the detect_service cache so subsequent Config() calls in tests return
+    the same service as import time. Without this, detect_service(sys.argv) in
+    a test would re-compute from sys.argv (which under ddtest has individual
+    files, yielding a subpackage like tests.tracer.runtime instead of
+    tests.tracer). Under riot CI xdist workers (sys.argv=['-c']), the natural
+    result is None, so we only seed when the env var differs from the natural
+    result — this avoids breaking tests that expect config.service is None.
+    """
+    _inferred_service_env = os.environ.pop("_DD_PYTEST_XDIST_INFERRED_SERVICE", None)
+    if _inferred_service_env:
+        from ddtrace.internal.settings._inferred_base_service import CACHE as _detect_service_cache
+        from ddtrace.internal.settings._inferred_base_service import detect_service as _detect_service
+
+        _natural = _detect_service(sys.argv)
+        if _natural != _inferred_service_env:
+            _detect_service_cache[tuple(sorted(sys.argv))] = _inferred_service_env
+    return _inferred_service_env

--- a/tests/_ddtest_env_helpers.py
+++ b/tests/_ddtest_env_helpers.py
@@ -1,0 +1,28 @@
+"""ddtest-specific environment helpers for test subprocesses.
+
+Encapsulates env var stripping so that removing ddtest support is a simple
+matter of deleting this file and reverting the import + call site in
+tests/utils.py.
+"""
+
+# PYTEST_ADDOPTS is set to "--ddtrace" by ddtest's platform env (ddtest/internal/
+# platform/python.go:GetPlatformEnv) so the pytest workers load the ddtrace
+# testing plugin. It leaks into every test-spawned subprocess via env
+# inheritance. Under normal riot CI this var is absent, so test subprocesses
+# don't activate CI Visibility. The leaked --ddtrace makes a nested
+# pytest.main() enable the plugin, which logs INFO to stderr (breaking tests
+# that assert err == b"") and computes stats (breaking snapshot tests). No
+# test sets PYTEST_ADDOPTS via call_program's env kwarg, so stripping it here
+# is safe. (ddtest's main.go also sets DD_CIVISIBILITY_ENABLED=1 globally, but
+# that var is inert on its own — the pytest plugin needs --ddtrace to activate
+# — so stripping PYTEST_ADDOPTS is sufficient to keep subprocesses
+# CI-Visibility-free.)
+_DDTEST_LEAKED_ENV_VARS = ("PYTEST_ADDOPTS",)
+
+
+def strip_ddtest_leaked_env(env):
+    """Remove env vars leaked from the ddtest parent worker."""
+    env = dict(env)
+    for key in _DDTEST_LEAKED_ENV_VARS:
+        env.pop(key, None)
+    return env

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,27 +32,17 @@ import pytest
 
 import ddtrace
 
-
 # DEV: Consumed by detect_service() during ddtrace import above; unset now so
 # it doesn't leak into tests (e.g. unit tests that call detect_service directly).
 # Save it so pytest_configure can propagate the correct value to xdist workers
 # (the suitespec may set this to the suite-level service, e.g. tests.tracer;
 # detect_service(sys.argv) under ddtest would pick the first file's subpackage).
-_inferred_service_env = os.environ.pop("_DD_PYTEST_XDIST_INFERRED_SERVICE", None)
-# Seed the detect_service cache so subsequent Config() calls in tests return
-# the same service as import time. Without this, detect_service(sys.argv) in
-# a test would re-compute from sys.argv (which under ddtest has individual
-# files, yielding a subpackage like tests.tracer.runtime instead of
-# tests.tracer). Under riot CI xdist workers (sys.argv=['-c']), the natural
-# result is None, so we only seed when the env var differs from the natural
-# result — this avoids breaking tests that expect config.service is None.
-if _inferred_service_env:
-    from ddtrace.internal.settings._inferred_base_service import CACHE as _detect_service_cache
-    from ddtrace.internal.settings._inferred_base_service import detect_service as _detect_service
+# All ddtest-specific logic is in _ddtest_conftest_helpers so it can be removed
+# cleanly if ddtest support is dropped.
+from tests._ddtest_conftest_helpers import pop_and_seed_inferred_service
 
-    _natural = _detect_service(sys.argv)
-    if _natural != _inferred_service_env:
-        _detect_service_cache[tuple(sorted(sys.argv))] = _inferred_service_env
+
+_inferred_service_env = pop_and_seed_inferred_service()
 
 
 from ddtrace._trace.provider import _DD_CONTEXTVAR

--- a/tests/internal/test_gen_gitlab_config.py
+++ b/tests/internal/test_gen_gitlab_config.py
@@ -82,13 +82,13 @@ def test_ddtest_requires_a_test_path_for_every_venv(gen_gitlab_config_mod):
     )
 
     with pytest.raises(ValueError, match="hash-without-path"):
-        gen_gitlab_config_mod._validate_ddtest_venv_test_locations("internal", info)
+        gen_gitlab_config_mod._ddtest_module().validate_ddtest_venv_test_locations("internal", info)
 
 
 def test_ddtest_jobs_emit_suite_environment(gen_gitlab_config_mod):
     output = io.StringIO()
 
-    gen_gitlab_config_mod._emit_ddtest_jobs(
+    gen_gitlab_config_mod._ddtest_module().emit_ddtest_jobs(
         output,
         suite="internal",
         stage="core",

--- a/tests/suitespec.yml
+++ b/tests/suitespec.yml
@@ -163,6 +163,8 @@ suites:
     paths:
       - 'conftest.py'
       - '**/conftest.py'
+      - 'tests/_ddtest_conftest_helpers.py'
+      - 'tests/_ddtest_env_helpers.py'
     pattern: meta-testing
     snapshot: false
   ddtracerun:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -50,6 +50,7 @@ from ddtrace.propagation._database_monitoring import unlisten as dbm_config_unli
 from ddtrace.propagation.http import _DatadogMultiHeader
 from ddtrace.trace import Span
 from ddtrace.trace import Tracer
+from tests._ddtest_env_helpers import strip_ddtest_leaked_env
 from tests.subprocesstest import SubprocessTestCase
 
 
@@ -1427,26 +1428,12 @@ class AnyFloat(object):
         return isinstance(other, float)
 
 
-# PYTEST_ADDOPTS is set to "--ddtrace" by ddtest's platform env (ddtest/internal/
-# platform/python.go:GetPlatformEnv) so the pytest workers load the ddtrace testing plugin. It
-# leaks into every test-spawned subprocess via env inheritance. Under normal
-# riot CI this var is absent, so test subprocesses don't activate CI Visibility.
-# The leaked --ddtrace makes a nested pytest.main() enable the plugin, which
-# logs INFO to stderr (breaking tests that assert err == b"") and computes
-# stats (breaking snapshot tests). No test sets PYTEST_ADDOPTS via call_program's
-# env kwarg, so stripping it here is safe. (ddtest's main.go also sets
-# DD_CIVISIBILITY_ENABLED=1 globally, but that var is inert on its own — the
-# pytest plugin needs --ddtrace to activate — so stripping PYTEST_ADDOPTS is
-# sufficient to keep subprocesses CI-Visibility-free.)
-_DDTEST_LEAKED_PYTEST_ADDOPTS = ("PYTEST_ADDOPTS",)
-
-
-def _strip_ddtest_leaked_env(env):
-    """Remove PYTEST_ADDOPTS leaked from the ddtest parent worker."""
-    env = dict(env)
-    for key in _DDTEST_LEAKED_PYTEST_ADDOPTS:
-        env.pop(key, None)
-    return env
+# ddtest sets PYTEST_ADDOPTS="--ddtrace" globally for pytest workers. It leaks
+# into test-spawned subprocesses, enabling CI Visibility which logs to stderr
+# (breaking tests that assert err == b"") and computes stats (breaking
+# snapshot tests). All ddtest-specific env stripping is encapsulated in
+# _ddtest_env_helpers so it can be removed cleanly if ddtest support is
+# dropped.
 
 
 def call_program(*args, **kwargs):
@@ -1460,7 +1447,7 @@ def call_program(*args, **kwargs):
         cleaned_env = dict(os.environ)
     # Strip the ddtest-leaked PYTEST_ADDOPTS so the subprocess matches normal
     # riot CI, where it is absent. See _DDTEST_LEAKED_PYTEST_ADDOPTS above.
-    kwargs["env"] = _strip_ddtest_leaked_env(cleaned_env)
+    kwargs["env"] = strip_ddtest_leaked_env(cleaned_env)
     close_fds = sys.platform != "win32"
     subp = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=close_fds, **kwargs)
     try:


### PR DESCRIPTION
Move all ddtest-specific code into dedicated modules so that removing ddtest support is a simple matter of deleting a few files and reverting import lines:

- scripts/ddtest_jobs.py: all ddtest job emission logic (emit_ddtest_jobs, validate_ddtest_venv_test_locations, ddtest_k, template helpers) extracted from scripts/gen_gitlab_config.py (~200 lines removed from the latter)
- tests/_ddtest_conftest_helpers.py: _DD_PYTEST_XDIST_INFERRED_SERVICE pop + cache-seed logic extracted from tests/conftest.py
- tests/_ddtest_env_helpers.py: PYTEST_ADDOPTS stripping extracted from tests/utils.py

gen_gitlab_config.py now imports from ddtest_jobs (1 line). conftest.py now imports from _ddtest_conftest_helpers (1 line). utils.py now imports from _ddtest_env_helpers (1 line).

To remove ddtest: delete the 3 helper files, revert the 3 import lines, remove ddtest templates from .gitlab/tests.yml, and remove ddtest: true from suitespec.yml files.

## Description

<!-- Provide an overview of the change and motivation for the change.
     Implementation detail and rationale belong here, not in the release note -
     release notes are customer-facing (see docs/releasenotes.rst). -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
