### PR TITLE
test(iast): unwrap weak hash before each test patches it [APPSEC-69907]

### DIFF
--- a/tests/appsec/iast/conftest.py
+++ b/tests/appsec/iast/conftest.py
@@ -81,6 +81,7 @@ def iast_context(env, request_sampling=100.0, deduplication=False, asm_enabled=F
         # map, causing api_taint_pyobject to silently return untainted objects.
         _iast_finish_request()
         _start_iast_context_and_oce(span)
+        weak_hash_unpatch()
         weak_hash_patch()
         weak_cipher_patch()
         unstrusted_serialization_patch()


### PR DESCRIPTION
## Description

APPSEC-69907. Eleven active flaky rows across four tests in `test_weak_hash.py` — and they are exactly the four that assert `span_report is None`. Every other test in the file asserts a vulnerability *is* reported, and none of those flake. Datadog categorises most of the rows `order_dependency`.

`weak_hash_patch()` decides *which* algorithms to wrap from `get_weak_hash_algorithms()` (`weak_hash.py:78-95`), but the wrapper it installs reports unconditionally: `wrapped_function` has no call-time check (`weak_hash.py:182-194`). Its siblings `wrapped_digest_function` and `wrapped_new_function` *do* re-check on every call — and neither is flaky. So a wrapper left over from an earlier test under a different `DD_IAST_WEAK_HASH_ALGORITHMS` reports an algorithm the current test did not configure. In every captured failure the reported vulnerability's line is the `m.digest()` call inside the failing test itself.

`iast_context` already unwraps on the way out. It now also unwraps on the way in, so each test patches from a known state whatever the previous one left. `try_unwrap` deregisters pending `ModuleWatchdog` import hooks as well, so a lazy wrap that had not fired yet is dropped too.

## Testing

CI, and specifically the attempt-to-fix runs on the 11 tokens in the commit subject.

I could not reproduce this locally — it needs a built ddtrace and the interleaving only shows up under `--dist=worksteal` across a full worker. The reasoning is from the source and the captured failures rather than from a local repro, so **CI is the evidence here, not a local run**.

## Risks

Test-only, and idempotent: `unpatch_iast()` is already called on every teardown, so calling it once more at setup adds no new behaviour, only a second occasion. It does not touch the config-independent `hashlib.md5` / `sha1` / `new` wrappers, and re-patching is guarded by the existing "avoid double patching" check in `apply_patch`.

## Additional Notes

**This is not a production bug.** In production `weak_hash_patch()` runs once behind `_IS_PATCHED` with a fixed env config, so a wrapper can never disagree with the configuration. The mismatch is reachable only because `_iast_is_testing=True` re-runs the patch per test with a different config each time.

**A caveat on this fix.** Two mechanisms can leave a stale wrapper, and I did not isolate which is at play:
1. these targets are methods on immutable C types (`_md5.MD5Type`, `Crypto.Hash.MD5.MD5Hash`), so `apply_patch` falls through `setattr`'s `TypeError` into `patch_builtins` — if restoring through that path does not fully take, `try_unwrap` silently leaves the wrapper;
2. wrapping is lazy, so a hook registered by one test can fire on a later import.

This fix closes (2) outright, and closes (1) only for the case where teardown never ran or ran in a different state. **If (1) is the real cause, this will not help** — it is the same `try_unwrap` call. That is falsifiable: if these rows keep flaking after this lands, (1) is confirmed and the fix becomes the call-time config check in `wrapped_function`, matching its siblings. That one touches the IAST hot path and would want `get_weak_hash_algorithms()` memoised, since it currently re-reads and re-parses the env var on every call.