### PR TITLE
fix(ci_visibility): isolate per-test coverage context across threads

### DIFF
--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -46,8 +46,14 @@ def _is_site_packages_path(path: Path) -> bool:
     return not _SITE_PACKAGES_DIRNAMES.isdisjoint(path.parts)
 
 
-ctx_covered: ContextVar[list[defaultdict[str, CoverageLines]]] = ContextVar("ctx_covered", default=[])
-ctx_covered_files: ContextVar[list[set[str]]] = ContextVar("ctx_covered_files", default=[])
+# AIDEV-NOTE: These ContextVars MUST use default=None, not default=[]. A mutable default ([]) is a single
+# shared object returned by .get() in every thread/context, which defeats ContextVar isolation: the
+# CollectInContext.__init__ guard below ("if ... is None: ...set([])") only initializes a context-local
+# list when the default is None. With default=[] the guard never fires, so every thread appends to and
+# pops from the SAME shared stack, corrupting per-test coverage and racing with get_coverage_bitmaps()
+# iteration (RuntimeError: dictionary changed size during iteration). Do not change back to default=[].
+ctx_covered: ContextVar[t.Optional[list[defaultdict[str, CoverageLines]]]] = ContextVar("ctx_covered", default=None)
+ctx_covered_files: ContextVar[t.Optional[list[set[str]]]] = ContextVar("ctx_covered_files", default=None)
 ctx_is_import_coverage = ContextVar("ctx_is_import_coverage", default=False)
 ctx_coverage_enabled = ContextVar("ctx_coverage_enabled", default=False)
 

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -46,7 +46,7 @@ def _is_site_packages_path(path: Path) -> bool:
     return not _SITE_PACKAGES_DIRNAMES.isdisjoint(path.parts)
 
 
-# AIDEV-NOTE: These ContextVars MUST use default=None, not default=[]. A mutable default ([]) is a single
+# NOTE: These ContextVars MUST use default=None, not default=[]. A mutable default ([]) is a single
 # shared object returned by .get() in every thread/context, which defeats ContextVar isolation: the
 # CollectInContext.__init__ guard below ("if ... is None: ...set([])") only initializes a context-local
 # list when the default is None. With default=[] the guard never fires, so every thread appends to and

--- a/tests/coverage/test_coverage_threading.py
+++ b/tests/coverage/test_coverage_threading.py
@@ -114,14 +114,15 @@ def test_coverage_concurrent_futures_threadpool_session():
 
 @pytest.mark.subprocess(env={"_DD_COVERAGE_FILE_LEVEL": "false"})
 def test_coverage_context_isolated_across_threads():
-    """Regression: ctx_covered must be context-local, not a shared mutable default.
+    """Regression: ctx_covered and ctx_covered_files must be context-local, not shared defaults.
 
     A background thread entering its own CollectInContext must not push onto (or pop from) the
-    main thread's coverage stack. Previously ctx_covered used default=[] (a single shared list
-    object returned by ContextVar.get() in every thread), so the CollectInContext.__init__
-    ``is None`` guard never fired and every thread shared one stack. A thread's push/pop then
-    corrupted the main stack and could mutate the dict that get_coverage_bitmaps() was
-    iterating, raising ``RuntimeError: dictionary changed size during iteration``.
+    main thread's coverage stacks. Previously ctx_covered and ctx_covered_files used default=[]
+    (a single shared list object returned by ContextVar.get() in every thread), so the
+    CollectInContext.__init__ ``is None`` guard never fired and every thread shared one stack.
+    A thread's push/pop then corrupted the main stack and could mutate the dict that
+    get_coverage_bitmaps() was iterating, raising ``RuntimeError: dictionary changed size
+    during iteration``.
     """
     import os
     from pathlib import Path
@@ -129,6 +130,7 @@ def test_coverage_context_isolated_across_threads():
 
     from ddtrace.internal.coverage.code import ModuleCodeCollector
     from ddtrace.internal.coverage.code import ctx_covered
+    from ddtrace.internal.coverage.code import ctx_covered_files
     from ddtrace.internal.coverage.installer import install
 
     cwd = os.getcwd()
@@ -141,6 +143,7 @@ def test_coverage_context_isolated_across_threads():
 
     with ModuleCodeCollector.CollectInContext():
         main_top_dict = ctx_covered.get()[-1]
+        main_top_files = ctx_covered_files.get()[-1]
 
         def worker():
             # threading_coverage auto-enters a CollectInContext in _bootstrap_inner before
@@ -156,19 +159,32 @@ def test_coverage_context_isolated_across_threads():
         thread_entered.wait()
 
         # While the thread's CollectInContext is active, the main thread must still observe its
-        # OWN stack and top dict, unaffected by the thread's push.
+        # OWN stacks and top entries, unaffected by the thread's push. CollectInContext.__enter__
+        # appends to both ctx_covered and ctx_covered_files unconditionally, so both must remain
+        # isolated. (With the buggy default=[] the thread's push lands on the shared stack and
+        # the main thread sees the thread's entry on top.)
         observed["top_is_main"] = ctx_covered.get()[-1] is main_top_dict
         observed["stack_len"] = len(ctx_covered.get())
+        observed["files_top_is_main"] = ctx_covered_files.get()[-1] is main_top_files
+        observed["files_stack_len"] = len(ctx_covered_files.get())
 
         thread_can_exit.set()
         t.join()
 
     assert observed["top_is_main"], (
-        "Main thread's coverage stack was corrupted by a background thread: "
+        "Main thread's ctx_covered stack was corrupted by a background thread: "
         "ctx_covered is shared across threads instead of being context-local"
     )
     assert observed["stack_len"] == 1, (
-        f"Main thread's coverage stack should contain only its own context, got len={observed['stack_len']}"
+        f"Main thread's ctx_covered stack should contain only its own context, got len={observed['stack_len']}"
+    )
+    assert observed["files_top_is_main"], (
+        "Main thread's ctx_covered_files stack was corrupted by a background thread: "
+        "ctx_covered_files is shared across threads instead of being context-local"
+    )
+    assert observed["files_stack_len"] == 1, (
+        f"Main thread's ctx_covered_files stack should contain only its own context, "
+        f"got len={observed['files_stack_len']}"
     )
 
 

--- a/tests/coverage/test_coverage_threading.py
+++ b/tests/coverage/test_coverage_threading.py
@@ -113,6 +113,66 @@ def test_coverage_concurrent_futures_threadpool_session():
 
 
 @pytest.mark.subprocess(env={"_DD_COVERAGE_FILE_LEVEL": "false"})
+def test_coverage_context_isolated_across_threads():
+    """Regression: ctx_covered must be context-local, not a shared mutable default.
+
+    A background thread entering its own CollectInContext must not push onto (or pop from) the
+    main thread's coverage stack. Previously ctx_covered used default=[] (a single shared list
+    object returned by ContextVar.get() in every thread), so the CollectInContext.__init__
+    ``is None`` guard never fired and every thread shared one stack. A thread's push/pop then
+    corrupted the main stack and could mutate the dict that get_coverage_bitmaps() was
+    iterating, raising ``RuntimeError: dictionary changed size during iteration``.
+    """
+    import os
+    from pathlib import Path
+    import threading
+
+    from ddtrace.internal.coverage.code import ModuleCodeCollector
+    from ddtrace.internal.coverage.code import ctx_covered
+    from ddtrace.internal.coverage.installer import install
+
+    cwd = os.getcwd()
+    install(include_paths=[Path(cwd) / "tests/coverage/included_path/"])
+    ModuleCodeCollector.start_coverage()
+
+    thread_entered = threading.Event()
+    thread_can_exit = threading.Event()
+    observed = {}
+
+    with ModuleCodeCollector.CollectInContext():
+        main_top_dict = ctx_covered.get()[-1]
+
+        def worker():
+            # threading_coverage auto-enters a CollectInContext in _bootstrap_inner before
+            # running this target, so the thread's context is active by the time we signal.
+            thread_entered.set()
+            from tests.coverage.included_path.callee import called_in_context_main
+
+            called_in_context_main(1, 2)
+            thread_can_exit.wait()
+
+        t = threading.Thread(target=worker)
+        t.start()
+        thread_entered.wait()
+
+        # While the thread's CollectInContext is active, the main thread must still observe its
+        # OWN stack and top dict, unaffected by the thread's push.
+        observed["top_is_main"] = ctx_covered.get()[-1] is main_top_dict
+        observed["stack_len"] = len(ctx_covered.get())
+
+        thread_can_exit.set()
+        t.join()
+
+    assert observed["top_is_main"], (
+        "Main thread's coverage stack was corrupted by a background thread: "
+        "ctx_covered is shared across threads instead of being context-local"
+    )
+    assert observed["stack_len"] == 1, (
+        f"Main thread's coverage stack should contain only its own context, got len={observed['stack_len']}"
+    )
+
+
+@pytest.mark.subprocess(env={"_DD_COVERAGE_FILE_LEVEL": "false"})
 def test_coverage_concurrent_futures_threadpool_context():
     import concurrent.futures
     import os


### PR DESCRIPTION
ctx_covered and ctx_covered_files used ContextVar(default=[]), a mutable default. ContextVar.get() returns that same single list object in every thread/context (isolation only begins after .set()), and the CollectInContext.__init__ "is None" guard never fired because .get() returns [] rather than None. As a result every thread pushed onto and popped from one shared stack instead of a context-local one.

When a worker thread (e.g. via threading_coverage) entered its own CollectInContext while the main thread was iterating the top-of-stack defaultdict in CoverageData.get_coverage_bitmaps() (called from pytest_runtest_protocol_wrapper -> put_coverage), the thread mutated that same dict, raising RuntimeError: dictionary changed size during iteration and aborting the pytest session with INTERNALERROR.

Fix: use default=None so the existing __init__ guard initializes a context-local list per thread/context, restoring the isolation the code was written to assume. Confirmed present in v4.11.7.

Adds a regression test asserting a background thread's CollectInContext does not corrupt the main thread's coverage stack.

## Description

<!-- Provide an overview of the change and motivation for the change.
     Implementation detail and rationale belong here, not in the release note -
     release notes are customer-facing (see docs/releasenotes.rst). -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
