### PR TITLE
test(appsec): stop waiting 0.5s per api10 test teardown [APPSEC-69907]

### DIFF
--- a/tests/appsec/contrib_appsec/conftest.py
+++ b/tests/appsec/contrib_appsec/conftest.py
@@ -135,7 +135,7 @@ def api10_http_server_port(monkeypatch):
 
     server = ThreadingHTTPServer(("127.0.0.1", 0), Api10Handler)
     _, port = server.server_address
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread = threading.Thread(target=lambda: server.serve_forever(poll_interval=0.01), daemon=True)
     thread.start()
 
     deadline = time.monotonic() + 2.0


### PR DESCRIPTION
## Description

APPSEC-69907. The `api10_http_server_port` fixture ran `serve_forever()` with its default **0.5s** `poll_interval`, and `shutdown()` blocks until that loop notices — so every test using it spent half a second in teardown doing nothing.

```python
thread = threading.Thread(target=lambda: server.serve_forever(poll_interval=0.01), daemon=True)
```

The fixture is shared by the django, flask, fastapi and tornado threats suites, so all four get the same saving.

It also narrows a flake window: `tests.appsec.contrib_appsec` has three active `timeout` flakes (all `Test_Tornado::test_exploit_prevention`), one with a captured **"Timeout while connecting"** after 20.2s and ~1.5h of lost pipeline time, plus four more already marked fixed. A job asleep a third of its runtime holds its runner, ports and threads a third longer than needed. No attempt-to-fix IDs attached — this shortens the window, it does not remove the cause.

## Testing

Locally on `appsec_threats_fastapi_no_iast` (`da812c0`, py3.13), same venv back to back: **131.78s → 90.14s (−32%)**, teardown **36.77s → 0.80s**, 2882 passed both times. 74 tests use the fixture and accounted for 36.71s of that teardown.

## Risks

Test-only. The polling thread wakes more often, but it is one thread living for a single test.

## Additional Notes

Verified on the `no_iast` fastapi venv only. `tests/appsec/appsec/test_common_modules.py:185` has the same pattern and is a one-line follow-up.

Bigger levers found but not touched, as they cost coverage or need their own trial: `test_exploit_prevention` is 864 of the 2882 fastapi tests (`itertools.product([7 ssrf clients], repeat=2)`); these jobs run serially with no xdist; the fastapi matrix is 32 venvs.