### PR TITLE
ci: install ddtest 1.7.0 and riot 0.23.0 in testrunner image

### DIFF
--- a/ci/requirements/ci.in
+++ b/ci/requirements/ci.in
@@ -19,7 +19,7 @@ pip-tools==7.5.2
 pip<25.3
 reno
 requests
-riot==0.22.0
+riot==0.23.0
 uv==0.9.25
 wrapt==1.16.0
 

--- a/ci/requirements/ci.txt
+++ b/ci/requirements/ci.txt
@@ -678,9 +678,8 @@ rich==14.2.0 \
     # via
     #   riot
     #   twine
-riot==0.22.0 \
-    --hash=sha256:8acd845bbdec248a21521aad1db9cb5323be8c6e2b4928509eb2025153252ada \
-    --hash=sha256:c92493dc906a7adf111efcefc30c4a21d67d2a6b00cae2bcc9c83237ca308b0b
+riot==0.23.0 \
+    --hash=sha256:acb57ade142013354b0ecab342b5123fe6bacb81504eb87fe494ac5e6d1ec25a
     # via -r ci/requirements/ci.in
 secretstorage==3.3.3 \
     --hash=sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@
 FROM debian:trixie-slim@sha256:4ffb3a1511099754cddc70eb1b12e50ffdb67619aa0ab6c13fcd800a78ef7c7a
 
 ARG TARGETARCH
-ARG RIOT_VERSION=0.22.0
+ARG RIOT_VERSION=0.23.0
 ARG UV_VERSION=0.11.14
 
 # http://bugs.python.org/issue19846
@@ -95,6 +95,12 @@ RUN apt-get update \
     fi \
     # Cleaning up apt cache space
     && rm -rf /var/lib/apt/lists/*
+
+# Install ddtest (pre-built binary from GitHub releases)
+# Must run as root before USER bits (below) — /usr/local/bin is root-owned.
+ARG DDTEST_VERSION=1.7.0
+RUN curl -fsSL "https://github.com/DataDog/ddtest/releases/download/v${DDTEST_VERSION}/ddtest-linux-${TARGETARCH}" -o /usr/local/bin/ddtest \
+  && chmod +x /usr/local/bin/ddtest
 
 
 USER bits


### PR DESCRIPTION
Update the testrunner Dockerfile to:
- Bump riot from 0.22.0 to 0.23.0
- Install ddtest 1.7.0 (pre-built binary from GitHub releases)

Update ci/requirements/ci.txt to pin riot==0.23.0 (with correct hash).

This is a prerequisite for the ddtest dogfooding PR (#19870): once the testrunner image is rebuilt with these changes, ddtest is available in PATH and the .ddtest_build CI job can be removed.

NOTE: the testrunner image hash in .gitlab/testrunner.yml must be updated after the image is rebuilt.

## Description

<!-- Provide an overview of the change and motivation for the change.
     Implementation detail and rationale belong here, not in the release note -
     release notes are customer-facing (see docs/releasenotes.rst). -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
