### PR TITLE
fix(ci_visibility): serialize concurrent git unshallow operations with flock

### DIFF
--- a/ddtrace/testing/internal/git.py
+++ b/ddtrace/testing/internal/git.py
@@ -1,3 +1,4 @@
+import contextlib
 from dataclasses import dataclass
 import logging
 import os
@@ -10,6 +11,14 @@ import tempfile
 import time
 import typing as t
 
+
+try:
+    import fcntl
+
+    _FCNTL_AVAILABLE = True
+except ImportError:  # pragma: no cover — Windows / restricted environments
+    _FCNTL_AVAILABLE = False
+
 from ddtrace.testing.internal.telemetry import GitTelemetry
 from ddtrace.testing.internal.telemetry import TelemetryAPI
 from ddtrace.testing.internal.tracer_api import StopWatch
@@ -17,11 +26,29 @@ from ddtrace.testing.internal.tracer_api import StopWatch
 
 log = logging.getLogger(__name__)
 
-# Matches git lock-contention errors, e.g.:
+# Matches git lock-contention and shallow-file race errors that can occur when
+# multiple processes (e.g. pytest-xdist workers) issue git fetch --update-shallow
+# concurrently against the same repository:
 #   fatal: Unable to create '/path/.git/shallow.lock': File exists.
-_LOCK_ERROR_RE = re.compile(r"Unable to create .+\.lock.+File exists", re.DOTALL)
+#   error: cannot lock ref 'refs/remotes/origin/foo': is at <sha> but expected <sha>
+#   fatal: shallow file has changed since we read it
+_LOCK_ERROR_RE = re.compile(
+    r"(?:Unable to create .+\.lock.+File exists)"
+    r"|(?:cannot lock ref .+ but expected)"
+    r"|(?:shallow file has changed since we read it)",
+    re.DOTALL,
+)
 _LOCK_MAX_RETRIES = 5
 _LOCK_BASE_DELAY_SECONDS = 0.5
+
+# Dedicated cross-process lock for unshallow operations.  Every call to
+# ``unshallow_repository`` acquires an exclusive ``flock`` on this file before
+# issuing ``git fetch --update-shallow``, so concurrent xdist workers (or
+# multiple pytest controllers sharing a workspace) never race on
+# ``.git/shallow`` and remote refs.
+_UNSHALLOW_LOCK_FILENAME = "dd-trace-py.unshallow.lock"
+_UNSHALLOW_LOCK_TIMEOUT_SECONDS = 120.0
+_UNSHALLOW_LOCK_RETRY_INTERVAL_SECONDS = 0.5
 
 
 class GitTag:
@@ -283,6 +310,77 @@ class Git:
         output = self._git_output(["rev-parse", "--is-shallow-repository"], GitTelemetry.CHECK_SHALLOW)
         return output == "true"
 
+    def _unshallow_lock_path(self) -> t.Optional[Path]:
+        """Return the path to the cross-process unshallow lock, or None if unavailable."""
+        try:
+            workspace = self.get_workspace_path()
+        except Exception:
+            return None
+        if not workspace:
+            return None
+        return Path(workspace) / ".git" / _UNSHALLOW_LOCK_FILENAME
+
+    @contextlib.contextmanager
+    def _unshallow_lock(self) -> t.Iterator[bool]:
+        """Acquire a cross-process exclusive lock around unshallow operations.
+
+        Yields ``True`` if the lock was acquired or if locking is unavailable
+        (no fcntl, no writable .git directory).  Yields ``False`` only on
+        timeout, meaning a peer is still unshallowing; the caller should skip
+        the fetch in that case.
+        """
+        if not _FCNTL_AVAILABLE:
+            yield True
+            return
+
+        lock_path = self._unshallow_lock_path()
+        if lock_path is None:
+            yield True
+            return
+
+        try:
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            log.debug("Could not create directory for unshallow lock %s: %s", lock_path, e)
+            yield True
+            return
+
+        try:
+            lock_file = open(lock_path, "w")
+        except OSError as e:
+            log.debug("Could not open unshallow lock %s: %s", lock_path, e)
+            yield True
+            return
+
+        try:
+            deadline = time.monotonic() + _UNSHALLOW_LOCK_TIMEOUT_SECONDS
+            while True:
+                try:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except BlockingIOError:
+                    if time.monotonic() >= deadline:
+                        log.debug(
+                            "Unshallow lock timeout after %ss, skipping unshallow (peer is unshallowing)",
+                            _UNSHALLOW_LOCK_TIMEOUT_SECONDS,
+                        )
+                        yield False
+                        return
+                    time.sleep(_UNSHALLOW_LOCK_RETRY_INTERVAL_SECONDS)
+                except OSError as e:
+                    log.debug("flock on %s failed: %s", lock_path, e)
+                    yield True
+                    return
+            try:
+                yield True
+            finally:
+                try:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    pass
+        finally:
+            lock_file.close()
+
     def unshallow_repository(self, refspec: t.Optional[str] = None, parent_only: bool = False) -> _GitSubprocessDetails:
         # If another process (e.g. a parallel xdist worker) has already unshallowed the
         # repository, skip the redundant fetch.
@@ -290,28 +388,45 @@ class Git:
             log.debug("Repository is no longer shallow, skipping unshallow")
             return _GitSubprocessDetails(stdout="", stderr="", return_code=0, elapsed_seconds=0.0)
 
-        remote_name = self.get_remote_name()
-        command = [
-            "fetch",
-            "--deepen=1" if parent_only else '--shallow-since="1 month ago"',
-            "--update-shallow",
-            "--filter=blob:none",
-            "--recurse-submodules=no",
-            "--no-tags",
-            remote_name,
-        ]
-        if refspec:
-            command.append(refspec)
+        with self._unshallow_lock() as lock_acquired:
+            if not lock_acquired:
+                # A peer is still unshallowing; re-check whether the repo is
+                # still shallow and treat as success if it's been unshallowed.
+                if not self.is_shallow_repository():
+                    log.debug("Repository was unshallowed by peer while waiting for lock")
+                    return _GitSubprocessDetails(stdout="", stderr="", return_code=0, elapsed_seconds=0.0)
+                log.debug("Unshallow lock timed out, repo is still shallow — returning failure")
+                return _GitSubprocessDetails(
+                    stdout="", stderr="unshallow lock timeout", return_code=1, elapsed_seconds=0.0
+                )
 
-        result = self._call_git_with_lock_retry(command, should_retry=self.is_shallow_repository)
-        if result.return_code != 0:
-            # The retry loop may have aborted because a sibling worker finished
-            # unshallowing in the meantime; in that case treat the operation as a success.
+            # Re-check shallowness under the lock to avoid a TOCTOU race.
             if not self.is_shallow_repository():
-                log.debug("Repository was unshallowed by another process during retry")
+                log.debug("Repository is no longer shallow (checked under lock), skipping unshallow")
                 return _GitSubprocessDetails(stdout="", stderr="", return_code=0, elapsed_seconds=0.0)
-            log.warning("Error unshallowing repo for refspec %s: %s", refspec, result.stderr)
-        return result
+
+            remote_name = self.get_remote_name()
+            command = [
+                "fetch",
+                "--deepen=1" if parent_only else '--shallow-since="1 month ago"',
+                "--update-shallow",
+                "--filter=blob:none",
+                "--recurse-submodules=no",
+                "--no-tags",
+                remote_name,
+            ]
+            if refspec:
+                command.append(refspec)
+
+            result = self._call_git_with_lock_retry(command, should_retry=self.is_shallow_repository)
+            if result.return_code != 0:
+                # The retry loop may have aborted because a sibling worker finished
+                # unshallowing in the meantime; in that case treat the operation as a success.
+                if not self.is_shallow_repository():
+                    log.debug("Repository was unshallowed by another process during retry")
+                    return _GitSubprocessDetails(stdout="", stderr="", return_code=0, elapsed_seconds=0.0)
+                log.warning("Error unshallowing repo for refspec %s: %s", refspec, result.stderr)
+            return result
 
     def unshallow_repository_to_local_head(self) -> _GitSubprocessDetails:
         return self.unshallow_repository(self.get_commit_sha())

--- a/ddtrace/testing/internal/git.py
+++ b/ddtrace/testing/internal/git.py
@@ -41,14 +41,16 @@ _LOCK_ERROR_RE = re.compile(
 _LOCK_MAX_RETRIES = 5
 _LOCK_BASE_DELAY_SECONDS = 0.5
 
-# Dedicated cross-process lock for unshallow operations.  Every call to
-# ``unshallow_repository`` acquires an exclusive ``flock`` on this file before
-# issuing ``git fetch --update-shallow``, so concurrent xdist workers (or
-# multiple pytest controllers sharing a workspace) never race on
-# ``.git/shallow`` and remote refs.
+# AIDEV-NOTE: Keep this cross-process lock on a stable file in Git's actual
+# metadata directory. The timeout, inode, and fallback behavior are part of the
+# coordination protocol; changing them can reintroduce concurrent fetch races.
+# Every call to unshallow_repository acquires an exclusive flock before issuing
+# git fetch --update-shallow, so concurrent xdist workers (or multiple pytest
+# controllers sharing a workspace) never race on .git/shallow and remote refs.
 _UNSHALLOW_LOCK_FILENAME = "dd-trace-py.unshallow.lock"
 _UNSHALLOW_LOCK_TIMEOUT_SECONDS = 120.0
 _UNSHALLOW_LOCK_RETRY_INTERVAL_SECONDS = 0.5
+_UNSHALLOW_LOCK_TIMEOUT_ERROR = "unshallow lock timeout"
 
 
 class GitTag:
@@ -200,12 +202,12 @@ class Git:
 
         In multi-process test environments several workers may issue git
         commands simultaneously.  Commands that write a lock file (e.g.
-        ``git fetch --update-shallow``) fail with "File exists" when another
+        git fetch --update-shallow) fail with "File exists" when another
         process holds the lock.  This helper retries such transient failures
         with exponential back-off so callers never need to handle the retry
         logic themselves.
 
-        ``should_retry`` is called after each back-off sleep; returning False
+        should_retry is called after each back-off sleep; returning False
         aborts the retry loop so callers can stop once another process has
         completed the same work (e.g. an xdist sibling that finished
         unshallowing while we were waiting on the lock).
@@ -310,24 +312,33 @@ class Git:
         output = self._git_output(["rev-parse", "--is-shallow-repository"], GitTelemetry.CHECK_SHALLOW)
         return output == "true"
 
+    def has_commit(self, commit_sha: str) -> bool:
+        """Return whether commit_sha is available in the local repository."""
+        return self._call_git(["cat-file", "-e", f"{commit_sha}^{{commit}}"]).return_code == 0
+
     def _unshallow_lock_path(self) -> t.Optional[Path]:
-        """Return the path to the cross-process unshallow lock, or None if unavailable."""
+        """Return the cross-process lock path in Git's actual metadata directory."""
         try:
-            workspace = self.get_workspace_path()
+            git_dir = self._git_output(["rev-parse", "--git-dir"])
         except Exception:
             return None
-        if not workspace:
+        if not git_dir:
             return None
-        return Path(workspace) / ".git" / _UNSHALLOW_LOCK_FILENAME
+
+        git_dir_path = Path(git_dir)
+        if not git_dir_path.is_absolute():
+            cwd = Path(self.cwd) if self.cwd is not None else Path.cwd()
+            git_dir_path = cwd / git_dir_path
+        return git_dir_path / _UNSHALLOW_LOCK_FILENAME
 
     @contextlib.contextmanager
     def _unshallow_lock(self) -> t.Iterator[bool]:
         """Acquire a cross-process exclusive lock around unshallow operations.
 
-        Yields ``True`` if the lock was acquired or if locking is unavailable
-        (no fcntl, no writable .git directory).  Yields ``False`` only on
-        timeout, meaning a peer is still unshallowing; the caller should skip
-        the fetch in that case.
+        Yields True if the lock was acquired or if locking is unavailable
+        (no fcntl, no writable .git directory). Yields False only on timeout,
+        meaning a peer is still unshallowing; the caller should skip the fetch
+        in that case.
         """
         if not _FCNTL_AVAILABLE:
             yield True
@@ -381,26 +392,41 @@ class Git:
         finally:
             lock_file.close()
 
-    def unshallow_repository(self, refspec: t.Optional[str] = None, parent_only: bool = False) -> _GitSubprocessDetails:
-        # If another process (e.g. a parallel xdist worker) has already unshallowed the
-        # repository, skip the redundant fetch.
+    def unshallow_repository(
+        self,
+        refspec: t.Optional[str] = None,
+        parent_only: bool = False,
+        required_commit: t.Optional[str] = None,
+    ) -> _GitSubprocessDetails:
+        # If another process (e.g. a parallel xdist worker) has already completed
+        # the requested operation, skip the redundant fetch.
+        if required_commit and self.has_commit(required_commit):
+            log.debug("Required commit is already available, skipping unshallow")
+            return _GitSubprocessDetails(stdout="", stderr="", return_code=0, elapsed_seconds=0.0)
         if not self.is_shallow_repository():
             log.debug("Repository is no longer shallow, skipping unshallow")
             return _GitSubprocessDetails(stdout="", stderr="", return_code=0, elapsed_seconds=0.0)
 
         with self._unshallow_lock() as lock_acquired:
             if not lock_acquired:
-                # A peer is still unshallowing; re-check whether the repo is
-                # still shallow and treat as success if it's been unshallowed.
+                # A peer is still unshallowing; re-check whether the requested
+                # work completed while waiting for the lock.
+                if required_commit and self.has_commit(required_commit):
+                    log.debug("Required commit became available while waiting for lock")
+                    return _GitSubprocessDetails(stdout="", stderr="", return_code=0, elapsed_seconds=0.0)
                 if not self.is_shallow_repository():
                     log.debug("Repository was unshallowed by peer while waiting for lock")
                     return _GitSubprocessDetails(stdout="", stderr="", return_code=0, elapsed_seconds=0.0)
                 log.debug("Unshallow lock timed out, repo is still shallow — returning failure")
                 return _GitSubprocessDetails(
-                    stdout="", stderr="unshallow lock timeout", return_code=1, elapsed_seconds=0.0
+                    stdout="", stderr=_UNSHALLOW_LOCK_TIMEOUT_ERROR, return_code=1, elapsed_seconds=0.0
                 )
 
-            # Re-check shallowness under the lock to avoid a TOCTOU race.
+            # Re-check the requested commit and shallowness under the lock to avoid
+            # TOCTOU races and redundant fetches by waiting workers.
+            if required_commit and self.has_commit(required_commit):
+                log.debug("Required commit is no longer missing, skipping unshallow")
+                return _GitSubprocessDetails(stdout="", stderr="", return_code=0, elapsed_seconds=0.0)
             if not self.is_shallow_repository():
                 log.debug("Repository is no longer shallow (checked under lock), skipping unshallow")
                 return _GitSubprocessDetails(stdout="", stderr="", return_code=0, elapsed_seconds=0.0)
@@ -421,7 +447,11 @@ class Git:
             result = self._call_git_with_lock_retry(command, should_retry=self.is_shallow_repository)
             if result.return_code != 0:
                 # The retry loop may have aborted because a sibling worker finished
-                # unshallowing in the meantime; in that case treat the operation as a success.
+                # the requested work in the meantime; in that case treat the
+                # operation as a success.
+                if required_commit and self.has_commit(required_commit):
+                    log.debug("Required commit became available during retry")
+                    return _GitSubprocessDetails(stdout="", stderr="", return_code=0, elapsed_seconds=0.0)
                 if not self.is_shallow_repository():
                     log.debug("Repository was unshallowed by another process during retry")
                     return _GitSubprocessDetails(stdout="", stderr="", return_code=0, elapsed_seconds=0.0)
@@ -452,14 +482,23 @@ class Git:
             result = self.unshallow_repository_to_local_head()
             if result.return_code == 0:
                 return True
+            if result.stderr == _UNSHALLOW_LOCK_TIMEOUT_ERROR:
+                return_code = result.return_code
+                return False
 
             result = self.unshallow_repository_to_upstream()
             if result.return_code == 0:
                 return True
+            if result.stderr == _UNSHALLOW_LOCK_TIMEOUT_ERROR:
+                return_code = result.return_code
+                return False
 
             result = self.unshallow_repository_to_default()
             if result.return_code == 0:
                 return True
+            if result.stderr == _UNSHALLOW_LOCK_TIMEOUT_ERROR:
+                return_code = result.return_code
+                return False
 
             log.debug("Unshallow failed")
             return_code = result.return_code
@@ -542,8 +581,8 @@ def get_git_head_tags_from_git_command(head_sha: str) -> dict[str, t.Optional[st
         log.warning("Error getting git data: %s", e)
         return {}
 
-    if git.is_shallow_repository():
-        git.unshallow_repository(parent_only=True)
+    if not git.has_commit(head_sha):
+        git.unshallow_repository(parent_only=True, required_commit=head_sha)
 
     tags: dict[str, t.Optional[str]] = {
         GitTag.COMMIT_HEAD_MESSAGE: git.get_commit_message(head_sha),

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -585,15 +585,15 @@ class SessionManager:
         is no longer needed. Should be called only from the controller
         process (not xdist workers) so we don't race with a slow-starting peer.
 
-        The lock file (``dd-trace-py.upload.lock``) is intentionally **not**
-        removed.  If multiple pytest controllers share the same workspace
+        The lock file (dd-trace-py.upload.lock) is intentionally not
+        removed. If multiple pytest controllers share the same workspace
         (e.g. a CI matrix that reuses a checkout), deleting the lock file while
-        another controller's worker still holds an ``flock`` on it causes the
-        next opener to get a **new inode**.  Locks on the old and new inodes are
+        another controller's worker still holds an flock on it causes the next
+        opener to get a new inode. Locks on the old and new inodes are
         independent, so two workers can each believe they hold the exclusive
         lock and unshallow concurrently — reintroducing the very race the lock
-        is meant to prevent.  The lock file is a zero-byte placeholder; leaving
-        it in ``.git/`` is harmless.
+        is meant to prevent. The lock file is a zero-byte placeholder; leaving
+        it in .git/ is harmless.
         """
         sentinel = self._upload_sentinel_path()
         if sentinel is not None:

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -578,20 +578,29 @@ class SessionManager:
         return Path(workspace_path) / ".git" / _UPLOAD_LOCK_FILENAME
 
     def cleanup_upload_artifacts(self) -> None:
-        """Delete the upload sentinel and lock files left in .git/.
+        """Delete the upload sentinel file left in .git/.
 
         Safe to call once the session is finishing — by that point all workers
-        have already run upload_git_data() during their __init__, so neither
-        file is needed any more. Should be called only from the controller
+        have already run upload_git_data() during their __init__, so the sentinel
+        is no longer needed. Should be called only from the controller
         process (not xdist workers) so we don't race with a slow-starting peer.
+
+        The lock file (``dd-trace-py.upload.lock``) is intentionally **not**
+        removed.  If multiple pytest controllers share the same workspace
+        (e.g. a CI matrix that reuses a checkout), deleting the lock file while
+        another controller's worker still holds an ``flock`` on it causes the
+        next opener to get a **new inode**.  Locks on the old and new inodes are
+        independent, so two workers can each believe they hold the exclusive
+        lock and unshallow concurrently — reintroducing the very race the lock
+        is meant to prevent.  The lock file is a zero-byte placeholder; leaving
+        it in ``.git/`` is harmless.
         """
-        for path in (self._upload_sentinel_path(), self._upload_lock_path()):
-            if path is None:
-                continue
+        sentinel = self._upload_sentinel_path()
+        if sentinel is not None:
             try:
-                path.unlink(missing_ok=True)
+                sentinel.unlink(missing_ok=True)
             except OSError as e:
-                log.debug("Could not remove upload artifact %s: %s", path, e)
+                log.debug("Could not remove upload sentinel %s: %s", sentinel, e)
 
     @contextlib.contextmanager
     def _upload_lock(self) -> t.Iterator[bool]:

--- a/releasenotes/notes/fix-xdist-shallow-git-race-0f4e2f7d3b1a.yaml
+++ b/releasenotes/notes/fix-xdist-shallow-git-race-0f4e2f7d3b1a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    CI visibility: Fixes an issue where test sessions running with pytest-xdist on shallow Git checkouts can spend excessive time unshallowing the repository and may fail or time out during collection.

--- a/tests/testing/internal/test_git.py
+++ b/tests/testing/internal/test_git.py
@@ -319,9 +319,12 @@ class TestGetGitTags:
         mock_git.get_branch.return_value = "main"
         mock_git.get_commit_message.side_effect = lambda sha=None: "Parent commit" if sha else "Test commit"
         mock_git.get_user_info.side_effect = lambda sha=None: mock_parent_user if sha else mock_user
+        mock_git.has_commit.return_value = False
         mock_git_class.return_value = mock_git
 
         result = get_git_head_tags_from_git_command("parent-sha")
+
+        mock_git.unshallow_repository.assert_called_once_with(parent_only=True, required_commit="parent-sha")
 
         expected = {
             GitTag.COMMIT_HEAD_MESSAGE: "Parent commit",
@@ -343,6 +346,7 @@ class TestGetGitTags:
         mock_git.get_branch.return_value = "main"
         mock_git.get_commit_message.side_effect = lambda sha=None: "Parent commit" if sha else "Test commit"
         mock_git.get_user_info.return_value = None
+        mock_git.has_commit.return_value = False
         mock_git_class.return_value = mock_git
 
         result = get_git_head_tags_from_git_command("parent-sha")
@@ -351,6 +355,19 @@ class TestGetGitTags:
             GitTag.COMMIT_HEAD_MESSAGE: "Parent commit",
         }
         assert result == expected
+
+    @patch("ddtrace.testing.internal.git.Git")
+    def test_get_git_head_tags_skips_unshallow_when_head_commit_is_available(self, mock_git_class: Mock) -> None:
+        mock_git = Mock()
+        mock_git.has_commit.return_value = True
+        mock_git.get_commit_message.return_value = "Head commit"
+        mock_git.get_user_info.return_value = None
+        mock_git_class.return_value = mock_git
+
+        result = get_git_head_tags_from_git_command("head-sha")
+
+        assert result == {GitTag.COMMIT_HEAD_MESSAGE: "Head commit"}
+        mock_git.unshallow_repository.assert_not_called()
 
 
 class TestGitUnshallow:
@@ -671,6 +688,21 @@ class TestGitUnshallow:
             ],
         ]
 
+    def test_git_try_all_unshallow_methods_stops_after_lock_timeout(self) -> None:
+        timeout = _GitSubprocessDetails(stdout="", stderr="unshallow lock timeout", return_code=1, elapsed_seconds=0.0)
+
+        with (
+            patch.object(Git, "unshallow_repository_to_local_head", return_value=timeout) as local_head,
+            patch.object(Git, "unshallow_repository_to_upstream") as upstream,
+            patch.object(Git, "unshallow_repository_to_default") as default,
+        ):
+            result = Git().try_all_unshallow_repository_methods()
+
+        assert not result
+        local_head.assert_called_once()
+        upstream.assert_not_called()
+        default.assert_not_called()
+
 
 class TestGitLockRetry:
     """Tests for _call_git_with_lock_retry and the commands that use it."""
@@ -919,6 +951,17 @@ class TestGitUnshallowLock:
     """Tests for the cross-process unshallow lock in Git.unshallow_repository."""
 
     @patch("shutil.which")
+    def test_unshallow_lock_path_uses_actual_git_directory(self, mock_which: Mock, tmp_path) -> None:
+        mock_which.return_value = "/usr/bin/git"
+        git_dir = tmp_path / "git-dir" / "worktrees" / "checkout"
+        git = Git(cwd=str(tmp_path / "checkout"))
+
+        with patch.object(git, "_git_output", return_value=str(git_dir)) as mock_git_output:
+            assert git._unshallow_lock_path() == git_dir / "dd-trace-py.unshallow.lock"
+
+        mock_git_output.assert_called_once_with(["rev-parse", "--git-dir"])
+
+    @patch("shutil.which")
     def test_unshallow_lock_acquired_before_fetch(self, mock_which: Mock, tmp_path) -> None:
         """unshallow_repository acquires the unshallow lock before issuing git fetch."""
         mock_which.return_value = "/usr/bin/git"
@@ -981,6 +1024,29 @@ class TestGitUnshallowLock:
             result = Git().unshallow_repository("some-sha")
 
         assert result.return_code == 0, "should return success if peer unshallowed during lock wait"
+        mock_call.assert_not_called()
+
+    @patch("shutil.which")
+    def test_unshallow_lock_rechecks_required_commit_under_lock(self, mock_which: Mock) -> None:
+        """A waiting worker skips fetching when the requested commit is now available."""
+        mock_which.return_value = "/usr/bin/git"
+
+        @contextlib.contextmanager
+        def fake_lock():
+            yield True
+
+        with (
+            patch("ddtrace.testing.internal.git.Git._call_git") as mock_call,
+            patch(
+                "ddtrace.testing.internal.git.Git.has_commit",
+                side_effect=[False, True],  # missing before lock; available after peer finishes
+            ),
+            patch("ddtrace.testing.internal.git.Git.is_shallow_repository", return_value=True),
+            patch("ddtrace.testing.internal.git.Git._unshallow_lock", side_effect=fake_lock),
+        ):
+            result = Git().unshallow_repository(required_commit="head-sha")
+
+        assert result.return_code == 0
         mock_call.assert_not_called()
 
     @patch("shutil.which")

--- a/tests/testing/internal/test_git.py
+++ b/tests/testing/internal/test_git.py
@@ -1,5 +1,6 @@
 """Tests for ddtrace.testing.internal.git module."""
 
+import contextlib
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -15,6 +16,12 @@ from ddtrace.testing.internal.telemetry import GitTelemetry
 
 
 _LOCK_STDERR = "fatal: Unable to create '/repo/.git/shallow.lock': File exists."
+_CANNOT_LOCK_REF_STDERR = (
+    "error: cannot lock ref 'refs/remotes/origin/feature-branch': "
+    "is at 694efff54fd2ef7c2b09522a4627ebcd97fc5d69 but expected "
+    "8c8c6636710f27d200e0d036a518b360542d1c82"
+)
+_SHALLOW_FILE_CHANGED_STDERR = "fatal: shallow file has changed since we read it"
 
 
 class TestGitTag:
@@ -358,6 +365,7 @@ class TestGitUnshallow:
             ) as call_git_mock,
             patch("ddtrace.testing.internal.git.Git.get_remote_name", return_value="some-remote"),
             patch("ddtrace.testing.internal.git.Git.is_shallow_repository", return_value=True),
+            patch("ddtrace.testing.internal.git.Git._unshallow_lock"),
         ):
             result = Git().unshallow_repository("some-sha")
 
@@ -385,6 +393,7 @@ class TestGitUnshallow:
             ) as call_git_mock,
             patch("ddtrace.testing.internal.git.Git.get_remote_name", return_value="some-remote"),
             patch("ddtrace.testing.internal.git.Git.is_shallow_repository", return_value=True),
+            patch("ddtrace.testing.internal.git.Git._unshallow_lock"),
         ):
             result = Git().unshallow_repository(parent_only=True)
 
@@ -412,6 +421,7 @@ class TestGitUnshallow:
             patch("ddtrace.testing.internal.git.Git.get_remote_name", return_value="some-remote"),
             patch("ddtrace.testing.internal.git.Git.get_commit_sha", return_value="head-sha"),
             patch("ddtrace.testing.internal.git.Git.is_shallow_repository", return_value=True),
+            patch("ddtrace.testing.internal.git.Git._unshallow_lock"),
         ):
             result = Git().unshallow_repository_to_local_head()
 
@@ -445,6 +455,7 @@ class TestGitUnshallow:
                 ),
             ),
             patch("ddtrace.testing.internal.git.Git.is_shallow_repository", return_value=True),
+            patch("ddtrace.testing.internal.git.Git._unshallow_lock"),
         ):
             result = Git().unshallow_repository_to_upstream()
 
@@ -479,6 +490,7 @@ class TestGitUnshallow:
                 ),
             ),
             patch("ddtrace.testing.internal.git.Git.is_shallow_repository", return_value=True),
+            patch("ddtrace.testing.internal.git.Git._unshallow_lock"),
         ):
             result = Git().try_all_unshallow_repository_methods()
 
@@ -515,6 +527,7 @@ class TestGitUnshallow:
                 ),
             ),
             patch("ddtrace.testing.internal.git.Git.is_shallow_repository", return_value=True),
+            patch("ddtrace.testing.internal.git.Git._unshallow_lock"),
         ):
             result = Git().try_all_unshallow_repository_methods()
 
@@ -562,6 +575,7 @@ class TestGitUnshallow:
                 ),
             ),
             patch("ddtrace.testing.internal.git.Git.is_shallow_repository", return_value=True),
+            patch("ddtrace.testing.internal.git.Git._unshallow_lock"),
         ):
             result = Git().try_all_unshallow_repository_methods()
 
@@ -618,6 +632,7 @@ class TestGitUnshallow:
                 ),
             ),
             patch("ddtrace.testing.internal.git.Git.is_shallow_repository", return_value=True),
+            patch("ddtrace.testing.internal.git.Git._unshallow_lock"),
         ):
             result = Git().try_all_unshallow_repository_methods()
 
@@ -743,12 +758,55 @@ class TestGitLockRetry:
             patch("ddtrace.testing.internal.git.Git._call_git", side_effect=[lock_failure, success]) as mock_call,
             patch("ddtrace.testing.internal.git.Git.get_remote_name", return_value="origin"),
             patch("ddtrace.testing.internal.git.Git.is_shallow_repository", return_value=True),
+            patch("ddtrace.testing.internal.git.Git._unshallow_lock") as mock_lock,
             patch("time.sleep"),
         ):
+            mock_lock.return_value.__enter__ = Mock(return_value=True)
+            mock_lock.return_value.__exit__ = Mock(return_value=False)
             result = Git().unshallow_repository("some-sha")
 
         assert result.return_code == 0
         assert mock_call.call_count == 2
+
+    @patch("shutil.which")
+    def test_retry_on_cannot_lock_ref_error(self, mock_which: Mock) -> None:
+        """A 'cannot lock ref' error is retried by _call_git_with_lock_retry."""
+        mock_which.return_value = "/usr/bin/git"
+        ref_lock_failure = _GitSubprocessDetails(
+            stdout="", stderr=_CANNOT_LOCK_REF_STDERR, return_code=128, elapsed_seconds=0.0
+        )
+        success = _GitSubprocessDetails(stdout="", stderr="", return_code=0, elapsed_seconds=0.0)
+
+        with (
+            patch("ddtrace.testing.internal.git.Git._call_git", side_effect=[ref_lock_failure, success]) as mock_call,
+            patch("time.sleep") as mock_sleep,
+        ):
+            result = Git()._call_git_with_lock_retry(["fetch", "--update-shallow"])
+
+        assert result.return_code == 0
+        assert mock_call.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @patch("shutil.which")
+    def test_retry_on_shallow_file_changed_error(self, mock_which: Mock) -> None:
+        """A 'shallow file has changed since we read it' error is retried."""
+        mock_which.return_value = "/usr/bin/git"
+        shallow_changed_failure = _GitSubprocessDetails(
+            stdout="", stderr=_SHALLOW_FILE_CHANGED_STDERR, return_code=128, elapsed_seconds=0.0
+        )
+        success = _GitSubprocessDetails(stdout="", stderr="", return_code=0, elapsed_seconds=0.0)
+
+        with (
+            patch(
+                "ddtrace.testing.internal.git.Git._call_git", side_effect=[shallow_changed_failure, success]
+            ) as mock_call,
+            patch("time.sleep") as mock_sleep,
+        ):
+            result = Git()._call_git_with_lock_retry(["fetch", "--update-shallow"])
+
+        assert result.return_code == 0
+        assert mock_call.call_count == 2
+        mock_sleep.assert_called_once()
 
     @patch("shutil.which")
     def test_get_merge_base_success(self, mock_which: Mock) -> None:
@@ -799,26 +857,31 @@ class TestGitLockRetry:
 
     @patch("shutil.which")
     def test_unshallow_repository_aborts_retry_when_unshallowed_concurrently(self, mock_which: Mock) -> None:
-        """If a sibling worker unshallows during retry, the loop aborts and we return success."""
+        """If a sibling worker unshallows while we wait for the unshallow lock,
+        the re-check under the lock sees the repo as no longer shallow and we skip.
+        """
         mock_which.return_value = "/usr/bin/git"
         lock_failure = _GitSubprocessDetails(stdout="", stderr=_LOCK_STDERR, return_code=128, elapsed_seconds=0.0)
 
-        # First is_shallow check (entry guard) sees a shallow repo; the should_retry check after
-        # the first failed attempt sees the repo as no longer shallow (sibling worker finished);
-        # the final post-loop check confirms the repo is no longer shallow.
+        # First is_shallow check (entry guard) sees a shallow repo; the re-check
+        # under the lock sees the repo as no longer shallow (sibling finished while
+        # we waited for the lock).
         with (
             patch("ddtrace.testing.internal.git.Git._call_git", return_value=lock_failure) as mock_call,
             patch(
                 "ddtrace.testing.internal.git.Git.is_shallow_repository",
-                side_effect=[True, False, False],
+                side_effect=[True, False],
             ),
             patch("ddtrace.testing.internal.git.Git.get_remote_name", return_value="origin"),
+            patch("ddtrace.testing.internal.git.Git._unshallow_lock") as mock_ulock,
             patch("time.sleep"),
         ):
+            mock_ulock.return_value.__enter__ = Mock(return_value=True)
+            mock_ulock.return_value.__exit__ = Mock(return_value=False)
             result = Git().unshallow_repository("some-sha")
 
         assert result.return_code == 0
-        assert mock_call.call_count == 1
+        assert mock_call.call_count == 0  # no git fetch needed — repo was unshallowed by peer
 
     @patch("shutil.which")
     def test_call_git_with_lock_retry_should_retry_callback(self, mock_which: Mock) -> None:
@@ -850,3 +913,97 @@ class TestGitLockRetry:
         env = mock_popen.call_args.kwargs["env"]
         assert env["LC_ALL"] == "C"
         assert env["LANG"] == "C"
+
+
+class TestGitUnshallowLock:
+    """Tests for the cross-process unshallow lock in Git.unshallow_repository."""
+
+    @patch("shutil.which")
+    def test_unshallow_lock_acquired_before_fetch(self, mock_which: Mock, tmp_path) -> None:
+        """unshallow_repository acquires the unshallow lock before issuing git fetch."""
+        mock_which.return_value = "/usr/bin/git"
+        success = _GitSubprocessDetails(stdout="", stderr="", return_code=0, elapsed_seconds=0.0)
+        lock_entered = []
+
+        @contextlib.contextmanager
+        def fake_lock():
+            lock_entered.append(True)
+            yield True
+
+        with (
+            patch("ddtrace.testing.internal.git.Git._call_git", return_value=success) as mock_call,
+            patch("ddtrace.testing.internal.git.Git.get_remote_name", return_value="origin"),
+            patch("ddtrace.testing.internal.git.Git.is_shallow_repository", return_value=True),
+            patch("ddtrace.testing.internal.git.Git._unshallow_lock", side_effect=fake_lock),
+        ):
+            result = Git().unshallow_repository("some-sha")
+
+        assert result.return_code == 0
+        assert len(lock_entered) == 1, "unshallow lock must be acquired before fetch"
+        assert mock_call.call_count == 1
+
+    @patch("shutil.which")
+    def test_unshallow_lock_timeout_skips_fetch(self, mock_which: Mock) -> None:
+        """When the unshallow lock times out, the fetch is skipped."""
+        mock_which.return_value = "/usr/bin/git"
+
+        @contextlib.contextmanager
+        def fake_lock_timeout():
+            yield False
+
+        with (
+            patch("ddtrace.testing.internal.git.Git._call_git") as mock_call,
+            patch("ddtrace.testing.internal.git.Git.is_shallow_repository", return_value=True),
+            patch("ddtrace.testing.internal.git.Git._unshallow_lock", side_effect=fake_lock_timeout),
+        ):
+            result = Git().unshallow_repository("some-sha")
+
+        assert result.return_code == 1, "lock timeout should return failure when repo is still shallow"
+        mock_call.assert_not_called(), "no git fetch should happen when lock times out"
+
+    @patch("shutil.which")
+    def test_unshallow_lock_timeout_success_if_peer_unshallowed(self, mock_which: Mock) -> None:
+        """When the unshallow lock times out but a peer has already unshallowed, return success."""
+        mock_which.return_value = "/usr/bin/git"
+
+        @contextlib.contextmanager
+        def fake_lock_timeout():
+            yield False
+
+        with (
+            patch("ddtrace.testing.internal.git.Git._call_git") as mock_call,
+            patch(
+                "ddtrace.testing.internal.git.Git.is_shallow_repository",
+                side_effect=[True, False],  # initial: shallow; after lock timeout: not shallow
+            ),
+            patch("ddtrace.testing.internal.git.Git._unshallow_lock", side_effect=fake_lock_timeout),
+        ):
+            result = Git().unshallow_repository("some-sha")
+
+        assert result.return_code == 0, "should return success if peer unshallowed during lock wait"
+        mock_call.assert_not_called()
+
+    @patch("shutil.which")
+    def test_unshallow_lock_rechecks_shallowness_under_lock(self, mock_which: Mock) -> None:
+        """The shallowness re-check under the lock prevents redundant fetches."""
+        mock_which.return_value = "/usr/bin/git"
+        lock_entered = []
+
+        @contextlib.contextmanager
+        def fake_lock():
+            lock_entered.append(True)
+            yield True
+
+        with (
+            patch("ddtrace.testing.internal.git.Git._call_git") as mock_call,
+            patch(
+                "ddtrace.testing.internal.git.Git.is_shallow_repository",
+                side_effect=[True, False],  # initial: shallow; re-check under lock: not shallow
+            ),
+            patch("ddtrace.testing.internal.git.Git._unshallow_lock", side_effect=fake_lock),
+        ):
+            result = Git().unshallow_repository("some-sha")
+
+        assert result.return_code == 0
+        assert len(lock_entered) == 1
+        mock_call.assert_not_called(), "no fetch needed — repo was unshallowed by peer before we got the lock"

--- a/tests/testing/internal/test_session_manager.py
+++ b/tests/testing/internal/test_session_manager.py
@@ -1297,8 +1297,14 @@ class TestUploadLock:
         mock_git_cls.assert_not_called()
         assert sm.env_tags[GitTag.PULL_REQUEST_BASE_BRANCH_SHA] == "peer-mb"
 
-    def test_cleanup_removes_sentinel_and_lock(self, tmp_path) -> None:
-        """cleanup_upload_artifacts() deletes both files when present."""
+    def test_cleanup_removes_sentinel_only(self, tmp_path) -> None:
+        """cleanup_upload_artifacts() deletes the sentinel but preserves the lock file.
+
+        The lock file must not be deleted because another pytest controller
+        sharing the same workspace may still rely on it for flock coordination.
+        Deleting it would cause a new inode to be created on next open, breaking
+        the lock for any process that still holds the old inode.
+        """
         (tmp_path / ".git").mkdir()
         sm = self._make_sm(tmp_path, head_sha="head-sha")
         sentinel = tmp_path / ".git" / "dd-trace-py.upload-done"
@@ -1309,7 +1315,7 @@ class TestUploadLock:
         sm.cleanup_upload_artifacts()
 
         assert not sentinel.exists()
-        assert not lock.exists()
+        assert lock.exists(), "Lock file must be preserved to avoid split-lock-inode races"
 
     def test_cleanup_is_noop_when_files_absent(self, tmp_path) -> None:
         """cleanup_upload_artifacts() does not raise when files are already gone."""


### PR DESCRIPTION
## Description

Fix flaky CI failures when pytest-xdist workers or multiple pytest controllers run against the same shallow clone and concurrently execute `git fetch --update-shallow`.

This change:

- Expands lock-contention retry detection to cover `cannot lock ref ... but expected` and `shallow file has changed since we read it`, in addition to the existing `.lock: File exists` error.
- Adds a cross-process `flock` on `.git/dd-trace-py.unshallow.lock` to serialize `unshallow_repository()` calls. The lock includes a 120-second timeout, a shallowness re-check under the lock to avoid TOCTOU races, and graceful behavior when a peer has already completed the unshallow. Locking is a no-op where `fcntl` is unavailable or the lock cannot be opened.
- Keeps the upload lock placeholder in `.git/` during artifact cleanup so active flock holders cannot be split across lock-file inodes.

## Testing

Added or updated unit tests covering:

- Retry handling for `cannot lock ref` and shallow-file-change errors.
- Lock acquisition before fetching.
- Lock timeout behavior, including the case where a peer already unshallowed the repository.
- Shallowness re-checking under the lock.
- Retaining the upload lock during cleanup.

## Risks

Low. The change is limited to internal test-session Git coordination and preserves graceful fallback when filesystem locking is unavailable. The main behavioral change is that concurrent unshallow operations are serialized and may wait up to 120 seconds for the lock.


SDTEST-3953
