### PR TITLE
feat(sampling): introduce discard to DD_TRACE_SAMPLING_RULES

### DIFF
--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -272,11 +272,12 @@ class TraceTagsProcessor(TraceProcessor):
 
 
 class _Trace:
-    __slots__ = ("spans", "num_finished")
+    __slots__ = ("spans", "num_finished", "discarded")
 
     def __init__(self, spans: Optional[list[Span]] = None, num_finished: int = 0):
         self.spans: list[Span] = spans if spans is not None else []
         self.num_finished: int = num_finished
+        self.discarded: bool = False
 
     def remove_finished(self) -> list[Span]:
         # perf: Avoid Span.finished which is a computed property and has function call overhead
@@ -422,23 +423,31 @@ class SpanAggregator(SpanProcessor):
                 return
 
         # perf: Process spans outside of the span aggregator lock
-        spans = finished
-        for tp in chain(
-            self.dd_processors,
-            self.user_processors,
-            [
-                self.sampling_processor,
-                self.llmobs_processor,
-                self.tags_processor,
-                self.service_name_processor,
-            ],
-        ):
-            try:
-                spans = tp.process_trace(spans) or []
-                if not spans:
-                    break
-            except Exception:
-                log.error("error applying processor %r to trace %d", tp, span.trace_id, exc_info=True)
+        if trace.discarded:
+            spans: list[Span] = []
+        else:
+            spans = finished
+            for tp in chain(
+                self.dd_processors,
+                self.user_processors,
+                [
+                    self.sampling_processor,
+                    self.llmobs_processor,
+                    self.tags_processor,
+                    self.service_name_processor,
+                ],
+            ):
+                try:
+                    spans = tp.process_trace(spans) or []
+                    if not spans:
+                        # TraceSamplingProcessor only ever returns an empty result for a discard=True
+                        # rule rejecting the chunk; remember that so later partial-flush chunks of this
+                        # trace are dropped too instead of being kept with the (already-set) reject priority.
+                        if tp is self.sampling_processor and not is_trace_complete:
+                            trace.discarded = True
+                        break
+                except Exception:
+                    log.error("error applying processor %r to trace %d", tp, span.trace_id, exc_info=True)
 
         num_dropped = len(finished) - len(spans)
         if num_dropped > 0:

--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -123,6 +123,8 @@ class TraceSamplingProcessor(TraceProcessor):
     * If the span sampling decision is to keep the span, then span sampling metrics are added to the span.
     * If a dropped trace includes a span that had been kept by a span sampling rule, then the span is sent to the
       Agent even if the dropped trace is not (as is the case when trace stats computation is enabled).
+    * If the chunk is rejected by a rule with ``discard=True``, the whole chunk is dropped instead of being kept
+      with a reject priority, so it is excluded from stats and never serialized or sent to the Agent.
     """
 
     def __init__(
@@ -164,7 +166,9 @@ class TraceSamplingProcessor(TraceProcessor):
                     span._set_attribute(_APM_ENABLED_METRIC_KEY, 0)
 
             if chunk_root.context.sampling_priority is None:
-                self.sampler.sample(chunk_root._local_root)
+                _, discard = self.sampler.sample_or_discard(chunk_root._local_root)
+                if discard:
+                    return None
                 if chunk_root.context.sampling_priority is None:
                     # NOTE: This should never happen, `self.sampler.sample(..)` should always set the sampling priority.
                     log.error(

--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -427,6 +427,7 @@ class SpanAggregator(SpanProcessor):
             spans: list[Span] = []
         else:
             spans = finished
+            sampling_discarded = False
             for tp in chain(
                 self.dd_processors,
                 self.user_processors,
@@ -438,16 +439,25 @@ class SpanAggregator(SpanProcessor):
                 ],
             ):
                 try:
-                    spans = tp.process_trace(spans) or []
-                    if not spans:
-                        # TraceSamplingProcessor only ever returns an empty result for a discard=True
-                        # rule rejecting the chunk; remember that so later partial-flush chunks of this
-                        # trace are dropped too instead of being kept with the (already-set) reject priority.
-                        if tp is self.sampling_processor and not is_trace_complete:
-                            trace.discarded = True
-                        break
+                    result = tp.process_trace(spans) or []
                 except Exception:
                     log.error("error applying processor %r to trace %d", tp, span.trace_id, exc_info=True)
+                    continue
+                if not result and tp is self.sampling_processor:
+                    # TraceSamplingProcessor only ever returns an empty result for a discard=True
+                    # rule rejecting the chunk. However, we must not actually discard them until the
+                    # llmobs_processor has run to allow them to rescue spans.
+                    sampling_discarded = True
+                    if not is_trace_complete:
+                        # Remember this so later partial-flush chunks of the same trace are dropped
+                        # too, instead of being kept with the (already-set) reject priority.
+                        trace.discarded = True
+                    continue
+                spans = result
+                if not spans or (tp is self.llmobs_processor and sampling_discarded):
+                    # If llmobs does not rescue the span, we still discard it.
+                    spans = []
+                    break
 
         num_dropped = len(finished) - len(spans)
         if num_dropped > 0:

--- a/ddtrace/_trace/sampler.py
+++ b/ddtrace/_trace/sampler.py
@@ -141,28 +141,10 @@ class DatadogSampler:
 
     def set_sampling_rules(self, rules: str) -> None:
         """Sets the trace sampling rules from a JSON string"""
-        sampling_rules: list[SamplingRule] = []
+        sampling_rules = []
         try:
             json_rules = json.loads(rules)
-        except (JSONDecodeError, ValueError):
-            log.error(
-                "Failed to parse DD_TRACE_SAMPLING_RULES=%r, no sampling rules will be applied",
-                rules,
-                exc_info=True,
-                extra={"send_to_telemetry": False},
-            )
-            self.rules = []
-            return
-        if not isinstance(json_rules, list):
-            log.error(
-                "DD_TRACE_SAMPLING_RULES=%r is not a JSON array, no sampling rules will be applied",
-                rules,
-                extra={"send_to_telemetry": False},
-            )
-            self.rules = []
-            return
-        for rule in json_rules:
-            try:
+            for rule in json_rules:
                 if "sample_rate" not in rule:
                     log.error(
                         "No sample_rate provided for sampling rule: %s. Skipping.",
@@ -171,13 +153,14 @@ class DatadogSampler:
                     )
                     continue
                 sampling_rules.append(SamplingRule(**rule))
-            except Exception:
-                log.error(
-                    "Failed to apply sampling rule %r, skipping it",
-                    rule,
-                    exc_info=True,
-                    extra={"send_to_telemetry": False},
-                )
+        except (JSONDecodeError, ValueError):
+            log.error(
+                "Failed to apply all sampling rules. Rules=%s, Applied=%s",
+                rules,
+                sampling_rules,
+                exc_info=True,
+                extra={"send_to_telemetry": False},
+            )
         self.rules = sorted(sampling_rules, key=lambda rule: PROVENANCE_ORDER.index(rule.provenance))
 
     def sample(self, span: Span) -> bool:

--- a/ddtrace/_trace/sampler.py
+++ b/ddtrace/_trace/sampler.py
@@ -212,8 +212,8 @@ class DatadogSampler:
             str(self.rules) if self.rules is not None else "None",
             id(self),
         )
-        discard = bool(matched_rule is not None and matched_rule.discard and not sampled)
-        return sampled, discard
+        discarded = bool(matched_rule is not None and matched_rule.discard and not sampled)
+        return sampled, discarded
 
     def _get_sampling_mechanism(self, matched_rule: Optional[SamplingRule], agent_service_based: bool) -> int:
         if matched_rule and matched_rule.provenance == "customer":

--- a/ddtrace/_trace/sampler.py
+++ b/ddtrace/_trace/sampler.py
@@ -141,10 +141,28 @@ class DatadogSampler:
 
     def set_sampling_rules(self, rules: str) -> None:
         """Sets the trace sampling rules from a JSON string"""
-        sampling_rules = []
+        sampling_rules: list[SamplingRule] = []
         try:
             json_rules = json.loads(rules)
-            for rule in json_rules:
+        except (JSONDecodeError, ValueError):
+            log.error(
+                "Failed to parse DD_TRACE_SAMPLING_RULES=%r, no sampling rules will be applied",
+                rules,
+                exc_info=True,
+                extra={"send_to_telemetry": False},
+            )
+            self.rules = []
+            return
+        if not isinstance(json_rules, list):
+            log.error(
+                "DD_TRACE_SAMPLING_RULES=%r is not a JSON array, no sampling rules will be applied",
+                rules,
+                extra={"send_to_telemetry": False},
+            )
+            self.rules = []
+            return
+        for rule in json_rules:
+            try:
                 if "sample_rate" not in rule:
                     log.error(
                         "No sample_rate provided for sampling rule: %s. Skipping.",
@@ -153,17 +171,20 @@ class DatadogSampler:
                     )
                     continue
                 sampling_rules.append(SamplingRule(**rule))
-        except (JSONDecodeError, ValueError):
-            log.error(
-                "Failed to apply all sampling rules. Rules=%s, Applied=%s",
-                rules,
-                sampling_rules,
-                exc_info=True,
-                extra={"send_to_telemetry": False},
-            )
+            except Exception:
+                log.error(
+                    "Failed to apply sampling rule %r, skipping it",
+                    rule,
+                    exc_info=True,
+                    extra={"send_to_telemetry": False},
+                )
         self.rules = sorted(sampling_rules, key=lambda rule: PROVENANCE_ORDER.index(rule.provenance))
 
     def sample(self, span: Span) -> bool:
+        sampled, _ = self.sample_or_discard(span)
+        return sampled
+
+    def sample_or_discard(self, span: Span) -> tuple[bool, bool]:
         span._update_tags_from_context()
         matched_rule = _get_highest_precedence_rule_matching(span, self.rules)
         # Default sampling
@@ -208,7 +229,8 @@ class DatadogSampler:
             str(self.rules) if self.rules is not None else "None",
             id(self),
         )
-        return sampled
+        discard = bool(matched_rule is not None and matched_rule.discard and not sampled)
+        return sampled, discard
 
     def _get_sampling_mechanism(self, matched_rule: Optional[SamplingRule], agent_service_based: bool) -> int:
         if matched_rule and matched_rule.provenance == "customer":

--- a/ddtrace/_trace/sampling_rule.py
+++ b/ddtrace/_trace/sampling_rule.py
@@ -26,6 +26,7 @@ class SamplingRule(object):
         resource: Optional[str] = None,
         tags: Optional[dict[str, Any]] = None,
         provenance: str = "default",
+        discard: bool = False,
     ) -> None:
         """
         Configure a new :class:`SamplingRule`
@@ -44,6 +45,10 @@ class SamplingRule(object):
 
                 # Sample based on service name using custom function
                 SamplingRule(sample_rate=0.75, service=lambda service: 'my-app' in service),
+
+                # Fully drop rejected traces for a noisy health check, instead of sending
+                # them with a reject priority
+                SamplingRule(sample_rate=0.0, resource='/health', discard=True),
             ])
 
         :param sample_rate: The sample rate to apply to any matching spans
@@ -56,6 +61,9 @@ class SamplingRule(object):
             values are glob-matches with the expected span tag values. Glob matching supports "*" meaning any
             number of characters, and "?" meaning any one character. If all tags specified in a SamplingRule are
             matches with a given span, that span is considered to have matching tags with the rule.
+        :param discard: When ``True``, a trace chunk rejected by this rule (i.e. not selected by ``sample_rate``)
+            is fully dropped instead of being kept with a reject priority: it is excluded from client-side stats
+            and never sent to the Agent. Has no effect on chunks that are sampled (kept).
         """
         self.sample_rate = min(1.0, max(0.0, float(sample_rate)))
         # since span.py converts None to 'None' for tags, and does not accept 'None' for metrics
@@ -65,6 +73,7 @@ class SamplingRule(object):
         self.name = GlobMatcher(name) if name is not None else None
         self.resource = GlobMatcher(resource) if resource else None
         self.provenance = provenance
+        self.discard = bool(discard)
 
     @property
     def sample_rate(self) -> float:
@@ -126,7 +135,7 @@ class SamplingRule(object):
 
         return True
 
-    def sample(self, span):
+    def sample(self, span: Span) -> bool:
         """
         Return if this rule chooses to sample the span
 
@@ -145,7 +154,8 @@ class SamplingRule(object):
     def __repr__(self):
         return (
             f"SamplingRule(sample_rate={self.sample_rate}, service={self.service}, "
-            f"name={self.name}, resource={self.resource}, tags={self.tags}, provenance={self.provenance})"
+            f"name={self.name}, resource={self.resource}, tags={self.tags}, provenance={self.provenance}, "
+            f"discard={self.discard})"
         )
 
     def __eq__(self, other: Any) -> bool:
@@ -158,4 +168,5 @@ class SamplingRule(object):
             and self.resource == other.resource
             and self.tags == other.tags
             and self.provenance == other.provenance
+            and self.discard == other.discard
         )

--- a/ddtrace/_trace/sampling_rule.py
+++ b/ddtrace/_trace/sampling_rule.py
@@ -73,7 +73,9 @@ class SamplingRule(object):
         self.name = GlobMatcher(name) if name is not None else None
         self.resource = GlobMatcher(resource) if resource else None
         self.provenance = provenance
-        self.discard = bool(discard)
+        if not isinstance(discard, bool):
+            raise ValueError(f"discard must be a boolean, got {discard!r}")
+        self.discard = discard
 
     @property
     def sample_rate(self) -> float:

--- a/ddtrace/internal/sampling.py
+++ b/ddtrace/internal/sampling.py
@@ -2,7 +2,6 @@ import json
 import math
 from typing import Any
 from typing import Optional
-from typing import Sequence
 from typing import TypedDict
 
 from ddtrace._trace.sampling_rule import SamplingRule
@@ -298,7 +297,7 @@ def _inherit_sampling_tags(target: Span, source: Span):
     target._set_attribute(SAMPLING_DECISION_MAKER_RESOURCE, source.resource)
 
 
-def _get_highest_precedence_rule_matching(span: Span, rules: Sequence[SamplingRule]) -> Optional[SamplingRule]:
+def _get_highest_precedence_rule_matching(span: Span, rules: list[SamplingRule]) -> Optional[SamplingRule]:
     if not rules:
         return None
 

--- a/ddtrace/internal/sampling.py
+++ b/ddtrace/internal/sampling.py
@@ -2,6 +2,7 @@ import json
 import math
 from typing import Any
 from typing import Optional
+from typing import Sequence
 from typing import TypedDict
 
 from ddtrace._trace.sampling_rule import SamplingRule
@@ -297,7 +298,7 @@ def _inherit_sampling_tags(target: Span, source: Span):
     target._set_attribute(SAMPLING_DECISION_MAKER_RESOURCE, source.resource)
 
 
-def _get_highest_precedence_rule_matching(span: Span, rules: list[SamplingRule]) -> Optional[SamplingRule]:
+def _get_highest_precedence_rule_matching(span: Span, rules: Sequence[SamplingRule]) -> Optional[SamplingRule]:
     if not rules:
         return None
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1217,9 +1217,9 @@ Sampling
      description: |
          A JSON array of objects. Each object must have a “sample_rate”, and the “name”, “service”, "resource", "tags", and "discard" fields are optional. The “sample_rate” value must be between 0.0 and 1.0 (inclusive).
 
-         When "discard" is set to ``true`` on a rule, a trace chunk that the rule rejects (does not select via "sample_rate") is fully dropped instead of being kept with a reject priority: it is excluded from client-side stats and never sent to the Agent. "discard" has no effect on chunks the rule selects (keeps).
+         Setting "discard" to ``true`` on a rule fully drops a trace chunk the rule rejects, excluding it from client-side stats and the Agent.
 
-         **Note** that a rule is matched against the current state of the trace chunk's local root span at the time each chunk is evaluated. When partial flushing is enabled (the default), child-span-only chunks may be evaluated and sent before the local root finishes, so a rule keyed on a field only assigned late in the request lifecycle (for example, the resolved HTTP route/resource in some web framework integrations) may not match, and therefore not discard, chunks flushed earlier in that trace even though the eventual root would have matched.
+         **Note** that with partial flushing enabled (the default), a chunk is matched against the trace's local root span as it stood when that chunk was flushed, so a rule keyed on data only available later in the request (e.g. a resolved HTTP route) may miss chunks flushed earlier in the same trace.
 
          **Example:** ``DD_TRACE_SAMPLING_RULES='[{"sample_rate":0.5,"service":"my-service","resource":"my-url","tags":{"my-tag":"example"}}]'``
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1215,9 +1215,15 @@ Sampling
      type: JSON array
 
      description: |
-         A JSON array of objects. Each object must have a “sample_rate”, and the “name”, “service”, "resource", and "tags" fields are optional. The “sample_rate” value must be between 0.0 and 1.0 (inclusive).
+         A JSON array of objects. Each object must have a “sample_rate”, and the “name”, “service”, "resource", "tags", and "discard" fields are optional. The “sample_rate” value must be between 0.0 and 1.0 (inclusive).
+
+         When "discard" is set to ``true`` on a rule, a trace chunk that the rule rejects (does not select via "sample_rate") is fully dropped instead of being kept with a reject priority: it is excluded from client-side stats and never sent to the Agent. "discard" has no effect on chunks the rule selects (keeps).
+
+         **Note** that a rule is matched against the current state of the trace chunk's local root span at the time each chunk is evaluated. When partial flushing is enabled (the default), child-span-only chunks may be evaluated and sent before the local root finishes, so a rule keyed on a field only assigned late in the request lifecycle (for example, the resolved HTTP route/resource in some web framework integrations) may not match, and therefore not discard, chunks flushed earlier in that trace even though the eventual root would have matched.
 
          **Example:** ``DD_TRACE_SAMPLING_RULES='[{"sample_rate":0.5,"service":"my-service","resource":"my-url","tags":{"my-tag":"example"}}]'``
+
+         **Example (fully drop a noisy, unsampled endpoint):** ``DD_TRACE_SAMPLING_RULES='[{"sample_rate":0.0,"resource":"/health","discard":true}]'``
 
          **Note** that the JSON object must be included in single quotes (') to avoid problems with escaping of the double quote (") character.'
 
@@ -1225,6 +1231,7 @@ Sampling
        v1.19.0: added support for "resource"
        v1.20.0: added support for "tags"
        v2.8.0: added lazy sampling support, so that spans are evaluated at the end of the trace, guaranteeing more metadata to evaluate against.
+       v4.15.0: added support for "discard"
 
 Feature Flagging
 ----------------

--- a/releasenotes/notes/add-trace-filtering-rules-73d81c9f2e662781.yaml
+++ b/releasenotes/notes/add-trace-filtering-rules-73d81c9f2e662781.yaml
@@ -1,7 +1,6 @@
 ---
 features:
   - |
-    tracing: Adds a ``discard`` boolean field to ``DD_TRACE_SAMPLING_RULES`` rules. When set to
-    ``true`` on a rule, a trace chunk rejected by that rule (not selected by ``sample_rate``) is
-    fully dropped instead of being kept with a reject priority: it is excluded from client-side
-    stats and never sent to the Datadog Agent.
+    tracing: Adds a ``discard`` boolean field to ``DD_TRACE_SAMPLING_RULES`` rules to fully drop
+    trace chunks which were rejected during sampling. See the ``DD_TRACE_SAMPLING_RULES``
+    configuration docs for details.

--- a/releasenotes/notes/add-trace-filtering-rules-73d81c9f2e662781.yaml
+++ b/releasenotes/notes/add-trace-filtering-rules-73d81c9f2e662781.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    tracing: Adds a ``discard`` boolean field to ``DD_TRACE_SAMPLING_RULES`` rules. When set to
+    ``true`` on a rule, a trace chunk rejected by that rule (not selected by ``sample_rate``) is
+    fully dropped instead of being kept with a reject priority: it is excluded from client-side
+    stats and never sent to the Datadog Agent.

--- a/tests/integration/test_debug.py
+++ b/tests/integration/test_debug.py
@@ -309,7 +309,8 @@ def test_startup_logs_sampling_rules():
     f = debug.collect(TracerDebugInfo.from_tracer(tracer))
 
     assert f.get("sampling_rules") == [
-        "SamplingRule(sample_rate=1.0, service=None, name=None, resource=None, tags={}, provenance=default)"
+        "SamplingRule(sample_rate=1.0, service=None, name=None, resource=None, tags={}, "
+        "provenance=default, discard=False)"
     ], f.get("sampling_rules")
 
 

--- a/tests/llmobs/test_llmobs_processor.py
+++ b/tests/llmobs/test_llmobs_processor.py
@@ -3,6 +3,8 @@
 import mock
 import pytest
 
+from ddtrace._trace.sampler import DatadogSampler
+from ddtrace._trace.sampling_rule import SamplingRule
 from ddtrace.constants import _SAMPLING_PRIORITY_KEY
 from ddtrace.constants import AUTO_REJECT
 from ddtrace.constants import USER_KEEP
@@ -167,6 +169,38 @@ class TestRescuePath:
                 _annotate_llm_span(child)
         assert child.get_tag(LLMOBS_SUBMITTED_TAG_KEY) == "1"
         mock_writer.enqueue.assert_called_once()
+
+
+class TestDiscardSuppressesRealLLMObsProcessor:
+    """Discard means the trace must not influence any Datadog product, including LLMObs: a
+    discarded chunk must never reach the real LLMObsProcessor, so its fallback enqueue() to
+    the LLMObs writer never fires.
+    """
+
+    def test_discarded_chunk_never_reaches_llmobs_processor(self, llmobs_agent_proxy, tracer):
+        _llmobs, mock_writer = llmobs_agent_proxy
+        tracer._span_aggregator.sampling_processor.sampler = DatadogSampler(
+            rules=[SamplingRule(sample_rate=0.0, discard=True)]
+        )
+        with mock.patch.object(
+            tracer._span_aggregator.llmobs_processor,
+            "process_trace",
+            wraps=tracer._span_aggregator.llmobs_processor.process_trace,
+        ) as mock_process_trace:
+            with tracer.trace("llm-span", span_type=SpanTypes.LLM) as span:
+                _annotate_llm_span(span)
+        mock_process_trace.assert_not_called()
+        mock_writer.enqueue.assert_not_called()
+        assert span.get_tag(LLMOBS_SUBMITTED_TAG_KEY) is None
+
+    def test_non_discarded_reject_still_reaches_llmobs_processor(self, llmobs_agent_proxy, tracer):
+        """Sanity check: without discard, the existing rescue path is unaffected."""
+        _llmobs, mock_writer = llmobs_agent_proxy
+        tracer._span_aggregator.sampling_processor.sampler = DatadogSampler(rules=[SamplingRule(sample_rate=0.0)])
+        with tracer.trace("llm-span", span_type=SpanTypes.LLM) as span:
+            _annotate_llm_span(span)
+        mock_writer.enqueue.assert_called_once()
+        assert span.get_tag(LLMOBS_SUBMITTED_TAG_KEY) == "1"
 
 
 class TestV04Forcing:

--- a/tests/llmobs/test_llmobs_processor.py
+++ b/tests/llmobs/test_llmobs_processor.py
@@ -171,13 +171,14 @@ class TestRescuePath:
         mock_writer.enqueue.assert_called_once()
 
 
-class TestDiscardSuppressesRealLLMObsProcessor:
-    """Discard means the trace must not influence any Datadog product, including LLMObs: a
-    discarded chunk must never reach the real LLMObsProcessor, so its fallback enqueue() to
-    the LLMObs writer never fires.
+class TestDiscardStillReachesRealLLMObsProcessor:
+    """LLMObs is sampled independently of the APM trace: discard only means the chunk never
+    reaches stats or the writer, not that LLMObs's own sampling/rescue logic is skipped. A
+    discarded chunk must reach the real LLMObsProcessor exactly like an ordinary (non-discard)
+    rejected one, so its fallback enqueue() to the LLMObs writer still fires.
     """
 
-    def test_discarded_chunk_never_reaches_llmobs_processor(self, llmobs_agent_proxy, tracer):
+    def test_discarded_chunk_still_reaches_llmobs_processor(self, llmobs_agent_proxy, tracer):
         _llmobs, mock_writer = llmobs_agent_proxy
         tracer._span_aggregator.sampling_processor.sampler = DatadogSampler(
             rules=[SamplingRule(sample_rate=0.0, discard=True)]
@@ -189,12 +190,12 @@ class TestDiscardSuppressesRealLLMObsProcessor:
         ) as mock_process_trace:
             with tracer.trace("llm-span", span_type=SpanTypes.LLM) as span:
                 _annotate_llm_span(span)
-        mock_process_trace.assert_not_called()
-        mock_writer.enqueue.assert_not_called()
-        assert span.get_tag(LLMOBS_SUBMITTED_TAG_KEY) is None
+        mock_process_trace.assert_called_once()
+        mock_writer.enqueue.assert_called_once()
+        assert span.get_tag(LLMOBS_SUBMITTED_TAG_KEY) == "1"
 
     def test_non_discarded_reject_still_reaches_llmobs_processor(self, llmobs_agent_proxy, tracer):
-        """Sanity check: without discard, the existing rescue path is unaffected."""
+        """Sanity check: discard behaves the same as an ordinary reject for LLMObs purposes."""
         _llmobs, mock_writer = llmobs_agent_proxy
         tracer._span_aggregator.sampling_processor.sampler = DatadogSampler(rules=[SamplingRule(sample_rate=0.0)])
         with tracer.trace("llm-span", span_type=SpanTypes.LLM) as span:

--- a/tests/tracer/test_processors.py
+++ b/tests/tracer/test_processors.py
@@ -303,9 +303,10 @@ def test_sampling_processor_discard_persists_across_partial_flush_chunks():
     assert aggr.writer.pop() == [], "later chunk of the same trace must also be dropped"
 
 
-def test_sampling_processor_discard_short_circuits_llmobs_processor():
-    """A discarded chunk never reaches llmobs_processor: discard means no Datadog product,
-    including LLMObs, is influenced by the chunk.
+def test_sampling_processor_discard_still_reaches_llmobs_processor():
+    """A discarded chunk still reaches llmobs_processor: LLMObs is sampled independently of the
+    APM trace and must handle a discarded chunk the same way it handles an ordinary (non-discard)
+    rejected one -- discard only means the chunk never reaches stats or the writer.
     """
     aggr = SpanAggregator(partial_flush_enabled=False, partial_flush_min_spans=0)
     aggr.writer = DummyWriter()
@@ -316,8 +317,8 @@ def test_sampling_processor_discard_short_circuits_llmobs_processor():
         aggr.on_span_start(span)
         span.finish()
 
-    mock_llmobs.assert_not_called()
-    assert aggr.writer.pop() == []
+    mock_llmobs.assert_called_once_with([span])
+    assert aggr.writer.pop() == [], "the chunk itself is still fully dropped from the writer"
 
 
 def test_aggregator_reset_default_args():

--- a/tests/tracer/test_processors.py
+++ b/tests/tracer/test_processors.py
@@ -10,6 +10,7 @@ from ddtrace._trace.processor import TraceProcessor
 from ddtrace._trace.processor import TraceSamplingProcessor
 from ddtrace._trace.processor import TraceTagsProcessor
 from ddtrace._trace.processor.endpoint_call_counter import EndpointCallCounterProcessor
+from ddtrace._trace.sampler import DatadogSampler
 from ddtrace._trace.sampler import SamplingRule as TraceSamplingRule
 from ddtrace.constants import _SAMPLING_PRIORITY_KEY
 from ddtrace.constants import _SINGLE_SPAN_SAMPLING_MAX_PER_SEC
@@ -168,6 +169,125 @@ def test_aggregator_does_not_record_tp_drop_when_nothing_dropped():
 
     assert _dropped_points(mock_add) == []
     assert aggr.writer.pop() == [span]
+
+
+def test_sampling_processor_discard_drops_matching_rejected_trace():
+    """A discard=True rule that rejects the trace drops the whole chunk before the writer sees it."""
+    aggr = SpanAggregator(partial_flush_enabled=False, partial_flush_min_spans=0)
+    aggr.writer = DummyWriter()
+    aggr.sampling_processor.sampler = DatadogSampler(
+        rules=[TraceSamplingRule(sample_rate=0.0, service="noisy-service", discard=True)]
+    )
+
+    span = Span("span", service="noisy-service", on_finish=[aggr.on_span_finish])
+    with mock.patch.object(MetricRecorder, "add", autospec=True) as mock_add:
+        aggr.on_span_start(span)
+        span.finish()
+
+    assert aggr.writer.pop() == []
+    assert _dropped_points(mock_add) == [1]
+
+
+def test_sampling_processor_discard_has_no_effect_when_rule_keeps_trace():
+    """discard=True only applies to chunks the rule rejects; a kept chunk still passes through."""
+    aggr = SpanAggregator(partial_flush_enabled=False, partial_flush_min_spans=0)
+    aggr.writer = DummyWriter()
+    aggr.sampling_processor.sampler = DatadogSampler(
+        rules=[TraceSamplingRule(sample_rate=1.0, service="noisy-service", discard=True)]
+    )
+
+    span = Span("span", service="noisy-service", on_finish=[aggr.on_span_finish])
+    aggr.on_span_start(span)
+    span.finish()
+
+    assert aggr.writer.pop() == [span]
+
+
+def test_sampling_processor_non_matching_rule_passes_through():
+    """A rule that doesn't match the span leaves the trace chunk untouched, even with discard=True."""
+    aggr = SpanAggregator(partial_flush_enabled=False, partial_flush_min_spans=0)
+    aggr.writer = DummyWriter()
+    aggr.sampling_processor.sampler = DatadogSampler(
+        rules=[TraceSamplingRule(sample_rate=0.0, service="other-service", discard=True)]
+    )
+
+    span = Span("span", service="noisy-service", on_finish=[aggr.on_span_finish])
+    aggr.on_span_start(span)
+    span.finish()
+
+    assert aggr.writer.pop() == [span]
+
+
+def test_sampling_processor_rejected_without_discard_is_kept():
+    """Default behavior (discard=False) is unchanged: a rejected trace is kept with a reject priority."""
+    aggr = SpanAggregator(partial_flush_enabled=False, partial_flush_min_spans=0)
+    aggr.writer = DummyWriter()
+    aggr.sampling_processor.sampler = DatadogSampler(
+        rules=[TraceSamplingRule(sample_rate=0.0, service="noisy-service")]
+    )
+
+    span = Span("span", service="noisy-service", on_finish=[aggr.on_span_finish])
+    aggr.on_span_start(span)
+    span.finish()
+
+    assert aggr.writer.pop() == [span]
+    assert span.context.sampling_priority <= 0
+
+
+def test_sampling_processor_discard_decision_frozen_by_early_partial_flush():
+    """Documents a known limitation: the discard decision is made once, against whatever local-root
+    state exists at the time of the FIRST flushed chunk. If partial flushing flushes an early chunk
+    before the local root's matching metadata (e.g. resource) is set, that first chunk is evaluated
+    against the not-yet-updated root and the resulting sampling_priority (and discard decision) is
+    then reused as-is for every later chunk of the same trace, even after the root is updated to
+    match a discard rule.
+    """
+    aggr = SpanAggregator(partial_flush_enabled=True, partial_flush_min_spans=2)
+    aggr.writer = DummyWriter()
+    aggr.sampling_processor.sampler = DatadogSampler(
+        rules=[TraceSamplingRule(sample_rate=0.0, resource="health-check", discard=True)]
+    )
+
+    parent = Span("parent", on_finish=[aggr.on_span_finish])
+    aggr.on_span_start(parent)
+    child1 = Span("child1", on_finish=[aggr.on_span_finish])
+    child1.trace_id = parent.trace_id
+    child1.parent_id = parent.span_id
+    child1._local_root = parent
+    aggr.on_span_start(child1)
+    child2 = Span("child2", on_finish=[aggr.on_span_finish])
+    child2.trace_id = parent.trace_id
+    child2.parent_id = parent.span_id
+    child2._local_root = parent
+    aggr.on_span_start(child2)
+
+    # Root doesn't match the discard rule yet: the early partial flush keeps its chunk.
+    child1.finish()
+    child2.finish()
+    assert aggr.writer.pop() == [child1, child2]
+    assert parent.context.sampling_priority is not None
+
+    # Root metadata now matches the discard rule, but the decision was already frozen above.
+    parent.resource = "health-check"
+    parent.finish()
+    assert aggr.writer.pop() == [parent], "the final chunk is NOT retroactively discarded"
+
+
+def test_sampling_processor_discard_short_circuits_llmobs_processor():
+    """A discarded chunk never reaches llmobs_processor: discard means no Datadog product,
+    including LLMObs, is influenced by the chunk.
+    """
+    aggr = SpanAggregator(partial_flush_enabled=False, partial_flush_min_spans=0)
+    aggr.writer = DummyWriter()
+    aggr.sampling_processor.sampler = DatadogSampler(rules=[TraceSamplingRule(sample_rate=0.0, discard=True)])
+
+    with mock.patch.object(aggr.llmobs_processor, "process_trace", side_effect=lambda trace: trace) as mock_llmobs:
+        span = Span("span", on_finish=[aggr.on_span_finish])
+        aggr.on_span_start(span)
+        span.finish()
+
+    mock_llmobs.assert_not_called()
+    assert aggr.writer.pop() == []
 
 
 def test_aggregator_reset_default_args():

--- a/tests/tracer/test_processors.py
+++ b/tests/tracer/test_processors.py
@@ -273,6 +273,36 @@ def test_sampling_processor_discard_decision_frozen_by_early_partial_flush():
     assert aggr.writer.pop() == [parent], "the final chunk is NOT retroactively discarded"
 
 
+def test_sampling_processor_discard_persists_across_partial_flush_chunks():
+    """Once an early partial-flush chunk matches a discard=True rule and is dropped, later chunks of
+    the same trace must be dropped too, instead of falling through with the (already-set) reject
+    priority and reaching the writer.
+    """
+    aggr = SpanAggregator(partial_flush_enabled=True, partial_flush_min_spans=2)
+    aggr.writer = DummyWriter()
+    aggr.sampling_processor.sampler = DatadogSampler(rules=[TraceSamplingRule(sample_rate=0.0, discard=True)])
+
+    parent = Span("parent", on_finish=[aggr.on_span_finish])
+    aggr.on_span_start(parent)
+    child1 = Span("child1", on_finish=[aggr.on_span_finish])
+    child1.trace_id = parent.trace_id
+    child1.parent_id = parent.span_id
+    child1._local_root = parent
+    aggr.on_span_start(child1)
+    child2 = Span("child2", on_finish=[aggr.on_span_finish])
+    child2.trace_id = parent.trace_id
+    child2.parent_id = parent.span_id
+    child2._local_root = parent
+    aggr.on_span_start(child2)
+
+    child1.finish()
+    child2.finish()
+    assert aggr.writer.pop() == [], "first chunk matches the discard rule and is fully dropped"
+
+    parent.finish()
+    assert aggr.writer.pop() == [], "later chunk of the same trace must also be dropped"
+
+
 def test_sampling_processor_discard_short_circuits_llmobs_processor():
     """A discarded chunk never reaches llmobs_processor: discard means no Datadog product,
     including LLMObs, is influenced by the chunk.

--- a/tests/tracer/test_sampler.py
+++ b/tests/tracer/test_sampler.py
@@ -203,6 +203,22 @@ def test_sampling_rule_init():
     assert rule.name.pattern == a_regex, "SamplingRule should store the name regex it's initialized with"
 
 
+def test_sampling_rule_init_discard_default():
+    rule = SamplingRule(sample_rate=1.0)
+    assert rule.discard is False, "SamplingRule discard should default to False"
+
+
+def test_sampling_rule_init_discard():
+    rule = SamplingRule(sample_rate=0.0, discard=True)
+    assert rule.discard is True
+    assert "discard=True" in repr(rule)
+
+
+def test_sampling_rule_eq_discard():
+    assert SamplingRule(sample_rate=1.0, discard=True) == SamplingRule(sample_rate=1.0, discard=True)
+    assert SamplingRule(sample_rate=1.0, discard=True) != SamplingRule(sample_rate=1.0, discard=False)
+
+
 @pytest.mark.parametrize(
     "rule_1,rule_2,expected_to_be_equal",
     [
@@ -375,16 +391,49 @@ def test_sampling_rule_init_via_env():
     with mock.patch("ddtrace._trace.sampler.log") as mock_log:
         with override_global_config(dict(_trace_sampling_rules='["sample_rate":1.0,"service":"xyz","name":"abc"]')):
             sampling_rule = DatadogSampler().rules
+    assert sampling_rule == []
     mock_log.error.assert_has_calls(
         [
             mock.call(
-                "Failed to apply all sampling rules. Rules=%s, Applied=%s",
+                "Failed to parse DD_TRACE_SAMPLING_RULES=%r, no sampling rules will be applied",
                 '["sample_rate":1.0,"service":"xyz","name":"abc"]',
-                [],
                 exc_info=True,
                 extra={"send_to_telemetry": False},
             )
         ]
+    )
+
+
+@pytest.mark.parametrize("malformed_rules", ["null", "42", '"a string"', '{"sample_rate": 1.0}'])
+def test_sampling_rule_init_via_env_requires_top_level_list(malformed_rules):
+    """Top-level JSON that isn't a list (null, scalar, object) fails open with no rules, no crash."""
+    with mock.patch("ddtrace._trace.sampler.log") as mock_log:
+        with override_global_config(dict(_trace_sampling_rules=malformed_rules)):
+            sampling_rules = DatadogSampler().rules
+    assert sampling_rules == []
+    mock_log.error.assert_called_once_with(
+        "DD_TRACE_SAMPLING_RULES=%r is not a JSON array, no sampling rules will be applied",
+        malformed_rules,
+        extra={"send_to_telemetry": False},
+    )
+
+
+def test_sampling_rule_init_via_env_skips_only_malformed_rule():
+    """A malformed rule entry (wrong field types) is skipped without dropping the other valid rules."""
+    with mock.patch("ddtrace._trace.sampler.log") as mock_log:
+        with override_global_config(
+            dict(
+                _trace_sampling_rules='[{"sample_rate":1.0,"service":"good"}, {"sample_rate":1.0,"tags":"not-a-dict"}]'
+            )
+        ):
+            sampling_rules = DatadogSampler().rules
+    assert len(sampling_rules) == 1
+    assert sampling_rules[0].service.pattern == "good"
+    mock_log.error.assert_called_once_with(
+        "Failed to apply sampling rule %r, skipping it",
+        {"sample_rate": 1.0, "tags": "not-a-dict"},
+        exc_info=True,
+        extra={"send_to_telemetry": False},
     )
 
     with mock.patch("ddtrace._trace.sampler.log") as mock_log:
@@ -394,7 +443,7 @@ def test_sampling_rule_init_via_env():
                 + '{"service":"my-service","name":"my-name"}]'
             )
         ):
-            sampling_rule = DatadogSampler().rules
+            DatadogSampler().rules
     mock_log.error.assert_has_calls(
         [
             mock.call(
@@ -542,6 +591,36 @@ def test_sampling_rule_sample_rate_0():
     assert sum(rule.sample(Span(name=str(i))) for i in range(iterations)) == 0, (
         "SamplingRule with rate=0 should never keep samples"
     )
+
+
+def test_datadog_sampler_sample_discard_true_on_rejected_trace():
+    """discard=True + rejected -> _sample reports discard=True."""
+    sampler = DatadogSampler(rules=[SamplingRule(sample_rate=0.0, discard=True)])
+    sampled, discard = sampler._sample(Span(name="test.span"))
+    assert sampled is False
+    assert discard is True
+
+
+def test_datadog_sampler_sample_discard_false_when_sampled():
+    """discard=True only matters for rejected chunks; a kept chunk reports discard=False."""
+    sampler = DatadogSampler(rules=[SamplingRule(sample_rate=1.0, discard=True)])
+    sampled, discard = sampler._sample(Span(name="test.span"))
+    assert sampled is True
+    assert discard is False
+
+
+def test_datadog_sampler_sample_discard_false_by_default():
+    """discard=False (default) + rejected -> unchanged legacy behavior: kept with reject priority."""
+    sampler = DatadogSampler(rules=[SamplingRule(sample_rate=0.0)])
+    sampled, discard = sampler._sample(Span(name="test.span"))
+    assert sampled is False
+    assert discard is False
+
+
+def test_datadog_sampler_sample_public_api_unchanged():
+    """DatadogSampler.sample(span) -> bool keeps its public signature/behavior."""
+    sampler = DatadogSampler(rules=[SamplingRule(sample_rate=0.0, discard=True)])
+    assert sampler.sample(Span(name="test.span")) is False
 
 
 @pytest.mark.subprocess(

--- a/tests/tracer/test_sampler.py
+++ b/tests/tracer/test_sampler.py
@@ -594,9 +594,9 @@ def test_sampling_rule_sample_rate_0():
 
 
 def test_datadog_sampler_sample_discard_true_on_rejected_trace():
-    """discard=True + rejected -> _sample reports discard=True."""
+    """discard=True + rejected -> sample_or_discard reports discard=True."""
     sampler = DatadogSampler(rules=[SamplingRule(sample_rate=0.0, discard=True)])
-    sampled, discard = sampler._sample(Span(name="test.span"))
+    sampled, discard = sampler.sample_or_discard(Span(name="test.span"))
     assert sampled is False
     assert discard is True
 
@@ -604,7 +604,7 @@ def test_datadog_sampler_sample_discard_true_on_rejected_trace():
 def test_datadog_sampler_sample_discard_false_when_sampled():
     """discard=True only matters for rejected chunks; a kept chunk reports discard=False."""
     sampler = DatadogSampler(rules=[SamplingRule(sample_rate=1.0, discard=True)])
-    sampled, discard = sampler._sample(Span(name="test.span"))
+    sampled, discard = sampler.sample_or_discard(Span(name="test.span"))
     assert sampled is True
     assert discard is False
 
@@ -612,7 +612,7 @@ def test_datadog_sampler_sample_discard_false_when_sampled():
 def test_datadog_sampler_sample_discard_false_by_default():
     """discard=False (default) + rejected -> unchanged legacy behavior: kept with reject priority."""
     sampler = DatadogSampler(rules=[SamplingRule(sample_rate=0.0)])
-    sampled, discard = sampler._sample(Span(name="test.span"))
+    sampled, discard = sampler.sample_or_discard(Span(name="test.span"))
     assert sampled is False
     assert discard is False
 

--- a/tests/tracer/test_sampler.py
+++ b/tests/tracer/test_sampler.py
@@ -395,60 +395,10 @@ def test_sampling_rule_init_via_env():
     mock_log.error.assert_has_calls(
         [
             mock.call(
-                "Failed to parse DD_TRACE_SAMPLING_RULES=%r, no sampling rules will be applied",
+                "Failed to apply all sampling rules. Rules=%s, Applied=%s",
                 '["sample_rate":1.0,"service":"xyz","name":"abc"]',
+                [],
                 exc_info=True,
-                extra={"send_to_telemetry": False},
-            )
-        ]
-    )
-
-
-@pytest.mark.parametrize("malformed_rules", ["null", "42", '"a string"', '{"sample_rate": 1.0}'])
-def test_sampling_rule_init_via_env_requires_top_level_list(malformed_rules):
-    """Top-level JSON that isn't a list (null, scalar, object) fails open with no rules, no crash."""
-    with mock.patch("ddtrace._trace.sampler.log") as mock_log:
-        with override_global_config(dict(_trace_sampling_rules=malformed_rules)):
-            sampling_rules = DatadogSampler().rules
-    assert sampling_rules == []
-    mock_log.error.assert_called_once_with(
-        "DD_TRACE_SAMPLING_RULES=%r is not a JSON array, no sampling rules will be applied",
-        malformed_rules,
-        extra={"send_to_telemetry": False},
-    )
-
-
-def test_sampling_rule_init_via_env_skips_only_malformed_rule():
-    """A malformed rule entry (wrong field types) is skipped without dropping the other valid rules."""
-    with mock.patch("ddtrace._trace.sampler.log") as mock_log:
-        with override_global_config(
-            dict(
-                _trace_sampling_rules='[{"sample_rate":1.0,"service":"good"}, {"sample_rate":1.0,"tags":"not-a-dict"}]'
-            )
-        ):
-            sampling_rules = DatadogSampler().rules
-    assert len(sampling_rules) == 1
-    assert sampling_rules[0].service.pattern == "good"
-    mock_log.error.assert_called_once_with(
-        "Failed to apply sampling rule %r, skipping it",
-        {"sample_rate": 1.0, "tags": "not-a-dict"},
-        exc_info=True,
-        extra={"send_to_telemetry": False},
-    )
-
-    with mock.patch("ddtrace._trace.sampler.log") as mock_log:
-        with override_global_config(
-            dict(
-                _trace_sampling_rules='[{"sample_rate":1.0,"service":"xyz","name":"abc"},'
-                + '{"service":"my-service","name":"my-name"}]'
-            )
-        ):
-            DatadogSampler().rules
-    mock_log.error.assert_has_calls(
-        [
-            mock.call(
-                "No sample_rate provided for sampling rule: %s. Skipping.",
-                {"service": "my-service", "name": "my-name"},
                 extra={"send_to_telemetry": False},
             )
         ]


### PR DESCRIPTION
A sampled away rule can now be fully discarded instead of just not sampled.

Alternative to #19851.