### PR TITLE
fix(asm): report the frame that raised in filesystem RASP tracebacks

### DIFF
--- a/ddtrace/appsec/_contrib/filesystem/patch.py
+++ b/ddtrace/appsec/_contrib/filesystem/patch.py
@@ -7,7 +7,6 @@ from typing import Union
 from ddtrace.appsec._asm_request_context import call_waf_callback
 from ddtrace.appsec._asm_request_context import get_blocked
 from ddtrace.appsec._constants import EXPLOIT_PREVENTION
-from ddtrace.appsec._patch_utils import _raise_without_wrapper_frame
 from ddtrace.appsec._patch_utils import try_unwrap
 from ddtrace.appsec._patch_utils import try_wrap_function_wrapper
 from ddtrace.appsec._rasp import _must_block
@@ -41,10 +40,7 @@ def wrapped_builtin_open(
             if filename:
                 handle_lfi(filename)
 
-    try:
-        return original(*args, **kwargs)
-    except Exception as exc:
-        raise _raise_without_wrapper_frame(exc)
+    return original(*args, **kwargs)
 
 
 def wrapped_path_open(
@@ -62,10 +58,7 @@ def wrapped_path_open(
             if filename:
                 handle_lfi(filename)
 
-    try:
-        return original(*args, **kwargs)
-    except Exception as exc:
-        raise _raise_without_wrapper_frame(exc)
+    return original(*args, **kwargs)
 
 
 def handle_lfi(filename: Union[str, bytes]) -> None:

--- a/ddtrace/appsec/_patch_utils.py
+++ b/ddtrace/appsec/_patch_utils.py
@@ -1,7 +1,6 @@
 import ctypes
 import os
 import sysconfig
-from types import TracebackType
 from typing import Any
 from typing import Callable
 from typing import Optional
@@ -79,17 +78,6 @@ def get_caller_frame_info() -> tuple[Optional[str], Optional[int], Optional[str]
 
 _DD_ORIGINAL_ATTRIBUTES: dict[Any, Any] = {}
 _MODULE_HOOKS: dict[tuple[str, str], list[Callable[[Any], None]]] = {}
-
-
-def _raise_without_wrapper_frame(exc: Exception) -> Exception:
-    """Prepare an exception so its caller can raise it without the wrapped-call frame."""
-    traceback = exc.__traceback__
-    if traceback is None:
-        return exc
-    previous_frame = traceback.tb_frame.f_back
-    if previous_frame is None:
-        return exc
-    return exc.with_traceback(TracebackType(None, previous_frame, previous_frame.f_lasti, previous_frame.f_lineno))
 
 
 def _module_name(module: Any) -> str:

--- a/releasenotes/notes/fix-asm-filesystem-rasp-traceback-8a19039f7563ae5f.yaml
+++ b/releasenotes/notes/fix-asm-filesystem-rasp-traceback-8a19039f7563ae5f.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    ASM: Fixes an issue where exceptions raised by ``open()`` or ``pathlib.Path.open()`` are
+    reported with a corrupted traceback when Exploit Prevention is enabled, showing a duplicated
+    caller frame and omitting the frame that actually raised.

--- a/tests/appsec/appsec/test_filesystem.py
+++ b/tests/appsec/appsec/test_filesystem.py
@@ -160,7 +160,7 @@ def test_lfi_normal_exception() -> None:
             with open("/unknown/do_not_exist_test.txt", "w"):
                 pass
         assert raised.type is FileNotFoundError
-        assert raised.traceback[-1].path.as_posix() == __file__
+        assert raised.traceback[0].path.as_posix() == __file__
         line_number = getframeinfo(currentframe()).lineno
         try:
             with open("/unknown/do_not_exist_test.txt", "w"):
@@ -169,9 +169,13 @@ def test_lfi_normal_exception() -> None:
             assert exc.__class__.__name__ == "FileNotFoundError"
             assert exc.__traceback__.tb_frame.f_code.co_filename == __file__
             assert traceback.format_exc(limit=1).startswith(exception_repr.format(__file__, line_number + 2))
-            assert "_raise_without_wrapper_frame" not in (
-                frame.name for frame in traceback.extract_tb(exc.__traceback__)
-            )
+            frames = traceback.extract_tb(exc.__traceback__)
+            # The caller must appear exactly once: the removed _raise_without_wrapper_frame used to
+            # append a synthetic duplicate of it on top of the wrapper frame.
+            assert [frame.filename for frame in frames].count(__file__) == 1
+            # builtins.open is a C function and leaves no frame, so the RASP wrapper is necessarily
+            # the innermost Python frame here. Removing it needs APPSEC-69877.
+            assert frames[-1].name == "wrapped_builtin_open"
     finally:
         cmp.unpatch_common_modules()
 
@@ -188,7 +192,7 @@ def test_lfi_normal_exception_pathlib() -> None:
             with Path("/unknown/do_not_exist_test.txt").open("w"):
                 pass
         assert raised.type is FileNotFoundError
-        assert raised.traceback[-1].path.as_posix() == __file__
+        assert raised.traceback[0].path.as_posix() == __file__
         line_number = getframeinfo(currentframe()).lineno
         try:
             with Path("/unknown/do_not_exist_test.txt").open("w"):
@@ -197,8 +201,13 @@ def test_lfi_normal_exception_pathlib() -> None:
             assert exc.__class__.__name__ == "FileNotFoundError"
             assert exc.__traceback__.tb_frame.f_code.co_filename == __file__
             assert traceback.format_exc(limit=1).startswith(exception_repr.format(__file__, line_number + 2))
-            assert "_raise_without_wrapper_frame" not in (
-                frame.name for frame in traceback.extract_tb(exc.__traceback__)
-            )
+            frames = traceback.extract_tb(exc.__traceback__)
+            # The caller must appear exactly once: the removed _raise_without_wrapper_frame used to
+            # append a synthetic duplicate of it on top of the wrapper frame.
+            assert [frame.filename for frame in frames].count(__file__) == 1
+            # Path.open is pure Python, so the frame that actually raised is now reported again.
+            # _raise_without_wrapper_frame used to discard it.
+            assert frames[-1].name == "open"
+            assert frames[-1].filename != __file__
     finally:
         cmp.unpatch_common_modules()

--- a/tests/appsec/appsec/test_filesystem.py
+++ b/tests/appsec/appsec/test_filesystem.py
@@ -205,9 +205,9 @@ def test_lfi_normal_exception_pathlib() -> None:
             # The caller must appear exactly once: the removed _raise_without_wrapper_frame used to
             # append a synthetic duplicate of it on top of the wrapper frame.
             assert [frame.filename for frame in frames].count(__file__) == 1
-            # Path.open is pure Python, so the frame that actually raised is now reported again.
-            # _raise_without_wrapper_frame used to discard it.
-            assert frames[-1].name == "open"
-            assert frames[-1].filename != __file__
+            # Path.open is pure Python, so the frames below our wrapper are reported again; the
+            # removed helper discarded them, leaving wrapped_path_open last.
+            assert [frame.name for frame in frames].index("wrapped_path_open") < len(frames) - 1
+            assert "pathlib" in frames[-1].filename
     finally:
         cmp.unpatch_common_modules()


### PR DESCRIPTION
## Description

`_raise_without_wrapper_frame` (`ddtrace/appsec/_patch_utils.py`) is intended to "prepare an
exception so its caller can raise it without the wrapped-call frame". In practice it does not have
that effect, and the traceback the customer sees ends up less accurate than a plain re-raise.

Measured with a minimal wrapper / customer / original call chain:

```
plain re-raise (no helper)      ['<module>', 'customer', 'wrapper', 'original']
_raise_without_wrapper_frame    ['<module>', 'customer', 'wrapper', 'customer']
```

Three things to note:

1. The wrapper frame it aims to remove is still present.
2. An extra copy of the caller frame is appended.
3. The frame that actually raised (`original`) is no longer reported.

The approach cannot really work: `raise` appends the raising frame as the exception propagates out
of the frame, so the wrapper frame reappears and the synthetic caller entry remains as a duplicate.
A pure-Python wrapper frame cannot be removed from a traceback by re-raising.

For `pathlib.Path.open` this is visible: the frame that raises is `open` in `pathlib.py`, and today
it does not reach the customer.

This PR removes the helper and re-raises plainly from both filesystem LFI hooks.

Jira: https://datadoghq.atlassian.net/browse/APPSEC-69951
Related: https://datadoghq.atlassian.net/browse/APPSEC-69877

🤖 Generated with [Claude Code](https://claude.com/claude-code)
