### PR TITLE
ci(testrunner): install pip-tools for Python 3.15

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -132,4 +132,9 @@ RUN git clone --depth 1 --branch "v2.6.31" https://github.com/pyenv/pyenv "${PYE
 
 RUN pip install --no-cache-dir -U "riot==${RIOT_VERSION}" "uv==${UV_VERSION}"
 
+# TODO(py-315): Remove or revisit once the GA 3.15 testrunner image provides
+# pip-tools for every target interpreter. Lock generation runs pip-tools with
+# the target interpreter, while Python 3.15 is not the image's default.
+RUN PYENV_VERSION=3.15-dev python -m pip install --no-cache-dir "pip<25.3" "pip-tools==7.5.2"
+
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Description

This PR was done with codex.

While trying to enable CI for Python 3.15 support in https://github.com/DataDog/dd-trace-py/pull/19909, I came across a bunch of tests that failed because they are missing the lock file/requirements.


Note that Codex found that we have to use `pip<25.3` for now because newer versions of pip with `pip-tools 7.5.2` (what dd-trace-py uses right now), it throws `ImportError: cannot import name stdlib_pkgs from pip._internal.utils.compat`.


## Testing

- Built `docker/Dockerfile` locally successfully.
- Verified `python3.15 -m piptools compile --help` succeeds in the rebuilt image.

## Risks

None to tracer runtime code. This changes only testrunner build tooling.

## Additional Notes

This is temporary until Python 3.15 is out.