### PR TITLE
feat(profiling): default MEM-domain heap hook on (PROF-15886)

### DIFF
--- a/ddtrace/internal/settings/profiling.py
+++ b/ddtrace/internal/settings/profiling.py
@@ -537,14 +537,13 @@ class ProfilingConfigMemory(DDConfig):
     mem_domain_enabled = DDConfig.v(
         bool,
         "mem_domain_enabled",
-        default=False,
+        default=True,
         help_type="Boolean",
         help=(
             "Hook PyMem_Malloc/Calloc/Realloc in the heap profiler to capture C-level "
             "Python allocations (list internal buffers, array.array data) in addition "
-            "to PyObject_Malloc allocations. Requires Python 3.12 or later. Disabled "
-            "by default for incremental rollout; will be enabled by default once the "
-            "feature is GA."
+            "to PyObject_Malloc allocations. Requires Python 3.12 or later. Enabled "
+            "by default; set DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED=false to disable."
         ),
     )
 

--- a/ddtrace/internal/settings/profiling.py
+++ b/ddtrace/internal/settings/profiling.py
@@ -540,7 +540,7 @@ class ProfilingConfigMemory(DDConfig):
         default=True,
         help_type="Boolean",
         help=(
-            "Profile PyMem_Malloc/Calloc/Realloc events (allocations in the MEM-domain). "
+            "Profile PyMem_Malloc/Calloc/Realloc events (allocations in the Mem domain). "
             "Requires Python 3.12 or later. Enabled by default."
         ),
     )

--- a/ddtrace/internal/settings/profiling.py
+++ b/ddtrace/internal/settings/profiling.py
@@ -540,10 +540,8 @@ class ProfilingConfigMemory(DDConfig):
         default=True,
         help_type="Boolean",
         help=(
-            "Hook PyMem_Malloc/Calloc/Realloc in the heap profiler to capture C-level "
-            "Python allocations (list internal buffers, array.array data) in addition "
-            "to PyObject_Malloc allocations. Requires Python 3.12 or later. Enabled "
-            "by default; set DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED=false to disable."
+            "Profile PyMem_Malloc/Calloc/Realloc events (allocations in the MEM-domain). "
+            "Requires Python 3.12 or later. Enabled by default."
         ),
     )
 

--- a/ddtrace/profiling/collector/_memalloc.cpp
+++ b/ddtrace/profiling/collector/_memalloc.cpp
@@ -271,12 +271,12 @@ PyDoc_STRVAR(memalloc_start__doc__,
              "If heap_sample_interval is set to 0, it is disabled entirely.\n"
              "If mem_domain_enabled is true and the Python version supports it\n"
              "(>= 3.12), MEM-domain allocations (PyMem_Malloc/Calloc/Realloc)\n"
-             "are tracked in addition to OBJ-domain allocations. This is off\n"
-             "by default because MEM-domain interposition adds per-allocation\n"
-             "overhead on hot paths (list/dict resize, buffer growth) and can\n"
-             "extend the time threads hold Python locks that allocate inside\n"
-             "critical sections. Enable it when you need visibility into\n"
-             "PyMem_*-only allocations that the OBJ hook does not capture.\n");
+             "are tracked in addition to OBJ-domain allocations. This is on\n"
+             "by default. Set DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED=false to\n"
+             "disable. MEM-domain interposition adds per-allocation overhead\n"
+             "on hot paths (list/dict resize, buffer growth) and can extend\n"
+             "the time threads hold Python locks that allocate inside\n"
+             "critical sections.\n");
 static PyObject*
 memalloc_start(PyObject* Py_UNUSED(module), PyObject* args)
 {

--- a/ddtrace/profiling/collector/_memalloc.cpp
+++ b/ddtrace/profiling/collector/_memalloc.cpp
@@ -269,14 +269,9 @@ PyDoc_STRVAR(memalloc_start__doc__,
              "Sets the average number of bytes allocated between samples to\n"
              "heap_sample_interval.\n"
              "If heap_sample_interval is set to 0, it is disabled entirely.\n"
-             "If mem_domain_enabled is true and the Python version supports it\n"
-             "(>= 3.12), MEM-domain allocations (PyMem_Malloc/Calloc/Realloc)\n"
-             "are tracked in addition to OBJ-domain allocations. This is on\n"
-             "by default. Set DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED=false to\n"
-             "disable. MEM-domain interposition adds per-allocation overhead\n"
-             "on hot paths (list/dict resize, buffer growth) and can extend\n"
-             "the time threads hold Python locks that allocate inside\n"
-             "critical sections.\n");
+            
+            "Enables profiling of PyMem_Malloc/Calloc/Realloc events (allocations in the MEM-domain).\n"
+            "Requires Python 3.12 or later.\n"
 static PyObject*
 memalloc_start(PyObject* Py_UNUSED(module), PyObject* args)
 {

--- a/ddtrace/profiling/collector/_memalloc.cpp
+++ b/ddtrace/profiling/collector/_memalloc.cpp
@@ -269,9 +269,8 @@ PyDoc_STRVAR(memalloc_start__doc__,
              "Sets the average number of bytes allocated between samples to\n"
              "heap_sample_interval.\n"
              "If heap_sample_interval is set to 0, it is disabled entirely.\n"
-            
-            "Enables profiling of PyMem_Malloc/Calloc/Realloc events (allocations in the MEM-domain).\n"
-            "Requires Python 3.12 or later.\n"
+             "Enables profiling of PyMem_Malloc/Calloc/Realloc events (allocations in the MEM-domain).\n"
+             "Requires Python 3.12 or later.\n");
 static PyObject*
 memalloc_start(PyObject* Py_UNUSED(module), PyObject* args)
 {

--- a/ddtrace/profiling/collector/_memalloc.cpp
+++ b/ddtrace/profiling/collector/_memalloc.cpp
@@ -269,7 +269,7 @@ PyDoc_STRVAR(memalloc_start__doc__,
              "Sets the average number of bytes allocated between samples to\n"
              "heap_sample_interval.\n"
              "If heap_sample_interval is set to 0, it is disabled entirely.\n"
-             "Enables profiling of PyMem_Malloc/Calloc/Realloc events (allocations in the MEM-domain).\n"
+             "Enables profiling of PyMem_Malloc/Calloc/Realloc events (allocations in the Mem domain).\n"
              "Requires Python 3.12 or later.\n");
 static PyObject*
 memalloc_start(PyObject* Py_UNUSED(module), PyObject* args)

--- a/releasenotes/notes/profiling-mem-domain-default-on-7c2a9e1b4d8f6013.yaml
+++ b/releasenotes/notes/profiling-mem-domain-default-on-7c2a9e1b4d8f6013.yaml
@@ -2,5 +2,4 @@
 features:
   - |
     profiling: ``DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED`` now defaults to
-    ``true``, so the heap profiler also tracks ``PyMem_Malloc`` /
-    ``Calloc`` / ``Realloc`` allocations in MEM-domain on Python 3.12+.
+    ``true``, so the heap profiler also tracks allocations in the Mem domain on Python 3.12+.

--- a/releasenotes/notes/profiling-mem-domain-default-on-7c2a9e1b4d8f6013.yaml
+++ b/releasenotes/notes/profiling-mem-domain-default-on-7c2a9e1b4d8f6013.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    profiling: ``DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED`` now defaults to
+    ``true``, so the heap profiler also tracks ``PyMem_Malloc`` /
+    ``Calloc`` / ``Realloc`` allocations on Python 3.12+. Set it to
+    ``false`` to opt out.

--- a/releasenotes/notes/profiling-mem-domain-default-on-7c2a9e1b4d8f6013.yaml
+++ b/releasenotes/notes/profiling-mem-domain-default-on-7c2a9e1b4d8f6013.yaml
@@ -3,5 +3,4 @@ features:
   - |
     profiling: ``DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED`` now defaults to
     ``true``, so the heap profiler also tracks ``PyMem_Malloc`` /
-    ``Calloc`` / ``Realloc`` allocations on Python 3.12+. Set it to
-    ``false`` to opt out.
+    ``Calloc`` / ``Realloc`` allocations in MEM-domain on Python 3.12+.

--- a/supported-configurations.json
+++ b/supported-configurations.json
@@ -2957,7 +2957,7 @@
       {
         "implementation": "A",
         "type": "boolean",
-        "default": "false"
+        "default": "true"
       }
     ],
     "DD_PROFILING_NAME_INSPECT_DIR": [

--- a/supported-configurations.json
+++ b/supported-configurations.json
@@ -2955,7 +2955,7 @@
     ],
     "DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED": [
       {
-        "implementation": "A",
+        "implementation": "B",
         "type": "boolean",
         "default": "true"
       }

--- a/tests/profiling/test_profiling_config.py
+++ b/tests/profiling/test_profiling_config.py
@@ -269,6 +269,20 @@ class TestEmbeddedInterpreterFastCopy:
         assert _is_python_embedded() is True
 
 
+class TestMemDomainConfig:
+    """Config plumbing for PYMEM_DOMAIN_MEM heap-profiler hooks."""
+
+    def test_default_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED", raising=False)
+        config: ProfilingConfig = ProfilingConfig()
+        assert config.memory.mem_domain_enabled is True
+
+    def test_disabled_via_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED", "false")
+        config: ProfilingConfig = ProfilingConfig()
+        assert config.memory.mem_domain_enabled is False
+
+
 class TestNativeHeapConfig:
     """Config plumbing for experimental native (C/C++) heap profiling.
 


### PR DESCRIPTION
## Description

PROF-15886


This PR turns the memory-profiler hook on by default on Python 3.12 and later. The hook has shipped since 4.11; the only change here is the default, so new processes get the extra heap coverage without setting anything. Numbers are in the two tables under Testing, AB experiments: a same-build staging run on ai_gateway, and two production services that already had the hook on through Monday's app deploys.

## Testing

`tests/profiling/test_profiling_config.py` pins the flag true when the env var is unset and false when it is `false`.

### AB experiments

**Clean same-build AB (dd-source)**

_no crashes or noticeable perf regressions_
| Service | When | CPU | Memory | Traffic | Notes |
| --- | --- | --- | --- | --- | --- |
| ai_gateway (staging), `5dc0569` | Tue Sep 1 1:28–2:28 PM EDT | 59.4 vs 60.8 (+2.2%) | 822 vs 819 MiB (−0.4%) | HTTP 85555 vs 85512 / 0 err | Same build, hook off vs on |

**Already on in prod (dogweb)**

_no crashes or noticeable perf regressions_
| Service | When | CPU | Memory | Traffic | Notes |
| --- | --- | --- | --- | --- | --- |
| log_anomaly_processing `#3428` `441931aa` | Mon Aug 31 2:37–9:55 PM vs 7:19 AM–2:37 PM EDT | 1.07 vs 1.16 (new app) | 710 vs 712 MiB | kafka +0.5% | Hook already on |
| ds-metrics-workers (ap2, us1) `#3415` | Mon Aug 31 3:36–10:00 PM vs 9:12 AM–3:36 PM EDT | 8.01 vs 8.18 (new app) | 1452 vs 1431 MiB | grpc +0.8% | Hook already on |

## Risks

* Perf regressions; easily mitigated with setting `DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED=false`.

## Additional Notes

Add implementation B (`boolean`, default `true`) for `DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED` at https://feature-parity.us1.prod.dog/#/configurations?viewType=configurations so the Feature Parity job can pass.

## Pre-review checklist

- [x] The changes have been tested in real services in staging
- [x] The PR does not result in new crashes

