### PR TITLE
chore(aiguard): add source and integration telemetry metric tags

### DIFF
--- a/ddtrace/aiguard/_api_client.py
+++ b/ddtrace/aiguard/_api_client.py
@@ -135,9 +135,12 @@ class AIGuardClient:
     def _call_path_tags(source: str, integration: str) -> tuple[tuple[str, str], ...]:
         """Tags identifying the call path that reached the evaluation, required on every metric.
 
-        Normalized here because the spec pins integration to none for direct SDK calls.
+        Clamped to the declared values: the spec pins integration to none for direct SDK calls,
+        and evaluate is public API, so an off-spec value must not reach telemetry as a new series.
         """
-        if source != AI_GUARD.SOURCE_AUTO:
+        if source not in AI_GUARD.SOURCES:
+            source = AI_GUARD.SOURCE_SDK
+        if source != AI_GUARD.SOURCE_AUTO or integration not in AI_GUARD.INTEGRATIONS:
             integration = AI_GUARD.INTEGRATION_NONE
         return (("source", source), ("integration", integration))
 

--- a/ddtrace/aiguard/_api_client.py
+++ b/ddtrace/aiguard/_api_client.py
@@ -132,21 +132,36 @@ class AIGuardClient:
         self._timeout = aiguard_config._ai_guard_timeout // 1000
 
     @staticmethod
+    def _call_path_tags(source: str, integration: str) -> tuple[tuple[str, str], ...]:
+        """Tags identifying the call path that reached the evaluation, required on every metric.
+
+        Normalized here because the spec pins integration to none for direct SDK calls.
+        """
+        if source != AI_GUARD.SOURCE_AUTO:
+            integration = AI_GUARD.INTEGRATION_NONE
+        return (("source", source), ("integration", integration))
+
+    @staticmethod
     def _add_request_to_telemetry(tags: MetricTagType) -> None:
         telemetry.telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.AI_GUARD, AI_GUARD.REQUESTS_METRIC, 1, tags)
 
     @staticmethod
-    def _add_error_to_telemetry(error_type: str) -> None:
+    def _add_error_to_telemetry(error_type: str, call_path_tags: tuple[tuple[str, str], ...] = ()) -> None:
         telemetry.telemetry_writer.add_count_metric(
-            TELEMETRY_NAMESPACE.AI_GUARD, AI_GUARD.ERROR_METRIC, 1, (("type", error_type),)
+            TELEMETRY_NAMESPACE.AI_GUARD, AI_GUARD.ERROR_METRIC, 1, (("type", error_type),) + call_path_tags
         )
 
     @staticmethod
-    def _messages_for_meta_struct(messages: list[Message]) -> list[Message]:
+    def _messages_for_meta_struct(
+        messages: list[Message], call_path_tags: tuple[tuple[str, str], ...] = ()
+    ) -> list[Message]:
         max_messages_length = aiguard_config._ai_guard_max_messages_length
         if len(messages) > max_messages_length:
             telemetry.telemetry_writer.add_count_metric(
-                TELEMETRY_NAMESPACE.AI_GUARD, AI_GUARD.TRUNCATED_METRIC, 1, (("type", "messages"),)
+                TELEMETRY_NAMESPACE.AI_GUARD,
+                AI_GUARD.TRUNCATED_METRIC,
+                1,
+                (("type", "messages"),) + call_path_tags,
             )
         messages = messages[-max_messages_length:]
 
@@ -175,7 +190,10 @@ class AIGuardClient:
         result = [truncate_message(message) for message in messages]
         if content_truncated:
             telemetry.telemetry_writer.add_count_metric(
-                TELEMETRY_NAMESPACE.AI_GUARD, AI_GUARD.TRUNCATED_METRIC, 1, (("type", "content"),)
+                TELEMETRY_NAMESPACE.AI_GUARD,
+                AI_GUARD.TRUNCATED_METRIC,
+                1,
+                (("type", "content"),) + call_path_tags,
             )
         return result
 
@@ -227,7 +245,13 @@ class AIGuardClient:
             return True
         return options.get("block", True)
 
-    def evaluate(self, messages: list[Message], options: Optional[Options] = None) -> Evaluation:
+    def evaluate(
+        self,
+        messages: list[Message],
+        options: Optional[Options] = None,
+        source: str = AI_GUARD.SOURCE_SDK,
+        integration: str = AI_GUARD.INTEGRATION_NONE,
+    ) -> Evaluation:
         """Evaluate if the list of messages are safe to execute.
 
         Args:
@@ -235,6 +259,11 @@ class AIGuardClient:
             options: Optional configuration with 'block' parameter. By default, block follows
                 the AI Guard response is_blocking_enabled setting; set block=False to force
                 non-blocking behavior.
+            source: Which call path triggered the evaluation, reported as the source telemetry
+                tag. Defaults to sdk (a direct customer call); our AI package
+                auto-instrumentation passes auto.
+            integration: Name of the auto-instrumented AI package, reported as the integration
+                telemetry tag. Only meaningful when source is auto; otherwise reported as none.
 
         Returns:
             EvaluationResult containing action and reason
@@ -251,6 +280,7 @@ class AIGuardClient:
         # Classifies the error metric when a raise below escapes. Transport failures and
         # unexpected internal errors keep the default; response-driven raises narrow it.
         error_type: str = AI_GUARD.ERROR_CLIENT
+        call_path_tags = self._call_path_tags(source, integration)
 
         with tracer.trace(AI_GUARD.RESOURCE_TYPE) as span:
             try:
@@ -318,7 +348,7 @@ class AIGuardClient:
                     if redaction_enabled:
                         span.set_tag(AI_GUARD.REDACTED_TAG, "true" if redacted else "false")
 
-                    meta_struct = {"messages": self._messages_for_meta_struct(redacted_messages)}
+                    meta_struct = {"messages": self._messages_for_meta_struct(redacted_messages, call_path_tags)}
                     span._set_struct_tag(AI_GUARD.STRUCT, meta_struct)
 
                     if tags:
@@ -346,6 +376,7 @@ class AIGuardClient:
                 # No tag at all when redaction is off, so absent is distinguishable from "nothing redacted".
                 if redaction_enabled:
                     telemetry_tags.append(("redacted", "true" if redacted else "false"))
+                telemetry_tags.extend(call_path_tags)
                 self._add_request_to_telemetry(tuple(telemetry_tags))
                 root_span = span_bus.get_root_span()
                 if root_span:
@@ -391,8 +422,8 @@ class AIGuardClient:
                 raise
 
             except Exception:
-                self._add_request_to_telemetry((("error", "true"),))
-                self._add_error_to_telemetry(error_type)
+                self._add_request_to_telemetry((("error", "true"),) + call_path_tags)
+                self._add_error_to_telemetry(error_type, call_path_tags)
                 # Log the size only: the messages may carry sensitive data that redaction would have
                 # removed, and this runs before any redaction decision is known.
                 logger.debug("AI Guard evaluation failed for %d messages", len(messages), exc_info=True)

--- a/ddtrace/aiguard/_api_client.py
+++ b/ddtrace/aiguard/_api_client.py
@@ -146,14 +146,14 @@ class AIGuardClient:
         telemetry.telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.AI_GUARD, AI_GUARD.REQUESTS_METRIC, 1, tags)
 
     @staticmethod
-    def _add_error_to_telemetry(error_type: str, call_path_tags: tuple[tuple[str, str], ...] = ()) -> None:
+    def _add_error_to_telemetry(error_type: str, call_path_tags: tuple[tuple[str, str], ...]) -> None:
         telemetry.telemetry_writer.add_count_metric(
             TELEMETRY_NAMESPACE.AI_GUARD, AI_GUARD.ERROR_METRIC, 1, (("type", error_type),) + call_path_tags
         )
 
     @staticmethod
     def _messages_for_meta_struct(
-        messages: list[Message], call_path_tags: tuple[tuple[str, str], ...] = ()
+        messages: list[Message], call_path_tags: tuple[tuple[str, str], ...]
     ) -> list[Message]:
         max_messages_length = aiguard_config._ai_guard_max_messages_length
         if len(messages) > max_messages_length:

--- a/ddtrace/aiguard/_common.py
+++ b/ddtrace/aiguard/_common.py
@@ -9,6 +9,12 @@ from collections.abc import Mapping
 from typing import Any
 
 from ddtrace.aiguard._api_client import AIGuardAbortError
+from ddtrace.aiguard._api_client import AIGuardClient
+from ddtrace.aiguard._api_client import Evaluation
+from ddtrace.aiguard._api_client import Message
+from ddtrace.aiguard._api_client import Options
+from ddtrace.aiguard._constants import AI_GUARD
+from ddtrace.internal.settings.aiguard import aiguard_config
 
 
 def _get(obj: Any, key: str, default: Any = None) -> Any:
@@ -41,3 +47,17 @@ def wrap_abort_error(cause: AIGuardAbortError, compound_cls: type[AIGuardAbortEr
     )
     wrapped.__cause__ = cause
     return wrapped
+
+
+def evaluate_auto(client: AIGuardClient, messages: list[Message], integration: str) -> Evaluation:
+    """Evaluate messages on behalf of an auto-instrumented AI package.
+
+    Every provider listener shares one policy -- block per DD_AI_GUARD_BLOCK, report the call
+    path as auto -- so binding it here keeps a listener from forgetting or mismatching a tag.
+    """
+    return client.evaluate(
+        messages,
+        Options(block=aiguard_config._ai_guard_block),
+        source=AI_GUARD.SOURCE_AUTO,
+        integration=integration,
+    )

--- a/ddtrace/aiguard/_constants.py
+++ b/ddtrace/aiguard/_constants.py
@@ -64,6 +64,18 @@ class AI_GUARD(metaclass=Constant_Class):
     INTEGRATION_LITELLM: Literal["litellm"] = "litellm"
     INTEGRATION_STRANDS: Literal["strands"] = "strands"
 
+    # Closed tag sets: anything else reaching the metrics is clamped back to these defaults,
+    # so a bad value from a caller cannot invent telemetry series.
+    SOURCES: tuple[str, ...] = (SOURCE_SDK, SOURCE_AUTO)
+    INTEGRATIONS: tuple[str, ...] = (
+        INTEGRATION_NONE,
+        INTEGRATION_OPENAI,
+        INTEGRATION_ANTHROPIC,
+        INTEGRATION_LANGCHAIN,
+        INTEGRATION_LITELLM,
+        INTEGRATION_STRANDS,
+    )
+
     # environment variables
     ENV_ENABLED: Literal["DD_AI_GUARD_ENABLED"] = "DD_AI_GUARD_ENABLED"
     ENV_ENDPOINT: Literal["DD_AI_GUARD_ENDPOINT"] = "DD_AI_GUARD_ENDPOINT"

--- a/ddtrace/aiguard/_constants.py
+++ b/ddtrace/aiguard/_constants.py
@@ -50,6 +50,20 @@ class AI_GUARD(metaclass=Constant_Class):
     ERROR_BAD_STATUS: Literal["bad_status"] = "bad_status"
     ERROR_BAD_RESPONSE: Literal["bad_response"] = "bad_response"
 
+    # Values of the "source" tag: which call path reached the evaluation. sdk means the
+    # customer called evaluate() directly, auto means our AI package instrumentation did.
+    SOURCE_SDK: Literal["sdk"] = "sdk"
+    SOURCE_AUTO: Literal["auto"] = "auto"
+
+    # Values of the "integration" tag: the auto-instrumented AI package name, or none when
+    # the evaluation came from a direct SDK call.
+    INTEGRATION_NONE: Literal["none"] = "none"
+    INTEGRATION_OPENAI: Literal["openai"] = "openai"
+    INTEGRATION_ANTHROPIC: Literal["anthropic"] = "anthropic"
+    INTEGRATION_LANGCHAIN: Literal["langchain"] = "langchain"
+    INTEGRATION_LITELLM: Literal["litellm"] = "litellm"
+    INTEGRATION_STRANDS: Literal["strands"] = "strands"
+
     # environment variables
     ENV_ENABLED: Literal["DD_AI_GUARD_ENABLED"] = "DD_AI_GUARD_ENABLED"
     ENV_ENDPOINT: Literal["DD_AI_GUARD_ENDPOINT"] = "DD_AI_GUARD_ENDPOINT"

--- a/ddtrace/aiguard/integrations/_anthropic.py
+++ b/ddtrace/aiguard/integrations/_anthropic.py
@@ -35,6 +35,7 @@ from ddtrace.aiguard._api_client import Options
 from ddtrace.aiguard._api_client import ToolCall
 from ddtrace.aiguard._common import _get
 from ddtrace.aiguard._common import wrap_abort_error
+from ddtrace.aiguard._constants import AI_GUARD
 from ddtrace.aiguard._context import is_aiguard_context_active
 from ddtrace.internal import telemetry
 import ddtrace.internal.logger as ddlogger
@@ -650,7 +651,12 @@ def _anthropic_messages_create_before(client: AIGuardClient, kwargs: dict[str, A
 
     logger.debug("AI Guard anthropic before-hook evaluating %d message(s)", len(ai_guard_messages))
     try:
-        client.evaluate(ai_guard_messages, Options(block=aiguard_config._ai_guard_block))
+        client.evaluate(
+            ai_guard_messages,
+            Options(block=aiguard_config._ai_guard_block),
+            source=AI_GUARD.SOURCE_AUTO,
+            integration=AI_GUARD.INTEGRATION_ANTHROPIC,
+        )
     except AIGuardAbortError as e:
         raise _wrap_abort_error(e)
     except Exception:
@@ -690,7 +696,12 @@ def _anthropic_messages_create_after(client: AIGuardClient, kwargs: dict[str, An
     all_messages = request_messages + response_messages
 
     try:
-        client.evaluate(all_messages, Options(block=aiguard_config._ai_guard_block))
+        client.evaluate(
+            all_messages,
+            Options(block=aiguard_config._ai_guard_block),
+            source=AI_GUARD.SOURCE_AUTO,
+            integration=AI_GUARD.INTEGRATION_ANTHROPIC,
+        )
     except AIGuardAbortError as e:
         raise _wrap_abort_error(e)
     except Exception:

--- a/ddtrace/aiguard/integrations/_anthropic.py
+++ b/ddtrace/aiguard/integrations/_anthropic.py
@@ -31,15 +31,14 @@ from ddtrace.aiguard._api_client import ContentPart
 from ddtrace.aiguard._api_client import Function
 from ddtrace.aiguard._api_client import ImageURL
 from ddtrace.aiguard._api_client import Message
-from ddtrace.aiguard._api_client import Options
 from ddtrace.aiguard._api_client import ToolCall
 from ddtrace.aiguard._common import _get
+from ddtrace.aiguard._common import evaluate_auto
 from ddtrace.aiguard._common import wrap_abort_error
 from ddtrace.aiguard._constants import AI_GUARD
 from ddtrace.aiguard._context import is_aiguard_context_active
 from ddtrace.internal import telemetry
 import ddtrace.internal.logger as ddlogger
-from ddtrace.internal.settings.aiguard import aiguard_config
 from ddtrace.internal.telemetry.constants import TELEMETRY_LOG_LEVEL
 
 
@@ -651,12 +650,7 @@ def _anthropic_messages_create_before(client: AIGuardClient, kwargs: dict[str, A
 
     logger.debug("AI Guard anthropic before-hook evaluating %d message(s)", len(ai_guard_messages))
     try:
-        client.evaluate(
-            ai_guard_messages,
-            Options(block=aiguard_config._ai_guard_block),
-            source=AI_GUARD.SOURCE_AUTO,
-            integration=AI_GUARD.INTEGRATION_ANTHROPIC,
-        )
+        evaluate_auto(client, ai_guard_messages, AI_GUARD.INTEGRATION_ANTHROPIC)
     except AIGuardAbortError as e:
         raise _wrap_abort_error(e)
     except Exception:
@@ -696,12 +690,7 @@ def _anthropic_messages_create_after(client: AIGuardClient, kwargs: dict[str, An
     all_messages = request_messages + response_messages
 
     try:
-        client.evaluate(
-            all_messages,
-            Options(block=aiguard_config._ai_guard_block),
-            source=AI_GUARD.SOURCE_AUTO,
-            integration=AI_GUARD.INTEGRATION_ANTHROPIC,
-        )
+        evaluate_auto(client, all_messages, AI_GUARD.INTEGRATION_ANTHROPIC)
     except AIGuardAbortError as e:
         raise _wrap_abort_error(e)
     except Exception:

--- a/ddtrace/aiguard/integrations/_langchain.py
+++ b/ddtrace/aiguard/integrations/_langchain.py
@@ -9,8 +9,8 @@ from ddtrace.aiguard import AIGuardAbortError
 from ddtrace.aiguard import AIGuardClient
 from ddtrace.aiguard import Function
 from ddtrace.aiguard import Message
-from ddtrace.aiguard import Options
 from ddtrace.aiguard import ToolCall
+from ddtrace.aiguard._common import evaluate_auto
 from ddtrace.aiguard._constants import AI_GUARD
 from ddtrace.aiguard._context import reset_aiguard_context_active_current
 from ddtrace.aiguard._context import set_aiguard_context_active
@@ -18,7 +18,6 @@ from ddtrace.aiguard.messages import try_format_json
 from ddtrace.contrib.internal.trace_utils import unwrap
 from ddtrace.contrib.internal.trace_utils import wrap
 import ddtrace.internal.logger as ddlogger
-from ddtrace.internal.settings.aiguard import aiguard_config
 from ddtrace.internal.utils import get_argument_value
 
 
@@ -240,12 +239,7 @@ def _handle_agent_action_result(client: AIGuardClient, result: Any, args: Any, k
                         ],
                     )
                 )
-                client.evaluate(
-                    messages,
-                    Options(block=aiguard_config._ai_guard_block),
-                    source=AI_GUARD.SOURCE_AUTO,
-                    integration=AI_GUARD.INTEGRATION_LANGCHAIN,
-                )
+                evaluate_auto(client, messages, AI_GUARD.INTEGRATION_LANGCHAIN)
             except AIGuardAbortError:
                 raise
             except Exception:
@@ -308,12 +302,7 @@ def _evaluate_langchain_tool_call(client: AIGuardClient, args: Any, kwargs: Any)
                 ],
             )
         )
-        client.evaluate(
-            messages,
-            Options(block=aiguard_config._ai_guard_block),
-            source=AI_GUARD.SOURCE_AUTO,
-            integration=AI_GUARD.INTEGRATION_LANGCHAIN,
-        )
+        evaluate_auto(client, messages, AI_GUARD.INTEGRATION_LANGCHAIN)
     except AIGuardAbortError:
         raise
     except Exception:
@@ -411,12 +400,7 @@ def _evaluate_langchain_messages(client: AIGuardClient, messages: list[Any]) -> 
 
     if len(messages) > 0 and isinstance(messages[-1], (HumanMessage, ToolMessage)):
         try:
-            client.evaluate(
-                _convert_messages(messages),
-                Options(block=aiguard_config._ai_guard_block),
-                source=AI_GUARD.SOURCE_AUTO,
-                integration=AI_GUARD.INTEGRATION_LANGCHAIN,
-            )
+            evaluate_auto(client, _convert_messages(messages), AI_GUARD.INTEGRATION_LANGCHAIN)
         except AIGuardAbortError:
             raise
         except Exception:

--- a/ddtrace/aiguard/integrations/_langchain.py
+++ b/ddtrace/aiguard/integrations/_langchain.py
@@ -11,6 +11,7 @@ from ddtrace.aiguard import Function
 from ddtrace.aiguard import Message
 from ddtrace.aiguard import Options
 from ddtrace.aiguard import ToolCall
+from ddtrace.aiguard._constants import AI_GUARD
 from ddtrace.aiguard._context import reset_aiguard_context_active_current
 from ddtrace.aiguard._context import set_aiguard_context_active
 from ddtrace.aiguard.messages import try_format_json
@@ -239,7 +240,12 @@ def _handle_agent_action_result(client: AIGuardClient, result: Any, args: Any, k
                         ],
                     )
                 )
-                client.evaluate(messages, Options(block=aiguard_config._ai_guard_block))
+                client.evaluate(
+                    messages,
+                    Options(block=aiguard_config._ai_guard_block),
+                    source=AI_GUARD.SOURCE_AUTO,
+                    integration=AI_GUARD.INTEGRATION_LANGCHAIN,
+                )
             except AIGuardAbortError:
                 raise
             except Exception:
@@ -302,7 +308,12 @@ def _evaluate_langchain_tool_call(client: AIGuardClient, args: Any, kwargs: Any)
                 ],
             )
         )
-        client.evaluate(messages, Options(block=aiguard_config._ai_guard_block))
+        client.evaluate(
+            messages,
+            Options(block=aiguard_config._ai_guard_block),
+            source=AI_GUARD.SOURCE_AUTO,
+            integration=AI_GUARD.INTEGRATION_LANGCHAIN,
+        )
     except AIGuardAbortError:
         raise
     except Exception:
@@ -400,7 +411,12 @@ def _evaluate_langchain_messages(client: AIGuardClient, messages: list[Any]) -> 
 
     if len(messages) > 0 and isinstance(messages[-1], (HumanMessage, ToolMessage)):
         try:
-            client.evaluate(_convert_messages(messages), Options(block=aiguard_config._ai_guard_block))
+            client.evaluate(
+                _convert_messages(messages),
+                Options(block=aiguard_config._ai_guard_block),
+                source=AI_GUARD.SOURCE_AUTO,
+                integration=AI_GUARD.INTEGRATION_LANGCHAIN,
+            )
         except AIGuardAbortError:
             raise
         except Exception:

--- a/ddtrace/aiguard/integrations/_openai_chat.py
+++ b/ddtrace/aiguard/integrations/_openai_chat.py
@@ -12,14 +12,13 @@ from ddtrace.aiguard._api_client import AIGuardAbortError
 from ddtrace.aiguard._api_client import AIGuardClient
 from ddtrace.aiguard._api_client import Function
 from ddtrace.aiguard._api_client import Message
-from ddtrace.aiguard._api_client import Options
 from ddtrace.aiguard._api_client import ToolCall
 from ddtrace.aiguard._common import _get
+from ddtrace.aiguard._common import evaluate_auto
 from ddtrace.aiguard._constants import AI_GUARD
 from ddtrace.aiguard._context import is_aiguard_context_active
 from ddtrace.aiguard.integrations._openai import _wrap_abort_error
 import ddtrace.internal.logger as ddlogger
-from ddtrace.internal.settings.aiguard import aiguard_config
 
 
 logger = ddlogger.get_logger(__name__)
@@ -180,12 +179,7 @@ def _openai_chat_completion_before(client: AIGuardClient, kwargs: dict[str, Any]
 
     logger.debug("AI Guard openai before-hook evaluating %d message(s)", len(ai_guard_messages))
     try:
-        client.evaluate(
-            ai_guard_messages,
-            Options(block=aiguard_config._ai_guard_block),
-            source=AI_GUARD.SOURCE_AUTO,
-            integration=AI_GUARD.INTEGRATION_OPENAI,
-        )
+        evaluate_auto(client, ai_guard_messages, AI_GUARD.INTEGRATION_OPENAI)
     except AIGuardAbortError as e:
         raise _wrap_abort_error(e)
     except Exception:
@@ -218,12 +212,7 @@ def _openai_chat_completion_after(client: AIGuardClient, kwargs: dict[str, Any],
     all_messages = request_messages + response_messages
 
     try:
-        client.evaluate(
-            all_messages,
-            Options(block=aiguard_config._ai_guard_block),
-            source=AI_GUARD.SOURCE_AUTO,
-            integration=AI_GUARD.INTEGRATION_OPENAI,
-        )
+        evaluate_auto(client, all_messages, AI_GUARD.INTEGRATION_OPENAI)
     except AIGuardAbortError as e:
         raise _wrap_abort_error(e)
     except Exception:

--- a/ddtrace/aiguard/integrations/_openai_chat.py
+++ b/ddtrace/aiguard/integrations/_openai_chat.py
@@ -15,6 +15,7 @@ from ddtrace.aiguard._api_client import Message
 from ddtrace.aiguard._api_client import Options
 from ddtrace.aiguard._api_client import ToolCall
 from ddtrace.aiguard._common import _get
+from ddtrace.aiguard._constants import AI_GUARD
 from ddtrace.aiguard._context import is_aiguard_context_active
 from ddtrace.aiguard.integrations._openai import _wrap_abort_error
 import ddtrace.internal.logger as ddlogger
@@ -179,7 +180,12 @@ def _openai_chat_completion_before(client: AIGuardClient, kwargs: dict[str, Any]
 
     logger.debug("AI Guard openai before-hook evaluating %d message(s)", len(ai_guard_messages))
     try:
-        client.evaluate(ai_guard_messages, Options(block=aiguard_config._ai_guard_block))
+        client.evaluate(
+            ai_guard_messages,
+            Options(block=aiguard_config._ai_guard_block),
+            source=AI_GUARD.SOURCE_AUTO,
+            integration=AI_GUARD.INTEGRATION_OPENAI,
+        )
     except AIGuardAbortError as e:
         raise _wrap_abort_error(e)
     except Exception:
@@ -212,7 +218,12 @@ def _openai_chat_completion_after(client: AIGuardClient, kwargs: dict[str, Any],
     all_messages = request_messages + response_messages
 
     try:
-        client.evaluate(all_messages, Options(block=aiguard_config._ai_guard_block))
+        client.evaluate(
+            all_messages,
+            Options(block=aiguard_config._ai_guard_block),
+            source=AI_GUARD.SOURCE_AUTO,
+            integration=AI_GUARD.INTEGRATION_OPENAI,
+        )
     except AIGuardAbortError as e:
         raise _wrap_abort_error(e)
     except Exception:

--- a/ddtrace/aiguard/integrations/_openai_responses.py
+++ b/ddtrace/aiguard/integrations/_openai_responses.py
@@ -31,6 +31,7 @@ from ddtrace.aiguard._api_client import Message
 from ddtrace.aiguard._api_client import Options
 from ddtrace.aiguard._api_client import ToolCall
 from ddtrace.aiguard._common import _get
+from ddtrace.aiguard._constants import AI_GUARD
 from ddtrace.aiguard._context import is_aiguard_context_active
 from ddtrace.aiguard.integrations._openai import _wrap_abort_error
 import ddtrace.internal.logger as ddlogger
@@ -444,7 +445,12 @@ def _openai_response_create_before(client: AIGuardClient, kwargs: dict[str, Any]
 
     logger.debug("AI Guard openai responses before-hook evaluating %d message(s)", len(messages))
     try:
-        client.evaluate(messages, Options(block=aiguard_config._ai_guard_block))
+        client.evaluate(
+            messages,
+            Options(block=aiguard_config._ai_guard_block),
+            source=AI_GUARD.SOURCE_AUTO,
+            integration=AI_GUARD.INTEGRATION_OPENAI,
+        )
     except AIGuardAbortError as e:
         raise _wrap_abort_error(e)
     except Exception:
@@ -478,7 +484,12 @@ def _openai_response_create_after(client: AIGuardClient, kwargs: dict[str, Any],
     all_messages = request_messages + response_messages
 
     try:
-        client.evaluate(all_messages, Options(block=aiguard_config._ai_guard_block))
+        client.evaluate(
+            all_messages,
+            Options(block=aiguard_config._ai_guard_block),
+            source=AI_GUARD.SOURCE_AUTO,
+            integration=AI_GUARD.INTEGRATION_OPENAI,
+        )
     except AIGuardAbortError as e:
         raise _wrap_abort_error(e)
     except Exception:

--- a/ddtrace/aiguard/integrations/_openai_responses.py
+++ b/ddtrace/aiguard/integrations/_openai_responses.py
@@ -28,9 +28,9 @@ from ddtrace.aiguard._api_client import AIGuardAbortError
 from ddtrace.aiguard._api_client import AIGuardClient
 from ddtrace.aiguard._api_client import Function
 from ddtrace.aiguard._api_client import Message
-from ddtrace.aiguard._api_client import Options
 from ddtrace.aiguard._api_client import ToolCall
 from ddtrace.aiguard._common import _get
+from ddtrace.aiguard._common import evaluate_auto
 from ddtrace.aiguard._constants import AI_GUARD
 from ddtrace.aiguard._context import is_aiguard_context_active
 from ddtrace.aiguard.integrations._openai import _wrap_abort_error
@@ -445,12 +445,7 @@ def _openai_response_create_before(client: AIGuardClient, kwargs: dict[str, Any]
 
     logger.debug("AI Guard openai responses before-hook evaluating %d message(s)", len(messages))
     try:
-        client.evaluate(
-            messages,
-            Options(block=aiguard_config._ai_guard_block),
-            source=AI_GUARD.SOURCE_AUTO,
-            integration=AI_GUARD.INTEGRATION_OPENAI,
-        )
+        evaluate_auto(client, messages, AI_GUARD.INTEGRATION_OPENAI)
     except AIGuardAbortError as e:
         raise _wrap_abort_error(e)
     except Exception:
@@ -484,12 +479,7 @@ def _openai_response_create_after(client: AIGuardClient, kwargs: dict[str, Any],
     all_messages = request_messages + response_messages
 
     try:
-        client.evaluate(
-            all_messages,
-            Options(block=aiguard_config._ai_guard_block),
-            source=AI_GUARD.SOURCE_AUTO,
-            integration=AI_GUARD.INTEGRATION_OPENAI,
-        )
+        evaluate_auto(client, all_messages, AI_GUARD.INTEGRATION_OPENAI)
     except AIGuardAbortError as e:
         raise _wrap_abort_error(e)
     except Exception:

--- a/ddtrace/aiguard/integrations/litellm.py
+++ b/ddtrace/aiguard/integrations/litellm.py
@@ -30,6 +30,7 @@ from ddtrace.aiguard import Message
 from ddtrace.aiguard import Options
 from ddtrace.aiguard import ToolCall
 from ddtrace.aiguard import new_ai_guard_client
+from ddtrace.aiguard._constants import AI_GUARD
 from ddtrace.internal.settings.aiguard import aiguard_config
 
 
@@ -206,7 +207,13 @@ class DatadogAIGuardGuardrail(CustomGuardrail):  # type: ignore[misc]
         try:
             verbose_proxy_logger.debug("Datadog AI Guard: Making request to endpoint")
             block = self._resolve_block(dynamic_params)
-            response = await asyncio.to_thread(self._client.evaluate, messages, Options(block=block))
+            response = await asyncio.to_thread(
+                self._client.evaluate,
+                messages,
+                Options(block=block),
+                source=AI_GUARD.SOURCE_AUTO,
+                integration=AI_GUARD.INTEGRATION_LITELLM,
+            )
             if response["action"] in ("DENY", "ABORT"):
                 verbose_proxy_logger.debug(
                     "Datadog AI Guard: monitor mode - violation detected but allowing request. "

--- a/ddtrace/aiguard/integrations/strands.py
+++ b/ddtrace/aiguard/integrations/strands.py
@@ -71,15 +71,14 @@ from ddtrace.aiguard._api_client import AIGuardAbortError
 from ddtrace.aiguard._api_client import AIGuardClient
 from ddtrace.aiguard._api_client import Function
 from ddtrace.aiguard._api_client import Message
-from ddtrace.aiguard._api_client import Options
 from ddtrace.aiguard._api_client import ToolCall
 from ddtrace.aiguard._api_client import new_ai_guard_client
+from ddtrace.aiguard._common import evaluate_auto
 from ddtrace.aiguard._constants import AI_GUARD
 from ddtrace.aiguard._context import reset_aiguard_context_active
 from ddtrace.aiguard._context import set_aiguard_context_active
 from ddtrace.aiguard.messages import try_format_json
 from ddtrace.internal.logger import get_logger
-from ddtrace.internal.settings.aiguard import aiguard_config
 
 
 logger = get_logger(__name__)
@@ -294,12 +293,7 @@ class AIGuardStrandsIntegration:
             # already scanned in AfterToolCall; re-scanning would be redundant.
             ai_guard_messages = _convert_strands_messages(messages, system_prompt, exclude_tool_results=True)
             if ai_guard_messages:
-                self._client.evaluate(
-                    ai_guard_messages,
-                    Options(block=aiguard_config._ai_guard_block),
-                    source=AI_GUARD.SOURCE_AUTO,
-                    integration=AI_GUARD.INTEGRATION_STRANDS,
-                )
+                evaluate_auto(self._client, ai_guard_messages, AI_GUARD.INTEGRATION_STRANDS)
         except AIGuardAbortError:
             raise
         except Exception:
@@ -328,12 +322,7 @@ class AIGuardStrandsIntegration:
                 return
             ai_guard_messages = _convert_strands_messages([text_only_message])
             if ai_guard_messages:
-                self._client.evaluate(
-                    ai_guard_messages,
-                    Options(block=aiguard_config._ai_guard_block),
-                    source=AI_GUARD.SOURCE_AUTO,
-                    integration=AI_GUARD.INTEGRATION_STRANDS,
-                )
+                evaluate_auto(self._client, ai_guard_messages, AI_GUARD.INTEGRATION_STRANDS)
         except AIGuardAbortError:
             raise
         except Exception:
@@ -380,12 +369,7 @@ class AIGuardStrandsIntegration:
         tool_name = ""
         try:
             ai_guard_messages, tool_name = self._build_tool_call_messages(event)
-            self._client.evaluate(
-                ai_guard_messages,
-                Options(block=aiguard_config._ai_guard_block),
-                source=AI_GUARD.SOURCE_AUTO,
-                integration=AI_GUARD.INTEGRATION_STRANDS,
-            )
+            evaluate_auto(self._client, ai_guard_messages, AI_GUARD.INTEGRATION_STRANDS)
         except AIGuardAbortError as e:
             if self._raise_error_on_tool_calls:
                 raise
@@ -414,12 +398,7 @@ class AIGuardStrandsIntegration:
                 )
             )
 
-            self._client.evaluate(
-                ai_guard_messages,
-                Options(block=aiguard_config._ai_guard_block),
-                source=AI_GUARD.SOURCE_AUTO,
-                integration=AI_GUARD.INTEGRATION_STRANDS,
-            )
+            evaluate_auto(self._client, ai_guard_messages, AI_GUARD.INTEGRATION_STRANDS)
         except AIGuardAbortError as e:
             if self._raise_error_on_tool_calls:
                 raise

--- a/ddtrace/aiguard/integrations/strands.py
+++ b/ddtrace/aiguard/integrations/strands.py
@@ -74,6 +74,7 @@ from ddtrace.aiguard._api_client import Message
 from ddtrace.aiguard._api_client import Options
 from ddtrace.aiguard._api_client import ToolCall
 from ddtrace.aiguard._api_client import new_ai_guard_client
+from ddtrace.aiguard._constants import AI_GUARD
 from ddtrace.aiguard._context import reset_aiguard_context_active
 from ddtrace.aiguard._context import set_aiguard_context_active
 from ddtrace.aiguard.messages import try_format_json
@@ -293,7 +294,12 @@ class AIGuardStrandsIntegration:
             # already scanned in AfterToolCall; re-scanning would be redundant.
             ai_guard_messages = _convert_strands_messages(messages, system_prompt, exclude_tool_results=True)
             if ai_guard_messages:
-                self._client.evaluate(ai_guard_messages, Options(block=aiguard_config._ai_guard_block))
+                self._client.evaluate(
+                    ai_guard_messages,
+                    Options(block=aiguard_config._ai_guard_block),
+                    source=AI_GUARD.SOURCE_AUTO,
+                    integration=AI_GUARD.INTEGRATION_STRANDS,
+                )
         except AIGuardAbortError:
             raise
         except Exception:
@@ -322,7 +328,12 @@ class AIGuardStrandsIntegration:
                 return
             ai_guard_messages = _convert_strands_messages([text_only_message])
             if ai_guard_messages:
-                self._client.evaluate(ai_guard_messages, Options(block=aiguard_config._ai_guard_block))
+                self._client.evaluate(
+                    ai_guard_messages,
+                    Options(block=aiguard_config._ai_guard_block),
+                    source=AI_GUARD.SOURCE_AUTO,
+                    integration=AI_GUARD.INTEGRATION_STRANDS,
+                )
         except AIGuardAbortError:
             raise
         except Exception:
@@ -369,7 +380,12 @@ class AIGuardStrandsIntegration:
         tool_name = ""
         try:
             ai_guard_messages, tool_name = self._build_tool_call_messages(event)
-            self._client.evaluate(ai_guard_messages, Options(block=aiguard_config._ai_guard_block))
+            self._client.evaluate(
+                ai_guard_messages,
+                Options(block=aiguard_config._ai_guard_block),
+                source=AI_GUARD.SOURCE_AUTO,
+                integration=AI_GUARD.INTEGRATION_STRANDS,
+            )
         except AIGuardAbortError as e:
             if self._raise_error_on_tool_calls:
                 raise
@@ -398,7 +414,12 @@ class AIGuardStrandsIntegration:
                 )
             )
 
-            self._client.evaluate(ai_guard_messages, Options(block=aiguard_config._ai_guard_block))
+            self._client.evaluate(
+                ai_guard_messages,
+                Options(block=aiguard_config._ai_guard_block),
+                source=AI_GUARD.SOURCE_AUTO,
+                integration=AI_GUARD.INTEGRATION_STRANDS,
+            )
         except AIGuardAbortError as e:
             if self._raise_error_on_tool_calls:
                 raise

--- a/tests/aiguard/anthropic/test_anthropic.py
+++ b/tests/aiguard/anthropic/test_anthropic.py
@@ -904,7 +904,7 @@ def test_before_hook_materializes_iterator_messages():
         def __init__(self):
             self.evaluated = None
 
-        def evaluate(self, messages, options):
+        def evaluate(self, messages, options, **kwargs):
             self.evaluated = list(messages)
             return None
 
@@ -927,7 +927,7 @@ def test_before_hook_materializes_iterator_system():
         def __init__(self):
             self.evaluated = None
 
-        def evaluate(self, messages, options):
+        def evaluate(self, messages, options, **kwargs):
             self.evaluated = list(messages)
             return None
 
@@ -954,7 +954,7 @@ def test_before_hook_evaluates_final_assistant_prefill():
         def __init__(self):
             self.evaluated = None
 
-        def evaluate(self, messages, options):
+        def evaluate(self, messages, options, **kwargs):
             self.evaluated = list(messages)
             return None
 
@@ -981,7 +981,7 @@ def test_before_hook_evaluates_document_only_prompt():
         def __init__(self):
             self.evaluated = None
 
-        def evaluate(self, messages, options):
+        def evaluate(self, messages, options, **kwargs):
             self.evaluated = list(messages)
             return None
 
@@ -1219,7 +1219,7 @@ def test_collision_after_listener_short_circuits(aiguard_active_context):
         def __init__(self):
             self.calls = 0
 
-        def evaluate(self, messages, options):
+        def evaluate(self, messages, options, **kwargs):
             self.calls += 1
 
     client = _SpyClient()
@@ -1234,7 +1234,7 @@ def test_collision_before_listener_short_circuits(aiguard_active_context):
         def __init__(self):
             self.calls = 0
 
-        def evaluate(self, messages, options):
+        def evaluate(self, messages, options, **kwargs):
             self.calls += 1
 
     client = _SpyClient()
@@ -1691,7 +1691,7 @@ def test_before_listener_fails_open_on_converter_error():
         def __init__(self):
             self.calls = 0
 
-        def evaluate(self, messages, options):
+        def evaluate(self, messages, options, **kwargs):
             self.calls += 1
 
     from ddtrace.aiguard.integrations import _anthropic as anthropic_mod
@@ -1717,7 +1717,7 @@ def test_before_listener_empty_messages_emits_telemetry():
         def __init__(self):
             self.calls = 0
 
-        def evaluate(self, messages, options):
+        def evaluate(self, messages, options, **kwargs):
             self.calls += 1
 
     from ddtrace.aiguard.integrations._anthropic import _anthropic_messages_create_before

--- a/tests/aiguard/api/test_api_client.py
+++ b/tests/aiguard/api/test_api_client.py
@@ -92,9 +92,13 @@ def _build_test_params():
     return params
 
 
-def assert_telemetry(mocked, metric, tags):
+def assert_telemetry(mocked, metric, tags, source=AI_GUARD.SOURCE_SDK, integration=AI_GUARD.INTEGRATION_NONE):
+    """Assert one metric was emitted. Every AI Guard metric ends with the call-path tags, which
+    default here to a direct SDK call.
+    """
     metrics = [(args[0].value,) + args[1:] for args, kwargs in mocked.call_args_list]
-    assert ("ai_guard", metric, 1, tags) in metrics
+    expected_tags = tuple(tags) + (("source", source), ("integration", integration))
+    assert ("ai_guard", metric, 1, expected_tags) in metrics
 
 
 @pytest.mark.parametrize("action,reason,tags,blocking,suite,target,messages", _build_test_params())
@@ -365,6 +369,74 @@ def test_message_immutability(mock_execute_request, telemetry_mock, ai_guard_cli
     messages = meta["messages"]
     assert len(messages) == 1
     assert len(messages[0]["tool_calls"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# source / integration telemetry tags (APPSEC-69866)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected_source,expected_integration",
+    [
+        pytest.param({}, "sdk", "none", id="defaults to a direct sdk call"),
+        pytest.param(
+            {"source": AI_GUARD.SOURCE_AUTO, "integration": AI_GUARD.INTEGRATION_OPENAI},
+            "auto",
+            "openai",
+            id="auto instrumentation reports its package",
+        ),
+        pytest.param(
+            {"source": AI_GUARD.SOURCE_SDK, "integration": AI_GUARD.INTEGRATION_OPENAI},
+            "sdk",
+            "none",
+            id="sdk source pins integration to none",
+        ),
+    ],
+)
+@patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
+@patch("ddtrace.aiguard._api_client.AIGuardClient._execute_request")
+def test_evaluate_reports_call_path_tags(
+    mock_execute_request, telemetry_mock, ai_guard_client, kwargs, expected_source, expected_integration
+):
+    mock_execute_request.return_value = mock_evaluate_response("ALLOW")
+
+    ai_guard_client.evaluate(TOOL_CALL, **kwargs)
+
+    assert_telemetry(
+        telemetry_mock,
+        "requests",
+        (("action", "ALLOW"), ("block", "false"), ("error", "false"), ("redacted", "false")),
+        source=expected_source,
+        integration=expected_integration,
+    )
+
+
+@patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
+@patch("ddtrace.aiguard._api_client.AIGuardClient._execute_request")
+def test_evaluate_error_metrics_report_call_path_tags(mock_execute_request, telemetry_mock, ai_guard_client):
+    """A failed auto-instrumented evaluation still attributes both the requests and error metrics."""
+    mock_execute_request.side_effect = Exception("Connection refused")
+
+    with pytest.raises(AIGuardClientError):
+        ai_guard_client.evaluate(TOOL_CALL, source=AI_GUARD.SOURCE_AUTO, integration=AI_GUARD.INTEGRATION_ANTHROPIC)
+
+    for metric, tags in (("requests", (("error", "true"),)), ("error", (("type", "client_error"),))):
+        assert_telemetry(telemetry_mock, metric, tags, source="auto", integration="anthropic")
+
+
+@patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
+@patch("ddtrace.aiguard._api_client.AIGuardClient._execute_request")
+def test_truncated_metric_reports_call_path_tags(mock_execute_request, telemetry_mock, ai_guard_client):
+    mock_execute_request.return_value = mock_evaluate_response("ALLOW")
+
+    messages = [
+        Message(role="user", content="Tell me 10 things I should know about DataDog")
+        for _ in range(aiguard_config._ai_guard_max_messages_length + 1)
+    ]
+    ai_guard_client.evaluate(messages, source=AI_GUARD.SOURCE_AUTO, integration=AI_GUARD.INTEGRATION_LANGCHAIN)
+
+    assert_telemetry(telemetry_mock, "truncated", (("type", "messages"),), source="auto", integration="langchain")
 
 
 @pytest.mark.parametrize(

--- a/tests/aiguard/api/test_call_path_tags.py
+++ b/tests/aiguard/api/test_call_path_tags.py
@@ -1,0 +1,81 @@
+"""Every auto-instrumentation evaluate() call site must tag its call path (APPSEC-69866).
+
+Checked statically rather than by exercising each provider: the assertion is uniform across
+providers and a source scan is the only way to cover litellm and strands from this suite, which
+does not install those packages. It also fails loudly when a new call site (or a whole new
+integration module) forgets the tags -- the regression the telemetry spec is guarding against.
+Spec: https://datadoghq.atlassian.net/wiki/spaces/AIGuard/pages/6600426215
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+from ddtrace.aiguard._constants import AI_GUARD
+
+
+INTEGRATIONS_DIR = pathlib.Path(__file__).parents[3] / "ddtrace" / "aiguard" / "integrations"
+
+# Module basename -> the AI_GUARD.INTEGRATION_* constant its evaluate() calls must report.
+EXPECTED_INTEGRATION = {
+    "_anthropic.py": "INTEGRATION_ANTHROPIC",
+    "_langchain.py": "INTEGRATION_LANGCHAIN",
+    "_openai_chat.py": "INTEGRATION_OPENAI",
+    "_openai_responses.py": "INTEGRATION_OPENAI",
+    "litellm.py": "INTEGRATION_LITELLM",
+    "strands.py": "INTEGRATION_STRANDS",
+}
+
+
+def _is_evaluate_attribute(node):
+    return isinstance(node, ast.Attribute) and node.attr == "evaluate"
+
+
+def _evaluate_calls(tree):
+    """Yield the Call nodes carrying the evaluate() keyword arguments.
+
+    Direct calls (client.evaluate(...)) carry them themselves; litellm dispatches through
+    asyncio.to_thread(self._client.evaluate, ...), where the outer call carries them instead.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if _is_evaluate_attribute(node.func) or any(_is_evaluate_attribute(arg) for arg in node.args):
+            yield node
+
+
+def _constant_name(keyword):
+    """The AI_GUARD.<NAME> referenced by a keyword argument, or None if it is not one."""
+    value = keyword.value
+    if isinstance(value, ast.Attribute) and isinstance(value.value, ast.Name) and value.value.id == "AI_GUARD":
+        return value.attr
+    return None
+
+
+@pytest.mark.parametrize("path", sorted(INTEGRATIONS_DIR.glob("*.py")), ids=lambda path: path.name)
+def test_auto_instrumentation_evaluate_calls_tag_the_call_path(path):
+    tree = ast.parse(path.read_text())
+    calls = list(_evaluate_calls(tree))
+    if not calls:
+        return
+
+    assert path.name in EXPECTED_INTEGRATION, (
+        f"{path.name} calls evaluate() but has no expected integration tag; add it to "
+        "EXPECTED_INTEGRATION and to AI_GUARD.INTEGRATION_*"
+    )
+    expected_integration = EXPECTED_INTEGRATION[path.name]
+
+    for call in calls:
+        keywords = {keyword.arg: keyword for keyword in call.keywords if keyword.arg}
+        where = f"{path.name}:{call.lineno}"
+        assert "source" in keywords and "integration" in keywords, f"{where}: evaluate() call is untagged"
+        assert _constant_name(keywords["source"]) == "SOURCE_AUTO", f"{where}: source must be AI_GUARD.SOURCE_AUTO"
+        assert _constant_name(keywords["integration"]) == expected_integration, (
+            f"{where}: integration must be AI_GUARD.{expected_integration}"
+        )
+
+
+def test_expected_integrations_are_declared_constants():
+    for name in set(EXPECTED_INTEGRATION.values()):
+        assert name in AI_GUARD

--- a/tests/aiguard/api/test_call_path_tags.py
+++ b/tests/aiguard/api/test_call_path_tags.py
@@ -1,10 +1,10 @@
-"""Every auto-instrumentation evaluate() call site must tag its call path (APPSEC-69866).
+"""Auto-instrumentation must reach evaluate() through evaluate_auto (APPSEC-69866).
 
-Checked statically rather than by exercising each provider: the assertion is uniform across
-providers and a source scan is the only way to cover litellm and strands from this suite, which
-does not install those packages. It also fails loudly when a new call site (or a whole new
-integration module) forgets the tags -- the regression the telemetry spec is guarding against.
-Spec: https://datadoghq.atlassian.net/wiki/spaces/AIGuard/pages/6600426215
+evaluate_auto binds source=auto and the DD_AI_GUARD_BLOCK policy, so a listener cannot forget
+or mismatch a call-path tag. What it cannot prevent is a listener calling client.evaluate()
+directly and going out untagged, which is what the source scan below guards. Checked statically
+because it is the only way to cover litellm and strands from this suite, which does not install
+those packages. Spec: https://datadoghq.atlassian.net/wiki/spaces/AIGuard/pages/6600426215
 """
 
 import ast
@@ -12,70 +12,51 @@ import pathlib
 
 import pytest
 
+from ddtrace.aiguard._common import evaluate_auto
 from ddtrace.aiguard._constants import AI_GUARD
+from ddtrace.internal.settings.aiguard import aiguard_config
 
 
 INTEGRATIONS_DIR = pathlib.Path(__file__).parents[3] / "ddtrace" / "aiguard" / "integrations"
 
-# Module basename -> the AI_GUARD.INTEGRATION_* constant its evaluate() calls must report.
-EXPECTED_INTEGRATION = {
-    "_anthropic.py": "INTEGRATION_ANTHROPIC",
-    "_langchain.py": "INTEGRATION_LANGCHAIN",
-    "_openai_chat.py": "INTEGRATION_OPENAI",
-    "_openai_responses.py": "INTEGRATION_OPENAI",
-    "litellm.py": "INTEGRATION_LITELLM",
-    "strands.py": "INTEGRATION_STRANDS",
-}
+# litellm resolves block per request from its own dynamic guardrail params, so it tags its
+# evaluate() call explicitly instead of going through evaluate_auto.
+ALLOWED_DIRECT_CALLERS = {"litellm.py"}
 
 
-def _is_evaluate_attribute(node):
-    return isinstance(node, ast.Attribute) and node.attr == "evaluate"
+class _FakeClient:
+    def __init__(self):
+        self.calls = []
+
+    def evaluate(self, messages, options=None, source=None, integration=None):
+        self.calls.append({"messages": messages, "options": options, "source": source, "integration": integration})
 
 
-def _evaluate_calls(tree):
-    """Yield the Call nodes carrying the evaluate() keyword arguments.
+def test_evaluate_auto_reports_the_package_as_the_call_path():
+    client = _FakeClient()
+    messages = [{"role": "user", "content": "hi"}]
 
-    Direct calls (client.evaluate(...)) carry them themselves; litellm dispatches through
-    asyncio.to_thread(self._client.evaluate, ...), where the outer call carries them instead.
-    """
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        if _is_evaluate_attribute(node.func) or any(_is_evaluate_attribute(arg) for arg in node.args):
-            yield node
+    evaluate_auto(client, messages, AI_GUARD.INTEGRATION_OPENAI)
 
-
-def _constant_name(keyword):
-    """The AI_GUARD.<NAME> referenced by a keyword argument, or None if it is not one."""
-    value = keyword.value
-    if isinstance(value, ast.Attribute) and isinstance(value.value, ast.Name) and value.value.id == "AI_GUARD":
-        return value.attr
-    return None
+    assert client.calls == [
+        {
+            "messages": messages,
+            "options": {"block": aiguard_config._ai_guard_block},
+            "source": AI_GUARD.SOURCE_AUTO,
+            "integration": AI_GUARD.INTEGRATION_OPENAI,
+        }
+    ]
 
 
 @pytest.mark.parametrize("path", sorted(INTEGRATIONS_DIR.glob("*.py")), ids=lambda path: path.name)
-def test_auto_instrumentation_evaluate_calls_tag_the_call_path(path):
-    tree = ast.parse(path.read_text())
-    calls = list(_evaluate_calls(tree))
-    if not calls:
+def test_listeners_do_not_call_evaluate_directly(path):
+    if path.name in ALLOWED_DIRECT_CALLERS:
         return
 
-    assert path.name in EXPECTED_INTEGRATION, (
-        f"{path.name} calls evaluate() but has no expected integration tag; add it to "
-        "EXPECTED_INTEGRATION and to AI_GUARD.INTEGRATION_*"
-    )
-    expected_integration = EXPECTED_INTEGRATION[path.name]
-
-    for call in calls:
-        keywords = {keyword.arg: keyword for keyword in call.keywords if keyword.arg}
-        where = f"{path.name}:{call.lineno}"
-        assert "source" in keywords and "integration" in keywords, f"{where}: evaluate() call is untagged"
-        assert _constant_name(keywords["source"]) == "SOURCE_AUTO", f"{where}: source must be AI_GUARD.SOURCE_AUTO"
-        assert _constant_name(keywords["integration"]) == expected_integration, (
-            f"{where}: integration must be AI_GUARD.{expected_integration}"
-        )
-
-
-def test_expected_integrations_are_declared_constants():
-    for name in set(EXPECTED_INTEGRATION.values()):
-        assert name in AI_GUARD
+    tree = ast.parse(path.read_text())
+    direct = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "evaluate"
+    ]
+    assert not direct, f"{path.name}:{direct} calls evaluate() directly; use evaluate_auto so the call path is tagged"

--- a/tests/aiguard/api/test_call_path_tags.py
+++ b/tests/aiguard/api/test_call_path_tags.py
@@ -12,6 +12,7 @@ import pathlib
 
 import pytest
 
+from ddtrace.aiguard._api_client import AIGuardClient
 from ddtrace.aiguard._common import evaluate_auto
 from ddtrace.aiguard._constants import AI_GUARD
 from ddtrace.internal.settings.aiguard import aiguard_config
@@ -46,6 +47,22 @@ def test_evaluate_auto_reports_the_package_as_the_call_path():
             "integration": AI_GUARD.INTEGRATION_OPENAI,
         }
     ]
+
+
+@pytest.mark.parametrize(
+    "source,integration,expected",
+    [
+        (AI_GUARD.SOURCE_AUTO, AI_GUARD.INTEGRATION_OPENAI, (AI_GUARD.SOURCE_AUTO, AI_GUARD.INTEGRATION_OPENAI)),
+        (AI_GUARD.SOURCE_SDK, AI_GUARD.INTEGRATION_OPENAI, (AI_GUARD.SOURCE_SDK, AI_GUARD.INTEGRATION_NONE)),
+        ("req-42", "openai", (AI_GUARD.SOURCE_SDK, AI_GUARD.INTEGRATION_NONE)),
+        (AI_GUARD.SOURCE_AUTO, "openaii", (AI_GUARD.SOURCE_AUTO, AI_GUARD.INTEGRATION_NONE)),
+    ],
+)
+def test_call_path_tags_clamped_to_declared_values(source, integration, expected):
+    assert AIGuardClient._call_path_tags(source, integration) == (
+        ("source", expected[0]),
+        ("integration", expected[1]),
+    )
 
 
 @pytest.mark.parametrize("path", sorted(INTEGRATIONS_DIR.glob("*.py")), ids=lambda path: path.name)

--- a/tests/aiguard/api/test_redaction.py
+++ b/tests/aiguard/api/test_redaction.py
@@ -296,7 +296,9 @@ def test_redaction_survives_message_truncation(
     assert struct_messages[-1]["content"] == "message 19 ssn <REDACTED>"
     assert struct_messages[0]["content"] == "message 4 ssn 123-45-6789"
     # Truncating twice must not be reported twice.
-    assert _metrics(add_count_metric, AI_GUARD.TRUNCATED_METRIC) == [(1, (("type", "messages"),))]
+    assert _metrics(add_count_metric, AI_GUARD.TRUNCATED_METRIC) == [
+        (1, (("type", "messages"), ("source", AI_GUARD.SOURCE_SDK), ("integration", AI_GUARD.INTEGRATION_NONE)))
+    ]
 
 
 @patch("ddtrace.aiguard._api_client.AIGuardClient._execute_request")

--- a/tests/aiguard/openai/test_openai.py
+++ b/tests/aiguard/openai/test_openai.py
@@ -10,6 +10,7 @@ import warnings
 import pytest
 
 from ddtrace.aiguard import AIGuardAbortError
+from ddtrace.aiguard._constants import AI_GUARD
 from ddtrace.aiguard._context import is_aiguard_context_active
 from ddtrace.aiguard._context import reset_aiguard_context_active
 from ddtrace.aiguard._context import set_aiguard_context_active
@@ -391,7 +392,7 @@ def test_before_hook_materializes_iterator_messages():
         def __init__(self):
             self.evaluated = None
 
-        def evaluate(self, messages, options):
+        def evaluate(self, messages, options, **kwargs):
             self.evaluated = list(messages)
             return None
 
@@ -426,6 +427,21 @@ def test_chat_sync_allow(mock_execute_request, openai_client):
     assert resp is not None
     # Before + after evaluations
     assert mock_execute_request.call_count == 2
+
+
+@patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
+@patch("ddtrace.aiguard._api_client.AIGuardClient._execute_request")
+def test_chat_sync_reports_auto_call_path_telemetry(mock_execute_request, telemetry_mock, openai_client):
+    """Auto-instrumented evaluations attribute their metrics to auto/openai (APPSEC-69866)."""
+    mock_execute_request.return_value = mock_evaluate_response("ALLOW")
+
+    openai_client.chat.completions.create(messages=_user_messages(), **CHAT_PARAMS)
+
+    request_metrics = [args[3] for args, _ in telemetry_mock.call_args_list if args[1] == AI_GUARD.REQUESTS_METRIC]
+    assert len(request_metrics) == 2  # before + after evaluations
+    for tags in request_metrics:
+        assert dict(tags)["source"] == AI_GUARD.SOURCE_AUTO
+        assert dict(tags)["integration"] == AI_GUARD.INTEGRATION_OPENAI
 
 
 @pytest.mark.parametrize("decision", ["DENY", "ABORT"], ids=["deny", "abort"])

--- a/tests/aiguard/openai/test_responses.py
+++ b/tests/aiguard/openai/test_responses.py
@@ -812,7 +812,7 @@ class _RecordingClient:
     def __init__(self):
         self.calls: list = []
 
-    def evaluate(self, messages, options):
+    def evaluate(self, messages, options, **kwargs):
         self.calls.append(list(messages))
         return None
 


### PR DESCRIPTION
## Description

Implements [APPSEC-69866](https://datadoghq.atlassian.net/browse/APPSEC-69866).

Every AI Guard telemetry metric now carries the two tags the [telemetry metrics spec](https://datadoghq.atlassian.net/wiki/spaces/AIGuard/pages/6600426215) requires:

- `source` — `sdk` when the customer called `evaluate()` directly, `auto` when our auto-instrumentation of an AI package triggered the evaluation.
- `integration` — the AI package name (`openai`, `anthropic`, `langchain`, `litellm`, `strands`), or `none` when `source` is `sdk`.

Without them, SDK versus auto-instrumentation adoption cannot be monitored independently, and when auto-instrumentation triggers an evaluation we cannot tell which AI library caused it.

### Propagation mechanism

Two optional keyword arguments on `AIGuardClient.evaluate()`, defaulting to `sdk`/`none`. The clients are shared singletons, so keeping the attribution in the call signature keeps it local to the evaluation — no per-provider client view (the approach rejected in the first attempt), no per-call client copies, and the default keeps the public SDK contract unchanged for direct callers.

`_call_path_tags()` normalizes the pair in the client: `integration` is reported as `none` unless `source` is `auto`, so no caller can emit an inconsistent combination.

### Coverage

Tags are applied to `ai_guard.requests`, `ai_guard.truncated` (both the `messages` and `content` types) and `ai_guard.error`, on the success and the failure paths alike.

All 14 auto-instrumentation call sites report their own package. 13 of them go through `_common.evaluate_auto(client, messages, integration)`, which binds the one policy every provider listener shares — block per `DD_AI_GUARD_BLOCK`, `source=auto` — so a listener cannot forget a tag or pair `source` with the wrong package: OpenAI Chat Completions (2), OpenAI Responses (2), Anthropic (2), LangChain (3), Strands (4). LiteLLM (1) keeps an explicit call because it resolves `block` per request from its own dynamic guardrail params and dispatches through `asyncio.to_thread`.

`ai_guard.duration` is out of scope per the ticket — it is a distribution metric and the tracers have no ddsketch support yet.

New constants on `AI_GUARD`: `SOURCE_SDK`, `SOURCE_AUTO`, `INTEGRATION_NONE`, `INTEGRATION_OPENAI`, `INTEGRATION_ANTHROPIC`, `INTEGRATION_LANGCHAIN`, `INTEGRATION_LITELLM`, `INTEGRATION_STRANDS`.

## Testing

Both evaluation paths are covered, as the ticket asks.

**Direct SDK path** — `tests/aiguard/api/test_api_client.py`: the defaults (`sdk`/`none`), the `auto` path, `sdk` pinning `integration` to `none` even when a package is passed, and the tags on the `error` and `truncated` metrics. The shared `assert_telemetry` helper now appends the expected call-path tags, so every existing telemetry assertion in the suite checks them too.

**Auto-instrumentation paths** — `tests/aiguard/api/test_call_path_tags.py` (new) covers `evaluate_auto` directly (the options, `source` and `integration` that reach `evaluate`), plus a static guard that no module under `integrations/` calls `client.evaluate()` directly and slips out untagged — LiteLLM is the one allowlisted exception. The guard is static because that is the only way to cover LiteLLM and Strands from the `api` suite, which does not install those packages. One real end-to-end assertion in `tests/aiguard/openai/test_openai.py` proves the tags reach telemetry through an actual patched SDK call.

The fake `evaluate` implementations in the OpenAI/Anthropic suites gained `**kwargs`; one exact-tuple assertion in `test_redaction.py` was updated for the new trailing tags.

All six AI Guard suites pass locally on Python 3.12:

| Suite | Result |
|---|---|
| `aiguard::ai_guard_api` | 297 passed |
| `aiguard::ai_guard_openai` | 197 passed |
| `aiguard::ai_guard_anthropic` | 114 passed |
| `aiguard::ai_guard_langchain` | 58 passed, 5 skipped |
| `aiguard::ai_guard_strands` | 131 passed |
| `aiguard::ai_guard_litellm_guardrail` | 70 passed |

`scripts/lint style`, `typing`, `security`, `spelling` and `suitespec-check` are clean.

## Risks

Low. The new parameters are keyword arguments with defaults, so `evaluate(messages)` and `evaluate(messages, options)` behave exactly as before — no public API breakage. The only behavioral change is two extra tags on internal telemetry metrics. The tag values are a closed set of constants, so metric cardinality stays bounded.

Note for anyone building on this: the `requests` metric tag order is now `action, block, error, [redacted,] source, integration` — the call-path tags are appended last so the optional `redacted` tag keeps its position.

## Additional Notes

Second commit is a cleanup pass over the first: the tags initially landed as five identical lines repeated at every listener, so it extracts `evaluate_auto`, drops the imports and two unused default arguments that duplication had left behind, and trims the convention test. Net −68 lines, no behavior change — the suite counts above are from after that pass.

No release note: the tags feed Datadog's internal instrumentation telemetry and the new `evaluate()` arguments exist for our own listeners, so there is nothing for an upgrading customer to act on. Labelled `changelog/no-changelog`.

The equivalent dd-trace-js work is tracked separately under the same ticket; this PR keeps the tag names, values and the "integration is `none` when source is `sdk`" rule identical so the two tracers stay consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[APPSEC-69866]: https://datadoghq.atlassian.net/browse/APPSEC-69866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
