### PR TITLE
fix(http-client): release responses after event dispatch

### DIFF
--- a/.claude/skills/apm-integrations/references/design-decisions.md
+++ b/.claude/skills/apm-integrations/references/design-decisions.md
@@ -33,7 +33,10 @@ Typed event-driven pattern using `core.context_with_event()` with `TracingEvent`
 subclasses and `TracingSubscriber`. Infrastructure exists in `ddtrace/_trace/events.py`
 and `ddtrace/_trace/subscribers/`. Read concrete contrib examples such as
 `ddtrace/contrib/internal/httpx/patch.py` and `ddtrace/contrib/internal/aiohttp/patch.py`.
-See `ddtrace/internal/core/__init__.py` for the API.
+See `ddtrace/internal/core/__init__.py` for the API. An event is available through
+its synchronous `context.ended` subscriber dispatch and is released immediately
+afterward. Deferred integrations must set `dispatch_end_event=False` and call
+`ctx.dispatch_ended_event()` only after they have attached all final event data.
 
 **`context_with_data()` + `trace_handlers.py`** (preferred for existing): Wrappers use
 `with core.context_with_data(...)` to emit events that `trace_handlers.py`

--- a/ddtrace/appsec/_contrib/httpx/subscribers.py
+++ b/ddtrace/appsec/_contrib/httpx/subscribers.py
@@ -63,8 +63,9 @@ class AppSecHttpxRequestContextSubscriber(ContextSubscriber[HttpClientRequestEve
         }
 
         if ctx.get_item(APPSEC_SSRF_ANALYZE_BODY_KEY):
-            if event.response_body is not None:
-                addresses["DOWN_RES_BODY"] = event.response_body
+            if event.response is not None:
+                with contextlib.suppress(Exception):
+                    addresses["DOWN_RES_BODY"] = event.response.json()
 
         call_waf_callback(
             addresses,

--- a/ddtrace/contrib/_events/http.py
+++ b/ddtrace/contrib/_events/http.py
@@ -53,17 +53,13 @@ class HttpBaseEvent(Event):
     response_headers: Mapping[str, str] = event_field(default_factory=dict)
     response_status_code: Optional[int] = event_field(default=None)
     response_status_msg: Optional[str] = event_field(default=None)
-    response_body: Optional[JsonType] = event_field(default=None)
 
-    def set_response_attributes(self, response: _HttpResponse) -> None:
+    def set_response(self, response: _HttpResponse) -> None:
         self.response_status_code = getattr(response, "status_code", None)
         if self.response_status_code is None:
             self.response_status_code = getattr(response, "status", None)
         self.response_status_msg = getattr(response, "reason", None)
         self.response_headers = response.headers
-
-    def set_response_body(self, response_body: JsonType) -> None:
-        self.response_body = response_body
 
 
 @dataclass

--- a/ddtrace/contrib/_events/http_client.py
+++ b/ddtrace/contrib/_events/http_client.py
@@ -7,6 +7,7 @@ from typing import Union
 from ddtrace._trace.events import TracingEvent
 from ddtrace.contrib._events.http import HttpBaseEvent
 from ddtrace.contrib._events.http import HttpRequestBaseEvent
+from ddtrace.contrib._events.http import _HttpResponse
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.core.events import event_field
@@ -37,11 +38,16 @@ class HttpClientRequestEvent(HttpRequestBaseEvent, TracingEvent):
     target_host: Optional[str] = event_field(default=None)
     retries_remain: Optional[Union[int, str]] = event_field(default=None)
     server_address: Optional[str] = event_field(default=None)
+    response: Optional[_HttpResponse] = event_field(default=None)
 
     def __post_init__(self):
         self.operation_name = schematize_url_operation(
             self.http_operation, protocol="http", direction=SpanDirection.OUTBOUND
         )
+
+    def set_response(self, response: _HttpResponse) -> None:
+        super().set_response(response)
+        self.response = response
 
 
 @dataclass

--- a/ddtrace/contrib/internal/aiohttp/patch.py
+++ b/ddtrace/contrib/internal/aiohttp/patch.py
@@ -129,7 +129,7 @@ async def _traced_clientsession_request(func, instance, args, kwargs):
             return resp
         finally:
             if resp is not None:
-                ctx.event.set_response_attributes(resp)
+                ctx.event.set_response(resp)
 
 
 def _traced_clientsession_init(func, instance, args, kwargs):

--- a/ddtrace/contrib/internal/httpx/common.py
+++ b/ddtrace/contrib/internal/httpx/common.py
@@ -1,4 +1,3 @@
-import json
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Awaitable
@@ -13,7 +12,6 @@ from ddtrace.contrib.internal.trace_utils import ext_service
 from ddtrace.internal import core
 from ddtrace.internal.compat import ensure_binary
 from ddtrace.internal.compat import ensure_text
-from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.wrappers import unwrap as _u
 
@@ -61,7 +59,7 @@ class HttpxPatcher:
                 return response
             finally:
                 if response is not None:
-                    ctx.event.set_response_attributes(response)
+                    ctx.event.set_response(response)
 
     async def _wrapped_async_send_single_request(
         self,
@@ -87,7 +85,7 @@ class HttpxPatcher:
                 return response
             finally:
                 if response is not None:
-                    ctx.event.set_response_attributes(response)
+                    ctx.event.set_response(response)
 
     async def _wrapped_async_send(
         self,
@@ -118,7 +116,7 @@ class HttpxPatcher:
                 return response
             finally:
                 if response is not None:
-                    _set_response(ctx.event, response)
+                    ctx.event.set_response(response)
 
     def _wrapped_sync_send(
         self,
@@ -149,7 +147,7 @@ class HttpxPatcher:
                 return response
             finally:
                 if response is not None:
-                    _set_response(ctx.event, response)
+                    ctx.event.set_response(response)
 
     def patch(self) -> None:
         if getattr(self._module, "_datadog_patch", False):
@@ -172,21 +170,6 @@ class HttpxPatcher:
         _u(self._module.Client, "send")
         _u(self._module.Client, "_send_single_request")
         _u(self._module.AsyncClient, "_send_single_request")
-
-
-def _set_response(event: HttpClientRequestEvent, response: Any) -> None:
-    event.set_response_attributes(response)
-
-    if not asm_config._asm_enabled:
-        return
-
-    # Preserve HTTPX response JSON for AppSec SSRF analysis without retaining the response.
-    try:
-        if not response.is_closed or not response.content:
-            return
-        event.set_response_body(response.json())
-    except (RuntimeError, json.JSONDecodeError, UnicodeDecodeError):
-        event.set_response_body(None)
 
 
 def httpx_url_to_str(url: Any) -> str:

--- a/ddtrace/contrib/internal/requests/connection.py
+++ b/ddtrace/contrib/internal/requests/connection.py
@@ -152,7 +152,7 @@ def _wrap_send(func, instance, args, kwargs):
             return response
         finally:
             if response is not None:
-                ctx.event.set_response_attributes(response)
+                ctx.event.set_response(response)
 
 
 def _wrap_adapter_send(func, instance, args, kwargs):

--- a/ddtrace/contrib/internal/urllib3/patch.py
+++ b/ddtrace/contrib/internal/urllib3/patch.py
@@ -140,4 +140,4 @@ def _wrap_urlopen(func, instance, args, kwargs):
             return response
         finally:
             if response is not None:
-                ctx.event.set_response_attributes(response)
+                ctx.event.set_response(response)

--- a/ddtrace/internal/core/__init__.py
+++ b/ddtrace/internal/core/__init__.py
@@ -222,6 +222,7 @@ class ExecutionContext(Generic[EventType]):
             # PERF: inline `dispatch_ended_event` here to avoid function call overhead in this branch
             dispatch("context.ended." + self.identifier, (self, (exc_type, exc_value, traceback)))
             self._end_event_dispatched = True
+            self._event = None
         try:
             if self._token is not None:
                 _CURRENT_CONTEXT.reset(self._token)
@@ -233,6 +234,8 @@ class ExecutionContext(Generic[EventType]):
             )
         except LookupError:
             log.debug("Encountered LookupError during core contextvar reset() call. I don't know why this is possible.")
+        finally:
+            self._token = None
         return (
             True
             if exc_type is None
@@ -253,6 +256,7 @@ class ExecutionContext(Generic[EventType]):
             return
         dispatch("context.ended." + self.identifier, (self, (exc_type, exc_value, traceback)))
         self._end_event_dispatched = True
+        self._event = None
 
     def find_item(self, data_key: str, default: Optional[Any] = None) -> Any:
         """Traverse up the context tree to find the first occurrence of `data_key`."""

--- a/ddtrace/internal/core/events.py
+++ b/ddtrace/internal/core/events.py
@@ -18,7 +18,9 @@ More specifically, this module defines dataclass-based event objects that are us
 2. Context lifecycle events with ``core.context_with_event(event_instance)``.
    The context manager emits ``context.started.<event_name>`` and
    ``context.ended.<event_name>`` events, and listeners can access the original event
-   through ``ctx.event``.
+   through ``ctx.event`` during both synchronous dispatches. The context releases its
+   reference to the event after ended dispatch completes. Deferred flows keep the event
+   until they call ctx.dispatch_ended_event().
 
    Example::
 

--- a/releasenotes/notes/fix-aiohttp-client-response-retention-2eb42c161e53edc2.yaml
+++ b/releasenotes/notes/fix-aiohttp-client-response-retention-2eb42c161e53edc2.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    aiohttp: Fixes an issue where memory usage grows over time when tracing outbound
+    client requests.

--- a/releasenotes/notes/fix-aiohttp-client-response-retention-2eb42c161e53edc2.yaml
+++ b/releasenotes/notes/fix-aiohttp-client-response-retention-2eb42c161e53edc2.yaml
@@ -1,4 +1,4 @@
 fixes:
   - |
-    aiohttp: Fixes an issue where memory usage grows over time when tracing outbound
-    client requests.
+    AAP: Fixes an issue where memory usage grows over time when AAP is enabled for
+    applications making traced outbound HTTP requests.

--- a/tests/appsec/appsec/test_httpx_subscribers.py
+++ b/tests/appsec/appsec/test_httpx_subscribers.py
@@ -1,0 +1,44 @@
+from unittest import mock
+
+import pytest
+
+from ddtrace.appsec._contrib.httpx import subscribers
+from ddtrace.contrib._events.http_client import HttpClientRequestEvent
+from ddtrace.internal import core
+
+
+def _request_context(response, analyze_body):
+    event = HttpClientRequestEvent(
+        http_operation="http.request",
+        service=None,
+        component="httpx",
+        integration_config={},
+        request_method="GET",
+        request_headers={},
+        request_url="https://example.test/",
+        query="",
+    )
+    event.set_response(response)
+    ctx = core.ExecutionContext(event.event_name, event=event)
+    ctx.set_item(subscribers.APPSEC_SSRF_ANALYZE_BODY_KEY, analyze_body)
+    return ctx
+
+
+@pytest.mark.parametrize("analyze_body", [False, True])
+def test_response_body_is_parsed_only_when_analysis_is_selected(analyze_body):
+    response = mock.Mock(status_code=200, reason="OK", headers={})
+    response.json.return_value = {"response": "body"}
+    ctx = _request_context(response, analyze_body)
+
+    with (
+        mock.patch.object(subscribers, "get_rasp_capability", return_value=True),
+        mock.patch.object(subscribers, "call_waf_callback") as call_waf_callback,
+    ):
+        subscribers.AppSecHttpxRequestContextSubscriber.on_ended(ctx, (None, None, None))
+
+    assert response.json.call_count == int(analyze_body)
+    addresses = call_waf_callback.call_args.args[0]
+    if analyze_body:
+        assert addresses["DOWN_RES_BODY"] == {"response": "body"}
+    else:
+        assert "DOWN_RES_BODY" not in addresses

--- a/tests/contrib/httpx/test_httpx.py
+++ b/tests/contrib/httpx/test_httpx.py
@@ -1,11 +1,7 @@
-from unittest import mock
-
 import httpx
 import pytest
 
 from ddtrace import config
-from ddtrace.contrib._events.http_client import HttpClientRequestEvent
-from ddtrace.contrib.internal.httpx.common import _set_response
 from ddtrace.contrib.internal.httpx.patch import HTTPX_VERSION
 from ddtrace.contrib.internal.httpx.patch import patch
 from ddtrace.contrib.internal.httpx.patch import unpatch
@@ -53,30 +49,6 @@ def test_patching():
     unpatch()
     assert not is_wrapted(httpx.Client.send)
     assert not is_wrapted(httpx.AsyncClient.send)
-
-
-def _http_client_event():
-    return HttpClientRequestEvent(
-        http_operation="http.request",
-        service=None,
-        component=config.httpx.integration_name,
-        integration_config=config.httpx,
-        request_method="GET",
-        request_headers={},
-        request_url="https://example.test/",
-        query="",
-    )
-
-
-def test_httpx_response_body_is_captured_after_response_is_buffered():
-    event = _http_client_event()
-    response = httpx.Response(200, json={"response": "body"})
-    response.close()
-
-    with mock.patch("ddtrace.contrib.internal.httpx.common.asm_config._asm_enabled", True):
-        _set_response(event, response)
-
-    assert event.response_body == {"response": "body"}
 
 
 @pytest.mark.snapshot(ignores=["meta.http.useragent"])

--- a/tests/internal/events/test_context_events.py
+++ b/tests/internal/events/test_context_events.py
@@ -1,7 +1,10 @@
+import contextvars
 from dataclasses import InitVar
 from dataclasses import dataclass
+import gc
 import sys
 from typing import Any
+import weakref
 
 import pytest
 
@@ -42,6 +45,70 @@ def test_basic_context_event():
     assert called == [f"{ContextEvent.event_name}.started", f"{ContextEvent.event_name}.ended"], (
         "event should trigger started then ended handlers in order; got %r" % (called,)
     )
+
+
+def test_context_event_is_released_after_ended_dispatch():
+    """The event remains available to ended listeners but not to retained context snapshots."""
+
+    @dataclass
+    class ContextEvent(Event):
+        event_name = "test.event.release"
+
+        payload: object = event_field()
+
+    ended_event_refs = []
+
+    def on_context_ended(ctx: core.ExecutionContext, err_info: Any):
+        ended_event_refs.append(weakref.ref(ctx.event))
+
+    core.on(f"context.ended.{ContextEvent.event_name}", on_context_ended)
+
+    payload = object()
+    event = ContextEvent(payload=payload)
+    event_ref = weakref.ref(event)
+    with core.context_with_event(event) as ctx:
+        retained_context = contextvars.copy_context()
+        assert ctx._token is not None
+
+    assert ended_event_refs == [event_ref]
+    assert ctx._event is None
+    assert ctx._token is None
+    assert retained_context.run(lambda: core.current) is ctx
+    with pytest.raises(AttributeError):
+        ctx.event
+
+    del event
+    gc.collect()
+    assert event_ref() is None
+
+
+def test_deferred_context_event_is_released_after_manual_end_dispatch():
+    """Deferred contexts keep their event until subscribers receive the manual ended event."""
+
+    @dataclass
+    class ContextEvent(Event):
+        event_name = "test.event.deferred_release"
+
+    ended_events = []
+
+    def on_context_ended(ctx: core.ExecutionContext, err_info: Any):
+        ended_events.append(ctx.event)
+
+    core.on(f"context.ended.{ContextEvent.event_name}", on_context_ended)
+
+    event = ContextEvent()
+    with core.context_with_event(event, dispatch_end_event=False) as ctx:
+        pass
+
+    assert ctx._token is None
+    assert ctx.event is event
+
+    ctx.dispatch_ended_event()
+
+    assert ended_events == [event]
+    assert ctx._event is None
+    with pytest.raises(AttributeError):
+        ctx.event
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="Requires Python 3.10+")


### PR DESCRIPTION
## Description

PR #18795 avoided retaining HTTP client responses by parsing HTTPX response bodies in the shared integration when AppSec was enabled. That reintroduced a product dependency into the integration and parsed JSON before AppSec had selected response-body analysis.

For AppSec it meant:
- memory growth was not solved when appsec is turned on
- a json body became unconditionally parsed when appsec is on, even when appsec doesn't need to parse it
- httpx integration became coupled with appsec (imports asm_config) which is the point of core events

This change keeps the response available on the typed HTTP client event through synchronous ended-event subscribers, then releases the event and its context token. AppSec remains the owner of response-body parsing and only calls `response.json()` when downstream response analysis is selected. Deferred event flows retain their event until `dispatch_ended_event()` runs.

## Testing

- Regression tests

## Risks

The typed event is intentionally unavailable after ended-event dispatch. Existing deferred integrations continue to own the event until they dispatch their ended event; focused lifecycle tests cover both synchronous and deferred paths.

## Additional Notes

This replaces the product-coupled response-body handling introduced by #18795 while preserving its aiohttp memory-retention regression coverage.
