### PR TITLE
test(iast): assert MODULES_TO_UNPATCH deltas [APPSEC-69907]

### DIFF
--- a/tests/appsec/iast/test_patch_modules.py
+++ b/tests/appsec/iast/test_patch_modules.py
@@ -92,7 +92,8 @@ class TestWrapModulesForIAST:
     @pytest.fixture
     def wrap_modules(self):
         """Create a WrapFunctonsForIAST instance for testing."""
-        # MODULES_TO_UNPATCH is process-wide and these tests assert on its exact size.
+        # MODULES_TO_UNPATCH is process-wide and the global IAST patch can fill it at any point,
+        # so these tests assert on the entries they add rather than on its total size.
         MODULES_TO_UNPATCH.clear()
         wrap_modules = WrapFunctonsForIAST()
         yield wrap_modules
@@ -134,18 +135,20 @@ class TestWrapModulesForIAST:
         wrap_modules.testing = True
         wrap_modules.wrap_function("test_patch_with_testing", "test_function", "test_hook")
         mock_patch.return_value = True
+        already_registered = set(MODULES_TO_UNPATCH)
         wrap_modules.patch()
-        assert len(MODULES_TO_UNPATCH) == 1
+        assert MODULES_TO_UNPATCH - already_registered == wrap_modules.functions
 
     @patch("ddtrace.appsec._iast._patch_modules.IASTFunction.unpatch")
     def test_testing_unpatch(self, mock_unpatch, wrap_modules):
         """Test unpatching in testing mode."""
         wrap_modules.testing = True
         wrap_modules.wrap_function("test_testing_unpatch", "test_function", "test_hook")
+        already_registered = set(MODULES_TO_UNPATCH)
         wrap_modules.patch()
-        assert len(MODULES_TO_UNPATCH) == 1, f"There are more than 1 function: {MODULES_TO_UNPATCH}"
+        assert MODULES_TO_UNPATCH - already_registered == wrap_modules.functions
         wrap_modules.testing_unpatch()
-        mock_unpatch.assert_called_once()
+        assert mock_unpatch.call_count == len(already_registered) + 1
         assert len(MODULES_TO_UNPATCH) == 0
 
     @patch("ddtrace.appsec._iast._patch_modules.IASTFunction.unpatch")


### PR DESCRIPTION
## Description

APPSEC-69907. `MODULES_TO_UNPATCH` is a process-wide set in `ddtrace/appsec/_iast/_patch_modules.py`, and the global IAST patch adds its 44 functions to it at a point these tests do not control. Clearing it in the `wrap_modules` fixture is not enough — under `--dist=worksteal`, whether that patch has already run in the worker decides whether the set holds 1 entry or 45.

That produced two distinct failures:
- `test_patch_with_testing` — `assert 45 == 1`, with the test's own `IASTFunction` visible among the 44 real ones in the failure output.
- `test_testing_unpatch` — `testing_unpatch()` drains the whole set, so `mock_unpatch.assert_called_once()` saw 45 calls.

Both now assert on what they actually contribute: the delta across their own `patch()` call, and an unpatch count relative to what was already registered. `IASTFunction.patch()` always returns `True`, so that delta is exactly `wrap_modules.functions`.

Fixes flaky `TestWrapModulesForIAST::test_patch_with_testing` (py3.9, 3.10, 3.12, 3.13, 3.14) and `test_testing_unpatch[py3.13]`.

## Testing

CI. Locally, a stand-in harness replays the fixture-and-test flow against clean and polluted versions of the set: the old assertions pass clean and fail polluted (reproducing the CI failure), the new ones pass in both.

## Risks

Test-only, and the assertions get *stronger*, not weaker: `MODULES_TO_UNPATCH - already_registered == wrap_modules.functions` checks set identity of the entries added, where the old `len(...) == 1` only checked the count.

## Additional Notes

`test_testing_unpatch` was not in the original triage list — it turned up as an active flaky row (`order_dependency`) while collecting the IDs, and it is the same defect, so it is fixed here too.

One thing this PR does *not* change, worth a look separately: the fixture's teardown calls `testing_unpatch()`, which drains the whole process-wide set and therefore really unpatches the 44 global IAST functions whenever pollution is present. That is a cross-test side effect on everything that runs later in the same worker.