### PR TITLE
feat(testing): upload coverage once from xdist controller with pytest…

### DIFF
--- a/ddtrace/testing/internal/pytest/plugin.py
+++ b/ddtrace/testing/internal/pytest/plugin.py
@@ -441,33 +441,24 @@ class TestOptPlugin(TestOptPluginProtocol):
         # If coverage report upload is enabled, generate and upload the report.
         # NOTE: Skip in payload-files mode (Bazel): coverage data is already
         # written as JSON files by TestCoverageWriter; network upload is not possible.
-        # AIDEV-NOTE: This hook runs in every process, so an xdist session uploads one report per process, each
-        # covering only what that process ran. That is by design: the intake merges the coverage reports it receives
-        # for a session, so the partial uploads add up to full coverage.
-        #
-        # Do NOT "fix" this by restricting the upload to the controller. Which process holds which data depends on who
-        # owns coverage.py:
-        #   - with pytest-cov, workers ship their data to the controller and pytest-cov merges it in its
-        #     pytest_runtestloop wrapper, i.e. before this hook, so the controller's report is complete;
-        #   - without pytest-cov, ddtrace starts coverage.py per process in pytest_configure and nothing merges across
-        #     processes, so the controller (which runs no tests under xdist) has an empty report and the workers hold
-        #     all the real data.
-        # Controller-only upload would therefore be harmless in the first case and lose everything in the second.
-        # Uploading once from the controller would only save bandwidth, and would first require implementing the
-        # cross-process merge that pytest-cov does for us in the first case but nobody does in the second.
+        # AIDEV-NOTE: Under xdist only one process should upload -- see _should_upload_coverage_report for which one
+        # and why that depends on whether pytest-cov owns the coverage.py instance.
         if self.manager.settings.coverage_report_upload_enabled and not get_offline_mode().payload_files_enabled:
-            # Create upload function wrapper for manager
-            def upload_func(coverage_report_bytes: bytes, coverage_format: str) -> bool:
-                return self.manager.upload_coverage_report(
-                    coverage_report_bytes=coverage_report_bytes, coverage_format=coverage_format, tags=None
-                )
+            if self._should_upload_coverage_report(session.config):
+                # Create upload function wrapper for manager
+                def upload_func(coverage_report_bytes: bytes, coverage_format: str) -> bool:
+                    return self.manager.upload_coverage_report(
+                        coverage_report_bytes=coverage_report_bytes, coverage_format=coverage_format, tags=None
+                    )
 
-            handle_coverage_report(
-                config=session.config,
-                upload_func=upload_func,
-                is_pytest_cov_enabled_func=_is_pytest_cov_enabled,
-                stop_coverage_func=stop_coverage,
-            )
+                handle_coverage_report(
+                    config=session.config,
+                    upload_func=upload_func,
+                    is_pytest_cov_enabled_func=_is_pytest_cov_enabled,
+                    stop_coverage_func=stop_coverage,
+                )
+            else:
+                log.debug("Skipping coverage report upload on xdist worker; controller will upload the merged report")
 
         coverage_percentage = get_coverage_percentage(_is_pytest_cov_enabled(session.config))
         if coverage_percentage is not None:
@@ -1192,6 +1183,30 @@ class TestOptPlugin(TestOptPluginProtocol):
 
         self.outcomes_by_nodeid.pop(nodeid, None)
         return status, tags
+
+    def _should_upload_coverage_report(self, config: pytest.Config) -> bool:
+        """Return whether this process is responsible for uploading the coverage report.
+
+        The caller has already checked that upload is configured (``coverage_report_upload_enabled`` and not
+        payload-files mode); this answers only the *who* question. The answer hinges on which process holds a
+        complete report when ``pytest_sessionfinish`` runs:
+
+        - With pytest-cov under xdist, every worker ships its coverage data to the controller and pytest-cov merges
+          it there (``DistMaster.finish`` -> ``cov.combine``) inside its ``pytest_runtestloop`` wrapper, which completes
+          *before* this hook. The controller therefore holds the full merged report, so only it uploads -- N+1 partial
+          uploads of the same data become one complete upload. Workers skip.
+        - Without pytest-cov, ddtrace starts coverage.py per process in ``pytest_configure`` and nothing merges across
+          processes: each process holds only what it ran (the controller, which runs no tests under xdist, has an empty
+          report). Every process must therefore upload its own partial report and the intake merges them; restricting
+          the upload to the controller here would lose every worker's data.
+
+        Safe by construction: the only case that returns False is an xdist worker that is also running pytest-cov,
+        where the controller is guaranteed to have already merged the worker's data. Any other case uploads, exactly as
+        it did before this optimization existed.
+        """
+        if self.is_xdist_worker and _is_pytest_cov_enabled(config):
+            return False
+        return True
 
     def _handle_itr(self, item: pytest.Item, test_ref: TestRef, test: Test) -> None:
         if not self.manager.is_skippable_test(test_ref):

--- a/tests/testing/internal/pytest/test_pytest_xdist.py
+++ b/tests/testing/internal/pytest/test_pytest_xdist.py
@@ -257,6 +257,9 @@ def _make_env(mock_server_url: str, extra: t.Optional[dict[str, str]] = None) ->
         DD_TEST_OPTIMIZATION_MANIFEST_FILE,
         DD_TEST_OPTIMIZATION_PAYLOADS_IN_FILES,
         TEST_UNDECLARED_OUTPUTS_DIR,
+        # The outer test process may set kill switches that override the backend settings we configure per test;
+        # drop them so the mock backend's response is authoritative.
+        "DD_CIVISIBILITY_CODE_COVERAGE_REPORT_UPLOAD_ENABLED",
     ):
         env.pop(name, None)
     env.update(
@@ -1212,3 +1215,39 @@ def test_mock_settings_payload_is_parseable() -> None:
     assert settings.early_flake_detection.slow_test_retries_5s == 10
     assert settings.early_flake_detection.faulty_session_threshold == 30
     assert settings.test_management.attempt_to_fix_retries == 20
+
+
+class TestXdistCoverageUpload:
+    """Under xdist the controller holds the merged coverage report; workers should not also upload.
+
+    pytest-cov ships every worker's coverage data to the controller and merges it there
+    (``DistMaster.finish`` -> ``cov.combine``) before ``pytest_sessionfinish`` runs, so the controller's
+    report is complete.  Workers therefore skip the upload and the controller uploads once -- N+1 partial
+    uploads become one complete upload.  This is the clean, low-risk case; without pytest-cov nothing merges
+    across processes and every process must still upload its own partial report.
+    """
+
+    def test_coverage_uploaded_once_with_pytest_cov(
+        self, mock_server: MockCIVisibilityServer, test_project: Path
+    ) -> None:
+        pytest.importorskip("pytest_cov")
+
+        settings = _settings_attributes()
+        settings["coverage_report_upload_enabled"] = True
+        assert mock_server.server is not None
+        mock_server.server.settings_attributes = settings  # type: ignore[attr-defined]
+
+        (test_project / "test_a.py").write_text("def test_one():\n    assert True\n")
+        (test_project / "test_b.py").write_text("def test_two():\n    assert True\n")
+        _git_commit(test_project)
+
+        env = _make_env(mock_server.url)
+        result = _run_pytest_subprocess(test_project, "-n", "2", "--cov", env=env)
+
+        assert result.returncode == 0, f"pytest failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+        # The controller uploads one merged report; workers skip. Exactly one upload, not one per process.
+        assert mock_server.count_requests("/api/v2/cicovreprt") == 1, (
+            f"expected a single coverage upload from the controller, "
+            f"got {mock_server.count_requests('/api/v2/cicovreprt')}"
+        )


### PR DESCRIPTION
…-cov

Under xdist every process uploaded its own partial coverage report and the intake merged them. With pytest-cov that is wasteful: workers ship their data to the controller and pytest-cov merges it there (DistMaster.finish -> cov.combine) inside its pytest_runtestloop wrapper, which completes *before* pytest_sessionfinish. By the time the controller reaches our hook its report already holds every worker's data, so only the controller needs to upload -- N+1 partial uploads become one complete upload.

The decision is extracted into _should_upload_coverage_report so the call site reads as plain intent and the timing argument lives in one documented place. It returns False only for an xdist worker running pytest-cov, where the controller is guaranteed to have already merged that worker's data; every other case uploads exactly as before. Without pytest-cov nothing merges across processes (each process holds only what it ran), so every process still uploads its own partial report -- restricting the upload to the controller there would lose every worker's data, so that path is unchanged.

Testing: tests/testing/internal/pytest/test_pytest_xdist.py
 - TestXdistCoverageUpload.test_coverage_uploaded_once_with_pytest_cov: subprocess run with --ddtrace --cov -n 2 against a mock backend (coverage_report_upload_enabled=True) asserts exactly one request to /api/v2/cicovreprt.  _make_env now also pops DD_CIVISIBILITY_CODE_COVERAGE_REPORT_UPLOAD_ENABLED so the riot suite env does not override the backend setting in the subprocess.

Verified: riot venv py3.12 / pytest~=8.0 / pytest-xdist / pytest-cov.
 - tests/testing/internal/pytest/test_pytest_xdist.py::TestXdistCoverageUpload: 1 passed
 - tests/testing/internal/pytest/test_pytest_coverage_report_upload.py: 16 passed, 1 skipped (single-process upload path unchanged)
 - scripts/lint fmt + scripts/lint checks: 25/25 pass

No release note (changelog/no-changelog): same data, fewer requests.

## Description

<!-- Provide an overview of the change and motivation for the change.
     Implementation detail and rationale belong here, not in the release note -
     release notes are customer-facing (see docs/releasenotes.rst). -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
