### PR TITLE
test(iast): stop the global vulnerability limit leaking between tests [APPSEC-69907]

### DIFF
--- a/tests/appsec/iast/conftest.py
+++ b/tests/appsec/iast/conftest.py
@@ -52,6 +52,18 @@ def no_request_sampling(tracer):
         yield
 
 
+def _run_cleanups(steps):
+    """Run every step, then re-raise the first failure, so one failing step cannot skip the rest."""
+    first_error = None
+    for step in steps:
+        try:
+            step()
+        except Exception as exc:
+            first_error = first_error or exc
+    if first_error is not None:
+        raise first_error
+
+
 def iast_context(env, request_sampling=100.0, deduplication=False, asm_enabled=False, vulnerabilities_per_requests=100):
     class MockSpan:
         _trace_id_64bits = 17577308072598193742
@@ -91,18 +103,22 @@ def iast_context(env, request_sampling=100.0, deduplication=False, asm_enabled=F
         try:
             yield
         finally:
-            unpatch_common_modules()
-            weak_hash_unpatch()
-            _testing_unpatch_iast()
-            _end_iast_context_and_oce(span)
-            reset_taint_range_limit_cache()
-            reset_source_truncation_cache()
-            clear_all_request_context_slots()
-            # Keep ContextVar in sync with the freed C++ slots. clear_all_request_context_slots()
-            # frees all taint maps but does NOT update IAST_CONTEXT. If a subsequent test's
-            # _start_iast_context_and_oce still sees is_iast_request_enabled()=True (stale),
-            # it would skip slot allocation, leaving the test with a dangling slot reference.
-            IAST_CONTEXT.set(None)
+            _run_cleanups(
+                [
+                    unpatch_common_modules,
+                    weak_hash_unpatch,
+                    _testing_unpatch_iast,
+                    lambda: _end_iast_context_and_oce(span),
+                    reset_taint_range_limit_cache,
+                    reset_source_truncation_cache,
+                    clear_all_request_context_slots,
+                    # Keep ContextVar in sync with the freed C++ slots. clear_all_request_context_slots()
+                    # frees all taint maps but does NOT update IAST_CONTEXT. If a subsequent test's
+                    # _start_iast_context_and_oce still sees is_iast_request_enabled()=True (stale),
+                    # it would skip slot allocation, leaving the test with a dangling slot reference.
+                    lambda: IAST_CONTEXT.set(None),
+                ]
+            )
 
 
 @pytest.fixture
@@ -141,18 +157,26 @@ def reset_iast_process_state():
     that drives IAST directly, or fails before its own cleanup, cannot poison its neighbours.
     """
     yield
+
     # testing_unpatch() is a no-op unless _iast_is_testing is set, and the test's own override
     # is already gone by teardown time.
-    with override_global_config(dict(_iast_is_testing=True)):
-        _testing_unpatch_iast()
-    weak_hash_unpatch()
-    _reset_global_limit()
-    VulnerabilityBase._prepare_report._reset_cache()
-    core.discard_item(IAST.REQUEST_CONTEXT_KEY)
-    clear_all_request_context_slots()
-    IAST_CONTEXT.set(None)
-    reset_taint_range_limit_cache()
-    reset_source_truncation_cache()
+    def _unpatch_iast():
+        with override_global_config(dict(_iast_is_testing=True)):
+            _testing_unpatch_iast()
+
+    _run_cleanups(
+        [
+            _unpatch_iast,
+            weak_hash_unpatch,
+            _reset_global_limit,
+            VulnerabilityBase._prepare_report._reset_cache,
+            lambda: core.discard_item(IAST.REQUEST_CONTEXT_KEY),
+            clear_all_request_context_slots,
+            lambda: IAST_CONTEXT.set(None),
+            reset_taint_range_limit_cache,
+            reset_source_truncation_cache,
+        ]
+    )
 
 
 def pytest_configure(config):

--- a/tests/appsec/iast/test_overhead_control_engine.py
+++ b/tests/appsec/iast/test_overhead_control_engine.py
@@ -8,6 +8,7 @@ from ddtrace.appsec._iast._taint_tracking._context import debug_context_array_fr
 from ddtrace.appsec._iast._taint_tracking._context import debug_context_array_size
 from ddtrace.appsec._iast._taint_tracking._context import finish_request_context
 from ddtrace.appsec._iast._taint_tracking._context import start_request_context
+from ddtrace.appsec._iast.sampling.vulnerability_detection import _reset_global_limit
 from ddtrace.appsec._iast.sampling.vulnerability_detection import reset_request_vulnerabilities
 from ddtrace.appsec._iast.taint_sinks.weak_hash import WeakHash
 from ddtrace.internal.settings.asm import config as asm_config
@@ -51,6 +52,7 @@ def test_oce_max_vulnerabilities_per_request(iast_context_deduplication_enabled)
 
     # Reset deduplication cache to ensure clean state
     WeakHash._prepare_report._reset_cache()
+    _reset_global_limit()
 
     # Verify IAST context is enabled
     assert is_iast_request_enabled(), "IAST request context should be enabled"
@@ -88,6 +90,7 @@ def test_oce_reset_vulnerabilities_report(iast_context_deduplication_enabled):
 
     # Reset deduplication cache to ensure clean state
     WeakHash._prepare_report._reset_cache()
+    _reset_global_limit()
 
     # Verify IAST context is enabled
     assert is_iast_request_enabled(), "IAST request context should be enabled"


### PR DESCRIPTION
## Description

APPSEC-69907. `should_process_vulnerability` seeds each request from `GLOBAL_VULNERABILITIES_LIMIT` (`sampling/vulnerability_detection.py:18`), a process-wide dict written by `update_global_vulnerability_limit()` at the end of any request that exhausted its budget. Detections below the stored count are dropped **without consuming budget**.

With a stored `WEAK_HASH` count of 1:

| call | current vs stored | outcome |
|---|---|---|
| line 98 | `0 < 1` | dropped, budget still 0 |
| line 99 | `1 < 1` false | reported, budget 1 |
| line 100 | `2 < 1` false | reported, budget 2 |
| `reset_request_vulnerabilities()` | sets `is_first_vulnerability = True` | |
| line 126 | re-copies the global, `0 < 1` | dropped |

Two vulnerabilities, at lines 99 and 100 — exactly the reported failure. Note the reset makes it worse: it re-reads the global instead of clearing its influence.

The autouse `reset_iast_process_state` fixture already resets that global (added in #19643, *"make iast tests independent of execution order"*), but its teardown is a bare sequence after `yield`, so anything raising in `_testing_unpatch_iast()` or `weak_hash_unpatch()` skips `_reset_global_limit()` and everything after it. `iast_context`'s teardown has the same shape. That is consistent with the test still flaking on 2026-08-26, two weeks after that fixture landed.

Both halves are fixed: cleanups run through `_run_cleanups`, which runs every step and re-raises the first failure; and both OCE tests reset the global themselves, next to the deduplication cache they already reset.

## Testing

CI, plus the 20 attempt-to-fix runs on `DD_5O1YXQ`.

Locally I replayed the sampling algorithm against a clean and a dirty global. Dirty reproduces the CI failure exactly — two vulnerabilities at lines 99 and 100 — and resetting the global restores the expected `[98, 99, 126]`. That validates the mechanism and the test-level fix; it does not exercise the fixture change.

## Risks

Test-only. `_run_cleanups` is strictly more forgiving than the bare sequence: every step now runs, and the first failure is still raised, so a genuinely broken teardown still fails the test.

## Additional Notes

`test_oce_max_vulnerabilities_per_request` gets the same reset. It is not flagged flaky, but it shares the prologue and the same exposure to a dirty global.

The teardown-hardening half is inference. The failure mechanism and the test-level fix are certain; *why* the existing reset was not reached is not directly observed, and a bare cleanup sequence is the most likely candidate. If this row keeps flaking, the next thing to check is whether `endpoint_key` is shared across these unit tests in a way that makes contamination reachable by another path.