### PR TITLE
fix(ci-visibility): preserve shared git upload locks across pytest sessions

### DIFF
--- a/ddtrace/testing/internal/git.py
+++ b/ddtrace/testing/internal/git.py
@@ -17,9 +17,13 @@ from ddtrace.testing.internal.tracer_api import StopWatch
 
 log = logging.getLogger(__name__)
 
-# Matches git lock-contention errors, e.g.:
+# Matches transient git errors from another process racing us for the same repo
+# state, where retrying (re-reading that state) resolves it, e.g.:
 #   fatal: Unable to create '/path/.git/shallow.lock': File exists.
-_LOCK_ERROR_RE = re.compile(r"Unable to create .+\.lock.+File exists", re.DOTALL)
+#   fatal: shallow file has changed since we read it
+_LOCK_ERROR_RE = re.compile(
+    r"Unable to create .+\.lock.+File exists|shallow file has changed since we read it", re.DOTALL
+)
 _LOCK_MAX_RETRIES = 5
 _LOCK_BASE_DELAY_SECONDS = 0.5
 
@@ -128,8 +132,8 @@ class Git:
         git_cmd = [self.git_command, *args]
         log.debug("Running git command: %r", git_cmd)
 
-        # Force C locale so git's error messages are predictable; the lock-contention
-        # regex in _call_git_with_lock_retry matches the English "File exists" string.
+        # Force C locale so git's error messages are predictable; the retryable-error
+        # regex in _call_git_with_lock_retry matches specific English error strings.
         git_env = {**os.environ, "LC_ALL": "C", "LANG": "C"}
 
         with StopWatch() as sw:
@@ -169,13 +173,15 @@ class Git:
         input_string: t.Optional[str] = None,
         should_retry: t.Optional[t.Callable[[], bool]] = None,
     ) -> _GitSubprocessDetails:
-        """Call git with automatic retry on lock-file contention errors.
+        """Call git with automatic retry on transient contention errors.
 
-        In multi-process test environments several workers may issue git
-        commands simultaneously.  Commands that write a lock file (e.g.
-        ``git fetch --update-shallow``) fail with "File exists" when another
-        process holds the lock.  This helper retries such transient failures
-        with exponential back-off so callers never need to handle the retry
+        In multi-process test environments several workers may issue git commands
+        simultaneously. Commands that write a lock file (e.g. ``git fetch
+        --update-shallow``) fail with "File exists" when another process holds the
+        lock, or with "shallow file has changed since we read it" when a sibling
+        commits an updated ``.git/shallow`` between our read and write of it even
+        though we acquired the lock ourselves. This helper retries both transient
+        failures with exponential back-off so callers never need to handle the retry
         logic themselves.
 
         ``should_retry`` is called after each back-off sleep; returning False

--- a/ddtrace/testing/internal/pytest/plugin.py
+++ b/ddtrace/testing/internal/pytest/plugin.py
@@ -489,9 +489,6 @@ class TestOptPlugin(TestOptPluginProtocol):
         if not self.is_xdist_worker:
             # When running with xdist, only the main process writes the session event.
             self.manager.writer.put_item(self.session)
-            # All workers have finished by this point, so the upload sentinel and lock
-            # file are no longer needed. Clean them up to keep .git/ tidy.
-            self.manager.cleanup_upload_artifacts()
 
         if self.manager.settings.coverage_enabled:
             uninstall_coverage()

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -577,22 +577,6 @@ class SessionManager:
             return None
         return Path(workspace_path) / ".git" / _UPLOAD_LOCK_FILENAME
 
-    def cleanup_upload_artifacts(self) -> None:
-        """Delete the upload sentinel and lock files left in .git/.
-
-        Safe to call once the session is finishing — by that point all workers
-        have already run upload_git_data() during their __init__, so neither
-        file is needed any more. Should be called only from the controller
-        process (not xdist workers) so we don't race with a slow-starting peer.
-        """
-        for path in (self._upload_sentinel_path(), self._upload_lock_path()):
-            if path is None:
-                continue
-            try:
-                path.unlink(missing_ok=True)
-            except OSError as e:
-                log.debug("Could not remove upload artifact %s: %s", path, e)
-
     @contextlib.contextmanager
     def _upload_lock(self) -> t.Iterator[bool]:
         """Acquire a cross-process exclusive lock around upload_git_data.

--- a/releasenotes/notes/ci-visibility-fix-upload-lock-unlink-race-f63981faf332ebf1.yaml
+++ b/releasenotes/notes/ci-visibility-fix-upload-lock-unlink-race-f63981faf332ebf1.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    CI Visibility: Fixes a race where concurrent or nested pytest controllers sharing a
+    workspace could break each other's git-metadata-upload mutual exclusion. The shared
+    ``.git/dd-trace-py.upload.lock`` file was unlinked at session finish; since
+    ``flock()`` locks an inode rather than a path, this could let a new controller open
+    an unrelated inode at the same path while a peer still held the old one, silently
+    defeating the lock. The lock and upload-completion sentinel files are no longer
+    deleted. Also, git command retries now cover ``shallow file has changed since we
+    read it``, a second transient error from concurrent ``git fetch --update-shallow``
+    calls that was previously not retried.

--- a/tests/testing/internal/test_git.py
+++ b/tests/testing/internal/test_git.py
@@ -15,6 +15,7 @@ from ddtrace.testing.internal.telemetry import GitTelemetry
 
 
 _LOCK_STDERR = "fatal: Unable to create '/repo/.git/shallow.lock': File exists."
+_SHALLOW_CHANGED_STDERR = "fatal: shallow file has changed since we read it"
 
 
 class TestGitTag:
@@ -711,6 +712,57 @@ class TestGitLockRetry:
         assert result.return_code == 0
         assert mock_call.call_count == 2
         mock_sleep.assert_called_once()
+
+    @patch("shutil.which")
+    def test_retry_on_shallow_changed_error_then_succeed(self, mock_which: Mock) -> None:
+        """A 'shallow file has changed since we read it' race is retried and succeeds next attempt.
+
+        Regression test: this error is distinct from the '.lock: File exists' message
+        (it fires after the lock was acquired, when a sibling committed a new
+        .git/shallow between our read and write of it) and previously fell through
+        _LOCK_ERROR_RE unmatched, so it was never retried.
+        """
+        mock_which.return_value = "/usr/bin/git"
+        shallow_changed_failure = _GitSubprocessDetails(
+            stdout="", stderr=_SHALLOW_CHANGED_STDERR, return_code=128, elapsed_seconds=0.0
+        )
+        success = _GitSubprocessDetails(stdout="", stderr="", return_code=0, elapsed_seconds=0.0)
+
+        with (
+            patch(
+                "ddtrace.testing.internal.git.Git._call_git",
+                side_effect=[shallow_changed_failure, success],
+            ) as mock_call,
+            patch("time.sleep") as mock_sleep,
+        ):
+            result = Git()._call_git_with_lock_retry(["fetch", "--update-shallow"])
+
+        assert result.return_code == 0
+        assert mock_call.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @patch("shutil.which")
+    def test_unshallow_repository_retries_on_shallow_changed_error(self, mock_which: Mock) -> None:
+        """unshallow_repository retries when git reports the shallow-file-changed race."""
+        mock_which.return_value = "/usr/bin/git"
+        shallow_changed_failure = _GitSubprocessDetails(
+            stdout="", stderr=_SHALLOW_CHANGED_STDERR, return_code=128, elapsed_seconds=0.0
+        )
+        success = _GitSubprocessDetails(stdout="", stderr="", return_code=0, elapsed_seconds=0.0)
+
+        with (
+            patch(
+                "ddtrace.testing.internal.git.Git._call_git",
+                side_effect=[shallow_changed_failure, success],
+            ) as mock_call,
+            patch("ddtrace.testing.internal.git.Git.get_remote_name", return_value="origin"),
+            patch("ddtrace.testing.internal.git.Git.is_shallow_repository", return_value=True),
+            patch("time.sleep"),
+        ):
+            result = Git().unshallow_repository("some-sha")
+
+        assert result.return_code == 0
+        assert mock_call.call_count == 2
 
     @patch("shutil.which")
     def test_retry_exhausted_returns_last_failure(self, mock_which: Mock) -> None:

--- a/tests/testing/internal/test_session_manager.py
+++ b/tests/testing/internal/test_session_manager.py
@@ -1297,31 +1297,62 @@ class TestUploadLock:
         mock_git_cls.assert_not_called()
         assert sm.env_tags[GitTag.PULL_REQUEST_BASE_BRANCH_SHA] == "peer-mb"
 
-    def test_cleanup_removes_sentinel_and_lock(self, tmp_path) -> None:
-        """cleanup_upload_artifacts() deletes both files when present."""
-        (tmp_path / ".git").mkdir()
+    def test_cleanup_upload_artifacts_removed(self, tmp_path) -> None:
+        """Regression guard: SessionManager must not re-grow a method that deletes the
+        stable lock or sentinel files. See test_lock_and_sentinel_survive_session_lifecycle
+        for why: unlinking either file while a peer process references it is unsafe.
+        """
         sm = self._make_sm(tmp_path, head_sha="head-sha")
-        sentinel = tmp_path / ".git" / "dd-trace-py.upload-done"
-        lock = tmp_path / ".git" / "dd-trace-py.upload.lock"
-        sentinel.write_text("{}")
-        lock.write_text("")
+        assert not hasattr(sm, "cleanup_upload_artifacts")
 
-        sm.cleanup_upload_artifacts()
+    def test_lock_and_sentinel_survive_session_lifecycle(self, tmp_path) -> None:
+        """Regression test for the split-lock-inode race.
 
-        assert not sentinel.exists()
-        assert not lock.exists()
+        A peer holds a real ``flock()`` on the stable lock path (standing in for another
+        pytest controller mid-``upload_git_data``) and has written a sentinel for its own
+        commit. This session then goes through the normal lock-timeout path — ``_upload_lock()``
+        must time out rather than break the peer's lock — and reads the sentinel, without
+        ever becoming the elected uploader (so it never legitimately writes to either file).
 
-    def test_cleanup_is_noop_when_files_absent(self, tmp_path) -> None:
-        """cleanup_upload_artifacts() does not raise when files are already gone."""
+        ``flock()`` locks an inode, not a path, so unlinking the lock file out from under
+        the peer would let a later opener create an unrelated inode at the same path and
+        silently defeat mutual exclusion. Neither file is ever unlinked by SessionManager,
+        so the peer's lock, its inode, and its sentinel must all remain exactly as it left
+        them, regardless of what this session does.
+        """
+        fcntl = pytest.importorskip("fcntl")
+
         (tmp_path / ".git").mkdir()
-        sm = self._make_sm(tmp_path, head_sha="head-sha")
-        sm.cleanup_upload_artifacts()  # no files present — must not raise
+        lock_path = tmp_path / ".git" / "dd-trace-py.upload.lock"
+        sentinel_path = tmp_path / ".git" / "dd-trace-py.upload-done"
+        lock_path.write_text("")
+        sentinel_path.write_text('{"head_sha": "peer-head-sha"}')
+        inode_before = lock_path.stat().st_ino
 
-    def test_cleanup_is_noop_without_workspace_path(self) -> None:
-        """cleanup_upload_artifacts() does not raise when workspace_path is unset."""
-        sm = SessionManager.__new__(SessionManager)
-        sm.env_tags = {}
-        sm.cleanup_upload_artifacts()  # no workspace_path — must not raise
+        peer_fd = open(lock_path, "w")
+        fcntl.flock(peer_fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            sm = self._make_sm(tmp_path, head_sha="our-head-sha")
+            with (
+                patch("ddtrace.testing.internal.session_manager.time.monotonic", side_effect=[0.0, 9999.0]),
+                patch("ddtrace.testing.internal.session_manager.time.sleep"),
+            ):
+                with sm._upload_lock() as acquired:
+                    assert acquired is False  # peer holds it; we must not force our way in
+            sm._read_upload_sentinel()
+
+            assert lock_path.exists()
+            assert lock_path.stat().st_ino == inode_before
+            assert sentinel_path.read_text() == '{"head_sha": "peer-head-sha"}'
+
+            # A fresh open+flock on the (unchanged) lock path must still contend with the
+            # peer's lock — proving nothing severed the path from the peer's fd.
+            with open(lock_path, "w") as third_party_fd:
+                with pytest.raises(BlockingIOError):
+                    fcntl.flock(third_party_fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        finally:
+            fcntl.flock(peer_fd.fileno(), fcntl.LOCK_UN)
+            peer_fd.close()
 
 
 class TestParallelInit:


### PR DESCRIPTION
## Description

Fix two related races in Test Optimization Git metadata collection when independent or nested pytest controllers share a shallow checkout:

- Stop deleting the workspace-scoped upload lock and TTL-protected sentinel at session finish. `flock()` protects an inode, so unlinking the lock path while another controller holds it lets a later opener create and lock a different inode, defeating mutual exclusion.
- Treat Git's `shallow file has changed since we read it` result as transient contention, alongside the existing `.lock: File exists` case, and retry it through the existing bounded backoff path.

The lock is a zero-byte stable coordination file. The sentinel is already bounded by `_UPLOAD_SENTINEL_TTL_SECONDS` and atomically replaced by later successful uploads, so neither needs lifecycle cleanup.

## Testing

Added regression coverage for:

- retrying `shallow file has changed since we read it` directly and through `unshallow_repository()`;
- preserving the lock inode, active `flock()`, and sentinel across another session's lifecycle.

Validation performed locally:

- `scripts/lint fmt`
- `scripts/lint typing`
- `scripts/lint spelling`
- `scripts/lint security` scoped to `ddtrace/`
- 146 targeted tests across `tests/testing/internal/test_git.py` and `tests/testing/internal/test_session_manager.py` passed using the production modules in a scratch import harness.

The repository's Docker-based `scripts/run-tests` harness could not start because the local Docker daemon returned HTTP 500. This PR is draft pending the upstream CI result / an official harness run.

## Risks

Low. The behavioral change leaves two tiny files under `.git/` instead of deleting them. The sentinel already expires logically after five minutes and is atomically overwritten; the lock file contains no data.

## Additional Notes

This preserves test telemetry and shallow checkouts; it does not require disabling Git metadata upload, increasing CI timeouts, or fetching full repository history.
