### PR TITLE
chore(internal): add a new forksafe type: RLock

### DIFF
--- a/ddtrace/internal/README.md
+++ b/ddtrace/internal/README.md
@@ -270,6 +270,32 @@ forksafe.register(my_after_child_hook)  # after_in_child
 forksafe.register_after_parent(my_after_parent_hook)
 ```
 
+#### Fork-safe synchronization primitives
+
+`forksafe` also provides drop-in replacements for process-local synchronization
+objects that must not inherit lock state across `fork()`:
+
+| Factory | Returns |
+|---------|---------|
+| `forksafe.Lock()` | Fork-safe `threading.Lock` |
+| `forksafe.RLock()` | Fork-safe `threading.RLock` |
+| `forksafe.Event()` | Fork-safe `threading.Event` |
+
+Each factory returns a `ResetObject` wrapper around a fresh instance of the
+underlying type. After `fork()`, registered hooks replace the wrapped object with
+a new, unlocked (or unset, for events) instance in the child process.
+
+`ResetObject` instances are not picklable as-is — the underlying `_thread.lock`
+primitive cannot cross process boundaries. `__reduce__` reconstructs a fresh
+`ResetObject` instead, so `pickle` and `cloudpickle` round-trips yield an
+unlocked lock or unset event in the destination process.
+
+`ResetObject` defines the lock protocol methods (`acquire`, `release`, `locked`,
+and for `RLock`: `_release_save`, `_acquire_restore`, `_is_owned`) on the
+proxy itself. This is required because `threading.Condition` caches bound methods
+from its lock at construction time; without proxy-level delegation, a Condition
+would keep using the pre-fork inner lock after reset.
+
 **Keep hooks non-blocking.** By the time a hook registered *after*
 `ddtrace.internal.threads._before_fork` runs, all periodic threads have already
 been stopped, so there are no locks held by those threads to worry about. (Hooks

--- a/ddtrace/internal/forksafe.py
+++ b/ddtrace/internal/forksafe.py
@@ -172,5 +172,9 @@ def Lock() -> _unpatched.threading_Lock:
     return ResetObject(_unpatched.threading_Lock)
 
 
+def RLock() -> _unpatched.threading_RLock:
+    return ResetObject(_unpatched.threading_RLock)
+
+
 def Event() -> _unpatched.threading_Event:
     return ResetObject(_unpatched.threading_Event)

--- a/ddtrace/internal/forksafe.py
+++ b/ddtrace/internal/forksafe.py
@@ -120,6 +120,22 @@ if hasattr(os, "register_at_fork"):
 _T = typing.TypeVar("_T")
 
 
+class _LockProtocol(typing.Protocol):
+    def acquire(self, blocking: bool = ..., timeout: float = ...) -> bool: ...
+
+    def release(self) -> None: ...
+
+    def locked(self) -> bool: ...
+
+
+class _RLockProtocol(_LockProtocol, typing.Protocol):
+    def _release_save(self) -> int: ...
+
+    def _acquire_restore(self, state: int) -> None: ...
+
+    def _is_owned(self) -> bool: ...
+
+
 class ResetObject(wrapt.ObjectProxy, typing.Generic[_T]):
     """An object wrapper object that is fork-safe and resets itself after a fork.
 
@@ -127,6 +143,9 @@ class ResetObject(wrapt.ObjectProxy, typing.Generic[_T]):
     are gone, Lock objects needs to be reset. CPython does this with an internal `threading._after_fork` function. We
     use the same mechanism here.
 
+    ``threading.Condition`` caches bound methods from its lock at construction time,
+    so lock protocol methods are defined on the proxy rather than delegated through
+    ``ObjectProxy`` to the wrapped object.
     """
 
     def __init__(
@@ -140,6 +159,18 @@ class ResetObject(wrapt.ObjectProxy, typing.Generic[_T]):
     def _reset_object(self) -> None:
         self.__wrapped__ = self._self_wrapped_class()
 
+    def acquire(self, blocking: bool = True, timeout: float = -1) -> bool:
+        lock: _LockProtocol = typing.cast(_LockProtocol, self.__wrapped__)
+        return lock.acquire(blocking, timeout)
+
+    def release(self) -> None:
+        lock: _LockProtocol = typing.cast(_LockProtocol, self.__wrapped__)
+        lock.release()
+
+    def locked(self) -> bool:
+        lock: _LockProtocol = typing.cast(_LockProtocol, self.__wrapped__)
+        return lock.locked()
+
     def __reduce__(self) -> "typing.Tuple[type, typing.Tuple[type[_T]]]":  # noqa: UP006
         # A lock/event is process-local, and so it cannot be carried across a process
         # boundary (e.g. by cloudpickle in Ray Serve).
@@ -151,6 +182,30 @@ class ResetObject(wrapt.ObjectProxy, typing.Generic[_T]):
     # wrapt's ObjectProxy routes __reduce_ex__ to the wrapped object, which is
     # unpicklable for locks; override it so the picklers use __reduce__ above.
     def __reduce_ex__(self, protocol: "typing.SupportsIndex") -> "typing.Tuple[type, typing.Tuple[type[_T]]]":  # noqa: UP006
+        return self.__reduce__()
+
+
+class ResetRLock(ResetObject[_unpatched.threading_RLock]):
+    """``ResetObject`` for reentrant locks, including the RLock protocol used by ``threading.Condition``."""
+
+    def _release_save(self) -> int:
+        lock: _RLockProtocol = typing.cast(_RLockProtocol, self.__wrapped__)
+        return lock._release_save()
+
+    def _acquire_restore(self, state: int) -> None:
+        lock: _RLockProtocol = typing.cast(_RLockProtocol, self.__wrapped__)
+        lock._acquire_restore(state)
+
+    def _is_owned(self) -> bool:
+        lock: _RLockProtocol = typing.cast(_RLockProtocol, self.__wrapped__)
+        return lock._is_owned()
+
+    def __reduce__(self) -> "typing.Tuple[type, typing.Tuple[type[_unpatched.threading_RLock]]]":  # noqa: UP006
+        return (ResetRLock, (self._self_wrapped_class,))
+
+    def __reduce_ex__(
+        self, protocol: "typing.SupportsIndex"
+    ) -> "typing.Tuple[type, typing.Tuple[type[_unpatched.threading_RLock]]]":  # noqa: UP006
         return self.__reduce__()
 
 
@@ -173,7 +228,7 @@ def Lock() -> _unpatched.threading_Lock:
 
 
 def RLock() -> _unpatched.threading_RLock:
-    return ResetObject(_unpatched.threading_RLock)
+    return ResetRLock(_unpatched.threading_RLock)
 
 
 def Event() -> _unpatched.threading_Event:

--- a/tests/internal/test_forksafe.py
+++ b/tests/internal/test_forksafe.py
@@ -282,6 +282,78 @@ def test_rlock_fork() -> None:
 
 
 @pytest.mark.subprocess
+def test_condition_rlock_fork() -> None:
+    """Check that threading.Condition with a forksafe.RLock resets after fork().
+
+    Parent holds the lock reentrantly via the Condition. After fork the child
+    must acquire through the Condition; a regular threading.RLock would stay held.
+    """
+    import os
+    import threading
+
+    from ddtrace.internal import forksafe
+
+    lock: threading.RLock = forksafe.RLock()
+    condition: threading.Condition = threading.Condition(lock)
+    assert condition.acquire(blocking=False) is True
+    assert condition.acquire(blocking=False) is True
+
+    pid: int = os.fork()
+
+    if pid == 0:
+        # child: ResetObject replaced the held lock
+        assert condition.acquire(blocking=False) is True
+        condition.release()
+        os._exit(12)
+
+    # parent still owns it (reentrant)
+    assert condition.acquire(blocking=False) is True
+    condition.release()
+    condition.release()
+    condition.release()
+
+    _: int
+    status: int
+    _, status = os.waitpid(pid, 0)
+    exit_code: int = os.WEXITSTATUS(status)
+    assert exit_code == 12
+
+
+@pytest.mark.subprocess
+def test_condition_lock_fork() -> None:
+    """Check that threading.Condition with a forksafe.Lock resets after fork().
+
+    Parent holds the lock via the Condition. After fork the child must acquire
+    through the Condition; a regular threading.Lock would stay held.
+    """
+    import os
+    import threading
+
+    from ddtrace.internal import forksafe
+
+    lock: threading.Lock = forksafe.Lock()
+    condition: threading.Condition = threading.Condition(lock)
+    assert condition.acquire(blocking=False) is True
+
+    pid: int = os.fork()
+
+    if pid == 0:
+        # child: ResetObject replaced the held lock
+        assert condition.acquire(blocking=False) is True
+        condition.release()
+        os._exit(12)
+
+    # parent still owns it (non-reentrant)
+    condition.release()
+
+    _: int
+    status: int
+    _, status = os.waitpid(pid, 0)
+    exit_code: int = os.WEXITSTATUS(status)
+    assert exit_code == 12
+
+
+@pytest.mark.subprocess
 def test_double_fork():
     import os
 

--- a/tests/internal/test_forksafe.py
+++ b/tests/internal/test_forksafe.py
@@ -233,6 +233,51 @@ def test_event_fork():
     assert exit_code == 12
 
 
+def test_rlock_reentry() -> None:
+    """A forksafe.RLock can be acquired twice on the same thread."""
+    lock: threading.RLock = forksafe.RLock()
+    acquired_first: bool = lock.acquire(blocking=False)
+    acquired_second: bool = lock.acquire(blocking=False)
+    assert acquired_first is True
+    assert acquired_second is True
+    lock.release()
+    lock.release()
+
+
+@pytest.mark.subprocess
+def test_rlock_fork() -> None:
+    """Check that a forksafe.RLock is reset after a fork().
+
+    Parent holds the lock reentrantly. After fork the child gets a
+    fresh unlocked RLock; a regular threading.RLock would stay held.
+    """
+    import os
+
+    from ddtrace.internal import forksafe
+
+    lock = forksafe.RLock()
+    assert lock.acquire(blocking=False) is True
+    assert lock.acquire(blocking=False) is True
+
+    pid = os.fork()
+
+    if pid == 0:
+        # child: ResetObject replaced the held lock
+        assert lock.acquire(blocking=False) is True
+        lock.release()
+        os._exit(12)
+
+    # parent still owns it (reentrant)
+    assert lock.acquire(blocking=False) is True
+    lock.release()
+    lock.release()
+    lock.release()
+
+    _, status = os.waitpid(pid, 0)
+    exit_code = os.WEXITSTATUS(status)
+    assert exit_code == 12
+
+
 @pytest.mark.subprocess
 def test_double_fork():
     import os
@@ -371,6 +416,21 @@ def test_lock_pickle_roundtrip(serializer: ModuleType) -> None:
 
     data: bytes = serializer.dumps(lock)
     restored: threading.Lock = serializer.loads(data)
+
+    assert isinstance(restored, forksafe.ResetObject)
+    assert restored.acquire(blocking=False) is True
+    restored.release()
+    assert restored in forksafe._resetable_objects
+
+
+@pytest.mark.parametrize("serializer", [pickle, cloudpickle], ids=["pickle", "cloudpickle"])
+def test_rlock_pickle_roundtrip(serializer: ModuleType) -> None:
+    """A forksafe.RLock must survive (cloud)pickle as a fresh, unlocked RLock."""
+    lock: threading.RLock = forksafe.RLock()
+    lock.acquire()
+
+    data: bytes = serializer.dumps(lock)
+    restored: threading.RLock = serializer.loads(data)
 
     assert isinstance(restored, forksafe.ResetObject)
     assert restored.acquire(blocking=False) is True

--- a/tests/internal/test_forksafe.py
+++ b/tests/internal/test_forksafe.py
@@ -252,14 +252,15 @@ def test_rlock_fork() -> None:
     fresh unlocked RLock; a regular threading.RLock would stay held.
     """
     import os
+    import threading
 
     from ddtrace.internal import forksafe
 
-    lock = forksafe.RLock()
+    lock: threading.RLock = forksafe.RLock()
     assert lock.acquire(blocking=False) is True
     assert lock.acquire(blocking=False) is True
 
-    pid = os.fork()
+    pid: int = os.fork()
 
     if pid == 0:
         # child: ResetObject replaced the held lock
@@ -273,8 +274,10 @@ def test_rlock_fork() -> None:
     lock.release()
     lock.release()
 
+    _: int
+    status: int
     _, status = os.waitpid(pid, 0)
-    exit_code = os.WEXITSTATUS(status)
+    exit_code: int = os.WEXITSTATUS(status)
     assert exit_code == 12
 
 


### PR DESCRIPTION
## Description

I needed a new RLock safe type for https://github.com/DataDog/dd-trace-py/pull/19937/, so this PR adds it for general use.

## Testing

* unit tests