### PR TITLE
test(appsec): appsec_threats 55% faster, ~12h of CI saved per pipeline [APPSEC-69907]

### DIFF
--- a/tests/appsec/contrib_appsec/conftest.py
+++ b/tests/appsec/contrib_appsec/conftest.py
@@ -15,7 +15,9 @@ except Exception:
 
 from http.server import BaseHTTPRequestHandler  # noqa: E402
 from http.server import ThreadingHTTPServer  # noqa: E402
+import os  # noqa: E402
 import socket  # noqa: E402
+import sys  # noqa: E402
 import threading  # noqa: E402
 import time  # noqa: E402
 
@@ -219,5 +221,102 @@ def printer(request):
     return printer
 
 
+def _cgroup(path):
+    """Read a cgroup file, or a marker naming the failure.
+
+    These paths are cgroup v2. On a cgroup v1 host the same values live under per-controller
+    directories with different names, so they come back as <FileNotFoundError> and only the
+    benchmarks stay meaningful. Non-Linux never reaches here, see _env_probe.
+    """
+    try:
+        with open(path) as f:
+            return f.read().strip().replace("\n", " | ")
+    except Exception as exc:
+        return f"<{exc.__class__.__name__}>"
+
+
+def _env_probe(label):
+    """Report what the machine gave this job, so a slow run can be attributed rather than guessed at.
+
+    Called at session start and end; most of the value is in diffing the two. Skipped entirely off
+    Linux, where neither the cgroup files nor sched_getaffinity exist; these suites always run in
+    the Linux testrunner container, locally and in CI alike.
+
+    affinity / cpu_count
+        How many CPUs the process may actually use. Separates "few cores" from "throttled": a job
+        pinned to one core and a job throttled to a fraction of 96 both look slow but need
+        different fixes. affinity needs sched_getaffinity, which is Linux only.
+
+    cpu.max
+        The CFS quota and period, e.g. "25000 100000" for a quarter core. A literal "max" means no
+        quota at all, which also means quota throttling cannot be happening, so the counters below
+        will stay at zero however contended the node is.
+
+    cpu.stat
+        usage_usec is the CPU time the container has consumed. Diffing it between the two probes and
+        comparing against wall clock gives utilisation, which is the one number that separates
+        "computing hard" from "sitting in a blocking call". A job at 24% is waiting on something;
+        a job near 100% is genuinely compute bound. nr_throttled and throttled_usec attribute any
+        stalling to quota enforcement, and are only ever non-zero when cpu.max sets a quota.
+
+    memory.max / memory.current
+        The limit this pod was given, against what it actually used. Worth watching where limits are
+        autoscaled rather than declared: a peak sitting close to the limit predicts intermittent
+        OOM kills, which surface as flaky infrastructure failures rather than test failures.
+
+    BENCH cpu_loop_5M
+        Pure-Python arithmetic throughput, no syscalls or allocation. The baseline for comparing one
+        runner against another, or against a laptop. Expect it to vary by more than 2x between
+        runners in the same pipeline, so read single-shard timings with that in mind.
+
+    BENCH syscall_getpid_200k
+        The cost of entering the kernel, using about the cheapest syscall there is. Isolates syscall
+        overhead from the work done in a syscall, which matters under seccomp or gVisor style
+        sandboxing.
+
+    BENCH stat_20k
+        Filesystem metadata cost. Sensitive to how many overlay and bind mount layers the checkout
+        sits behind, which is usually the difference between a container and a host filesystem.
+    """
+    if not sys.platform.startswith("linux"):
+        return
+
+    import time as _time
+
+    lines = [f"===== RUNTIME PROBE [{label}] ====="]
+    lines.append(f"affinity={len(os.sched_getaffinity(0))} cpu_count={os.cpu_count()}")
+    for path in (
+        "/sys/fs/cgroup/cpu.max",
+        "/sys/fs/cgroup/cpu.stat",
+        "/sys/fs/cgroup/memory.max",
+        "/sys/fs/cgroup/memory.current",
+    ):
+        lines.append(f"{path} = {_cgroup(path)}")
+
+    t0 = _time.perf_counter()
+    acc = 0
+    for i in range(5_000_000):
+        acc += i * i
+    lines.append(f"BENCH cpu_loop_5M = {_time.perf_counter() - t0:.3f}s")
+
+    t0 = _time.perf_counter()
+    for _ in range(200_000):
+        os.getpid()
+    lines.append(f"BENCH syscall_getpid_200k = {_time.perf_counter() - t0:.3f}s")
+
+    t0 = _time.perf_counter()
+    for _ in range(20_000):
+        os.stat(__file__)
+    lines.append(f"BENCH stat_20k = {_time.perf_counter() - t0:.3f}s")
+
+    lines.append("===== END RUNTIME PROBE =====")
+    print("\n" + "\n".join(lines), flush=True)
+
+
 def pytest_configure(config):
     config.addinivalue_line("markers", "xfail_interface: mark test to be xfailed for the given interface")
+    _env_probe("session start")
+
+
+def pytest_sessionfinish(session, exitstatus):
+    _env_probe("session end")

--- a/tests/appsec/contrib_appsec/utils.py
+++ b/tests/appsec/contrib_appsec/utils.py
@@ -1754,7 +1754,7 @@ class Contrib_TestClass_For_Threats(_Contrib_TestClass_Base):
             ),
         ]
         + [
-            ("ssrf", {f"url_{p1}_1": "169.254.169.254", f"url_{p2}_2": "169.254.169.253"}, "rasp-934-100", (f1, f2))
+            ("ssrf", {f"url_{p1}_1": "127.0.0.1:1", f"url_{p2}_2": "127.0.0.1:2"}, "rasp-934-100", (f1, f2))
             for (p1, f1), (p2, f2) in itertools.product(
                 [
                     ("urlopen_string", "do_open"),


### PR DESCRIPTION
## Description

APPSEC-69907. The `ssrf` cases of `test_exploit_prevention` sent outbound requests to `169.254.169.254` / `.253`. On CI those are routable but silent, so every request burned its client timeout — on a laptop they fail instantly, which is why this never showed up locally.

Closed local ports refuse immediately instead. `rasp-934-100` uses the `ssrf_detector` operator, correlating `server.io.net.url` with the request params rather than matching the target address, so every case still triggers.

Also keeps a runtime probe in the shared conftest (cgroup limits, throttling counters, three micro-benchmarks, at session start and end). It is what showed this was *waiting*, not slow hardware; ~2s per job.

## Testing

Measured on this commit's pipeline, 132/132 threats jobs green. Test counts are byte-identical to before: fastapi 2882 passed, django 2866+10 skipped+8 xfailed, flask 2900+2+8, tornado 1439+4.

| suite | shards | before | after | Δ |
|---|---|---|---|---|
| fastapi_no_iast | 14 | 980.7s | 287.6s | −70.7% |
| tornado_iast | 12 | 491.5s | 144.6s | −70.6% |
| fastapi_iast | 14 | 1013.0s | 305.5s | −69.8% |
| tornado_no_iast | 12 | 494.1s | 160.9s | −67.4% |
| django_no_iast | 20 | 560.5s | 313.8s | −44.0% |
| flask_no_iast | 12 | 574.4s | 346.3s | −39.7% |
| django_iast | 20 | 570.3s | 355.3s | −37.7% |
| flask_iast | 12 | 580.8s | 364.9s | −37.2% |
| *_rc (4 suites) | 4 each | 59–79s | 58–72s | −19% to +14% |

**Total: 77304s → 34929s per pipeline, −54.8% (~11.8h).**

Corroborating detail: `ssrf` has disappeared from the slowest-10 (now `test_api_endpoint_discovery` at 1.4s and `test_stream_response` at 0.65s), and container CPU went from 218s over 891s wall (76% idle) to 176.8s over 176.7s — saturated. The reduction tracks each app's hardcoded timeout, 0.5s for fastapi/tornado vs 0.15s for django/flask, which independently confirms the mechanism.

## Risks

Test-only, test counts unchanged. Assertions check that the RASP rule fired, not the response, so a refused connection is equivalent to a timed-out one.

## Additional Notes

The four framework apps hardcode inconsistent timeouts (0.15/0.25/0.5/1s for the same endpoint) — cosmetic now, worth harmonising separately.

Caveats: the `_rc` suites do not exercise these tests, so their ±15% is runner noise and sets the error bar for the rest. Single-shard timings are noisy — two runners in the same pipeline differed 2.5× on a CPU micro-benchmark (0.366s vs 0.899s). The `before` column comes from an earlier pipeline in which `fastapi_no_iast` ran with `--no-ddtrace`; it is instrumented again here, so that row's improvement is understated.