### PR TITLE
feat(llmobs): route experiments requests through the agent when no app key is set

### DIFF
--- a/ddtrace/internal/evp_proxy/constants.py
+++ b/ddtrace/internal/evp_proxy/constants.py
@@ -7,5 +7,6 @@ EVP_SUBDOMAIN_HEADER_COVERAGE_VALUE = "citestcov-intake"
 EVP_SUBDOMAIN_HEADER_EVENT_VALUE = "citestcycle-intake"
 EVP_SUBDOMAIN_HEADER_EVENT_PLATFORM_VALUE = "event-platform-intake"
 EVP_SUBDOMAIN_HEADER_NAME = "X-Datadog-EVP-Subdomain"
+EVP_NEEDS_APP_KEY_HEADER_NAME = "X-Datadog-NeedsAppKey"
 DEFAULT_EVP_PAYLOAD_SIZE_LIMIT = 5 << 20  # 5 MiB (actual server limit is 5.1 MB)
 DEFAULT_EVP_EVENT_SIZE_LIMIT = 5_000_000  # 5 MB, LLM Obs event size limit

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -609,7 +609,9 @@ class LLMObs(Service):
         # These endpoints need an app key on top of the api key. With one configured locally, keep
         # going straight to intake; without one, fall back to the agent's EVP proxy, which can supply
         # both credentials, rather than failing outright. Agentless still wins when it is requested.
-        dne_agentless = bool(self._app_key) or agentless_enabled
+        # An override origin stands in for intake rather than for an agent, so it stays direct too:
+        # proxying it would prefix /evp_proxy/v2 onto a server that cannot supply either credential.
+        dne_agentless = bool(self._app_key) or agentless_enabled or bool(_env.get("DD_LLMOBS_OVERRIDE_ORIGIN", ""))
         self._dne_client = LLMObsExperimentsClient(
             interval=float(_env.get("_DD_LLMOBS_WRITER_INTERVAL", 1.0)),
             timeout=float(_env.get("_DD_LLMOBS_WRITER_TIMEOUT", 5.0)),

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -606,11 +606,8 @@ class LLMObs(Service):
             interval=float(_env.get("_DD_LLMOBS_EVALUATOR_INTERVAL", 1.0)),
             llmobs_service=self,
         )
-        # These endpoints need an app key on top of the api key. With one configured locally, keep
-        # going straight to intake; without one, fall back to the agent's EVP proxy, which can supply
-        # both credentials, rather than failing outright. Agentless still wins when it is requested.
-        # An override origin stands in for intake rather than for an agent, so it stays direct too:
-        # proxying it would prefix /evp_proxy/v2 onto a server that cannot supply either credential.
+        # Without a local app key, fall back to the agent's EVP proxy, which supplies both
+        # credentials. An override origin stands in for intake, not an agent, so it stays direct.
         dne_agentless = bool(self._app_key) or agentless_enabled or bool(_env.get("DD_LLMOBS_OVERRIDE_ORIGIN", ""))
         self._dne_client = LLMObsExperimentsClient(
             interval=float(_env.get("_DD_LLMOBS_WRITER_INTERVAL", 1.0)),

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -606,12 +606,16 @@ class LLMObs(Service):
             interval=float(_env.get("_DD_LLMOBS_EVALUATOR_INTERVAL", 1.0)),
             llmobs_service=self,
         )
+        # These endpoints need an app key on top of the api key. With one configured locally, keep
+        # going straight to intake; without one, fall back to the agent's EVP proxy, which can supply
+        # both credentials, rather than failing outright. Agentless still wins when it is requested.
+        dne_agentless = bool(self._app_key) or agentless_enabled
         self._dne_client = LLMObsExperimentsClient(
             interval=float(_env.get("_DD_LLMOBS_WRITER_INTERVAL", 1.0)),
             timeout=float(_env.get("_DD_LLMOBS_WRITER_TIMEOUT", 5.0)),
             _app_key=self._app_key,
             _default_project=Project(name=self._project_name, _id=""),
-            is_agentless=True,  # agent proxy doesn't seem to work for experiments
+            is_agentless=dne_agentless,
         )
         self._api_client = LLMObsAPIClient(app_key=self._app_key)
 

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -377,11 +377,10 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
     SUPPORTED_UPLOAD_EXTS = {"csv"}
 
     def _auth_headers(self) -> dict[str, str]:
-        """Credentials for a direct intake call, or the headers that make the agent supply them.
+        """Our credentials for a direct call, or the headers that make the agent supply them.
 
-        These endpoints authenticate with an app key on top of the api key. The agent's EVP proxy
-        only attaches one when asked via the needs-app-key header, so omitting it would proxy an
-        unauthenticated request and look like the proxy itself was unsupported.
+        The proxy only attaches an app key when asked, so omitting that header proxies an
+        unauthenticated request and looks like the route is unsupported.
         """
         if self._agentless:
             return {"DD-API-KEY": self._api_key, "DD-APPLICATION-KEY": self._app_key}

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -15,6 +15,8 @@ from urllib.parse import urlparse
 
 from ddtrace import config
 from ddtrace.internal import agent
+from ddtrace.internal.evp_proxy.constants import EVP_NEEDS_APP_KEY_HEADER_NAME
+from ddtrace.internal.evp_proxy.constants import EVP_NEEDS_APP_KEY_HEADER_VALUE
 from ddtrace.internal.evp_proxy.constants import EVP_PROXY_AGENT_BASE_PATH
 from ddtrace.internal.evp_proxy.constants import EVP_SUBDOMAIN_HEADER_NAME
 from ddtrace.internal.logger import get_logger
@@ -374,6 +376,20 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
     LIST_RECORDS_TIMEOUT = 20
     SUPPORTED_UPLOAD_EXTS = {"csv"}
 
+    def _auth_headers(self) -> dict[str, str]:
+        """Credentials for a direct intake call, or the headers that make the agent supply them.
+
+        These endpoints authenticate with an app key on top of the api key. The agent's EVP proxy
+        only attaches one when asked via the needs-app-key header, so omitting it would proxy an
+        unauthenticated request and look like the proxy itself was unsupported.
+        """
+        if self._agentless:
+            return {"DD-API-KEY": self._api_key, "DD-APPLICATION-KEY": self._app_key}
+        return {
+            EVP_SUBDOMAIN_HEADER_NAME: self.EVP_SUBDOMAIN_HEADER_VALUE,
+            EVP_NEEDS_APP_KEY_HEADER_NAME: EVP_NEEDS_APP_KEY_HEADER_VALUE,
+        }
+
     def request(self, method: str, path: str, body: JSONType = None, timeout=TIMEOUT) -> Response:
         try:
             return self._request_with_retry(method, path, body, timeout)
@@ -390,13 +406,7 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
         until=lambda result: isinstance(result, Response) and result.status < 500,
     )
     def _request_with_retry(self, method: str, path: str, body: JSONType = None, timeout=TIMEOUT) -> Response:
-        headers = {
-            "Content-Type": "application/json",
-            "DD-API-KEY": self._api_key,
-            "DD-APPLICATION-KEY": self._app_key,
-        }
-        if not self._agentless:
-            headers[EVP_SUBDOMAIN_HEADER_NAME] = self.EVP_SUBDOMAIN_HEADER_VALUE
+        headers = {"Content-Type": "application/json", **self._auth_headers()}
 
         encoded_body = json.dumps(body).encode("utf-8") if body else b""
         conn = HTTPConnection(self._intake, timeout=timeout)
@@ -418,11 +428,7 @@ class LLMObsExperimentsClient(BaseLLMObsWriter):
             raise ValueError(f"Failed to publish evaluator {evaluation['eval_name']}: {resp.status}")
 
     def multipart_request(self, method: str, path: str, content_type: str, body: bytes = b"") -> Response:
-        headers = {
-            "Content-Type": content_type,
-            "DD-API-KEY": self._api_key,
-            "DD-APPLICATION-KEY": self._app_key,
-        }
+        headers = {"Content-Type": content_type, **self._auth_headers()}
 
         conn = HTTPConnection(self._intake, timeout=self.BULK_UPLOAD_TIMEOUT)
         try:

--- a/releasenotes/notes/llmobs-experiments-agent-proxy-fallback-894b431fdfe3c1b6.yaml
+++ b/releasenotes/notes/llmobs-experiments-agent-proxy-fallback-894b431fdfe3c1b6.yaml
@@ -2,5 +2,5 @@
 features:
   - |
     LLM Observability: Datasets, experiments, and custom evaluator publishing no longer require
-    ``DD_APP_KEY`` on the application. When it is unset, these requests are sent through a Datadog
+    ``DD_APP_KEY`` on the application when a Datadog Agent is used.
     Agent exposing the EVP proxy, which supplies both keys.

--- a/releasenotes/notes/llmobs-experiments-agent-proxy-fallback-894b431fdfe3c1b6.yaml
+++ b/releasenotes/notes/llmobs-experiments-agent-proxy-fallback-894b431fdfe3c1b6.yaml
@@ -3,4 +3,3 @@ features:
   - |
     LLM Observability: Datasets, experiments, and custom evaluator publishing no longer require
     ``DD_APP_KEY`` on the application when a Datadog Agent is used.
-    Agent exposing the EVP proxy, which supplies both keys.

--- a/releasenotes/notes/llmobs-experiments-agent-proxy-fallback-894b431fdfe3c1b6.yaml
+++ b/releasenotes/notes/llmobs-experiments-agent-proxy-fallback-894b431fdfe3c1b6.yaml
@@ -2,7 +2,5 @@
 features:
   - |
     LLM Observability: Datasets, experiments, and custom evaluator publishing no longer require
-    ``DD_APP_KEY`` to be set on the application. When it is unset and a Datadog Agent exposing the
-    EVP proxy is reachable, these requests are sent through the Agent, which supplies the API and
-    application keys. Setting ``DD_APP_KEY``, or setting ``DD_LLMOBS_AGENTLESS_ENABLED`` to
-    ``true``, sends them directly to Datadog as before.
+    ``DD_APP_KEY`` on the application. When it is unset, these requests are sent through a Datadog
+    Agent exposing the EVP proxy, which supplies both keys.

--- a/releasenotes/notes/llmobs-experiments-agent-proxy-fallback-894b431fdfe3c1b6.yaml
+++ b/releasenotes/notes/llmobs-experiments-agent-proxy-fallback-894b431fdfe3c1b6.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    LLM Observability: Datasets, experiments, and custom evaluator publishing no longer require
+    ``DD_APP_KEY`` to be set on the application. When it is unset and a Datadog Agent exposing the
+    EVP proxy is reachable, these requests are sent through the Agent, which supplies the API and
+    application keys. Setting ``DD_APP_KEY``, or setting ``DD_LLMOBS_AGENTLESS_ENABLED`` to
+    ``true``, sends them directly to Datadog as before.

--- a/tests/llmobs/conftest.py
+++ b/tests/llmobs/conftest.py
@@ -283,7 +283,13 @@ def llmobs(
         llmobs_service.enable(_tracer=tracer, agentless_enabled=False, **llmobs_enable_opts)
         llmobs_service._instance._llmobs_span_writer = llmobs_span_writer
         llmobs_service._instance._llmobs_span_writer.start()
-        llmobs_service._instance._dne_client._intake = llmobs_api_proxy_url
+        # The cassette proxy stands in for intake, so keep this client in direct mode. Without an
+        # app key it would otherwise pick the agent proxy and prefix every path with /evp_proxy/v2,
+        # which no recording matches.
+        dne_client = llmobs_service._instance._dne_client
+        dne_client._agentless = True
+        dne_client._endpoint = dne_client.ENDPOINT
+        dne_client._intake = llmobs_api_proxy_url
         tracer._span_aggregator.llmobs_processor = LLMObsProcessor(llmobs_span_writer, tracer, keep_meta_struct=True)
         try:
             yield llmobs_service

--- a/tests/llmobs/test_llmobs_experiments_agent_writer.py
+++ b/tests/llmobs/test_llmobs_experiments_agent_writer.py
@@ -98,10 +98,7 @@ def test_experiments_client_mode_selection(app_key, proxy_available, expected_ag
 
 
 def test_override_origin_stays_direct(monkeypatch):
-    """An override origin replaces intake, not the agent.
-
-    Proxying it would send /evp_proxy/v2-prefixed paths to a server that supplies no credentials.
-    """
+    """An override origin replaces intake, not the agent, so proxying it would drop credentials."""
     from ddtrace.llmobs._llmobs import LLMObs
 
     monkeypatch.setenv("DD_LLMOBS_OVERRIDE_ORIGIN", "http://localhost:1234")

--- a/tests/llmobs/test_llmobs_experiments_agent_writer.py
+++ b/tests/llmobs/test_llmobs_experiments_agent_writer.py
@@ -95,3 +95,24 @@ def test_experiments_client_mode_selection(app_key, proxy_available, expected_ag
         assert instance._dne_client._agentless is expected_agentless
     finally:
         LLMObs._app_key = original_app_key
+
+
+def test_override_origin_stays_direct(monkeypatch):
+    """An override origin replaces intake, not the agent.
+
+    Proxying it would send /evp_proxy/v2-prefixed paths to a server that supplies no credentials.
+    """
+    from ddtrace.llmobs._llmobs import LLMObs
+
+    monkeypatch.setenv("DD_LLMOBS_OVERRIDE_ORIGIN", "http://localhost:1234")
+    original_app_key = LLMObs._app_key
+    LLMObs._app_key = ""
+    try:
+        with mock.patch("ddtrace.llmobs._llmobs.should_use_agentless", return_value=False):
+            client = LLMObs()._dne_client
+        assert client._agentless is True
+        assert client._intake == "http://localhost:1234"
+        assert EVP_PROXY_AGENT_BASE_PATH not in client._endpoint
+        assert "DD-API-KEY" in client._auth_headers()
+    finally:
+        LLMObs._app_key = original_app_key

--- a/tests/llmobs/test_llmobs_experiments_agent_writer.py
+++ b/tests/llmobs/test_llmobs_experiments_agent_writer.py
@@ -1,0 +1,97 @@
+import mock
+import pytest
+
+from ddtrace.internal.evp_proxy.constants import EVP_NEEDS_APP_KEY_HEADER_NAME
+from ddtrace.internal.evp_proxy.constants import EVP_PROXY_AGENT_BASE_PATH
+from ddtrace.internal.evp_proxy.constants import EVP_SUBDOMAIN_HEADER_NAME
+from ddtrace.llmobs._writer import LLMObsExperimentsClient
+
+
+PUBLISH_EVALUATOR_PATH = "/api/unstable/llm-obs/v1/config/evaluators/custom"
+
+
+def _client(is_agentless):
+    return LLMObsExperimentsClient(
+        interval=1,
+        timeout=1,
+        is_agentless=is_agentless,
+        _api_key="test-api-key",
+        _app_key="test-app-key",
+    )
+
+
+@pytest.fixture
+def mock_conn():
+    with mock.patch("ddtrace.llmobs._writer.HTTPConnection") as conn_cls:
+        conn = conn_cls.return_value
+        conn.getresponse.return_value = mock.Mock(status=200, **{"read.return_value": b"{}"})
+        yield conn
+
+
+def test_agentless_sends_both_credentials():
+    assert _client(True)._auth_headers() == {"DD-API-KEY": "test-api-key", "DD-APPLICATION-KEY": "test-app-key"}
+
+
+def test_agent_proxy_asks_agent_for_credentials():
+    """The agent attaches both keys itself, so sending ours would leak them through the proxy."""
+    headers = _client(False)._auth_headers()
+    assert headers == {EVP_SUBDOMAIN_HEADER_NAME: "api", EVP_NEEDS_APP_KEY_HEADER_NAME: "true"}
+
+
+def test_publish_custom_evaluator_through_agent_proxy(mock_conn):
+    _client(False).publish_custom_evaluator({"eval_name": "my-eval"})
+
+    method, path, _body, headers = mock_conn.request.call_args[0]
+    assert method == "PUT"
+    assert path == "{}{}".format(EVP_PROXY_AGENT_BASE_PATH, PUBLISH_EVALUATOR_PATH)
+    assert headers[EVP_SUBDOMAIN_HEADER_NAME] == "api"
+    assert headers[EVP_NEEDS_APP_KEY_HEADER_NAME] == "true"
+    assert "DD-API-KEY" not in headers
+    assert "DD-APPLICATION-KEY" not in headers
+
+
+def test_publish_custom_evaluator_agentless_unchanged(mock_conn):
+    _client(True).publish_custom_evaluator({"eval_name": "my-eval"})
+
+    method, path, _body, headers = mock_conn.request.call_args[0]
+    assert method == "PUT"
+    assert path == PUBLISH_EVALUATOR_PATH
+    assert headers["DD-API-KEY"] == "test-api-key"
+    assert headers["DD-APPLICATION-KEY"] == "test-app-key"
+    assert EVP_SUBDOMAIN_HEADER_NAME not in headers
+
+
+def test_multipart_request_through_agent_proxy(mock_conn):
+    """Bulk CSV upload shares the credential swap; without it the proxy would reject the upload."""
+    _client(False).multipart_request("POST", "/api/unstable/upload", "multipart/form-data", b"payload")
+
+    _method, _path, _body, headers = mock_conn.request.call_args[0]
+    assert headers[EVP_SUBDOMAIN_HEADER_NAME] == "api"
+    assert headers[EVP_NEEDS_APP_KEY_HEADER_NAME] == "true"
+    assert "DD-API-KEY" not in headers
+    assert "DD-APPLICATION-KEY" not in headers
+
+
+@pytest.mark.parametrize(
+    "app_key,proxy_available,expected_agentless",
+    [
+        # An app key of our own means intake can authenticate us directly.
+        ("test-app-key", True, True),
+        ("test-app-key", False, True),
+        # No app key, but an agent that can supply one.
+        ("", True, False),
+        # No app key and no proxy to borrow one from, so there is nothing to fall back to.
+        ("", False, True),
+    ],
+)
+def test_experiments_client_mode_selection(app_key, proxy_available, expected_agentless):
+    from ddtrace.llmobs._llmobs import LLMObs
+
+    original_app_key = LLMObs._app_key
+    LLMObs._app_key = app_key
+    try:
+        with mock.patch("ddtrace.llmobs._llmobs.should_use_agentless", return_value=not proxy_available):
+            instance = LLMObs()
+        assert instance._dne_client._agentless is expected_agentless
+    finally:
+        LLMObs._app_key = original_app_key


### PR DESCRIPTION
# Motivation
Datasets, experiments, and `publish_custom_evaluator` required `DD_APP_KEY` on the application:.

These endpoints need an app key, and the Agent's EVP proxy only attaches one when asked via `X-Datadog-NeedsAppKey` — a header this repo defined but never sent, so proxying looked unsupported. This sends it, and selects the mode as `bool(app_key) or agentless_enabled`: an app key set locally behaves exactly as before, its absence now falls back to the Agent instead of failing outright. `multipart_request` needed the same credential swap.

**Verified** end-to-end against Agent 7.80.3 with no keys on the process — read `GET` and publish `PUT` both 200. This moves the app key to the Agent's config rather than removing it: without `app_key` there, the Agent returns 502 (`ApplicationKey needed but not set`).