### PR TITLE
ci(benchmarks): bump codeprovenancefork-fork-10 SLO

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -863,7 +863,7 @@ experiments:
           # codeprovenancefork
           - name: codeprovenancefork-fork-10
             thresholds:
-              - execution_time < 2400 ms
+              - execution_time < 2500 ms
 
           # forktime
           - name: forktime-baseline


### PR DESCRIPTION
Bump from 2.400s to 2.500s