### PR TITLE
test(testing): guard xdist manifest mode under worksteal and surface …

### DIFF
--- a/ddtrace/testing/internal/pytest/xdist.py
+++ b/ddtrace/testing/internal/pytest/xdist.py
@@ -84,7 +84,10 @@ def generate_xdist_manifest(session_manager: SessionManager, args: list[str]) ->
             session_manager.itr_correlation_id,
         )
     except Exception as e:
-        log.debug("Could not write xdist manifest cache %s: %s", manifest_dir, e)
+        # An unexpected failure here (read-only TMPDIR, no space left, ...) means the workers will each fall back to
+        # querying the backend and the optimization is silently lost for this session.  Say so out loud, matching the
+        # WARNING already emitted on the worker side when a worker cannot read its controller's manifest.
+        log.warning("Could not write xdist manifest cache %s: %s", manifest_dir, e)
         if manifest_dir is not None:
             shutil.rmtree(manifest_dir, ignore_errors=True)
         return None
@@ -122,8 +125,17 @@ def resolve_inherited_manifest_env() -> None:
     (``pytest.main()``, ``pytester.inline_run()``) shares the worker's pid, so it looks like the manifest's rightful
     owner and reads the outer session's cache. Dropping the env var would not help either: ``OfflineMode`` is a
     process-wide singleton that the worker already resolved. Fixing it properly means scoping offline mode to a
-    session rather than a process. In practice the nested run usually has the plugin disabled, and ``tests/testing``
-    clears the variable for the in-process cases that do enable it.
+    session rather than a process.
+
+    Investigated and left as-is: ``OfflineMode`` is first resolved during ``SessionManager.__init__`` (via
+    ``env_tags.get_env_tags()`` and ``BackendConnectorSetup.detect_setup()``), i.e. *before* any session object
+    exists, which is exactly why it is a process singleton today. Scoping it to a session means threading a resolved
+    value through ``env_tags``/``session_manager``/``plugin``/``writer`` instead of reading a module global, and
+    reworking the early-init order so the session exists before the first resolution. That is a cross-cutting refactor
+    of five modules with real test-isolation risk (the singleton is also what lets ``tests/testing/conftest.py`` reset
+    state between tests). The practical impact is narrow -- the nested run usually has the plugin disabled, and
+    ``tests/testing`` clears the variable for the in-process cases that do enable it -- so the cost does not yet
+    justify the risk. Revisit if in-process nested pytest under xdist becomes a supported workflow.
     """
     manifest_env = os.environ.get(DD_TEST_OPTIMIZATION_MANIFEST_FILE)
     if not manifest_env:

--- a/tests/testing/internal/pytest/test_pytest_xdist.py
+++ b/tests/testing/internal/pytest/test_pytest_xdist.py
@@ -356,6 +356,66 @@ def _git_commit(project_dir: Path, message: str = "test commit") -> None:
 # xdist behavior since inline_run + EventCapture cannot cross process boundaries.
 
 
+def _write_manifest_marker_project(test_project: Path, marker_dir: Path) -> None:
+    """Write a project whose conftest/tests record each worker's manifest env and offline mode.
+
+    Used by the manifest-mode regression tests: after the subprocess run, ``marker_dir`` holds one
+    file per worker recording the inherited manifest path and whether that worker actually entered
+    manifest mode, so a test can assert the controller's fetch was shared instead of fanned out.
+    """
+    (test_project / "conftest.py").write_text(
+        textwrap.dedent(f"""\
+            import os
+            from pathlib import Path
+
+            MARKER_DIR = Path({str(marker_dir)!r})
+
+            def pytest_configure(config):
+                worker = os.environ.get("PYTEST_XDIST_WORKER")
+                manifest = os.environ.get("DD_TEST_OPTIMIZATION_MANIFEST_FILE", "")
+                MARKER_DIR.mkdir(exist_ok=True)
+                (MARKER_DIR / (worker or "controller")).write_text(manifest)
+        """)
+    )
+    (test_project / "test_a.py").write_text(
+        textwrap.dedent(f"""\
+            import os
+            from pathlib import Path
+
+            MARKER_DIR = Path({str(marker_dir)!r})
+
+            def _record_test(name):
+                worker = os.environ.get("PYTEST_XDIST_WORKER", "controller")
+                with (MARKER_DIR / (worker + "-tests")).open("a") as f:
+                    f.write(name + "\\n")
+                if worker != "controller":
+                    from ddtrace.testing.internal.offline_mode import get_offline_mode
+
+                    offline_mode = get_offline_mode()
+                    (MARKER_DIR / (worker + "-manifest-mode")).write_text(
+                        f"enabled={{offline_mode.manifest_enabled}}\\n"
+                        f"dir={{offline_mode.test_optimization_dir}}\\n"
+                    )
+
+            def test_one():
+                _record_test("test_one")
+                assert True
+
+            def test_two():
+                _record_test("test_two")
+                assert True
+
+            def test_three():
+                _record_test("test_three")
+                assert True
+
+            def test_four():
+                _record_test("test_four")
+                assert True
+        """)
+    )
+
+
 class TestXdistManifestMode:
     def test_controller_generates_manifest_workers_avoid_backend_fanout(
         self, mock_server: MockCIVisibilityServer, test_project: Path
@@ -367,57 +427,7 @@ class TestXdistManifestMode:
         mock_server.server.settings_attributes = settings  # type: ignore[attr-defined]
 
         marker_dir = test_project / "xdist_markers"
-        (test_project / "conftest.py").write_text(
-            textwrap.dedent(f"""\
-                import os
-                from pathlib import Path
-
-                MARKER_DIR = Path({str(marker_dir)!r})
-
-                def pytest_configure(config):
-                    worker = os.environ.get("PYTEST_XDIST_WORKER")
-                    manifest = os.environ.get("DD_TEST_OPTIMIZATION_MANIFEST_FILE", "")
-                    MARKER_DIR.mkdir(exist_ok=True)
-                    (MARKER_DIR / (worker or "controller")).write_text(manifest)
-            """)
-        )
-        (test_project / "test_a.py").write_text(
-            textwrap.dedent(f"""\
-                import os
-                from pathlib import Path
-
-                MARKER_DIR = Path({str(marker_dir)!r})
-
-                def _record_test(name):
-                    worker = os.environ.get("PYTEST_XDIST_WORKER", "controller")
-                    with (MARKER_DIR / (worker + "-tests")).open("a") as f:
-                        f.write(name + "\\n")
-                    if worker != "controller":
-                        from ddtrace.testing.internal.offline_mode import get_offline_mode
-
-                        offline_mode = get_offline_mode()
-                        (MARKER_DIR / (worker + "-manifest-mode")).write_text(
-                            f"enabled={{offline_mode.manifest_enabled}}\\n"
-                            f"dir={{offline_mode.test_optimization_dir}}\\n"
-                        )
-
-                def test_one():
-                    _record_test("test_one")
-                    assert True
-
-                def test_two():
-                    _record_test("test_two")
-                    assert True
-
-                def test_three():
-                    _record_test("test_three")
-                    assert True
-
-                def test_four():
-                    _record_test("test_four")
-                    assert True
-            """)
-        )
+        _write_manifest_marker_project(test_project, marker_dir)
         _git_commit(test_project)
 
         env = _make_env(mock_server.url)
@@ -446,6 +456,53 @@ class TestXdistManifestMode:
 
         # The generated manifest cache is a private temp directory, removed when the session ends.
         manifest_dir = Path(worker_manifests[0]).parent
+        assert not manifest_dir.exists(), manifest_dir
+
+    def test_manifest_mode_active_under_worksteal_distribution(
+        self, mock_server: MockCIVisibilityServer, test_project: Path
+    ) -> None:
+        """Manifest mode must still activate under ``--dist worksteal``.
+
+        dd-trace-py's own suites run with ``--dist worksteal`` (see PR #19581).  Worksteal
+        redistributes tests between workers at runtime, but the manifest is read at worker startup
+        (before any stealing happens), so the optimization is unaffected.  This test guards that
+        interaction, which the default-``load`` test above does not exercise.
+
+        It asserts only the manifest-mode and backend-fan-out invariants: under worksteal the
+        per-worker test distribution is dynamic, so a worker may end up running all the tests,
+        which makes the load test's ``1 <= count <= 3`` assertion meaningless here.
+        """
+        settings = _settings_attributes()
+        settings["itr_enabled"] = True
+        settings["tests_skipping"] = True
+        assert mock_server.server is not None
+        mock_server.server.settings_attributes = settings  # type: ignore[attr-defined]
+
+        marker_dir = test_project / "xdist_markers"
+        _write_manifest_marker_project(test_project, marker_dir)
+        _git_commit(test_project)
+
+        env = _make_env(mock_server.url)
+        result = _run_pytest_subprocess(test_project, "-n", "2", "--dist", "worksteal", env=env)
+
+        assert result.returncode == 0, f"pytest failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+        worker_manifest_modes = [path.read_text() for path in marker_dir.glob("gw*-manifest-mode")]
+        assert len(worker_manifest_modes) == 2, (
+            f"expected 2 workers in manifest mode, got {len(worker_manifest_modes)}: {worker_manifest_modes}"
+        )
+        assert all("enabled=True" in mode for mode in worker_manifest_modes), worker_manifest_modes
+        assert all(XDIST_MANIFEST_DIR_PREFIX in mode for mode in worker_manifest_modes), worker_manifest_modes
+
+        # The controller fetches once; workers read the cache instead of querying the backend.
+        assert mock_server.count_requests("/api/v2/libraries/tests/services/setting") == 1
+        assert mock_server.count_requests("/api/v2/ci/tests/skippable") == 1
+
+        # All four tests ran somewhere (worksteal may concentrate them on one worker).
+        worker_test_counts = [len(path.read_text().splitlines()) for path in marker_dir.glob("gw*-tests")]
+        assert sum(worker_test_counts) == 4, worker_test_counts
+
+        manifest_dir = Path([path.read_text() for path in marker_dir.glob("gw[0-9]")][0]).parent
         assert not manifest_dir.exists(), manifest_dir
 
 
@@ -577,6 +634,24 @@ class TestGenerateXdistManifestFailures:
         assert generate_xdist_manifest(_session_manager_without_errors(), ["-n", "2"]) is None
         assert DD_TEST_OPTIMIZATION_MANIFEST_FILE not in os.environ
         assert created_dirs and not Path(created_dirs[0]).exists()
+
+    def test_logs_warning_on_unexpected_write_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A failure to write the cache silently loses the optimization for the whole session.
+
+        The PR surfaces worker-side degradation at WARNING; the controller's own write failure
+        (read-only TMPDIR, no space left, ...) must be just as visible so a user can tell the
+        optimization is not taking effect without having to enable ``DD_TEST_DEBUG``.
+        """
+        real_mkdtemp = tempfile.mkdtemp
+        monkeypatch.setattr(tempfile, "mkdtemp", lambda **kw: real_mkdtemp(**kw))
+        monkeypatch.setattr(xdist_module, "write_manifest_cache", mock.Mock(side_effect=OSError("no space left")))
+        warning = mock.Mock()
+        monkeypatch.setattr(xdist_module.log, "warning", warning)
+
+        assert generate_xdist_manifest(_session_manager_without_errors(), ["-n", "2"]) is None
+
+        assert warning.call_count == 1, warning.call_args_list
+        assert "Could not write xdist manifest cache" in warning.call_args.args[0]
 
 
 class TestXdistEventDelivery:


### PR DESCRIPTION
…write failures

Three small follow-ups to the xdist manifest-mode work (#19452), no behavior change beyond one log level.

Worksteal x manifest-mode regression test:
dd-trace-py's own suites run --dist worksteal (#19581), but TestXdistManifestMode only exercised default load distribution. The manifest is read at worker startup (before worksteal redistributes tests), so the two should be independent -- now guarded. Extracted the marker-project setup into a shared _write_manifest_marker_project helper (the existing load test now calls it, no behavior change).

Controller-side manifest write failure is now visible: generate_xdist_manifest already surfaced worker-side degradation at WARNING (a worker that can't read its controller's manifest), but the controller's own failure to *write* the cache was log.debug, invisible without DD_TEST_DEBUG. A read-only TMPDIR or "no space left" would silently lose the optimization for the whole session -- the exact "degrade silently" the PR avoided on the worker side. Bumped to log.warning for symmetry.

Session-vs-process OfflineMode scope (investigated, documented): the AIDEV-NOTE at resolve_inherited_manifest_env documenting the nested-in-process-run limitation now records that the proper fix (scoping OfflineMode to a session) was investigated and left as-is: OfflineMode is first resolved during SessionManager.__init__ (via env_tags and BackendConnectorSetup.detect_setup), before any session object exists, which is why it is a process singleton today. Scoping it to a session is a cross-cutting refactor of five modules with real test-isolation risk, for a narrow practical impact, so the cost does not yet justify the risk.

Testing: tests/testing/internal/pytest/test_pytest_xdist.py
 - TestXdistManifestMode.test_manifest_mode_active_under_worksteal_distribution
 - TestGenerateXdistManifestFailures.test_logs_warning_on_unexpected_write_failure
 - _write_manifest_marker_project helper shared by the manifest-mode tests.

Verified: riot venv py3.12 / pytest~=8.0 / pytest-xdist / pytest-cov.
 - tests/testing/internal/pytest/test_pytest_xdist.py: 32 passed
 - scripts/lint fmt + scripts/lint checks: 25/25 pass

No release note (changelog/no-changelog): tests and a log level only.

## Description

<!-- Provide an overview of the change and motivation for the change.
     Implementation detail and rationale belong here, not in the release note -
     release notes are customer-facing (see docs/releasenotes.rst). -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
