### PR TITLE
fix(profiling): preserve fault siginfo when ceding SIGSEGV/SIGBUS to the host (PROF-15342)

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
@@ -39,11 +39,10 @@ thread_local ThreadAltStack t_altstack;
 thread_local sigjmp_buf t_jmpenv;
 thread_local volatile sig_atomic_t t_handler_armed = 0;
 
-// Guards against a signal-handler chaining cycle. The unarmed path below chains
-// to the previously installed handler and re-raises; if that handler chains back
-// to us (e.g. profiler <-> crashtracker pointing at each other), we would loop
-// forever and hang the process. If we re-enter the unarmed path while already
-// chaining, fall through to the default disposition so termination is guaranteed.
+// Set once this thread has ceded a fault signal to its previous owner. Re-entering the
+// unarmed path afterwards means something reinstalled us and the fault is not making
+// progress, so we fall through to the default disposition and termination is guaranteed
+// instead of looping forever.
 thread_local volatile sig_atomic_t t_in_unarmed_chain = 0;
 
 static inline void
@@ -61,33 +60,66 @@ disarm_fault_handler()
 }
 
 static void
-segv_handler(int signo, siginfo_t*, void*)
+install_default_disposition(int signo)
+{
+    struct sigaction dfl
+    {};
+    dfl.sa_handler = SIG_DFL;
+    sigemptyset(&dfl.sa_mask);
+    dfl.sa_flags = 0;
+    sigaction(signo, &dfl, nullptr);
+}
+
+// Hands signo back to whoever owned it before us, removing us from the chain.
+//
+// A saved SIG_IGN disposition is replaced by SIG_DFL: ignoring a synchronous fault
+// leaves the faulting instruction to re-execute forever, so honoring it would hang
+// the process instead of terminating it.
+static void
+cede_fault_signal(int signo)
+{
+    const struct sigaction* saved = (signo == SIGSEGV) ? &g_old_segv : &g_old_bus;
+
+    if ((saved->sa_flags & SA_SIGINFO) == 0 && saved->sa_handler == SIG_IGN) {
+        install_default_disposition(signo);
+        return;
+    }
+
+    sigaction(signo, saved, nullptr);
+}
+
+static void
+segv_handler(int signo, siginfo_t* info, void*)
 {
     if (!t_handler_armed) {
         if (t_in_unarmed_chain) {
-            // We are being re-entered while already chaining to a previous
-            // handler: the handler chain has cycled back to us. Restore the
-            // default disposition and re-raise to guarantee the process
-            // terminates instead of looping forever.
-            struct sigaction dfl
-            {};
-            dfl.sa_handler = SIG_DFL;
-            sigemptyset(&dfl.sa_mask);
-            dfl.sa_flags = 0;
-            sigaction(signo, &dfl, nullptr);
-            pthread_kill(pthread_self(), signo);
+            // We already ceded this signal on this thread, so something reinstalled us
+            // and the fault is not making progress. Force the default disposition to
+            // guarantee the process terminates instead of looping forever.
+            install_default_disposition(signo);
             return;
         }
         t_in_unarmed_chain = 1;
 
-        struct sigaction* old = (signo == SIGSEGV) ? &g_old_segv : &g_old_bus;
-        // Restore the previous handler and re-raise so default/old handling occurs.
-        // Use pthread_kill(pthread_self(), signo): thread-directed (targets the
-        // faulting thread, which is guaranteed to be the current thread for
-        // synchronous signals like SIGSEGV/SIGBUS) and async-signal-safe per POSIX,
-        // unlike raise which acquires a lock internally.
-        sigaction(signo, old, nullptr);
-        pthread_kill(pthread_self(), signo);
+        // This fault is not one of ours to recover, so give the signal back to its
+        // previous owner and return without re-raising. For a kernel-generated fault
+        // (si_code > 0) returning re-executes the faulting instruction, so the new owner
+        // receives a genuine signal carrying the original si_code, si_addr and fault PC.
+        //
+        // Re-raising with pthread_kill instead delivers si_code == SI_TKILL with no fault
+        // address and a PC inside this handler. Hosts that read siginfo to classify a
+        // fault cannot recover from that: the Go runtime turns it into a fatal error
+        // rather than the nil-dereference panic it would otherwise raise (PROF-14568).
+        cede_fault_signal(signo);
+
+        if (info == nullptr || info->si_code <= 0) {
+            // Not a synchronous fault (SI_USER, SI_QUEUE, SI_TKILL, ...): no instruction
+            // will re-execute, so returning would swallow the signal. Re-deliver it
+            // thread-directed, which is async-signal-safe per POSIX unlike raise. The
+            // signal was already injected, so there is no fault siginfo to preserve.
+            pthread_kill(pthread_self(), signo);
+        }
+
         return;
     }
 

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
@@ -91,6 +91,7 @@ is_synchronous_fault(int signo, const siginfo_t* info)
     }
 #endif
 #endif
+    (void)signo;
     return true;
 }
 

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
@@ -109,7 +109,7 @@ segv_handler(int signo, siginfo_t* info, void*)
         // Re-raising with pthread_kill instead delivers si_code == SI_TKILL with no fault
         // address and a PC inside this handler. Hosts that read siginfo to classify a
         // fault cannot recover from that: the Go runtime turns it into a fatal error
-        // rather than the nil-dereference panic it would otherwise raise (PROF-14568).
+        // rather than the nil-dereference panic it would otherwise raise (PROF-15342).
         cede_fault_signal(signo);
 
         if (info == nullptr || info->si_code <= 0) {

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
@@ -17,7 +17,7 @@ static const size_t page_size = []() -> size_t {
 
 #ifdef PL_DARWIN
     if (v <= 0) {
-        // Fallback on macOS just in case
+        // sysconf(_SC_PAGESIZE) can return -1; getpagesize() is the BSD API on Darwin
         v = getpagesize();
     }
 #endif

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
@@ -70,18 +70,46 @@ install_default_disposition(int signo)
     sigaction(signo, &dfl, nullptr);
 }
 
+// Kernel-generated faults that re-execute the faulting instruction when the handler
+// returns. Injected signals (si_code <= 0) and a few positive Linux codes that are
+// still asynchronous must be re-delivered explicitly instead.
+static bool
+is_synchronous_fault(int signo, const siginfo_t* info)
+{
+    if (info == nullptr || info->si_code <= 0) {
+        return false;
+    }
+#if defined PL_LINUX
+#ifdef SEGV_MTEAERR
+    if (signo == SIGSEGV && info->si_code == SEGV_MTEAERR) {
+        return false;
+    }
+#endif
+#ifdef BUS_MCEERR_AO
+    if (signo == SIGBUS && info->si_code == BUS_MCEERR_AO) {
+        return false;
+    }
+#endif
+#endif
+    return true;
+}
+
 // Hands signo back to whoever owned it before us, removing us from the chain.
 //
-// A saved SIG_IGN disposition is replaced by SIG_DFL: ignoring a synchronous fault
-// leaves the faulting instruction to re-execute forever, so honoring it would hang
-// the process instead of terminating it.
+// A saved SIG_IGN disposition is replaced by SIG_DFL only for synchronous faults:
+// ignoring one leaves the faulting instruction to re-execute forever, so honoring it
+// would hang the process instead of terminating it. Asynchronous deliveries keep SIG_IGN.
 static void
-cede_fault_signal(int signo)
+cede_fault_signal(int signo, const siginfo_t* info)
 {
     const struct sigaction* saved = (signo == SIGSEGV) ? &g_old_segv : &g_old_bus;
 
     if ((saved->sa_flags & SA_SIGINFO) == 0 && saved->sa_handler == SIG_IGN) {
-        install_default_disposition(signo);
+        if (is_synchronous_fault(signo, info)) {
+            install_default_disposition(signo);
+            return;
+        }
+        sigaction(signo, saved, nullptr);
         return;
     }
 
@@ -97,22 +125,25 @@ segv_handler(int signo, siginfo_t* info, void*)
             // and the fault is not making progress. Force the default disposition to
             // guarantee the process terminates instead of looping forever.
             install_default_disposition(signo);
+            if (!is_synchronous_fault(signo, info)) {
+                pthread_kill(pthread_self(), signo);
+            }
             return;
         }
         t_in_unarmed_chain = 1;
 
         // This fault is not one of ours to recover, so give the signal back to its
-        // previous owner and return without re-raising. For a kernel-generated fault
-        // (si_code > 0) returning re-executes the faulting instruction, so the new owner
-        // receives a genuine signal carrying the original si_code, si_addr and fault PC.
+        // previous owner and return without re-raising. For a synchronous kernel fault
+        // returning re-executes the faulting instruction, so the new owner receives a
+        // genuine signal carrying the original si_code, si_addr and fault PC.
         //
         // Re-raising with pthread_kill instead delivers si_code == SI_TKILL with no fault
         // address and a PC inside this handler. Hosts that read siginfo to classify a
         // fault cannot recover from that: the Go runtime turns it into a fatal error
         // rather than the nil-dereference panic it would otherwise raise (PROF-15342).
-        cede_fault_signal(signo);
+        cede_fault_signal(signo, info);
 
-        if (info == nullptr || info->si_code <= 0) {
+        if (!is_synchronous_fault(signo, info)) {
             // Not a synchronous fault (SI_USER, SI_QUEUE, SI_TKILL, ...): no instruction
             // will re-execute, so returning would swallow the signal. Re-deliver it
             // thread-directed, which is async-signal-safe per POSIX unlike raise. The

--- a/ddtrace/internal/datadog/profiling/stack/test/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/stack/test/CMakeLists.txt
@@ -109,6 +109,12 @@ dd_wrapper_add_test(test_alt_stack_ownership test_alt_stack_ownership.cpp)
 # ThreadAltStack lives in the vendored echion header tree.
 target_include_directories(test_alt_stack_ownership PRIVATE ../echion)
 
+dd_wrapper_add_test(test_fault_chainback test_fault_chainback.cpp)
+# init_segv_catcher/safe_memcpy_wrapper are declared in the vendored echion header tree, behind the PL_LINUX/PL_DARWIN
+# platform switch that the extension defines.
+target_include_directories(test_fault_chainback PRIVATE ../echion)
+target_compile_definitions(test_fault_chainback PRIVATE "$<TARGET_PROPERTY:${EXTENSION_NAME},COMPILE_DEFINITIONS>")
+
 # vm.cc is compiled into the test binary: the fast-copy state lives in inline variables, so the copy in the test
 # executable is distinct from the one in the _stack library and only the constructor linked here initializes it.
 dd_wrapper_add_test(test_embedded_fast_copy test_embedded_fast_copy.cpp ../src/echion/vm.cc)

--- a/ddtrace/internal/datadog/profiling/stack/test/test_fault_chainback.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/test/test_fault_chainback.cpp
@@ -8,16 +8,17 @@
 #include <cstdint>
 #include <sys/mman.h>
 #include <thread>
+#include <unistd.h>
 
 namespace {
 
-constexpr size_t kGuardedPageSize = 4096;
+const size_t kGuardedPageSize = static_cast<size_t>(sysconf(_SC_PAGESIZE));
 
 struct HostFaultReport
 {
     volatile sig_atomic_t ran = 0;
-    volatile int signo = 0;
-    volatile int si_code = 0;
+    volatile sig_atomic_t signo = 0;
+    volatile sig_atomic_t si_code = 0;
     void* si_addr = nullptr;
 };
 

--- a/ddtrace/internal/datadog/profiling/stack/test/test_fault_chainback.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/test/test_fault_chainback.cpp
@@ -6,6 +6,7 @@
 #include <csetjmp>
 #include <csignal>
 #include <cstdint>
+#include <pthread.h>
 #include <sys/mman.h>
 #include <thread>
 #include <unistd.h>
@@ -148,7 +149,8 @@ TEST(FaultChainback, CedesUnarmedFaultWithOriginalSiginfo)
     EXPECT_GT(report.si_code, 0) << "si_code " << report.si_code << " is not a kernel-generated fault";
     EXPECT_EQ(report.fault_addr, outcome.page) << "si_addr did not survive the handoff to the host";
 
-    // After cede, segv_handler_installed() is false and the host handler is restored on top.
+    // Cedes only the faulting signal back to the host. segv_handler_installed() requires
+    // owning both SIGSEGV and SIGBUS, so it must read false even when we still hold the other.
     EXPECT_TRUE(host_handler_owns(delivered)) << "the profiler did not hand the signal back to the host";
     EXPECT_FALSE(segv_handler_installed()) << "the profiler still claims to own both fault signals";
 
@@ -192,4 +194,49 @@ TEST(FaultChainback, SafeMemcpyStillRecoversArmedFault)
     EXPECT_TRUE(segv_handler_installed());
 
     munmap(page, kGuardedPageSize);
+}
+
+// Injected signals have si_code <= 0 and must be re-delivered explicitly after cede;
+// returning would swallow them because no faulting instruction re-executes.
+TEST(FaultChainback, RedeliversInjectedSignalToHost)
+{
+    HostFaultReport report;
+
+    ASSERT_EQ(install_host_handler(SIGSEGV), 0);
+    ASSERT_EQ(install_host_handler(SIGBUS), 0);
+    ASSERT_EQ(init_segv_catcher(), 0);
+    ASSERT_TRUE(segv_handler_installed());
+
+    t_host_report = &report;
+    if (sigsetjmp(t_host_jmpenv, /* save sig mask = */ 1) == 0) {
+        ASSERT_EQ(pthread_kill(pthread_self(), SIGSEGV), 0);
+        FAIL() << "pthread_kill did not reach the host handler";
+    }
+    t_host_report = nullptr;
+
+    ASSERT_TRUE(report.ran) << "the host handler never received the injected signal";
+    EXPECT_EQ(report.signo, SIGSEGV);
+    EXPECT_LE(report.si_code, 0) << "expected an injected delivery, got si_code " << report.si_code;
+}
+
+// A saved SIG_IGN disposition must survive injected deliveries; only synchronous faults
+// upgrade it to SIG_DFL so the faulting instruction can terminate the process.
+TEST(FaultChainback, PreservesSigIgnForInjectedDelivery)
+{
+    struct sigaction ign
+    {};
+    ign.sa_handler = SIG_IGN;
+    sigemptyset(&ign.sa_mask);
+    ASSERT_EQ(sigaction(SIGSEGV, &ign, nullptr), 0);
+    ASSERT_EQ(sigaction(SIGBUS, &ign, nullptr), 0);
+
+    ASSERT_EQ(init_segv_catcher(), 0);
+    ASSERT_TRUE(segv_handler_installed());
+
+    ASSERT_EQ(pthread_kill(pthread_self(), SIGSEGV), 0);
+
+    struct sigaction current
+    {};
+    ASSERT_EQ(sigaction(SIGSEGV, nullptr, &current), 0);
+    EXPECT_EQ(current.sa_handler, reinterpret_cast<void (*)(int)>(SIG_IGN));
 }

--- a/ddtrace/internal/datadog/profiling/stack/test/test_fault_chainback.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/test/test_fault_chainback.cpp
@@ -118,7 +118,7 @@ run_cede_scenario(CedeOutcome& outcome, HostFaultReport& report)
 // siginfo intact. Re-raising via pthread_kill reports si_code == SI_TKILL with a null
 // fault address and a PC inside the profiler's handler, which stops a host such as the
 // Go runtime from classifying the fault as recoverable and turns a nil-dereference panic
-// into a fatal crash (PROF-14568).
+// into a fatal crash (PROF-15342).
 //
 // t_in_unarmed_chain latches after the first cede, so this scenario needs its own thread.
 TEST(FaultChainback, CedesUnarmedFaultWithOriginalSiginfo)

--- a/ddtrace/internal/datadog/profiling/stack/test/test_fault_chainback.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/test/test_fault_chainback.cpp
@@ -1,0 +1,195 @@
+#include "echion/danger.h"
+
+#include <gtest/gtest.h>
+
+#include <cerrno>
+#include <csetjmp>
+#include <csignal>
+#include <cstdint>
+#include <sys/mman.h>
+#include <thread>
+
+namespace {
+
+constexpr size_t kGuardedPageSize = 4096;
+
+struct HostFaultReport
+{
+    volatile sig_atomic_t ran = 0;
+    volatile int signo = 0;
+    volatile int si_code = 0;
+    void* si_addr = nullptr;
+};
+
+thread_local sigjmp_buf t_host_jmpenv;
+thread_local HostFaultReport* t_host_report = nullptr;
+
+void
+host_fault_handler(int signo, siginfo_t* info, void*)
+{
+    if (t_host_report != nullptr) {
+        t_host_report->signo = signo;
+        t_host_report->si_code = info != nullptr ? info->si_code : 0;
+        t_host_report->si_addr = info != nullptr ? info->si_addr : nullptr;
+        t_host_report->ran = 1;
+    }
+
+    siglongjmp(t_host_jmpenv, 1);
+}
+
+int
+install_host_handler(int signo)
+{
+    struct sigaction sa
+    {};
+    sa.sa_sigaction = host_fault_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
+    return sigaction(signo, &sa, nullptr);
+}
+
+bool
+host_handler_owns(int signo)
+{
+    struct sigaction current
+    {};
+    if (sigaction(signo, nullptr, &current) != 0) {
+        return false;
+    }
+    return current.sa_sigaction == host_fault_handler;
+}
+
+// Reads one byte from a PROT_NONE page, which faults with a known si_addr.
+void
+touch_guarded_page(void* page)
+{
+    volatile uint8_t sink = 0;
+    sink = *static_cast<volatile const uint8_t*>(page);
+    (void)sink;
+}
+
+// Outcome of the worker thread below. gtest fatal assertions are only safe on the main
+// thread, so the worker records what happened and the test body asserts on it.
+struct CedeOutcome
+{
+    bool page_mapped = false;
+    bool host_installed = false;
+    bool catcher_installed = false;
+    bool profiler_owned_before_fault = false;
+    bool faulted = false;
+    void* page = nullptr;
+};
+
+void
+run_cede_scenario(CedeOutcome& outcome, HostFaultReport& report)
+{
+    outcome.page = mmap(nullptr, kGuardedPageSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (outcome.page == MAP_FAILED) {
+        outcome.page = nullptr;
+        return;
+    }
+    outcome.page_mapped = true;
+
+    if (install_host_handler(SIGSEGV) != 0 || install_host_handler(SIGBUS) != 0) {
+        return;
+    }
+    outcome.host_installed = true;
+
+    // The profiler installs over the host, saving the host disposition to chain back to.
+    if (init_segv_catcher() != 0) {
+        return;
+    }
+    outcome.catcher_installed = true;
+    outcome.profiler_owned_before_fault = segv_handler_installed();
+
+    t_host_report = &report;
+    if (sigsetjmp(t_host_jmpenv, /* save sig mask = */ 1) == 0) {
+        // Not inside safe_memcpy, so the profiler's handler is unarmed.
+        touch_guarded_page(outcome.page);
+    } else {
+        outcome.faulted = true;
+    }
+    t_host_report = nullptr;
+}
+
+} // namespace
+
+// A fault the profiler is not recovering from must reach the host with its original
+// siginfo intact. Re-raising via pthread_kill reports si_code == SI_TKILL with a null
+// fault address and a PC inside the profiler's handler, which stops a host such as the
+// Go runtime from classifying the fault as recoverable and turns a nil-dereference panic
+// into a fatal crash (PROF-14568).
+//
+// t_in_unarmed_chain latches after the first cede, so this scenario needs its own thread.
+TEST(FaultChainback, CedesUnarmedFaultWithOriginalSiginfo)
+{
+    CedeOutcome outcome;
+    HostFaultReport report;
+
+    std::thread worker([&outcome, &report]() { run_cede_scenario(outcome, report); });
+    worker.join();
+
+    ASSERT_TRUE(outcome.page_mapped) << "could not map the guarded page";
+    ASSERT_TRUE(outcome.host_installed) << "could not install the host fault handlers";
+    ASSERT_TRUE(outcome.catcher_installed) << "init_segv_catcher failed";
+    EXPECT_TRUE(outcome.profiler_owned_before_fault) << "the profiler did not take ownership of the fault signals";
+
+    ASSERT_TRUE(outcome.faulted) << "the guarded page read did not fault";
+    ASSERT_TRUE(report.ran) << "the host handler never received the fault";
+
+    // Which signal a PROT_NONE read raises is platform-dependent: SIGSEGV on Linux,
+    // SIGBUS on macOS. Either way it must arrive at the host, not be swallowed.
+    const int delivered = report.signo;
+    ASSERT_TRUE(delivered == SIGSEGV || delivered == SIGBUS) << "unexpected signal " << delivered;
+
+    // A kernel-generated fault has si_code > 0. SI_TKILL (-6) here would mean the signal
+    // was re-raised instead of being allowed to re-fault.
+    EXPECT_GT(report.si_code, 0) << "si_code " << report.si_code << " is not a kernel-generated fault";
+    EXPECT_EQ(report.si_addr, outcome.page) << "si_addr did not survive the handoff to the host";
+
+    // Having ceded the faulting signal, the profiler no longer owns it, so the sampler's
+    // per-cycle ownership check falls back to the syscall copy.
+    EXPECT_TRUE(host_handler_owns(delivered)) << "the profiler did not hand the signal back to the host";
+    EXPECT_FALSE(segv_handler_installed()) << "the profiler still claims to own both fault signals";
+
+    if (outcome.page != nullptr) {
+        munmap(outcome.page, kGuardedPageSize);
+    }
+}
+
+// The armed path is unchanged: a fault raised inside safe_memcpy is still recovered
+// locally and reported as an error rather than handed to the host.
+TEST(FaultChainback, SafeMemcpyStillRecoversArmedFault)
+{
+    ASSERT_EQ(install_host_handler(SIGSEGV), 0);
+    ASSERT_EQ(install_host_handler(SIGBUS), 0);
+    ASSERT_EQ(init_segv_catcher(), 0);
+    ASSERT_TRUE(segv_handler_installed());
+
+    void* page = mmap(nullptr, kGuardedPageSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(page, MAP_FAILED);
+
+    uint8_t dst[64] = { 0 };
+
+#if defined PL_LINUX
+    struct iovec iov_dst = { dst, sizeof(dst) };
+    struct iovec iov_src = { page, sizeof(dst) };
+    errno = 0;
+    const ssize_t copied = safe_memcpy_wrapper(getpid(), &iov_dst, 1, &iov_src, 1, 0);
+    EXPECT_EQ(copied, -1);
+    EXPECT_EQ(errno, EFAULT);
+#elif defined PL_DARWIN
+    mach_vm_size_t outsize = 0;
+    const kern_return_t kr = safe_memcpy_wrapper(mach_task_self(),
+                                                 reinterpret_cast<mach_vm_address_t>(page),
+                                                 sizeof(dst),
+                                                 reinterpret_cast<mach_vm_address_t>(dst),
+                                                 &outsize);
+    EXPECT_NE(kr, KERN_SUCCESS);
+#endif
+
+    // Recovering locally must not disturb handler ownership.
+    EXPECT_TRUE(segv_handler_installed());
+
+    munmap(page, kGuardedPageSize);
+}

--- a/ddtrace/internal/datadog/profiling/stack/test/test_fault_chainback.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/test/test_fault_chainback.cpp
@@ -19,7 +19,7 @@ struct HostFaultReport
     volatile sig_atomic_t ran = 0;
     volatile sig_atomic_t signo = 0;
     volatile sig_atomic_t si_code = 0;
-    void* si_addr = nullptr;
+    void* fault_addr = nullptr;
 };
 
 thread_local sigjmp_buf t_host_jmpenv;
@@ -31,7 +31,7 @@ host_fault_handler(int signo, siginfo_t* info, void*)
     if (t_host_report != nullptr) {
         t_host_report->signo = signo;
         t_host_report->si_code = info != nullptr ? info->si_code : 0;
-        t_host_report->si_addr = info != nullptr ? info->si_addr : nullptr;
+        t_host_report->fault_addr = info != nullptr ? info->si_addr : nullptr;
         t_host_report->ran = 1;
     }
 
@@ -146,10 +146,9 @@ TEST(FaultChainback, CedesUnarmedFaultWithOriginalSiginfo)
     // A kernel-generated fault has si_code > 0. SI_TKILL (-6) here would mean the signal
     // was re-raised instead of being allowed to re-fault.
     EXPECT_GT(report.si_code, 0) << "si_code " << report.si_code << " is not a kernel-generated fault";
-    EXPECT_EQ(report.si_addr, outcome.page) << "si_addr did not survive the handoff to the host";
+    EXPECT_EQ(report.fault_addr, outcome.page) << "si_addr did not survive the handoff to the host";
 
-    // Having ceded the faulting signal, the profiler no longer owns it, so the sampler's
-    // per-cycle ownership check falls back to the syscall copy.
+    // After cede, segv_handler_installed() is false and the host handler is restored on top.
     EXPECT_TRUE(host_handler_owns(delivered)) << "the profiler did not hand the signal back to the host";
     EXPECT_FALSE(segv_handler_installed()) << "the profiler still claims to own both fault signals";
 

--- a/releasenotes/notes/profiling-stack-sampler-fault-chainback-siginfo-0b72894583e6fc6b.yaml
+++ b/releasenotes/notes/profiling-stack-sampler-fault-chainback-siginfo-0b72894583e6fc6b.yaml
@@ -1,0 +1,6 @@
+fixes:
+  - |
+    Profiling: fixed a crash in host applications that embed CPython. Faults the stack
+    sampler does not recover are now handed back to the previous signal handler with the
+    original fault address and cause intact, instead of being re-raised with metadata that
+    prevented the host from recovering.

--- a/releasenotes/notes/profiling-stack-sampler-fault-chainback-siginfo-0b72894583e6fc6b.yaml
+++ b/releasenotes/notes/profiling-stack-sampler-fault-chainback-siginfo-0b72894583e6fc6b.yaml
@@ -1,6 +1,5 @@
 fixes:
   - |
-    Profiling: fixed a crash in host applications that embed CPython. Faults the stack
-    sampler does not recover are now handed back to the previous signal handler with the
-    original fault address and cause intact, instead of being re-raised with metadata that
-    prevented the host from recovering.
+    profiling: Fixes an issue where a fault the stack sampler could not recover was passed
+    to the application's own signal handler with the fault address and cause replaced,
+    so the application crashed instead of handling the fault.

--- a/releasenotes/notes/profiling-stack-sampler-fault-chainback-siginfo-0b72894583e6fc6b.yaml
+++ b/releasenotes/notes/profiling-stack-sampler-fault-chainback-siginfo-0b72894583e6fc6b.yaml
@@ -1,5 +1,5 @@
 fixes:
   - |
-    profiling: Fixes an issue where a fault the stack sampler could not recover was passed
+    profiling: Fixes an issue where a fault that the stack sampler could not recover from was passed
     to the application's own signal handler with the fault address and cause replaced,
     so the application crashed instead of handling the fault.

--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+# mypy: follow-imports=silent
 import gc
 import inspect
 import os

--- a/tests/profiling/test_profiler.py
+++ b/tests/profiling/test_profiler.py
@@ -1,3 +1,4 @@
+# mypy: follow-imports=silent
 import logging
 import os
 import sys


### PR DESCRIPTION
## Description

The unarmed chain-back path in `danger.cc` restored the previously-installed SIGSEGV/SIGBUS handler, then called `pthread_kill(pthread_self(), signo)`. That re-raise delivers `si_code == SI_TKILL` with no fault address and a PC inside our own handler, so a host that reads `siginfo` to classify the fault gets garbage.

The handler now cedes the signal and *returns* for kernel-generated faults (`si_code > 0`), so the faulting instruction re-executes and the new owner receives the real `si_code`, `si_addr` and PC. Injected signals (`si_code <= 0`) still get an explicit re-delivery, since no instruction would re-execute. A saved `SIG_IGN` becomes `SIG_DFL`, so returning into an ignored fault terminates instead of spinning.

Motivation is [IR-59892](https://app.datadoghq.com/incidents/59892): datadog-agent 7.83.0 release candidates crash-looped. The Agent embeds CPython; the profiler installed over the Go runtime's handlers, and this bug turned Go's recoverable nil-dereference panics fatal. The crash log showed `sigcode=18446744073709551610` — `-6` as unsigned 64-bit, i.e. `SI_TKILL`.

Continues #18798 (4.12 backport #18993). #19920 mitigates the Agent by disabling fast copy for embedded interpreters; this fixes the defect itself, which corrupts `siginfo` for **any** host that reads it — Go, the JVM, .NET, Python's own `faulthandler`.

## Testing

New `test_fault_chainback.cpp` covers the ceded unarmed fault and the unchanged armed recovery. On this branch:

```
[ RUN      ] FaultChainback.CedesUnarmedFaultWithOriginalSiginfo
[       OK ] FaultChainback.CedesUnarmedFaultWithOriginalSiginfo (0 ms)
```

With `main`'s `danger.cc` and only the new test applied:

```
[ RUN      ] FaultChainback.CedesUnarmedFaultWithOriginalSiginfo
test_fault_chainback.cpp:148: Failure
Expected equality of these values:
  report.si_addr
    Which is: NULL
  outcome.page
    Which is: 0x102ba8000
si_addr did not survive the handoff to the host
[  FAILED  ] FaultChainback.CedesUnarmedFaultWithOriginalSiginfo (0 ms)
```

Full native stack suite on macOS arm64: 21/22; `ThreadAltStackOwnership.DestructorDisablesOwnAltStack` fails identically with `main`'s `danger.cc` restored (pre-existing macOS breakage).

Not run locally: the Linux path, and `tests/profiling/test_faulthandler.py` / `tests/profiling/collector/test_copy_memory_stats.py`, which need a full package build.

## Risks

Confined to the unarmed path, which previously always handed off or terminated. Returning without re-raising relies on the faulting instruction re-executing, which holds only for `si_code > 0`; injected signals keep the old re-delivery.

## Additional Notes

Out of scope: a probe that refuses to install over an existing handler. pytest enables `faulthandler` by default, so it would silently disable fast copy in every test run and for anyone calling `faulthandler.enable()`; telling it and crashtracker — chained intentionally — apart from torch/CUDA/abseil needs something like `dladdr` on the handler address.

Backports likely wanted; targets undecided, so no `backport` labels applied.


https://datadoghq.atlassian.net/browse/PROF-16018