### PR TITLE
test(iast): give appsec test servers their own port [APPSEC-69907]

### DIFF
--- a/tests/appsec/app.py
+++ b/tests/appsec/app.py
@@ -1040,7 +1040,7 @@ def return_headers(*args, **kwargs):
 @app.route("/vulnerablerequestdownstream", methods=["GET"])
 def vulnerable_request_downstream():
     _weak_hash_vulnerability()
-    port = str(request.args.get("port", "8050"))
+    port = str(request.args.get("port", os.getenv("FLASK_RUN_PORT", "8050")))
     # Propagate the received headers to the downstream service
     http_poolmanager = urllib3.PoolManager(num_pools=1)
     # Sending a GET request and getting back response as HTTPResponse object.

--- a/tests/appsec/appsec_utils.py
+++ b/tests/appsec/appsec_utils.py
@@ -42,6 +42,17 @@ def _port_is_available(port: int) -> bool:
             return False
 
 
+def get_free_port() -> int:
+    """A port nothing is bound to right now, for a server that would otherwise reuse a fixed one.
+
+    Tests sharing a fixed port inherit the previous server's orphaned workers, which hold it
+    bound well past teardown and make the next bind fail.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("0.0.0.0", 0))
+        return int(sock.getsockname()[1])
+
+
 def _wait_for_port_release(port: int, timeout: float = 10.0) -> bool:
     """Wait until the port can be bound again, returning False if it never can.
 

--- a/tests/appsec/appsec_utils.py
+++ b/tests/appsec/appsec_utils.py
@@ -14,6 +14,7 @@ from requests.exceptions import ConnectionError  # noqa: A004
 
 from ddtrace.appsec._constants import IAST
 from ddtrace.internal.compat import PYTHON_VERSION_INFO
+from tests.appsec.ports import port_is_available
 from tests.utils import _build_env
 from tests.webclient import Client
 
@@ -26,33 +27,6 @@ SERVER_STARTUP_TIMEOUT = float(os.environ.get("DD_TEST_SERVER_STARTUP_TIMEOUT", 
 SERVER_STARTUP_POLL_INTERVAL = 0.1
 
 
-def _port_is_available(port: int) -> bool:
-    """Whether a server could bind the port right now.
-
-    Binding is the question that matters, since it is what the next server does. Probing with
-    connect() instead reports a port as free once a bound server's listen backlog fills, and
-    opens real connections to a live server.
-    """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        try:
-            sock.bind(("0.0.0.0", int(port)))
-            return True
-        except OSError:
-            return False
-
-
-def get_free_port() -> int:
-    """A port nothing is bound to right now, for a server that would otherwise reuse a fixed one.
-
-    Tests sharing a fixed port inherit the previous server's orphaned workers, which hold it
-    bound well past teardown and make the next bind fail.
-    """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("0.0.0.0", 0))
-        return int(sock.getsockname()[1])
-
-
 def _wait_for_port_release(port: int, timeout: float = 10.0) -> bool:
     """Wait until the port can be bound again, returning False if it never can.
 
@@ -61,10 +35,10 @@ def _wait_for_port_release(port: int, timeout: float = 10.0) -> bool:
     """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        if _port_is_available(port):
+        if port_is_available(port):
             return True
         time.sleep(0.1)
-    return _port_is_available(port)
+    return port_is_available(port)
 
 
 def _process_exit_code(server_process) -> _t.Optional[int]:
@@ -114,7 +88,7 @@ def _server_diagnostics(server_process, port: int, cmd: list, port_was_free_at_s
         "free_port fixture) instead of sharing a fixed one."
     )
     return (
-        f"port={port} port_still_bound={not _port_is_available(port)} pid={server_process.pid} "
+        f"port={port} port_still_bound={not port_is_available(port)} pid={server_process.pid} "
         f"exit_code={exit_code} (None means it was still running, so it was too slow rather "
         f"than dead; a non-zero code with the port bound means another server still holds it)\n"
         f"command={cmd}" + already_taken

--- a/tests/appsec/appsec_utils.py
+++ b/tests/appsec/appsec_utils.py
@@ -102,14 +102,22 @@ def _wait_for_server_ready(client: Client, server_process, port: int, use_multip
             time.sleep(SERVER_STARTUP_POLL_INTERVAL)
 
 
-def _server_diagnostics(server_process, port: int, cmd: list) -> str:
+def _server_diagnostics(server_process, port: int, cmd: list, port_was_free_at_start: bool = True) -> str:
     """Facts that are not in the captured server output but explain most startup failures."""
     exit_code = _process_exit_code(server_process)
+    already_taken = (
+        ""
+        if port_was_free_at_start
+        else f"\nport {port} was ALREADY BOUND when this server was started, so it never had a "
+        "chance to bind and the failure above is a consequence, not the cause. Something a "
+        "previous test left running still holds the port; give this test its own port (the "
+        "free_port fixture) instead of sharing a fixed one."
+    )
     return (
         f"port={port} port_still_bound={not _port_is_available(port)} pid={server_process.pid} "
         f"exit_code={exit_code} (None means it was still running, so it was too slow rather "
         f"than dead; a non-zero code with the port bound means another server still holds it)\n"
-        f"command={cmd}"
+        f"command={cmd}" + already_taken
     )
 
 
@@ -497,8 +505,13 @@ def appsec_application_server(
             subprocess_kwargs["preexec_fn"] = preexec  # type: ignore[assignment]
 
     # A previous test's server may still hold the port, which would make this one fail to bind.
-    if not _wait_for_port_release(port):
-        print(f"WARNING: port {port} was still bound when starting the server")
+    port_was_free_at_start = _wait_for_port_release(port)
+    if not port_was_free_at_start:
+        print(
+            f"WARNING: port {port} is still bound by something a previous test left running. "
+            "Starting anyway, but this server will almost certainly fail to bind: expect the "
+            "startup failure below to be a symptom of this, not of the server itself."
+        )
 
     if use_multiprocess:
         # Run the server command by replacing the child Python process with the target binary (exec),
@@ -530,7 +543,7 @@ def appsec_application_server(
                 "DD_TEST_SERVER_STARTUP_TIMEOUT); its output is in the captured stdout/stderr "
                 "above.\n"
                 % (time.monotonic() - startup_started, SERVER_STARTUP_TIMEOUT)
-                + _server_diagnostics(server_process, port, cmd)
+                + _server_diagnostics(server_process, port, cmd, port_was_free_at_start)
             ) from exc
 
         # If we run a Gunicorn application, we want to get the child's pid, see test_flask_remoteconfig.py
@@ -553,7 +566,7 @@ def appsec_application_server(
                 "Server shutdown request failed after %.3fs; its output is in the captured "
                 "stdout/stderr above.\n"
                 % (time.monotonic() - shutdown_started)
-                + _server_diagnostics(server_process, port, cmd)
+                + _server_diagnostics(server_process, port, cmd, port_was_free_at_start)
                 + "\n"
                 + _dump_server_stacks(server_process)
             )
@@ -595,7 +608,11 @@ def appsec_application_server(
         finally:
             # Do not hand the port to the next test while a worker still holds it.
             if not _wait_for_port_release(port):
-                print(f"WARNING: port {port} still bound after server teardown")
+                print(
+                    f"WARNING: port {port} is still bound after tearing down the server; a worker "
+                    "outlived it. Harmless while each test uses its own port, but it will break "
+                    "the next test that asks for this one."
+                )
 
 
 def _mp_target(_cmd: list[str], _env: dict) -> None:

--- a/tests/appsec/integrations/conftest.py
+++ b/tests/appsec/integrations/conftest.py
@@ -1,8 +1,8 @@
 import pytest
 
-from tests.appsec.appsec_utils import get_free_port
 from tests.appsec.integrations.utils_testagent import clear_session
 from tests.appsec.integrations.utils_testagent import start_trace
+from tests.appsec.ports import get_free_port
 from tests.conftest import get_original_test_name
 
 

--- a/tests/appsec/integrations/conftest.py
+++ b/tests/appsec/integrations/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+from tests.appsec.appsec_utils import get_free_port
 from tests.appsec.integrations.utils_testagent import clear_session
 from tests.appsec.integrations.utils_testagent import start_trace
 from tests.conftest import get_original_test_name
@@ -20,3 +21,9 @@ def iast_test_token(request):
         yield token
     finally:
         clear_session(token)
+
+
+@pytest.fixture
+def free_port():
+    """A port of this test's own, so an orphan from the previous test cannot block its server."""
+    return get_free_port()

--- a/tests/appsec/integrations/django_tests/conftest.py
+++ b/tests/appsec/integrations/django_tests/conftest.py
@@ -13,7 +13,6 @@ from ddtrace.contrib.internal.django.patch import patch as django_patch
 from ddtrace.contrib.internal.psycopg.patch import patch as psycopg_patch
 from ddtrace.contrib.internal.requests.patch import patch as requests_patch
 from ddtrace.contrib.internal.sqlite3.patch import patch as sqlite3_patch
-from tests.appsec.appsec_utils import get_free_port
 from tests.utils import TracerSpanContainer
 from tests.utils import override_env
 from tests.utils import override_global_config
@@ -43,12 +42,6 @@ def pytest_configure():
         django_patch()
         enable_iast_propagation()
         django.setup()
-
-
-@pytest.fixture
-def free_port():
-    """A port of this test's own, so an orphan from the previous test cannot block its server."""
-    return get_free_port()
 
 
 @pytest.fixture

--- a/tests/appsec/integrations/django_tests/conftest.py
+++ b/tests/appsec/integrations/django_tests/conftest.py
@@ -13,6 +13,7 @@ from ddtrace.contrib.internal.django.patch import patch as django_patch
 from ddtrace.contrib.internal.psycopg.patch import patch as psycopg_patch
 from ddtrace.contrib.internal.requests.patch import patch as requests_patch
 from ddtrace.contrib.internal.sqlite3.patch import patch as sqlite3_patch
+from tests.appsec.appsec_utils import get_free_port
 from tests.utils import TracerSpanContainer
 from tests.utils import override_env
 from tests.utils import override_global_config
@@ -42,6 +43,12 @@ def pytest_configure():
         django_patch()
         enable_iast_propagation()
         django.setup()
+
+
+@pytest.fixture
+def free_port():
+    """A port of this test's own, so an orphan from the previous test cannot block its server."""
+    return get_free_port()
 
 
 @pytest.fixture

--- a/tests/appsec/integrations/django_tests/test_iast_django_testagent.py
+++ b/tests/appsec/integrations/django_tests/test_iast_django_testagent.py
@@ -34,7 +34,7 @@ log = get_logger(__name__)
     ],
 )
 @pytest.mark.parametrize("server", (gunicorn_django_server, django_server))
-def test_iast_cmdi_bodies(body, content_type, server):
+def test_iast_cmdi_bodies(body, content_type, server, free_port):
     """This test parametrizes body encodings to validate that IAST taints http.request.body
     across different content types and still reports CMDI on the vulnerable sink in
     tests/appsec/integrations/django_tests/django_app/views.py:command_injection
@@ -53,6 +53,7 @@ def test_iast_cmdi_bodies(body, content_type, server):
         iast_enabled="true",
         appsec_enabled="false",
         token=token,
+        port=free_port,
         env={
             "_DD_IAST_PATCH_MODULES": (
                 "benchmarks.,tests.appsec.,tests.appsec.integrations.django_tests.django_app.views."
@@ -103,11 +104,12 @@ def test_iast_cmdi_bodies(body, content_type, server):
 
 
 @pytest.mark.parametrize("server", (gunicorn_django_server, django_server))
-def test_iast_untrusted_serialization_yaml(server, iast_test_token):
+def test_iast_untrusted_serialization_yaml(server, iast_test_token, free_port):
     with server(
         use_ddtrace_cmd=False,
         iast_enabled="true",
         token=iast_test_token,
+        port=free_port,
         env={
             "_DD_IAST_PATCH_MODULES": (
                 "benchmarks.,tests.appsec.,tests.appsec.integrations.django_tests.django_app.views."
@@ -189,7 +191,7 @@ def test_iast_untrusted_serialization_yaml(server, iast_test_token):
         (django_server, {}),
     ),
 )
-def test_iast_vulnerable_request_downstream_django(server, config, iast_test_token):
+def test_iast_vulnerable_request_downstream_django(server, config, iast_test_token, free_port):
     """Mirror Flask downstream propagation test for Django server.
 
     Sends a request with Datadog headers to the Django endpoint which triggers a weak-hash
@@ -199,13 +201,13 @@ def test_iast_vulnerable_request_downstream_django(server, config, iast_test_tok
     # Base env, overridden by the parametrized config.
     config = dict(config)
     config["env"] = {"DD_TRACE_URLLIB3_ENABLED": "true", **config.get("env", {})}
-    with server(use_ddtrace_cmd=True, iast_enabled="true", token=iast_test_token, port=8050, **config) as context:
+    with server(use_ddtrace_cmd=True, iast_enabled="true", token=iast_test_token, port=free_port, **config) as context:
         _, django_client, pid = context
 
         trace_id = 1212121212121212121
         parent_id = 34343434
         response = django_client.get(
-            "/vulnerablerequestdownstream/?port=8050",
+            f"/vulnerablerequestdownstream/?port={free_port}",
             headers={
                 "x-datadog-trace-id": str(trace_id),
                 "x-datadog-parent-id": str(parent_id),
@@ -243,7 +245,7 @@ def test_iast_vulnerable_request_downstream_django(server, config, iast_test_tok
         assert vulnerability["hash"]
 
 
-def test_iast_concurrent_requests_limit_django(iast_test_token):
+def test_iast_concurrent_requests_limit_django(iast_test_token, free_port):
     """Ensure only DD_IAST_MAX_CONCURRENT_REQUESTS requests have IAST enabled concurrently in Django app.
 
     Hits /iast-enabled concurrently; the response contains whether IAST was enabled.
@@ -258,7 +260,7 @@ def test_iast_concurrent_requests_limit_django(iast_test_token):
         "DD_IAST_MAX_CONCURRENT_REQUESTS": str(max_concurrent),
     }
 
-    with django_server(iast_enabled="true", token=iast_test_token, env=env) as context:
+    with django_server(iast_enabled="true", token=iast_test_token, port=free_port, env=env) as context:
         _, django_client, pid = context
 
         def worker():
@@ -277,10 +279,11 @@ def test_iast_concurrent_requests_limit_django(iast_test_token):
     assert false_count <= rejected_requests, f"{len(results)} requests. Expected {rejected_requests}, got {false_count}"
 
 
-def test_iast_header_injection(iast_test_token):
+def test_iast_header_injection(iast_test_token, free_port):
     with django_server(
         iast_enabled="true",
         token=iast_test_token,
+        port=free_port,
         env={
             "_DD_IAST_PATCH_MODULES": (
                 "benchmarks.,tests.appsec.,tests.appsec.integrations.django_tests.django_app.views."

--- a/tests/appsec/integrations/fastapi_tests/test_iast_fastapi_testagent.py
+++ b/tests/appsec/integrations/fastapi_tests/test_iast_fastapi_testagent.py
@@ -19,10 +19,10 @@ IAST_ENV = {
 }
 
 
-def test_iast_header_injection_secure_attack(iast_test_token):
+def test_iast_header_injection_secure_attack(iast_test_token, free_port):
     """Test that header injection is prevented in a secure FastAPI endpoint."""
     with uvicorn_server(
-        iast_enabled="true", token=iast_test_token, port=8050, env={"DD_TRACE_DEBUG": "true"}
+        iast_enabled="true", token=iast_test_token, port=free_port, env={"DD_TRACE_DEBUG": "true"}
     ) as context:
         _, fastapi_client, pid = context
         with pytest.raises(ConnectionError):
@@ -47,10 +47,10 @@ def test_iast_header_injection_secure_attack(iast_test_token):
 
 
 @pytest.mark.parametrize("use_multiprocess", (True, False))
-def test_iast_header_injection(iast_test_token, use_multiprocess):
+def test_iast_header_injection(iast_test_token, use_multiprocess, free_port):
     """Test that header injection attempts are detected in FastAPI."""
     with uvicorn_server(
-        iast_enabled="true", token=iast_test_token, port=8050, use_multiprocess=use_multiprocess
+        iast_enabled="true", token=iast_test_token, port=free_port, use_multiprocess=use_multiprocess
     ) as context:
         _, fastapi_client, pid = context
 
@@ -74,10 +74,10 @@ def test_iast_header_injection(iast_test_token, use_multiprocess):
     assert len(vulnerabilities) == 0
 
 
-def test_iast_header_injection_attack(iast_test_token):
+def test_iast_header_injection_attack(iast_test_token, free_port):
     """Test that header injection attempts are detected in FastAPI."""
     with uvicorn_server(
-        iast_enabled="true", token=iast_test_token, port=8050, env={"DD_TRACE_DEBUG": "true"}
+        iast_enabled="true", token=iast_test_token, port=free_port, env={"DD_TRACE_DEBUG": "true"}
     ) as context:
         _, fastapi_client, pid = context
         with pytest.raises(ConnectionError):
@@ -101,9 +101,9 @@ def test_iast_header_injection_attack(iast_test_token):
 
 
 @pytest.mark.parametrize("use_multiprocess", (True, False))
-def test_iast_ssrf_secure_mark_validator(iast_test_token, use_multiprocess):
+def test_iast_ssrf_secure_mark_validator(iast_test_token, use_multiprocess, free_port):
     with uvicorn_server(
-        iast_enabled="true", token=iast_test_token, port=8050, use_multiprocess=use_multiprocess
+        iast_enabled="true", token=iast_test_token, port=free_port, use_multiprocess=use_multiprocess
     ) as context:
         _, fastapi_client, pid = context
         response = fastapi_client.post(
@@ -128,10 +128,10 @@ def test_iast_ssrf_secure_mark_validator(iast_test_token, use_multiprocess):
 
 
 @pytest.mark.parametrize("use_multiprocess", (True, False))
-def test_iast_cmdi_uvicorn(iast_test_token, use_multiprocess):
+def test_iast_cmdi_uvicorn(iast_test_token, use_multiprocess, free_port):
     """Test command injection vulnerability detection with uvicorn server."""
     with uvicorn_server(
-        iast_enabled="true", token=iast_test_token, port=8050, use_multiprocess=use_multiprocess
+        iast_enabled="true", token=iast_test_token, port=free_port, use_multiprocess=use_multiprocess
     ) as context:
         _, fastapi_client, pid = context
 
@@ -162,14 +162,14 @@ def test_iast_cmdi_uvicorn(iast_test_token, use_multiprocess):
     assert vulnerability["hash"]
 
 
-def test_iast_cmdi_form_request_fastapi(iast_test_token):
+def test_iast_cmdi_form_request_fastapi(iast_test_token, free_port):
     """Validate IAST CMDI detection when FastAPI parses forms via request.form().
 
     Targets the endpoint /iast-cmdi-vulnerability-form-request which reads the form from the
     Request object rather than using Form(...) in the signature.
     """
 
-    with uvicorn_server(iast_enabled="true", token=iast_test_token, port=8050, env=IAST_ENV) as context:
+    with uvicorn_server(iast_enabled="true", token=iast_test_token, port=free_port, env=IAST_ENV) as context:
         _, fastapi_client, pid = context
 
         response = fastapi_client.post(
@@ -204,14 +204,14 @@ def test_iast_cmdi_form_request_fastapi(iast_test_token):
     assert vulnerability["hash"]
 
 
-def test_iast_cmdi_form_multiple_fastapi(iast_test_token):
+def test_iast_cmdi_form_multiple_fastapi(iast_test_token, free_port):
     """Validate IAST CMDI detection with multiple Form parameters in FastAPI.
 
     Targets the endpoint /iast-cmdi-vulnerability-form-multiple which declares two Form parameters
     (command and flag). The vulnerable value is "command".
     """
 
-    with uvicorn_server(iast_enabled="true", token=iast_test_token, port=8050, env=IAST_ENV) as context:
+    with uvicorn_server(iast_enabled="true", token=iast_test_token, port=free_port, env=IAST_ENV) as context:
         _, fastapi_client, pid = context
 
         response = fastapi_client.post(
@@ -248,10 +248,10 @@ def test_iast_cmdi_form_multiple_fastapi(iast_test_token):
     assert vulnerability["hash"]
 
 
-def test_iast_cmdi_form_uvicorn(iast_test_token):
+def test_iast_cmdi_form_uvicorn(iast_test_token, free_port):
     """Test command injection vulnerability detection with form data using uvicorn server."""
     with uvicorn_server(
-        iast_enabled="true", token=iast_test_token, port=8050, env={"DD_TRACE_DEBUG": "true"}
+        iast_enabled="true", token=iast_test_token, port=free_port, env={"DD_TRACE_DEBUG": "true"}
     ) as context:
         _, fastapi_client, pid = context
 
@@ -284,7 +284,7 @@ def test_iast_cmdi_form_uvicorn(iast_test_token):
     assert vulnerability["hash"]
 
 
-def test_iast_concurrent_requests_limit(iast_test_token):
+def test_iast_concurrent_requests_limit(iast_test_token, free_port):
     """Ensure only DD_IAST_MAX_CONCURRENT_REQUESTS requests have IAST enabled concurrently.
 
     This test hits the /iast-enabled endpoint concurrently. The endpoint awaits a short sleep
@@ -300,7 +300,7 @@ def test_iast_concurrent_requests_limit(iast_test_token):
         "DD_IAST_MAX_CONCURRENT_REQUESTS": str(max_concurrent),
     }
 
-    with uvicorn_server(iast_enabled="true", token=iast_test_token, port=8050, env=env) as context:
+    with uvicorn_server(iast_enabled="true", token=iast_test_token, port=free_port, env=env) as context:
         _, fastapi_client, pid = context
 
         def worker():
@@ -320,7 +320,7 @@ def test_iast_concurrent_requests_limit(iast_test_token):
     assert false_count == rejected_requests
 
 
-def test_iast_vulnerable_request_downstream_fastapi(iast_test_token):
+def test_iast_vulnerable_request_downstream_fastapi(iast_test_token, free_port):
     """Mirror downstream propagation test for FastAPI server.
 
     Sends a request with Datadog headers to the FastAPI endpoint which triggers a weak-hash
@@ -331,14 +331,14 @@ def test_iast_vulnerable_request_downstream_fastapi(iast_test_token):
         "DD_APM_TRACING_ENABLED": "false",
         "DD_TRACE_URLLIB3_ENABLED": "true",
     }
-    with uvicorn_server(iast_enabled="true", token=iast_test_token, env=env, port=8050) as context:
+    with uvicorn_server(iast_enabled="true", token=iast_test_token, env=env, port=free_port) as context:
         _, fastapi_client, pid = context
 
         trace_id = 1212121212121212121
         parent_id = 34343434
         response = fastapi_client.get(
             "/vulnerablerequestdownstream",
-            params={"port": 8050},
+            params={"port": free_port},
             headers={
                 "x-datadog-trace-id": str(trace_id),
                 "x-datadog-parent-id": str(parent_id),
@@ -386,11 +386,11 @@ def test_iast_vulnerable_request_downstream_fastapi(iast_test_token):
         ('{"key":"master"}', "application/json"),  # simple JSON object
     ],
 )
-def test_iast_cmdi_bodies_fastapi(body, content_type, iast_test_token):
+def test_iast_cmdi_bodies_fastapi(body, content_type, iast_test_token, free_port):
     """Parametrized body encodings to validate that IAST taints http.request.body in FastAPI
     and still reports CMDI on the vulnerable sink in tests/appsec/integrations/fastapi_tests/app.py:cmdi_body
     """
-    with uvicorn_server(iast_enabled="true", token=iast_test_token, port=8050, env=IAST_ENV) as context:
+    with uvicorn_server(iast_enabled="true", token=iast_test_token, port=free_port, env=IAST_ENV) as context:
         _, fastapi_client, pid = context
 
         response = fastapi_client.post(
@@ -438,12 +438,12 @@ def test_iast_cmdi_bodies_fastapi(body, content_type, iast_test_token):
         ("[{}]", "application/json"),  # JSON array
     ],
 )
-def test_iast_cmdi_bodies_fastapi_no_vulnerabilities(body, content_type, iast_test_token):
+def test_iast_cmdi_bodies_fastapi_no_vulnerabilities(body, content_type, iast_test_token, free_port):
     """Parametrized body encodings to validate that IAST taints http.request.body in FastAPI
     and still reports CMDI on the vulnerable sink in tests/appsec/integrations/fastapi_tests/app.py:cmdi_body
     """
 
-    with uvicorn_server(iast_enabled="true", token=iast_test_token, port=8050, env=IAST_ENV) as context:
+    with uvicorn_server(iast_enabled="true", token=iast_test_token, port=free_port, env=IAST_ENV) as context:
         _, fastapi_client, pid = context
 
         response = fastapi_client.post(
@@ -469,13 +469,13 @@ def test_iast_cmdi_bodies_fastapi_no_vulnerabilities(body, content_type, iast_te
     assert len(vulnerabilities) == 0, f"Invalid number of vulnerabilities ({len(vulnerabilities)}):\n{vulnerabilities}"
 
 
-def test_iast_stream_fastapi(iast_test_token):
+def test_iast_stream_fastapi(iast_test_token, free_port):
     """Test IAST with streaming responses in FastAPI.
 
     Validates that IAST can handle streaming responses without segfaults or crashes.
     Also validates middleware correctly processes headers during streaming.
     """
-    with uvicorn_server(iast_enabled="true", token=iast_test_token, port=8050) as context:
+    with uvicorn_server(iast_enabled="true", token=iast_test_token, port=free_port) as context:
         _, fastapi_client, pid = context
 
         headers = {
@@ -507,13 +507,13 @@ def test_iast_stream_fastapi(iast_test_token):
     assert len(spans_with_iast) >= 1
 
 
-def test_iast_stream_cmdi_fastapi(iast_test_token):
+def test_iast_stream_cmdi_fastapi(iast_test_token, free_port):
     """Test IAST CMDI detection with streaming responses in FastAPI.
 
     Validates that IAST can detect CMDI vulnerabilities even when the response is streamed.
     Also validates middleware correctly processes headers during streaming with POST requests.
     """
-    with uvicorn_server(iast_enabled="true", token=iast_test_token, port=8050, env=IAST_ENV) as context:
+    with uvicorn_server(iast_enabled="true", token=iast_test_token, port=free_port, env=IAST_ENV) as context:
         _, fastapi_client, pid = context
 
         headers = {

--- a/tests/appsec/integrations/fastapi_tests/test_iast_mcp_testagent.py
+++ b/tests/appsec/integrations/fastapi_tests/test_iast_mcp_testagent.py
@@ -55,7 +55,7 @@ async def mcp_client_session(port: int):
             yield session
 
 
-def test_iast_mcp_baseline(iast_test_token):
+def test_iast_mcp_baseline(iast_test_token, free_port):
     """Baseline test: Regular CMDI endpoint works with IAST.
 
     Also validates that headers are properly processed by the middleware.
@@ -64,7 +64,7 @@ def test_iast_mcp_baseline(iast_test_token):
         python_cmd=sys.executable,
         iast_enabled="true",
         token=iast_test_token,
-        port=8051,
+        port=free_port,
         app="tests.appsec.integrations.fastapi_tests.mcp_app:app",
         env=MCP_IAST_ENV,
     ) as context:
@@ -108,7 +108,7 @@ def test_iast_mcp_baseline(iast_test_token):
 
 
 @pytest.mark.asyncio
-async def test_iast_mcp_tool_call_safe(iast_test_token):
+async def test_iast_mcp_tool_call_safe(iast_test_token, free_port):
     """Test MCP tool call (safe tool) with IAST enabled using in-memory connection.
 
     This test validates that IAST can handle MCP tool calls without causing segmentation faults.
@@ -120,7 +120,7 @@ async def test_iast_mcp_tool_call_safe(iast_test_token):
         python_cmd=sys.executable,
         iast_enabled="true",
         token=iast_test_token,
-        port=8051,
+        port=free_port,
         app="tests.appsec.integrations.fastapi_tests.mcp_app:app",
         env=MCP_IAST_ENV,
     ) as context:
@@ -160,7 +160,7 @@ async def test_iast_mcp_tool_call_safe(iast_test_token):
 
 
 @pytest.mark.asyncio
-async def test_iast_mcp_vulnerable_tool(iast_test_token):
+async def test_iast_mcp_vulnerable_tool(iast_test_token, free_port):
     """Test MCP vulnerable tool with IAST detection using in-memory connection.
 
     This test validates that IAST can detect vulnerabilities (CMDI) when MCP tools
@@ -177,7 +177,7 @@ async def test_iast_mcp_vulnerable_tool(iast_test_token):
         python_cmd=sys.executable,
         iast_enabled="true",
         token=iast_test_token,
-        port=8051,
+        port=free_port,
         app="tests.appsec.integrations.fastapi_tests.mcp_app:app",
         env=env,
     ) as context:
@@ -228,7 +228,7 @@ async def test_iast_mcp_vulnerable_tool(iast_test_token):
 
 
 @pytest.mark.asyncio
-async def test_iast_mcp_multiple_tool_calls(iast_test_token):
+async def test_iast_mcp_multiple_tool_calls(iast_test_token, free_port):
     """Test multiple MCP tool calls to stress test IAST with MCP interaction.
 
     This test makes multiple consecutive MCP tool calls to detect potential
@@ -240,7 +240,7 @@ async def test_iast_mcp_multiple_tool_calls(iast_test_token):
         python_cmd=sys.executable,
         iast_enabled="true",
         token=iast_test_token,
-        port=8051,
+        port=free_port,
         app="tests.appsec.integrations.fastapi_tests.mcp_app:app",
         env=MCP_IAST_ENV,
     ) as context:
@@ -289,7 +289,7 @@ async def test_iast_mcp_multiple_tool_calls(iast_test_token):
     assert len(spans_with_iast) >= 1
 
 
-def test_iast_mcp_header_tainting(iast_test_token):
+def test_iast_mcp_header_tainting(iast_test_token, free_port):
     """Test that HTTP headers are properly tainted by IAST.
 
     This test validates that IAST correctly taints incoming HTTP headers,
@@ -299,7 +299,7 @@ def test_iast_mcp_header_tainting(iast_test_token):
         python_cmd=sys.executable,
         iast_enabled="true",
         token=iast_test_token,
-        port=8051,
+        port=free_port,
         app="tests.appsec.integrations.fastapi_tests.mcp_app:app",
         env=MCP_IAST_ENV,
     ) as context:
@@ -338,7 +338,7 @@ def test_iast_mcp_header_tainting(iast_test_token):
     assert len(spans_with_iast) >= 1
 
 
-def test_iast_mcp_header_cmdi(iast_test_token):
+def test_iast_mcp_header_cmdi(iast_test_token, free_port):
     """Test CMDI detection using tainted header value.
 
     This test validates that IAST can detect CMDI vulnerabilities when the
@@ -351,7 +351,7 @@ def test_iast_mcp_header_cmdi(iast_test_token):
         python_cmd=sys.executable,
         iast_enabled="true",
         token=iast_test_token,
-        port=8051,
+        port=free_port,
         app="tests.appsec.integrations.fastapi_tests.mcp_app:app",
         env=env,
     ) as context:
@@ -408,7 +408,7 @@ def test_iast_mcp_header_cmdi(iast_test_token):
 
 
 @pytest.mark.asyncio
-async def test_iast_mcp_sse_streaming_safe_tool(iast_test_token):
+async def test_iast_mcp_sse_streaming_safe_tool(iast_test_token, free_port):
     """Test MCP tool call via HTTP/SSE streaming with IAST enabled (safe tool).
 
     This test uses the real HTTP/SSE transport to communicate with the MCP server,
@@ -419,7 +419,7 @@ async def test_iast_mcp_sse_streaming_safe_tool(iast_test_token):
         python_cmd=sys.executable,
         iast_enabled="true",
         token=iast_test_token,
-        port=8052,
+        port=free_port,
         app="tests.appsec.integrations.fastapi_tests.mcp_app:app",
         env=MCP_IAST_ENV,
     ) as context:
@@ -462,7 +462,7 @@ async def test_iast_mcp_sse_streaming_safe_tool(iast_test_token):
 
 
 @pytest.mark.asyncio
-async def test_iast_mcp_sse_streaming_vulnerable_tool(iast_test_token):
+async def test_iast_mcp_sse_streaming_vulnerable_tool(iast_test_token, free_port):
     """Test MCP vulnerable tool via HTTP/SSE streaming with IAST detection.
 
     **MOST CRITICAL TEST** - This test uses real HTTP/SSE streaming to call
@@ -481,7 +481,7 @@ async def test_iast_mcp_sse_streaming_vulnerable_tool(iast_test_token):
         python_cmd=sys.executable,
         iast_enabled="true",
         token=iast_test_token,
-        port=8052,
+        port=free_port,
         app="tests.appsec.integrations.fastapi_tests.mcp_app:app",
         env=env,
     ) as context:
@@ -529,7 +529,7 @@ async def test_iast_mcp_sse_streaming_vulnerable_tool(iast_test_token):
 
 
 @pytest.mark.asyncio
-async def test_iast_mcp_sse_streaming_multiple_calls(iast_test_token):
+async def test_iast_mcp_sse_streaming_multiple_calls(iast_test_token, free_port):
     """Test multiple MCP tool calls via HTTP/SSE streaming to stress test IAST.
 
     This test makes multiple consecutive calls through a real HTTP/SSE streaming
@@ -540,7 +540,7 @@ async def test_iast_mcp_sse_streaming_multiple_calls(iast_test_token):
         python_cmd=sys.executable,
         iast_enabled="true",
         token=iast_test_token,
-        port=8052,
+        port=free_port,
         app="tests.appsec.integrations.fastapi_tests.mcp_app:app",
         env=MCP_IAST_ENV,
     ) as context:
@@ -597,7 +597,7 @@ async def test_iast_mcp_sse_streaming_multiple_calls(iast_test_token):
 
 
 @pytest.mark.asyncio
-async def test_iast_mcp_sse_streaming_stress_test_hundreds(iast_test_token):
+async def test_iast_mcp_sse_streaming_stress_test_hundreds(iast_test_token, free_port):
     """Stress test: Call the same endpoint hundreds of times via HTTP/SSE streaming.
 
     This test repeatedly calls the same MCP tool endpoint hundreds of times to detect:
@@ -614,7 +614,7 @@ async def test_iast_mcp_sse_streaming_stress_test_hundreds(iast_test_token):
         python_cmd=sys.executable,
         iast_enabled="true",
         token=iast_test_token,
-        port=8053,
+        port=free_port,
         app="tests.appsec.integrations.fastapi_tests.mcp_app:app",
         env=MCP_IAST_ENV,
     ) as context:

--- a/tests/appsec/integrations/fastapi_tests/test_iast_mcp_testagent.py
+++ b/tests/appsec/integrations/fastapi_tests/test_iast_mcp_testagent.py
@@ -437,7 +437,7 @@ async def test_iast_mcp_sse_streaming_safe_tool(iast_test_token, free_port):
         assert response.status_code == 200
 
         # Now test MCP via HTTP/SSE streaming
-        async with mcp_client_session(8052) as session:
+        async with mcp_client_session(free_port) as session:
             # Initialize the session
             await session.initialize()
 
@@ -500,7 +500,7 @@ async def test_iast_mcp_sse_streaming_vulnerable_tool(iast_test_token, free_port
         assert response.status_code == 200
 
         # Test MCP vulnerable tool via HTTP/SSE streaming
-        async with mcp_client_session(8052) as session:
+        async with mcp_client_session(free_port) as session:
             # Initialize the session
             await session.initialize()
 
@@ -558,7 +558,7 @@ async def test_iast_mcp_sse_streaming_multiple_calls(iast_test_token, free_port)
         assert response.status_code == 200
 
         # Make multiple MCP calls via HTTP/SSE streaming
-        async with mcp_client_session(8052) as session:
+        async with mcp_client_session(free_port) as session:
             # Initialize
             await session.initialize()
 
@@ -632,7 +632,7 @@ async def test_iast_mcp_sse_streaming_stress_test_hundreds(iast_test_token, free
         assert response.status_code == 200
 
         # Make hundreds of calls to the same endpoint via HTTP/SSE streaming
-        async with mcp_client_session(8053) as session:
+        async with mcp_client_session(free_port) as session:
             # Initialize
             await session.initialize()
 

--- a/tests/appsec/integrations/flask_tests/test_appsec_flask.py
+++ b/tests/appsec/integrations/flask_tests/test_appsec_flask.py
@@ -8,7 +8,6 @@ from ddtrace.ext import http
 from ddtrace.internal import constants
 from ddtrace.internal.utils.http import _format_template
 from tests.appsec.appsec_utils import flask_server
-from tests.appsec.integrations.flask_tests.utils import _PORT
 import tests.appsec.rules as rules
 from tests.contrib.flask import BaseFlaskTestCase
 from tests.utils import override_global_config
@@ -105,9 +104,9 @@ class FlaskAppSecTestCase(BaseFlaskTestCase):
     ["true", "false"],
 )
 @pytest.mark.parametrize("appsec_enabled", ["true", "false"])
-def test_flask_common_modules_patch(function, iast_enabled, appsec_enabled):
+def test_flask_common_modules_patch(function, iast_enabled, appsec_enabled, free_port):
     with flask_server(
-        appsec_enabled=appsec_enabled, iast_enabled=iast_enabled, token=None, port=_PORT, assert_debug=False
+        appsec_enabled=appsec_enabled, iast_enabled=iast_enabled, token=None, port=free_port, assert_debug=False
     ) as context:
         _, flask_client, pid = context
 

--- a/tests/appsec/integrations/flask_tests/test_flask_remoteconfig.py
+++ b/tests/appsec/integrations/flask_tests/test_flask_remoteconfig.py
@@ -10,7 +10,6 @@ import uuid
 import pytest
 
 from tests.appsec.appsec_utils import gunicorn_flask_server
-from tests.appsec.integrations.flask_tests.utils import _PORT
 from tests.appsec.integrations.flask_tests.utils import _multi_requests
 from tests.appsec.integrations.flask_tests.utils import _request_200
 from tests.appsec.integrations.utils_testagent import _get_agent_client
@@ -177,9 +176,9 @@ def _request_403(client, debug_mode=False, max_retries=40, sleep_time=1):
     raise AssertionError("request_403 failed, max_retries=%d, sleep_time=%f" % (max_retries, sleep_time))
 
 
-def test_load_testing_appsec_ip_blocking_gunicorn_rc_disabled():
+def test_load_testing_appsec_ip_blocking_gunicorn_rc_disabled(free_port):
     token = "test_load_testing_appsec_ip_blocking_gunicorn_rc_disabled_{}".format(str(uuid.uuid4()))
-    with gunicorn_flask_server(remote_configuration_enabled="false", token=token, port=_PORT) as context:
+    with gunicorn_flask_server(remote_configuration_enabled="false", token=token, port=free_port) as context:
         _, gunicorn_client, pid = context
 
         _request_200(gunicorn_client)
@@ -191,9 +190,9 @@ def test_load_testing_appsec_ip_blocking_gunicorn_rc_disabled():
         _unblock_ip(token)
 
 
-def test_load_testing_appsec_ip_blocking_gunicorn_block():
+def test_load_testing_appsec_ip_blocking_gunicorn_block(free_port):
     token = "test_load_testing_appsec_ip_blocking_gunicorn_block_{}".format(str(uuid.uuid4()))
-    with gunicorn_flask_server(token=token, port=_PORT, use_ddtrace_cmd=False) as context:
+    with gunicorn_flask_server(token=token, port=free_port, use_ddtrace_cmd=False) as context:
         _, gunicorn_client, pid = context
 
         _request_200(gunicorn_client)
@@ -207,9 +206,9 @@ def test_load_testing_appsec_ip_blocking_gunicorn_block():
         _request_200(gunicorn_client)
 
 
-def test_load_testing_appsec_ip_blocking_gunicorn_block_and_kill_child_worker():
+def test_load_testing_appsec_ip_blocking_gunicorn_block_and_kill_child_worker(free_port):
     token = "test_load_testing_appsec_ip_blocking_gunicorn_block_and_kill_child_worker_{}".format(str(uuid.uuid4()))
-    with gunicorn_flask_server(token=token, port=_PORT, use_ddtrace_cmd=False) as context:
+    with gunicorn_flask_server(token=token, port=free_port, use_ddtrace_cmd=False) as context:
         _, gunicorn_client, pid = context
 
         _request_200(gunicorn_client)
@@ -229,11 +228,11 @@ def test_load_testing_appsec_ip_blocking_gunicorn_block_and_kill_child_worker():
 
 
 @pytest.mark.skip(reason="_request_403 is flaky, figure out the error. APPSEC-57052")
-def test_load_testing_appsec_1click_and_ip_blocking_gunicorn_block_and_kill_child_worker():
+def test_load_testing_appsec_1click_and_ip_blocking_gunicorn_block_and_kill_child_worker(free_port):
     token = "test_load_testing_appsec_1click_and_ip_blocking_gunicorn_block_and_kill_child_worker_{}".format(
         str(uuid.uuid4())
     )
-    with gunicorn_flask_server(appsec_enabled="", token=token, port=_PORT) as context:
+    with gunicorn_flask_server(appsec_enabled="", token=token, port=free_port) as context:
         _, gunicorn_client, pid = context
 
         _request_200(gunicorn_client, debug_mode=False)

--- a/tests/appsec/integrations/flask_tests/test_gunicorn_handlers.py
+++ b/tests/appsec/integrations/flask_tests/test_gunicorn_handlers.py
@@ -7,14 +7,11 @@ from tests.appsec.appsec_utils import flask_server
 from tests.appsec.appsec_utils import gunicorn_flask_server
 
 
-_PORT = 8030
-
-
 @pytest.mark.parametrize("appsec_enabled", ("true", "false"))
 @pytest.mark.parametrize("apm_tracing_enabled", ("true", "false"))
 @pytest.mark.parametrize("tracer_enabled", ("true", "false"))
 @pytest.mark.parametrize("server", ((gunicorn_flask_server, flask_server)))
-def test_when_appsec_reads_chunked_requests(appsec_enabled, apm_tracing_enabled, tracer_enabled, server):
+def test_when_appsec_reads_chunked_requests(appsec_enabled, apm_tracing_enabled, tracer_enabled, server, free_port):
     def read_in_chunks(filepath, chunk_size=1024):
         file_object = open(filepath, "rb")
         while True:
@@ -35,7 +32,7 @@ def test_when_appsec_reads_chunked_requests(appsec_enabled, apm_tracing_enabled,
             apm_tracing_enabled=apm_tracing_enabled,
             remote_configuration_enabled="false",
             token=None,
-            port=_PORT,
+            port=free_port,
         ) as context:
             _, gunicorn_client, pid = context
             headers = {
@@ -57,7 +54,11 @@ def test_when_appsec_reads_chunked_requests(appsec_enabled, apm_tracing_enabled,
 @pytest.mark.parametrize("tracer_enabled", ("true", "false"))
 @pytest.mark.parametrize("server", ((gunicorn_flask_server, flask_server)))
 def test_corner_case_when_appsec_reads_chunked_request_with_no_body(
-    appsec_enabled, apm_tracing_enabled, tracer_enabled, server
+    appsec_enabled,
+    apm_tracing_enabled,
+    tracer_enabled,
+    server,
+    free_port,
 ):
     """if Gunicorn receives an empty body but Transfer-Encoding is "chunked", the application hangs but gunicorn
     control it with a timeout
@@ -69,7 +70,7 @@ def test_corner_case_when_appsec_reads_chunked_request_with_no_body(
             apm_tracing_enabled=apm_tracing_enabled,
             remote_configuration_enabled="false",
             token=None,
-            port=_PORT,
+            port=free_port,
         ) as context:
             _, gunicorn_client, pid = context
             headers = {
@@ -83,7 +84,7 @@ def test_corner_case_when_appsec_reads_chunked_request_with_no_body(
 @pytest.mark.parametrize("apm_tracing_enabled", ("true", "false"))
 @pytest.mark.parametrize("tracer_enabled", ("true", "false"))
 @pytest.mark.parametrize("server", ((gunicorn_flask_server, flask_server)))
-def test_when_appsec_reads_empty_body_no_hang(appsec_enabled, apm_tracing_enabled, tracer_enabled, server):
+def test_when_appsec_reads_empty_body_no_hang(appsec_enabled, apm_tracing_enabled, tracer_enabled, server, free_port):
     """A bug was detected when running a Flask application locally
 
     file1.py:
@@ -102,7 +103,7 @@ def test_when_appsec_reads_empty_body_no_hang(appsec_enabled, apm_tracing_enable
         tracer_enabled=tracer_enabled,
         remote_configuration_enabled="false",
         token=None,
-        port=_PORT,
+        port=free_port,
     ) as context:
         _, gunicorn_client, pid = context
 
@@ -123,7 +124,11 @@ def test_when_appsec_reads_empty_body_no_hang(appsec_enabled, apm_tracing_enable
 @pytest.mark.parametrize("tracer_enabled", ("true", "false"))
 @pytest.mark.parametrize("server", ((gunicorn_flask_server,)))
 def test_when_appsec_reads_empty_body_and_content_length_no_hang(
-    appsec_enabled, apm_tracing_enabled, tracer_enabled, server
+    appsec_enabled,
+    apm_tracing_enabled,
+    tracer_enabled,
+    server,
+    free_port,
 ):
     """We test Gunicorn, Flask server hangs forever in all cases"""
     with server(
@@ -132,7 +137,7 @@ def test_when_appsec_reads_empty_body_and_content_length_no_hang(
         tracer_enabled=tracer_enabled,
         remote_configuration_enabled="false",
         token=None,
-        port=_PORT,
+        port=free_port,
     ) as context:
         _, gunicorn_client, pid = context
 

--- a/tests/appsec/integrations/flask_tests/test_iast_flask_patching.py
+++ b/tests/appsec/integrations/flask_tests/test_iast_flask_patching.py
@@ -2,11 +2,10 @@ import pytest
 
 from tests.appsec.appsec_utils import flask_server
 from tests.appsec.appsec_utils import gunicorn_flask_server
-from tests.appsec.integrations.flask_tests.utils import _PORT
 from tests.appsec.integrations.flask_tests.utils import _request_200
 
 
-def test_flask_iast_ast_patching_import_error():
+def test_flask_iast_ast_patching_import_error(free_port):
     """this is a regression test for a bug with IAST + BeautifulSoup4, we were catching the ImportError exception in
     ddtrace.appsec._iast._loader
     try:
@@ -17,7 +16,7 @@ def test_flask_iast_ast_patching_import_error():
         pass
     """
     with flask_server(
-        appsec_enabled="false", iast_enabled="true", token=None, port=_PORT, assert_debug=False
+        appsec_enabled="false", iast_enabled="true", token=None, port=free_port, assert_debug=False
     ) as context:
         _, flask_client, pid = context
 
@@ -44,7 +43,7 @@ def test_flask_iast_ast_patching_import_error():
         "subn",
     ],
 )
-def test_flask_iast_ast_patching_re(style, endpoint, function):
+def test_flask_iast_ast_patching_re(style, endpoint, function, free_port):
     """
     Tests re module patching end to end by checking that re.sub is propagating properly
     """
@@ -54,7 +53,7 @@ def test_flask_iast_ast_patching_re(style, endpoint, function):
 
         filename = quote_plus("Isaac Newton")
     with flask_server(
-        appsec_enabled="false", iast_enabled="true", token=None, port=_PORT, assert_debug=False
+        appsec_enabled="false", iast_enabled="true", token=None, port=free_port, assert_debug=False
     ) as context:
         _, flask_client, pid = context
 
@@ -72,13 +71,13 @@ def test_flask_iast_ast_patching_re(style, endpoint, function):
         "stringio-read",
     ],
 )
-def test_flask_iast_ast_patching_io(style, function, endpoint="io"):
+def test_flask_iast_ast_patching_io(style, function, free_port, endpoint="io"):
     """
     Tests _io/io BytesIO and StringIO patching end to end
     """
     filename = "path_traversal_test_file.txt"
     with flask_server(
-        appsec_enabled="false", iast_enabled="true", token=None, port=_PORT, assert_debug=False
+        appsec_enabled="false", iast_enabled="true", token=None, port=free_port, assert_debug=False
     ) as context:
         _, flask_client, pid = context
 
@@ -88,11 +87,11 @@ def test_flask_iast_ast_patching_io(style, function, endpoint="io"):
         assert response.content == b"OK"
 
 
-def test_multiple_requests():
+def test_multiple_requests(free_port):
     """we want to validate context is working correctly among multiple request and no race condition creating and
     destroying contexts
     """
-    with gunicorn_flask_server(remote_configuration_enabled="false", iast_enabled="true", port=_PORT) as context:
+    with gunicorn_flask_server(remote_configuration_enabled="false", iast_enabled="true", port=free_port) as context:
         _, client, pid = context
 
         _request_200(

--- a/tests/appsec/integrations/flask_tests/test_iast_flask_telemetry.py
+++ b/tests/appsec/integrations/flask_tests/test_iast_flask_telemetry.py
@@ -16,8 +16,8 @@ def _get_iast_metrics(test_agent_session, telemetry_writer):
     ]
 
 
-def test_iast_span_metrics():
-    with flask_server(iast_enabled="true", token=None, port=8050) as context:
+def test_iast_span_metrics(free_port):
+    with flask_server(iast_enabled="true", token=None, port=free_port) as context:
         _, flask_client, pid = context
 
         response = flask_client.get("/iast-cmdi-vulnerability?filename=path_traversal_test_file.txt")

--- a/tests/appsec/integrations/flask_tests/test_iast_flask_testagent.py
+++ b/tests/appsec/integrations/flask_tests/test_iast_flask_testagent.py
@@ -461,7 +461,7 @@ def test_iast_vulnerable_request_downstream(server, config, apm_tracing_enabled,
         trace_id = 1212121212121212121
         parent_id = 34343434
         response = flask_client.get(
-            f"/vulnerablerequestdownstream?port={free_port}",
+            "/vulnerablerequestdownstream",
             headers={
                 "x-datadog-trace-id": str(trace_id),
                 "x-datadog-parent-id": str(parent_id),

--- a/tests/appsec/integrations/flask_tests/test_iast_flask_testagent.py
+++ b/tests/appsec/integrations/flask_tests/test_iast_flask_testagent.py
@@ -45,8 +45,10 @@ _GEVENT_SERVERS_SCENARIOS = (
 
 
 @pytest.mark.skip(reason="Stacktrace error in debug mode doesn't work outside the request APPSEC-56862")
-def test_iast_stacktrace_error(iast_test_token):
-    with flask_server(iast_enabled="true", token=iast_test_token, port=8050, env={"FLASK_DEBUG": "true"}) as context:
+def test_iast_stacktrace_error(iast_test_token, free_port):
+    with flask_server(
+        iast_enabled="true", token=iast_test_token, port=free_port, env={"FLASK_DEBUG": "true"}
+    ) as context:
         _, flask_client, pid = context
         response = flask_client.get(
             "/iast-stacktrace-leak-vulnerability", headers={"X-Datadog-Test-Session-Token": iast_test_token}
@@ -162,7 +164,7 @@ def test_iast_stacktrace_error(iast_test_token):
 
 
 @pytest.mark.parametrize("server", (gunicorn_flask_server, flask_server))
-def test_iast_concurrent_requests_limit_flask(server, iast_test_token):
+def test_iast_concurrent_requests_limit_flask(server, iast_test_token, free_port):
     """Ensure only DD_IAST_MAX_CONCURRENT_REQUESTS requests have IAST enabled concurrently.
 
     This mirrors the FastAPI test by hitting /iast-enabled concurrently on the Flask app.
@@ -176,7 +178,7 @@ def test_iast_concurrent_requests_limit_flask(server, iast_test_token):
         "DD_IAST_MAX_CONCURRENT_REQUESTS": str(max_concurrent),
     }
 
-    with server(iast_enabled="true", token=iast_test_token, port=8050, env=env) as context:
+    with server(iast_enabled="true", token=iast_test_token, port=free_port, env=env) as context:
         _, client, pid = context
 
         def worker():
@@ -201,8 +203,8 @@ def test_iast_concurrent_requests_limit_flask(server, iast_test_token):
 
 
 @pytest.mark.parametrize("server", (gunicorn_flask_server, flask_server))
-def test_iast_cmdi(server, iast_test_token):
-    with server(iast_enabled="true", token=iast_test_token, port=8050) as context:
+def test_iast_cmdi(server, iast_test_token, free_port):
+    with server(iast_enabled="true", token=iast_test_token, port=free_port) as context:
         _, flask_client, pid = context
 
         response = flask_client.get("/iast-cmdi-vulnerability?filename=path_traversal_test_file.txt")
@@ -234,8 +236,8 @@ def test_iast_cmdi(server, iast_test_token):
 
 
 @pytest.mark.parametrize("server", (gunicorn_flask_server, flask_server))
-def test_iast_cmdi_secure(server, iast_test_token):
-    with server(iast_enabled="true", token=iast_test_token, port=8050) as context:
+def test_iast_cmdi_secure(server, iast_test_token, free_port):
+    with server(iast_enabled="true", token=iast_test_token, port=free_port) as context:
         _, flask_client, pid = context
 
         response = flask_client.get("/iast-cmdi-vulnerability-secure?filename=path_traversal_test_file.txt")
@@ -251,7 +253,7 @@ def test_iast_cmdi_secure(server, iast_test_token):
 
 
 @pytest.mark.parametrize("server", (gunicorn_flask_server, flask_server))
-def test_iast_sqli_complex(server, iast_test_token):
+def test_iast_sqli_complex(server, iast_test_token, free_port):
     """Test complex SQL injection detection with SQLAlchemy in a Flask application.
 
     This test verifies that IAST can properly detect SQL injection in complex SQLAlchemy
@@ -270,7 +272,7 @@ def test_iast_sqli_complex(server, iast_test_token):
     This test ensures that the fix remains effective in a real Flask application context.
     """
 
-    with server(iast_enabled="true", token=iast_test_token, port=8050) as context:
+    with server(iast_enabled="true", token=iast_test_token, port=free_port) as context:
         _, flask_client, pid = context
 
         response = flask_client.get("/iast-sqli-vulnerability-complex")
@@ -286,7 +288,7 @@ def test_iast_sqli_complex(server, iast_test_token):
 
 
 @pytest.mark.parametrize("server", (gunicorn_flask_server, flask_server))
-def test_iast_header_injection_secure(server, iast_test_token):
+def test_iast_header_injection_secure(server, iast_test_token, free_port):
     """Test that header injection is prevented in a real Flask application.
 
     This test demonstrates the secure behavior of Flask's header handling in a real application
@@ -301,7 +303,7 @@ def test_iast_header_injection_secure(server, iast_test_token):
     This is in contrast to the test client behavior (test_flask_header_injection) where header
     values can be set directly without going through Werkzeug's sanitization.
     """
-    with server(iast_enabled="true", token=iast_test_token, port=8050) as context:
+    with server(iast_enabled="true", token=iast_test_token, port=free_port) as context:
         _, flask_client, pid = context
 
         response = flask_client.get(
@@ -328,8 +330,8 @@ def test_iast_header_injection_secure(server, iast_test_token):
 
 
 @pytest.mark.parametrize("server", ((gunicorn_flask_server, flask_server)))
-def test_iast_header_injection(server, iast_test_token):
-    with server(iast_enabled="true", token=iast_test_token, port=8050) as context:
+def test_iast_header_injection(server, iast_test_token, free_port):
+    with server(iast_enabled="true", token=iast_test_token, port=free_port) as context:
         _, flask_client, pid = context
 
         response = flask_client.post(
@@ -369,9 +371,9 @@ def test_iast_header_injection(server, iast_test_token):
 
 
 @pytest.mark.parametrize("server", ((gunicorn_flask_server, flask_server)))
-def test_iast_code_injection_with_stacktrace(server, iast_test_token):
+def test_iast_code_injection_with_stacktrace(server, iast_test_token, free_port):
     tainted_string = "code_injection_string"
-    with server(iast_enabled="true", token=iast_test_token, port=8050) as context:
+    with server(iast_enabled="true", token=iast_test_token, port=free_port) as context:
         _, flask_client, pid = context
 
         response = flask_client.get(f"/iast-code-injection?filename={tainted_string}")
@@ -406,8 +408,8 @@ def test_iast_code_injection_with_stacktrace(server, iast_test_token):
 
 
 @pytest.mark.parametrize("server", (gunicorn_flask_server, flask_server))
-def test_iast_unvalidated_redirect(server, iast_test_token):
-    with server(iast_enabled="true", token=iast_test_token, port=8050) as context:
+def test_iast_unvalidated_redirect(server, iast_test_token, free_port):
+    with server(iast_enabled="true", token=iast_test_token, port=free_port) as context:
         _, flask_client, pid = context
 
         response = flask_client.get("/iast-unvalidated_redirect-header?location=malicious_url")
@@ -442,7 +444,7 @@ def test_iast_unvalidated_redirect(server, iast_test_token):
 
 @pytest.mark.parametrize("server, config", _GEVENT_SERVERS_SCENARIOS)
 @pytest.mark.parametrize("apm_tracing_enabled", ("true", "false"))
-def test_iast_vulnerable_request_downstream(server, config, apm_tracing_enabled, iast_test_token):
+def test_iast_vulnerable_request_downstream(server, config, apm_tracing_enabled, iast_test_token, free_port):
     """Gevent has a lot of problematic interactions with the tracer. When IAST applies AST transformations to a file
     and reloads the module using compile and exec, it can interfere with Gevent’s monkey patching
     """
@@ -452,14 +454,14 @@ def test_iast_vulnerable_request_downstream(server, config, apm_tracing_enabled,
         appsec_enabled="false",
         apm_tracing_enabled=apm_tracing_enabled,
         token=iast_test_token,
-        port=8050,
+        port=free_port,
         **config,
     ) as context:
         _, flask_client, pid = context
         trace_id = 1212121212121212121
         parent_id = 34343434
         response = flask_client.get(
-            "/vulnerablerequestdownstream",
+            f"/vulnerablerequestdownstream?port={free_port}",
             headers={
                 "x-datadog-trace-id": str(trace_id),
                 "x-datadog-parent-id": str(parent_id),
@@ -502,10 +504,10 @@ def test_iast_vulnerable_request_downstream(server, config, apm_tracing_enabled,
 
 @pytest.mark.parametrize("server, config", _GEVENT_SERVERS_SCENARIOS)
 @pytest.mark.parametrize("iast_enabled", ("true", "false"))
-def test_gevent_sensitive_socketpair(server, config, iast_enabled, iast_test_token):
+def test_gevent_sensitive_socketpair(server, config, iast_enabled, iast_test_token, free_port):
     """Validate socket.socketpair lifecycle under various Gunicorn/gevent configurations."""
     with server(
-        iast_enabled=iast_enabled, appsec_enabled="false", token=iast_test_token, port=8050, **config
+        iast_enabled=iast_enabled, appsec_enabled="false", token=iast_test_token, port=free_port, **config
     ) as context:
         _, flask_client, pid = context
         response = flask_client.get("/socketpair")
@@ -515,10 +517,10 @@ def test_gevent_sensitive_socketpair(server, config, iast_enabled, iast_test_tok
 
 @pytest.mark.parametrize("server, config", _GEVENT_SERVERS_SCENARIOS)
 @pytest.mark.parametrize("iast_enabled", ("true", "false"))
-def test_gevent_sensitive_greenlet(server, config, iast_enabled, iast_test_token):
+def test_gevent_sensitive_greenlet(server, config, iast_enabled, iast_test_token, free_port):
     """Validate gevent Greenlet execution under various Gunicorn/gevent configurations."""
     with server(
-        iast_enabled=iast_enabled, appsec_enabled="false", token=iast_test_token, port=8050, **config
+        iast_enabled=iast_enabled, appsec_enabled="false", token=iast_test_token, port=free_port, **config
     ) as context:
         _, flask_client, pid = context
         response = flask_client.get("/gevent-greenlet")
@@ -528,10 +530,10 @@ def test_gevent_sensitive_greenlet(server, config, iast_enabled, iast_test_token
 
 @pytest.mark.parametrize("server, config", _GEVENT_SERVERS_SCENARIOS)
 @pytest.mark.parametrize("iast_enabled", ("true", "false"))
-def test_gevent_sensitive_subprocess(server, config, iast_enabled, iast_test_token):
+def test_gevent_sensitive_subprocess(server, config, iast_enabled, iast_test_token, free_port):
     """Validate subprocess.Popen lifecycle under various Gunicorn/gevent configurations."""
     with server(
-        iast_enabled=iast_enabled, appsec_enabled="false", token=iast_test_token, port=8050, **config
+        iast_enabled=iast_enabled, appsec_enabled="false", token=iast_test_token, port=free_port, **config
     ) as context:
         _, flask_client, pid = context
         response = flask_client.get("/subprocess-popen")

--- a/tests/appsec/integrations/flask_tests/test_sca_flask_testagent.py
+++ b/tests/appsec/integrations/flask_tests/test_sca_flask_testagent.py
@@ -126,13 +126,13 @@ _SCA_ENV = {
 class TestSCAFlaskTelemetry:
     """SCA telemetry e2e tests using Flask + test agent."""
 
-    def test_sca_enabled_dependencies_have_metadata_key(self, iast_test_token):
+    def test_sca_enabled_dependencies_have_metadata_key(self, iast_test_token, free_port):
         """When DD_APPSEC_SCA_ENABLED=true, dependency events include metadata key."""
         with flask_server(
             appsec_enabled="false",
             iast_enabled="false",
             token=iast_test_token,
-            port=8050,
+            port=free_port,
             env=_SCA_ENV,
         ) as context:
             _, flask_client, pid = context
@@ -153,13 +153,13 @@ class TestSCAFlaskTelemetry:
             f"Sample: {all_deps[:3]}"
         )
 
-    def test_sca_disabled_dependencies_have_no_metadata_key(self, iast_test_token):
+    def test_sca_disabled_dependencies_have_no_metadata_key(self, iast_test_token, free_port):
         """When DD_APPSEC_SCA_ENABLED is not set, no metadata key on dependencies."""
         with flask_server(
             appsec_enabled="false",
             iast_enabled="false",
             token=iast_test_token,
-            port=8051,
+            port=free_port,
             env={
                 "DD_TELEMETRY_HEARTBEAT_INTERVAL": "2",
             },
@@ -180,7 +180,7 @@ class TestSCAFlaskTelemetry:
             f"Sample: {deps_with_metadata_key[:3]}"
         )
 
-    def test_sca_reports_cve_metadata_after_vulnerable_call(self, iast_test_token):
+    def test_sca_reports_cve_metadata_after_vulnerable_call(self, iast_test_token, free_port):
         """When a vulnerable function is called, its CVE metadata is reported.
 
         This test:
@@ -193,7 +193,7 @@ class TestSCAFlaskTelemetry:
             appsec_enabled="false",
             iast_enabled="false",
             token=iast_test_token,
-            port=8052,
+            port=free_port,
             env=_SCA_ENV,
         ) as context:
             _, flask_client, pid = context
@@ -234,7 +234,7 @@ class TestSCAFlaskTelemetry:
         )
         assert hit.get("line", 0) > 0, "Expected a non-zero caller line number"
 
-    def test_sca_same_cve_first_hit_wins(self, iast_test_token):
+    def test_sca_same_cve_first_hit_wins(self, iast_test_token, free_port):
         """Same CVE triggered from two different functions — first hit wins (max reached=1).
 
         /sca-test-requests and /sca-test-requests-alt both call
@@ -245,7 +245,7 @@ class TestSCAFlaskTelemetry:
             appsec_enabled="false",
             iast_enabled="false",
             token=iast_test_token,
-            port=8053,
+            port=free_port,
             env=_SCA_ENV,
         ) as context:
             _, flask_client, pid = context
@@ -280,7 +280,7 @@ class TestSCAFlaskTelemetry:
                 f"got {len(entry['reached'])}: {entry['reached']}"
             )
 
-    def test_sca_deduplication_repeated_calls(self, iast_test_token):
+    def test_sca_deduplication_repeated_calls(self, iast_test_token, free_port):
         """Calling the same vulnerable function multiple times from the same call site
         produces only ONE reached entry per CVE.
 
@@ -292,7 +292,7 @@ class TestSCAFlaskTelemetry:
             appsec_enabled="false",
             iast_enabled="false",
             token=iast_test_token,
-            port=8054,
+            port=free_port,
             env=_SCA_ENV,
         ) as context:
             _, flask_client, pid = context
@@ -321,7 +321,7 @@ class TestSCAFlaskTelemetry:
                 f"Expected at most 1 reached entry per CVE, got {len(entry['reached'])}"
             )
 
-    def test_sca_cve_registered_at_load_time(self, iast_test_token):
+    def test_sca_cve_registered_at_load_time(self, iast_test_token, free_port):
         """CVEs appear with reached=[] in telemetry without triggering any vulnerable endpoint.
 
         When SCA loads CVE data at startup, it registers all applicable CVEs
@@ -332,7 +332,7 @@ class TestSCAFlaskTelemetry:
             appsec_enabled="false",
             iast_enabled="false",
             token=iast_test_token,
-            port=8055,
+            port=free_port,
             env=_SCA_ENV,
         ) as context:
             _, flask_client, pid = context
@@ -467,13 +467,13 @@ class TestSCAFlaskExtendedHeartbeat:
     pin down that contract end-to-end.
     """
 
-    def test_extended_heartbeat_includes_dependencies_with_metadata_key(self, iast_test_token):
+    def test_extended_heartbeat_includes_dependencies_with_metadata_key(self, iast_test_token, free_port):
         """SCA on: extended heartbeat carries dependencies and metadata key is preserved."""
         with flask_server(
             appsec_enabled="false",
             iast_enabled="false",
             token=iast_test_token,
-            port=8056,
+            port=free_port,
             env=_SCA_EXTENDED_HEARTBEAT_ENV,
         ) as context:
             _, flask_client, pid = context
@@ -503,7 +503,7 @@ class TestSCAFlaskExtendedHeartbeat:
             f"Expected SCA-tracked deps to carry the 'metadata' key in extended heartbeat. Sample deps: {all_deps[:3]}"
         )
 
-    def test_extended_heartbeat_includes_cve_metadata_after_vulnerable_call(self, iast_test_token):
+    def test_extended_heartbeat_includes_cve_metadata_after_vulnerable_call(self, iast_test_token, free_port):
         """After a vulnerable call, CVE reachability shows up in app-extended-heartbeat too.
 
         This is the contract-critical scenario: even if the backend missed the
@@ -514,7 +514,7 @@ class TestSCAFlaskExtendedHeartbeat:
             appsec_enabled="false",
             iast_enabled="false",
             token=iast_test_token,
-            port=8057,
+            port=free_port,
             env=_SCA_EXTENDED_HEARTBEAT_ENV,
         ) as context:
             _, flask_client, pid = context
@@ -549,7 +549,7 @@ class TestSCAFlaskExtendedHeartbeat:
         assert "sca_test_requests" in hit.get("symbol", "")
         assert hit.get("line", 0) > 0
 
-    def test_extended_heartbeat_dependency_list_is_full_snapshot(self, iast_test_token):
+    def test_extended_heartbeat_dependency_list_is_full_snapshot(self, iast_test_token, free_port):
         """The extended-heartbeat dependency list must be a superset of the delta channel.
 
         Compares the union of dependencies seen across app-dependencies-loaded
@@ -566,7 +566,7 @@ class TestSCAFlaskExtendedHeartbeat:
             appsec_enabled="false",
             iast_enabled="false",
             token=iast_test_token,
-            port=8058,
+            port=free_port,
             env=_SCA_EXTENDED_HEARTBEAT_ENV,
         ) as context:
             _, flask_client, pid = context

--- a/tests/appsec/integrations/flask_tests/utils.py
+++ b/tests/appsec/integrations/flask_tests/utils.py
@@ -4,7 +4,6 @@ from multiprocessing.pool import ThreadPool
 import time
 
 
-_PORT = 8040
 try:
     werkzeug_version = tuple(map(int, version("werkzeug").split(".")))
 except PackageNotFoundError:

--- a/tests/appsec/ports.py
+++ b/tests/appsec/ports.py
@@ -1,0 +1,37 @@
+"""Port helpers, kept free of heavy imports.
+
+The shared integrations conftest needs get_free_port for every test under it, including
+suites whose venv has none of appsec_utils' dependencies.
+"""
+
+import socket
+
+
+def port_is_available(port: int) -> bool:
+    """Whether a server could bind the port right now.
+
+    Binding is the question that matters, since it is what the next server does. Probing with
+    connect() instead reports a port as free once a bound server's listen backlog fills, and
+    opens real connections to a live server.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind(("0.0.0.0", int(port)))
+            return True
+        except OSError:
+            return False
+
+
+def get_free_port() -> int:
+    """A port nothing is bound to right now, for a server that would otherwise reuse a fixed one.
+
+    Tests sharing a fixed port inherit the previous server's orphaned workers, which hold it
+    bound well past teardown and make the next bind fail.
+
+    Binds 0.0.0.0 because that is what the servers themselves bind: a port free on loopback can
+    already be taken on another interface.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("0.0.0.0", 0))
+        return int(sock.getsockname()[1])

--- a/tests/appsec/suitespec.yml
+++ b/tests/appsec/suitespec.yml
@@ -76,6 +76,7 @@ suites:
       - tests/appsec/iast_packages/*
       - tests/appsec/app.py
       - tests/appsec/appsec_utils.py
+      - tests/appsec/ports.py
     timeout: 50m
   iast_tdd_propagation:
     venvs_per_job: 1
@@ -88,6 +89,7 @@ suites:
       - tests/appsec/iast_tdd_propagation/*
       - tests/appsec/app.py
       - tests/appsec/appsec_utils.py
+      - tests/appsec/ports.py
     retry: 2
     snapshot: true
   appsec_integrations_pygoat:
@@ -154,6 +156,7 @@ suites:
       - tests/appsec/integrations/flask_tests/test_appsec_flask_telemetry.py
       - tests/appsec/app.py
       - tests/appsec/appsec_utils.py
+      - tests/appsec/ports.py
     retry: 2
     # test_appsec_flask_telemetry.py asserts on payloads received by the test agent.
     snapshot: true
@@ -170,6 +173,7 @@ suites:
       - tests/appsec/integrations/flask_tests/*
       - tests/appsec/app.py
       - tests/appsec/appsec_utils.py
+      - tests/appsec/ports.py
     retry: 2
     services:
       - testagent
@@ -185,6 +189,7 @@ suites:
       - '@remoteconfig'
       - tests/appsec/integrations/django_tests/*
       - tests/appsec/appsec_utils.py
+      - tests/appsec/ports.py
     retry: 2
     services:
       - testagent
@@ -200,6 +205,7 @@ suites:
       - '@remoteconfig'
       - tests/appsec/integrations/fastapi_tests/*
       - tests/appsec/appsec_utils.py
+      - tests/appsec/ports.py
     retry: 2
     services:
       - testagent


### PR DESCRIPTION
## Description

APPSEC-69907. Every server in the appsec integration suites reused a fixed port — 8050 shared by 31 tests, plus per-file constants (`_PORT` 8030/8040) and hand-allocated ranges (8050-8058 in the SCA tests, 8051-8053 in the MCP ones). A gunicorn worker orphaned by one test keeps its port bound past teardown, so the next test fails to bind: `exit_code=1` with `port_still_bound=True`, surfaced as a misleading "Server failed to start".

`_wait_for_port_release` already existed and already knew about this, but on timeout it only printed a warning and started the server anyway, into a certain failure.

All 65 server starts across django, flask and fastapi now take a port from a `free_port` fixture in the shared `tests/appsec/integrations/conftest.py`, so an orphan can no longer block anything. The fixed constants and hand-allocated ranges go away with it.

The contention paths in `appsec_utils` should now go cold, so this also makes what they print say what actually happened: a startup failure on an already-bound port now reports that the server never had a chance to bind, instead of reading as a failure of the server itself.

Fixes flaky `test_iast_vulnerable_request_downstream_django[gunicorn_django_server-config3 / config5][py3.11]`.

## Testing

CI. Locally verified that `get_free_port` hands out distinct ports a real server can then bind, and checked by AST walk over `tests/appsec/integrations/*/test_*.py` that all 65 `server(...)` / `flask_server(...)` / `uvicorn_server(...)` / `django_server(...)` calls pass `port=free_port` and that every one of their tests declares the fixture — 0 sites left on a fixed port.

## Risks

Test-only. Two things to know:
- Ports come from the ephemeral range now, so a server's port is no longer predictable from the test source. The three self-downstream tests (django, flask, fastapi `/vulnerablerequestdownstream`) pass the real port through explicitly; the flask one previously relied on the app defaulting to 8050.
- `get_free_port` closes its probe socket before the server binds, so a port could in principle be taken in between. Much narrower than the window this closes, and `_wait_for_port_release` still runs.

## Additional Notes

Untouched: the `port=8000` defaults inside the app modules themselves (`tests/appsec/app.py`, `fastapi_tests/app.py`) — those are the apps' own fallbacks, not test-side choices.