### PR TITLE
test(telemetry): support PathResolutionError in wrapt 2.4.0

### DIFF
--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -386,7 +386,11 @@ patch(raise_errors=False, sqlite3=True)
     assert len(integration_error) == 1
     assert integration_error[0]["type"] == "count"
     assert integration_error[0]["points"][0][1] == 1
-    assert integration_error[0]["tags"] == ["integration_name:sqlite3", "error_type:attributeerror"]
+    # wrapt 2.4.0 now throws PathResolutionError instead of AttributeError.
+    assert integration_error[0]["tags"] in (
+        ["integration_name:sqlite3", "error_type:attributeerror"],
+        ["integration_name:sqlite3", "error_type:pathresolutionerror"],
+    )
 
 
 def test_unhandled_integration_error(test_agent_session, ddtrace_run_python_code_in_subprocess):


### PR DESCRIPTION
**wrapt 2.4.0,** released yesterday, made changes for how errors are handled. It now throws PathResolutionError instead of AttributeError. 

See full wrapt 2.4.0 release notes: https://wrapt.readthedocs.io/en/latest/changes.html#version-2-4-0

Due to this change, the telemetry test was failing in the environments where they spun up wrapt 2.4.0.

Thanks to @christophe-papazian for reporting the error:

```
=========================== short test summary info ============================
FAILED tests/telemetry/test_telemetry.py::test_handled_integration_error[py3.10] - AssertionError: assert ['integration...olutionerror'] == ['integration...tributeerror']
  
  At index 1 diff: 'error_type:pathresolutionerror' != 'error_type:attributeerror'
  
  Full diff:
    [
        'integration_name:sqlite3',
  -     'error_type:attributeerror',
  ?                   ^ ^^  ^
  +     'error_type:pathresolutionerror',
  ?                 +  ^ ^^^^  ^^^
    ]
============================= Datadog Test Reports =============================
View detailed reports in Datadog (they may take a few minutes to become available):
* Commit report:
* ```