### PR TITLE
test(profiling): comment the unset-env mem_domain default pin

### DIFF
--- a/ddtrace/internal/settings/profiling.py
+++ b/ddtrace/internal/settings/profiling.py
@@ -537,14 +537,13 @@ class ProfilingConfigMemory(DDConfig):
     mem_domain_enabled = DDConfig.v(
         bool,
         "mem_domain_enabled",
-        default=False,
+        default=True,
         help_type="Boolean",
         help=(
             "Hook PyMem_Malloc/Calloc/Realloc in the heap profiler to capture C-level "
             "Python allocations (list internal buffers, array.array data) in addition "
-            "to PyObject_Malloc allocations. Requires Python 3.12 or later. Disabled "
-            "by default for incremental rollout; will be enabled by default once the "
-            "feature is GA."
+            "to PyObject_Malloc allocations. Requires Python 3.12 or later. Enabled "
+            "by default; set DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED=false to disable."
         ),
     )
 

--- a/ddtrace/profiling/collector/_memalloc.cpp
+++ b/ddtrace/profiling/collector/_memalloc.cpp
@@ -271,12 +271,12 @@ PyDoc_STRVAR(memalloc_start__doc__,
              "If heap_sample_interval is set to 0, it is disabled entirely.\n"
              "If mem_domain_enabled is true and the Python version supports it\n"
              "(>= 3.12), MEM-domain allocations (PyMem_Malloc/Calloc/Realloc)\n"
-             "are tracked in addition to OBJ-domain allocations. This is off\n"
-             "by default because MEM-domain interposition adds per-allocation\n"
-             "overhead on hot paths (list/dict resize, buffer growth) and can\n"
-             "extend the time threads hold Python locks that allocate inside\n"
-             "critical sections. Enable it when you need visibility into\n"
-             "PyMem_*-only allocations that the OBJ hook does not capture.\n");
+             "are tracked in addition to OBJ-domain allocations. This is on\n"
+             "by default. Set DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED=false to\n"
+             "disable. MEM-domain interposition adds per-allocation overhead\n"
+             "on hot paths (list/dict resize, buffer growth) and can extend\n"
+             "the time threads hold Python locks that allocate inside\n"
+             "critical sections.\n");
 static PyObject*
 memalloc_start(PyObject* Py_UNUSED(module), PyObject* args)
 {

--- a/releasenotes/notes/profiling-mem-domain-default-on-7c2a9e1b4d8f6013.yaml
+++ b/releasenotes/notes/profiling-mem-domain-default-on-7c2a9e1b4d8f6013.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    profiling: ``DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED`` now defaults to
+    ``true``, so the heap profiler also tracks ``PyMem_Malloc`` /
+    ``Calloc`` / ``Realloc`` allocations on Python 3.12+. Set it to
+    ``false`` to opt out.

--- a/supported-configurations.json
+++ b/supported-configurations.json
@@ -2957,7 +2957,7 @@
       {
         "implementation": "A",
         "type": "boolean",
-        "default": "false"
+        "default": "true"
       }
     ],
     "DD_PROFILING_NAME_INSPECT_DIR": [

--- a/tests/profiling/test_profiling_config.py
+++ b/tests/profiling/test_profiling_config.py
@@ -273,6 +273,7 @@ class TestMemDomainConfig:
     """Config plumbing for PYMEM_DOMAIN_MEM heap-profiler hooks."""
 
     def test_default_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Unset env already pins True on the base; this asserts that pin only.
         monkeypatch.delenv("DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED", raising=False)
         config: ProfilingConfig = ProfilingConfig()
         assert config.memory.mem_domain_enabled is True

--- a/tests/profiling/test_profiling_config.py
+++ b/tests/profiling/test_profiling_config.py
@@ -269,6 +269,20 @@ class TestEmbeddedInterpreterFastCopy:
         assert _is_python_embedded() is True
 
 
+class TestMemDomainConfig:
+    """Config plumbing for PYMEM_DOMAIN_MEM heap-profiler hooks."""
+
+    def test_default_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED", raising=False)
+        config: ProfilingConfig = ProfilingConfig()
+        assert config.memory.mem_domain_enabled is True
+
+    def test_disabled_via_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED", "false")
+        config: ProfilingConfig = ProfilingConfig()
+        assert config.memory.mem_domain_enabled is False
+
+
 class TestNativeHeapConfig:
     """Config plumbing for experimental native (C/C++) heap profiling.
 


### PR DESCRIPTION
## Description

One comment on `TestMemDomainConfig.test_default_enabled` so the unset-env pin already owned by #19999 is explicit. No config, hook, or default change.

| Layer | Meaning | Which PR in the stack? |
| --- | --- | --- |
| Compiled into artifact | MEM-domain heap hook | #19999 |
| Armed at runtime | `DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED` default True | #19999 |
| Observable in product/Python | comment on the existing pin | this PR |

## Testing

<!-- How has the PR been validated? -->

## Risks

<!-- What could go wrong with this PR? -->

## Additional Notes

Stacked on #19999. No customer reno: default-on already noted there. `changelog/no-changelog`.

A: default-on · E: comment on existing pin

## Pre-review checklist

- [ ] The changes have been tested in real services in staging
- [ ] The PR does not result in new crashes
