### PR TITLE
chore: test libdatadog OTLP gRPC size impact [DO NOT MERGE]

### DIFF
--- a/src/native/Cargo.lock
+++ b/src/native/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
 [[package]]
 name = "build_common"
 version = "42.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "cbindgen",
  "serde",
@@ -545,7 +545,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 [[package]]
 name = "datadog-live-debugger"
 version = "0.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "anyhow",
  "bytes",
@@ -792,6 +792,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,6 +983,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,6 +1167,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1525,7 +1551,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libdd-alloc"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "allocator-api2",
  "libc",
@@ -1535,7 +1561,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1548,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1562,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "5.2.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1602,7 +1628,7 @@ dependencies = [
 [[package]]
 name = "libdd-common-ffi"
 version = "42.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1616,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "libdd-crashtracker"
 version = "2.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "anyhow",
  "blazesym",
@@ -1652,7 +1678,7 @@ dependencies = [
 [[package]]
 name = "libdd-data-pipeline"
 version = "9.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1663,9 +1689,12 @@ dependencies = [
  "getrandom 0.2.17",
  "http",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common",
+ "libdd-data-pipeline-core",
  "libdd-ddsketch",
  "libdd-dogstatsd-client",
  "libdd-shared-runtime",
@@ -1676,21 +1705,36 @@ dependencies = [
  "libdd-trace-protobuf",
  "libdd-trace-stats",
  "libdd-trace-utils",
+ "prost",
  "rmp-serde",
  "serde",
  "serde_json",
  "sha2",
  "tokio",
  "tokio-util",
+ "tonic",
  "tracing",
  "uuid",
  "web-time",
 ]
 
 [[package]]
+name = "libdd-data-pipeline-core"
+version = "1.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
+dependencies = [
+ "http",
+ "libdd-capabilities",
+ "libdd-common",
+ "libdd-trace-utils",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "libdd-data-pipeline-ffi"
 version = "42.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "build_common",
  "libdd-capabilities-impl",
@@ -1707,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.1.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "prost",
 ]
@@ -1715,7 +1759,7 @@ dependencies = [
 [[package]]
 name = "libdd-dogstatsd-client"
 version = "5.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1731,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "libdd-ffe"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "chrono",
  "derive_more",
@@ -1753,7 +1797,7 @@ dependencies = [
 [[package]]
 name = "libdd-gotter"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "libc",
 ]
@@ -1761,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "libdd-http-client"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "bytes",
  "fastrand",
@@ -1777,7 +1821,7 @@ dependencies = [
 [[package]]
 name = "libdd-ipc"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1805,7 +1849,7 @@ dependencies = [
 [[package]]
 name = "libdd-ipc-macros"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1816,7 +1860,7 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "anyhow",
  "libc",
@@ -1833,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "libdd-library-config-ffi"
 version = "0.0.2"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1857,7 +1901,7 @@ dependencies = [
 [[package]]
 name = "libdd-log"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "chrono",
  "tracing",
@@ -1868,12 +1912,12 @@ dependencies = [
 [[package]]
 name = "libdd-otel-thread-ctx"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 
 [[package]]
 name = "libdd-otel-thread-ctx-ffi"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "build_common",
  "libdd-common-ffi",
@@ -1883,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1923,7 +1967,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling-ffi"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1948,7 +1992,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling-protobuf"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "prost",
 ]
@@ -1956,7 +2000,7 @@ dependencies = [
 [[package]]
 name = "libdd-remote-config"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "anyhow",
  "base64",
@@ -1989,7 +2033,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "async-trait",
  "futures",
@@ -2006,7 +2050,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime-ffi"
 version = "42.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "build_common",
  "libdd-shared-runtime",
@@ -2016,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "libdd-telemetry"
 version = "7.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2047,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.2"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "serde",
 ]
@@ -2055,7 +2099,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf",
@@ -2064,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-obfuscation"
 version = "7.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "anyhow",
  "fluent-uri",
@@ -2080,7 +2124,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "5.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "prost",
  "serde",
@@ -2090,7 +2134,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-stats"
 version = "8.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2119,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-utils"
 version = "11.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "anyhow",
  "base64",
@@ -2148,14 +2192,13 @@ dependencies = [
  "serde-transcode",
  "serde_json",
  "thin-vec",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "libdd-tracer-flare"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v42.0.0#64436d5a54191c9a9f2d2691f595370512462015"
+source = "git+https://github.com/DataDog/libdatadog?rev=1f2c50a29903ec6dcbf54427d6fc952631662d48#1f2c50a29903ec6dcbf54427d6fc952631662d48"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3938,6 +3981,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3988,6 +4042,26 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "tower"
@@ -4041,6 +4115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
@@ -4055,6 +4130,17 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/src/native/Cargo.toml
+++ b/src/native/Cargo.toml
@@ -31,18 +31,18 @@ serde = "1.0"
 serde_json = "1.0"
 smallvec = "1"
 tokio = "1"
-libdd-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0", optional = true, features = ["pyo3"] }
-libdd-ipc = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0", features = ["one_way_shm_futex"] }
-datadog-live-debugger = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0" }
-libdd-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0" }
-libdd-telemetry = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0" }
-libdd-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0" }
-libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0", optional = true }
-libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0", optional = true }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0" }
-libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0" }
-libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0", features = [
+libdd-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48", optional = true, features = ["pyo3"] }
+libdd-ipc = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48", features = ["one_way_shm_futex"] }
+datadog-live-debugger = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48" }
+libdd-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48" }
+libdd-telemetry = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48" }
+libdd-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48" }
+libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48", optional = true }
+libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48", optional = true }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48" }
+libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48" }
+libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48", features = [
   "stats-obfuscation"
 ] }
 # DEV: `hyper-backend` (rather than the default `reqwest-backend`) avoids
@@ -50,16 +50,16 @@ libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "v4
 # hostnames resolved through custom search/ndots resolv.conf setups (e.g.
 # Docker Compose/Kubernetes service names via embedded DNS) — it uses the
 # system resolver instead, like the stdlib http.client this replaces did.
-libdd-http-client = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0", default-features = false, features = [
+libdd-http-client = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48", default-features = false, features = [
   "https",
   "hyper-backend",
 ] }
-libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0" }
-libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0", optional = true, features = [
+libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48" }
+libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48", optional = true, features = [
     "cbindgen",
 ] }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48" }
 native-proc-macro = { path = "native_proc_macro" }
 strum = { version = "0.26", default-features = false }
 percent-encoding = "2.3"
@@ -68,8 +68,8 @@ tracing = { version = "0.1", default-features = false }
 pyo3-ffi = { version = "0.28", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0", features = ["otel-thread-ctx"]}
-libdd-otel-thread-ctx = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48", features = ["otel-thread-ctx"]}
+libdd-otel-thread-ctx = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48" }
 libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -77,7 +77,7 @@ libc = "0.2"
 
 [build-dependencies]
 pyo3-build-config = "0.28"
-build_common = { git = "https://github.com/DataDog/libdatadog", rev = "v42.0.0", features = [
+build_common = { git = "https://github.com/DataDog/libdatadog", rev = "1f2c50a29903ec6dcbf54427d6fc952631662d48", features = [
     "cbindgen",
 ] }
 


### PR DESCRIPTION
## Description

Temporary CI experiment. Do not merge.

Pins every libdatadog dependency from `v42.0.0` to commit `1f2c50a29903ec6dcbf54427d6fc952631662d48`, the current head of [DataDog/libdatadog#2273](https://github.com/DataDog/libdatadog/pull/2273). This lets the existing serverless CI measure the resulting Lambda layer size.

## Testing

- `cargo check --manifest-path src/native/Cargo.toml`
- `scripts/run-tests --venv 4a90061`
- `scripts/lint checks`
- Serverless Lambda layer-size CI on this draft PR

## Risks

None while this remains an unmerged experiment.

The size comparison is from libdatadog `v42.0.0` to the PR head, so it includes intervening libdatadog changes. At the pinned commit, the gRPC path is not yet wired into the exporter loop; release LTO may remove unreachable code and understate its eventual shipped cost.

## Additional Notes

No Cargo feature gate was added for the new dependencies.
