### PR TITLE
fix(profiling): fall back when PY_UNWIND is not a valid local event

### DIFF
--- a/ddtrace/internal/monitoring.py
+++ b/ddtrace/internal/monitoring.py
@@ -34,8 +34,14 @@ _E = sys.monitoring.events
 _DISABLE = sys.monitoring.DISABLE
 
 # On Python 3.15+, PY_UNWIND is a per-code "other" event and can be enabled via
-# set_local_events alongside PY_START/PY_RETURN/LINE.
+# set_local_events alongside PY_START/PY_RETURN/LINE. Pre-rc1 3.15 builds reject
+# it as a local event (ValueError: invalid local event set); we then enable it
+# globally via set_events and keep the other events local.
 _LOCAL_EVENTS = _E.PY_START | _E.PY_RETURN | _E.LINE | _E.PY_UNWIND
+
+# None = not yet probed; True = local PY_UNWIND accepted; False = use set_events.
+_py_unwind_local: Optional[bool] = None
+_active_global_events: int = 0
 
 _MULTIPLEXER_TOOL_NAME = "ddtrace"
 # sys.monitoring exposes six tool IDs (0–5). 0/1/2/5 are conventionally reserved
@@ -107,6 +113,14 @@ class _IdentityWeakKeyDictionary:
             raise
         del self[key]
         return value
+
+    def values(self) -> list[Any]:
+        result: list[Any] = []
+        for ref, value in self._data.values():
+            obj: Any = ref()
+            if obj is not None:
+                result.append(value)
+        return result
 
 
 _registry: _IdentityWeakKeyDictionary = _IdentityWeakKeyDictionary()
@@ -264,6 +278,10 @@ def _on_py_return(code: CodeType, instruction_offset: int, retval: object) -> Op
 def _on_py_unwind(code: CodeType, instruction_offset: int, exception: BaseException) -> Optional[object]:
     handlers: Optional[_CodeHandlers] = _registry.get(code)
     if not handlers or not handlers.snapshot:
+        # Global PY_UNWIND fires for every unwinding frame. DISABLE would stick
+        # for this code object, and register() does not call restart_events().
+        if _py_unwind_local is False:
+            return None
         return _DISABLE
     # Deliberately uncaught: see the propagation warning on MonitoringEventHandler.
     for e in handlers.snapshot:
@@ -294,7 +312,35 @@ def _on_py_line(code: CodeType, line_number: int) -> Optional[object]:
 
 
 def _set_local_events(tool_id: int, code: CodeType, events: int) -> None:
-    sys.monitoring.set_local_events(tool_id, code, events)
+    global _py_unwind_local
+    if _py_unwind_local is False:
+        sys.monitoring.set_local_events(tool_id, code, events & ~_E.PY_UNWIND)
+        return
+    try:
+        sys.monitoring.set_local_events(tool_id, code, events)
+    except ValueError:
+        if not (events & _E.PY_UNWIND):
+            raise
+        _py_unwind_local = False
+        sys.monitoring.set_local_events(tool_id, code, events & ~_E.PY_UNWIND)
+    else:
+        if _py_unwind_local is None and (events & _E.PY_UNWIND):
+            _py_unwind_local = True
+
+
+def _recompute_global_events() -> None:
+    """Enable or clear global PY_UNWIND when local set_local_events rejected it."""
+    global _active_global_events
+    if _py_unwind_local is not False or _tool_id is None:
+        return
+    needed: int = 0
+    for handlers in _registry.values():
+        if _events_for(handlers) & _E.PY_UNWIND:
+            needed = _E.PY_UNWIND
+            break
+    if needed != _active_global_events:
+        _active_global_events = needed
+        sys.monitoring.set_events(_tool_id, needed)
 
 
 def _rearm_local_events(tool_id: int, code: CodeType, events: int) -> None:
@@ -334,6 +380,7 @@ def register(code: CodeType, handler: MonitoringEventHandler) -> None:
             _rearm_local_events(tool_id, code, local_events)
         else:
             _set_local_events(tool_id, code, local_events)
+        _recompute_global_events()
 
 
 def refresh(code: CodeType) -> None:
@@ -347,6 +394,7 @@ def refresh(code: CodeType) -> None:
         if handlers and _tool_id is not None:
             events: int = _events_for(handlers) & _LOCAL_EVENTS
             _rearm_local_events(_tool_id, code, events)
+            _recompute_global_events()
 
 
 def unregister(code: CodeType, handler: MonitoringEventHandler) -> None:
@@ -365,3 +413,4 @@ def unregister(code: CodeType, handler: MonitoringEventHandler) -> None:
         else:
             assert _tool_id is not None  # nosec
             _set_local_events(_tool_id, code, _events_for(handlers) & _LOCAL_EVENTS)
+        _recompute_global_events()

--- a/tests/internal/test_monitoring.py
+++ b/tests/internal/test_monitoring.py
@@ -39,6 +39,16 @@ _DISABLE: object = cast(object, monitoring._DISABLE)  # type: ignore[has-type]
 _sys_monitoring: Any = getattr(sys, "monitoring", None)
 
 
+def _assert_unwind_armed(tool_id: int, code: CodeType) -> None:
+    """Pin local-only PY_UNWIND when CPython accepts it; otherwise global fallback."""
+    local_events: int = _sys_monitoring.get_local_events(tool_id, code)
+    global_events: int = _sys_monitoring.get_events(tool_id)
+    if local_events & _E.PY_UNWIND:
+        assert not (global_events & _E.PY_UNWIND), "PY_UNWIND must not be enabled globally"
+    else:
+        assert global_events & _E.PY_UNWIND, "fallback must enable PY_UNWIND globally"
+
+
 class UnwindHandler(monitoring.MonitoringEventHandler):
     def __init__(self) -> None:
         self.unwinds: list[tuple[CodeType, BaseException]] = []
@@ -101,6 +111,19 @@ class RaisingUnwindHandler(monitoring.MonitoringEventHandler):
         raise RuntimeError("unwind handler exploded")
 
 
+@pytest.fixture(autouse=True)
+def _reset_py_unwind_fallback() -> Iterator[None]:
+    """Keep the local/global PY_UNWIND probe from leaking across tests."""
+    monitoring._py_unwind_local = None
+    monitoring._active_global_events = 0
+    yield
+    tool_id: int | None = monitoring._tool_id
+    if tool_id is not None and _sys_monitoring is not None:
+        _sys_monitoring.set_events(tool_id, 0)
+    monitoring._py_unwind_local = None
+    monitoring._active_global_events = 0
+
+
 @pytest.fixture
 def registered() -> Iterator[
     Callable[[CodeType, monitoring.MonitoringEventHandler], monitoring.MonitoringEventHandler]
@@ -143,11 +166,7 @@ def test_unwind_enabled_locally(
     tool_id: int | None = monitoring._tool_id
     assert tool_id is not None
 
-    local_events: int = _sys_monitoring.get_local_events(tool_id, boom.__code__)
-    global_events: int = _sys_monitoring.get_events(tool_id)
-
-    assert local_events & _E.PY_UNWIND, "PY_UNWIND must be a local event on 3.15+"
-    assert not (global_events & _E.PY_UNWIND), "PY_UNWIND must not be enabled globally"
+    _assert_unwind_armed(tool_id, boom.__code__)
 
 
 def test_on_py_unwind_disables_unregistered_code() -> None:
@@ -189,12 +208,15 @@ def test_unregister_clears_local_unwind() -> None:
 
     tool_id: int | None = monitoring._tool_id
     assert tool_id is not None
-    assert _sys_monitoring.get_local_events(tool_id, boom.__code__) & _E.PY_UNWIND
+    _assert_unwind_armed(tool_id, boom.__code__)
 
     monitoring.unregister(boom.__code__, handler)
 
     assert not (_sys_monitoring.get_local_events(tool_id, boom.__code__) & _E.PY_UNWIND), (
         "local PY_UNWIND should be disabled once no handlers need it"
+    )
+    assert not (_sys_monitoring.get_events(tool_id) & _E.PY_UNWIND), (
+        "global PY_UNWIND should be cleared once no handlers need it"
     )
 
 
@@ -213,14 +235,57 @@ def test_mixed_local_events(
 
     local_events: int = _sys_monitoring.get_local_events(tool_id, fn.__code__)
     assert local_events & _E.PY_START, "PY_START must be a local event"
-    assert local_events & _E.PY_UNWIND, "PY_UNWIND must be a local event on 3.15+"
-    assert not (_sys_monitoring.get_events(tool_id) & _E.PY_UNWIND), "PY_UNWIND must not be global"
+    _assert_unwind_armed(tool_id, fn.__code__)
 
     with pytest.raises(ValueError):
         fn()
 
     assert handler.started, "on_py_start did not fire"
     assert handler.unwound, "on_py_unwind did not fire"
+
+
+def test_unwind_falls_back_to_global_when_local_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    registered: Callable[[CodeType, monitoring.MonitoringEventHandler], monitoring.MonitoringEventHandler],
+) -> None:
+    """If set_local_events rejects PY_UNWIND, enable it globally so unwind still fires."""
+    real_set_local: Any = _sys_monitoring.set_local_events
+
+    def reject_local_unwind(tool_id: int, code: CodeType, events: int) -> None:
+        if events & _E.PY_UNWIND:
+            raise ValueError("invalid local event set 0x2000")
+        real_set_local(tool_id, code, events)
+
+    monkeypatch.setattr(_sys_monitoring, "set_local_events", reject_local_unwind)
+
+    def boom() -> None:
+        raise ValueError("kaboom")
+
+    handler: UnwindHandler = registered(boom.__code__, UnwindHandler())  # type: ignore[assignment]
+
+    tool_id: int | None = monitoring._tool_id
+    assert tool_id is not None
+    local_events: int = _sys_monitoring.get_local_events(tool_id, boom.__code__)
+    global_events: int = _sys_monitoring.get_events(tool_id)
+    assert not (local_events & _E.PY_UNWIND)
+    assert global_events & _E.PY_UNWIND
+    assert monitoring._py_unwind_local is False
+
+    def unrelated() -> None:
+        pass
+
+    unregistered_result: object | None = monitoring._on_py_unwind(unrelated.__code__, 0, ValueError("x"))
+    assert unregistered_result is None
+
+    with pytest.raises(ValueError, match="kaboom"):
+        boom()
+
+    assert any(exc.args == ("kaboom",) for _, exc in handler.unwinds), (
+        "on_py_unwind must still fire after the global set_events fallback"
+    )
+
+    monitoring.unregister(boom.__code__, handler)
+    assert not (_sys_monitoring.get_events(tool_id) & _E.PY_UNWIND)
 
 
 def test_on_py_line_disables_when_all_handlers_return_disable(


### PR DESCRIPTION
## Description

Delta vs #19269: adds a local-event fallback for `PY_UNWIND`. When `sys.monitoring.set_local_events` rejects that event, the profiling setup retries without it; the global callback remains configured.

This PR does not add the native build or change the asyncio task-tracking path.

| Layer | Meaning | Which PR |
| --- | --- | --- |
| Compiled | Native prerequisite | #19269 |
| Armed | Local-event fallback | this PR |
| Observable | No standalone support claim | — |

## Testing

<!-- Leave a concise validation summary here before review. -->

## Risks

<!-- Describe rollout and rollback risks here before review. -->

## Additional Notes

Sibling of the other runtime compatibility fixes. `changelog/no-changelog`.
