### PR TITLE
test(iast): fix cloned venv poisoning [APPSEC-69907]

### DIFF
--- a/tests/appsec/iast_packages/test_packages.py
+++ b/tests/appsec/iast_packages/test_packages.py
@@ -50,6 +50,9 @@ FLASK_SERVER_START_LOCK_PATH = os.path.join(CLONED_VENVS_DIR, "flask_server_star
 _XDIST_WORKER = os.environ.get("PYTEST_XDIST_WORKER", "")
 _XDIST_WORKER_NUM = int(_XDIST_WORKER[2:]) if _XDIST_WORKER.startswith("gw") else 0
 
+# pip installs into the cloned venvs reach the network, which fails intermittently in CI.
+_PIP_INSTALL_ATTEMPTS = 3
+
 
 @pytest.fixture(scope="session", autouse=True)
 def cleanup(request):
@@ -206,8 +209,16 @@ class PackageForTesting:
         env.update(os.environ)
         # CAVEAT: we use subprocess instead of `pip.main(["install", package_fullversion])` due to pip package
         # doesn't work correctly with riot environment and python packages path
-        proc = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, close_fds=True, env=env)
-        proc.wait()
+        for attempt in range(_PIP_INSTALL_ATTEMPTS):
+            proc = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, close_fds=True, env=env)
+            returncode = proc.wait()
+            if returncode == 0:
+                return
+            print(
+                "pip install %s failed with code %s (attempt %s/%s)"
+                % (package_fullversion, returncode, attempt + 1, _PIP_INSTALL_ATTEMPTS)
+            )
+        raise RuntimeError("pip install %s failed after %s attempts" % (package_fullversion, _PIP_INSTALL_ATTEMPTS))
 
     def install(self, python_cmd, install_extra=True):
         self._install(python_cmd, self.name, self.package_version)
@@ -227,25 +238,31 @@ class PackageForTesting:
         """
         cloned_venv_dir = os.path.join(CLONED_VENVS_DIR, self.name)
         cloned_venv_dir_latest = cloned_venv_dir + "-latest"
+        python_executable = os.path.join(cloned_venv_dir, "bin", "python")
+        python_executable_latest = os.path.join(cloned_venv_dir_latest, "bin", "python")
+        # Written only once every install succeeded: the directory itself exists from the clone on,
+        # so keying reuse on it caches a venv whose package failed to install.
+        ready_marker = cloned_venv_dir + ".ready"
 
         os.makedirs(CLONED_VENVS_DIR, exist_ok=True)
         lock_path = cloned_venv_dir + ".lock"
         with open(lock_path, "w") as _lock:
             fcntl.flock(_lock, fcntl.LOCK_EX)
-            if not os.path.exists(cloned_venv_dir):
+            if not os.path.exists(ready_marker):
+                shutil.rmtree(cloned_venv_dir, ignore_errors=True)
+                shutil.rmtree(cloned_venv_dir_latest, ignore_errors=True)
+
                 base_venv = template_venv()
 
                 clonevirtualenv.clone_virtualenv(base_venv, cloned_venv_dir)
                 clonevirtualenv.clone_virtualenv(base_venv, cloned_venv_dir_latest)
 
                 with set_pip_cache_dir():
-                    python_executable = os.path.join(cloned_venv_dir, "bin", "python")
                     self.install(python_executable)
-                    python_executable_latest = os.path.join(cloned_venv_dir_latest, "bin", "python")
                     self.install_latest(python_executable_latest)
-            else:
-                python_executable = os.path.join(cloned_venv_dir, "bin", "python")
-                python_executable_latest = os.path.join(cloned_venv_dir_latest, "bin", "python")
+
+                with open(ready_marker, "w"):
+                    pass
 
         return python_executable, python_executable_latest
 


### PR DESCRIPTION
## Description

APPSEC-69907. `_install` ignored pip's return code and `create_venv` keyed reuse on the cloned directory, which exists from the clone on. A failed pip install left a package-less venv cached for every later test and worker (`ModuleNotFoundError: No module named 'virtualenv'`). Installs now retry and raise; reuse is keyed on a `.ready` marker written only after every install succeeded.

Fixes flaky `test_packages_not_patched[virtualenv]` on py3.11/3.12/3.13.

## Testing

CI. Locally verified with a stubbed harness: a failed install raises and writes no marker, the next call rebuilds rather than reusing the poisoned venv, a successful build is reused without recloning, and `_install` retries 3 times before raising.

## Risks

Test-only. A pip failure is now a hard error instead of a silently broken venv, so a persistent install problem fails loudly on first use.