### PR TITLE
feat(tracing): emit OTel HTTP semantics for client spans

### DIFF
--- a/ddtrace/_trace/subscribers/http_client.py
+++ b/ddtrace/_trace/subscribers/http_client.py
@@ -3,13 +3,17 @@ from types import TracebackType
 from typing import Optional
 from typing import cast
 
+from ddtrace import config
+from ddtrace._trace.http_semantics import normalize_http_method
+from ddtrace._trace.http_semantics import set_method_tag
+from ddtrace._trace.otel_http_naming import record_initial_instrumentation_resource
+from ddtrace._trace.otel_http_naming import set_otel_http_resource
 from ddtrace._trace.subscribers._base import TracingSubscriber
 from ddtrace.contrib import trace_utils
 from ddtrace.contrib._events.http_client import HttpClientEvents
 from ddtrace.contrib._events.http_client import HttpClientRequestEvent
 from ddtrace.internal import core
 from ddtrace.internal.logger import get_logger
-from ddtrace.internal.settings._config import config
 from ddtrace.internal.span_bus import span_from_context
 from ddtrace.propagation.http import HTTPPropagator
 
@@ -37,7 +41,13 @@ class HttpClientTracingSubscriber(TracingSubscriber):
         event: HttpClientRequestEvent = ctx.event
 
         if config._otel_trace_semantics_enabled and event.request_method:
-            span_from_context(ctx).resource = event.request_method.upper()
+            span = span_from_context(ctx)
+            set_method_tag(span, event.request_method)
+            # Span-start callbacks have already run. Record ownership only if they left the
+            # integration-supplied resource untouched.
+            record_initial_instrumentation_resource(span, event.resource)
+            normalized_method, original_method = normalize_http_method(event.request_method)
+            set_otel_http_resource(span, normalized_method, original_method)
 
         if _http_propagation_suppressed.get():
             return

--- a/ddtrace/_trace/subscribers/http_client.py
+++ b/ddtrace/_trace/subscribers/http_client.py
@@ -43,8 +43,7 @@ class HttpClientTracingSubscriber(TracingSubscriber):
         if config._otel_trace_semantics_enabled and event.request_method:
             span = span_from_context(ctx)
             set_method_tag(span, event.request_method)
-            # Span-start callbacks have already run. Record ownership only if they left the
-            # integration-supplied resource untouched.
+            # Preserve resources replaced by span-start callbacks.
             record_initial_instrumentation_resource(span, event.resource)
             normalized_method, original_method = normalize_http_method(event.request_method)
             set_otel_http_resource(span, normalized_method, original_method)

--- a/ddtrace/contrib/internal/httplib/patch.py
+++ b/ddtrace/contrib/internal/httplib/patch.py
@@ -168,8 +168,6 @@ def _wrap_putrequest(func, instance, args, kwargs):
         trace_utils.set_http_meta(
             span, config.httplib, method=method, url=sanitized_url, target_host=instance.host, query=parsed.query
         )
-        if config._otel_trace_semantics_enabled:
-            span.resource = method.upper()
 
     except Exception:
         log.debug("error applying request tags", exc_info=True)

--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -20,6 +20,7 @@ from urllib import parse
 
 import wrapt
 
+from ddtrace._trace.http_semantics import OTelHTTPSpanAttributes
 from ddtrace._trace.pin import Pin
 from ddtrace._trace.span import Span
 from ddtrace.constants import _ORIGIN_KEY
@@ -459,39 +460,59 @@ def set_http_meta(
         ``view_args``, ...), or a positional sequence of values for regex routes with only unnamed captures (Django
         ``resolver_match.args``, Tornado ``path_args``).
     """
+    otel_http = OTelHTTPSpanAttributes(span, integration_config) if config._otel_trace_semantics_enabled else None
+    if otel_http is not None and not otel_http.is_client:
+        otel_http = None
+
     if method is not None:
-        span._set_attribute(http.METHOD, method)
+        if otel_http is not None:
+            otel_http.set_method(method)
+        else:
+            span._set_attribute(http.METHOD, method)
 
-    if url is not None:
-        url = _sanitized_url(url)
-        _set_url_tag(integration_config, span, url, query)
+    if otel_http is not None:
+        otel_http.set_url(
+            url,
+            query=query,
+            server_address=server_address,
+            fallback_server_address=target_host,
+        )
+    else:
+        if url is not None:
+            url = _sanitized_url(url)
+            _set_url_tag(integration_config, span, url, query)
 
-    if target_host is not None:
-        span._set_attribute(net.TARGET_HOST, target_host)
+        if target_host is not None:
+            span._set_attribute(net.TARGET_HOST, target_host)
 
-    if server_address is not None:
-        span._set_attribute(net.SERVER_ADDRESS, server_address)
+        if server_address is not None:
+            span._set_attribute(net.SERVER_ADDRESS, server_address)
 
     if status_code is not None:
-        try:
-            int_status_code = int(status_code)
-        except (TypeError, ValueError):
-            log.debug("failed to convert http status code %r to int", status_code)
+        if otel_http is not None:
+            otel_http.set_status_code(status_code)
         else:
-            span._set_attribute(http.STATUS_CODE, str(status_code))
-            if config._http_server.is_error_code(int_status_code):
-                span.error = 1
+            try:
+                int_status_code = int(status_code)
+            except (TypeError, ValueError):
+                log.debug("failed to convert http status code %r to int", status_code)
+            else:
+                span._set_attribute(http.STATUS_CODE, str(status_code))
+                if config._http_server.is_error_code(int_status_code):
+                    span.error = 1
 
     if status_msg is not None:
         span._set_attribute(http.STATUS_MSG, status_msg)
 
-    if query is not None and integration_config.trace_query_string:
+    if otel_http is None and query is not None and integration_config.trace_query_string:
         span._set_attribute(http.QUERY_STRING, query)
 
     request_ip = peer_ip
     if request_headers:
         user_agent = _get_request_header_user_agent(request_headers, headers_are_case_sensitive)
-        if user_agent:
+        if otel_http is not None:
+            otel_http.set_user_agent(user_agent)
+        elif user_agent:
             span._set_attribute(http.USER_AGENT, user_agent)
 
         # Extract referrer host if referer header is present
@@ -552,6 +573,9 @@ def set_http_meta(
 
     if route is not None:
         span._set_attribute(http.ROUTE, route)
+
+    if otel_http is not None:
+        otel_http.set_resource(route)
 
 
 def activate_distributed_headers(

--- a/releasenotes/notes/otel-http-client-semantics-11ee892be11a1ba3.yaml
+++ b/releasenotes/notes/otel-http-client-semantics-11ee892be11a1ba3.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    tracing: Adds support for OpenTelemetry HTTP semantic conventions on HTTP client spans,
+    enabled with ``DD_TRACE_OTEL_SEMANTICS_ENABLED=true``. When enabled, client spans use
+    OpenTelemetry attribute names and low-cardinality resource names; the default remains the
+    existing Datadog behavior.

--- a/tests/contrib/httpx2/test_httpx2.py
+++ b/tests/contrib/httpx2/test_httpx2.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import httpx2
 import pytest
 
@@ -90,6 +92,19 @@ async def test_get_200():
     async with httpx2.AsyncClient() as client:
         resp = await client.get(url, headers=DEFAULT_HEADERS)
         assert resp.status_code == 200
+
+
+def test_otel_semantics_use_shared_http_client_subscriber(test_spans):
+    with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+        response = httpx2.get(get_url("/status/200"), headers=DEFAULT_HEADERS)
+
+    assert response.status_code == 200
+    span = test_spans.find_span(name="http.request")
+    assert span.resource == "GET"
+    assert span.get_tag("http.request.method") == "GET"
+    assert span.get_tag("url.full") == get_url("/status/200")
+    assert span.get_tag("http.method") is None
+    assert span.get_tag("http.url") is None
 
 
 @pytest.mark.asyncio

--- a/tests/tracer/test_otel_span_naming.py
+++ b/tests/tracer/test_otel_span_naming.py
@@ -1,0 +1,232 @@
+from unittest import mock
+
+import pytest
+
+from ddtrace._trace.http_semantics import normalize_http_method
+from ddtrace._trace.otel_http_naming import INSTRUMENTATION_HTTP_RESOURCE
+from ddtrace._trace.otel_http_naming import RESOURCE_SET_BY_USER
+from ddtrace._trace.otel_http_naming import set_otel_http_resource
+from ddtrace.constants import SPAN_KIND
+from ddtrace.contrib.internal import trace_utils
+from ddtrace.ext import SpanTypes
+from ddtrace.internal.settings._config import config
+from ddtrace.internal.settings.integration import IntegrationConfig
+from ddtrace.trace import tracer
+
+
+_INTEGRATION_RESOURCE = "composed by the integration"
+_OTEL_SUBPROCESS_ENV = {
+    "DD_TRACE_OTEL_SEMANTICS_ENABLED": "true",
+    "DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED": None,
+}
+
+
+def _integration_config():
+    return IntegrationConfig(config, "test")
+
+
+def _client_name(method=None, route=None, resource=_INTEGRATION_RESOURCE, span_hook=None):
+    with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+        with tracer.start_span("http.request", span_type=SpanTypes.HTTP, activate=False) as span:
+            if resource is not None:
+                span.resource = resource
+                span._set_ctx_item(INSTRUMENTATION_HTTP_RESOURCE, resource)
+            span._set_attribute(SPAN_KIND, "client")
+            if span_hook is not None:
+                span_hook(span)
+            trace_utils.set_http_meta(span, _integration_config(), method=method, route=route)
+            return span.resource
+
+
+def test_client_is_bare_method_without_url_template():
+    assert _client_name(method="GET") == "GET"
+
+
+def test_client_does_not_take_http_route_as_its_target():
+    assert _client_name(method="GET", route="/users/<int:id>") == "GET"
+
+
+def test_client_unaccepted_method_uses_http_resource():
+    assert _client_name(method="FROBNICATE") == "HTTP"
+
+
+def test_client_raw_method_never_leaks_into_the_name():
+    assert _client_name(method="get") == "GET"
+
+
+def test_client_user_set_resource_is_preserved():
+    def claim(span):
+        span._set_ctx_item(RESOURCE_SET_BY_USER, True)
+
+    assert _client_name(method="GET", span_hook=claim) == _INTEGRATION_RESOURCE
+
+
+def test_client_resource_replaced_by_user_code_is_detected_and_kept():
+    def replace(span):
+        span.resource = "my custom name"
+
+    assert _client_name(method="GET", resource=None, span_hook=replace) == "my custom name"
+
+
+def test_client_span_without_a_method_is_left_alone():
+    assert _client_name(method=None) == _INTEGRATION_RESOURCE
+
+
+def test_unaccepted_client_method_is_normalized_at_start():
+    with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+        with tracer.start_span("http.request", span_type=SpanTypes.HTTP, activate=False) as span:
+            span._set_attribute(SPAN_KIND, "client")
+            normalized, original = normalize_http_method("PROPFIND")
+            set_otel_http_resource(span, normalized, original)
+            at_sampling = span.resource
+            trace_utils.set_http_meta(span, _integration_config(), method="PROPFIND")
+            assert at_sampling == "HTTP"
+            assert span.resource == at_sampling
+
+
+def _client_event(method="GET"):
+    from ddtrace.contrib._events.http_client import HttpClientRequestEvent
+
+    return HttpClientRequestEvent(
+        http_operation="requests.request",
+        service="svc",
+        component="requests",
+        resource="{} /actual/path/42".format(method),
+        integration_config=config.requests,
+        request_method=method,
+        request_headers={},
+        query="",
+        request_url="http://host/actual/path/42",
+    )
+
+
+def _emit_client_span_through_the_subscriber():
+    from ddtrace.internal import core
+    from ddtrace.internal.span_bus import span_from_context
+
+    with core.context_with_event(_client_event()) as ctx:
+        span = span_from_context(ctx)
+    return span
+
+
+@pytest.mark.subprocess(env=_OTEL_SUBPROCESS_ENV, err=None)
+def test_event_supplied_resource_is_replaced_not_treated_as_user_owned():
+    from ddtrace.contrib._events.http_client import HttpClientRequestEvent
+    from ddtrace.internal import core
+    from ddtrace.internal.settings._config import config
+    from ddtrace.internal.span_bus import span_from_context
+
+    for method, expected in (("GET", "GET"), ("PROPFIND", "HTTP"), ("get", "GET")):
+        with core.context_with_event(
+            HttpClientRequestEvent(
+                http_operation="requests.request",
+                service="svc",
+                component="requests",
+                resource="{} /actual/path/42".format(method),
+                integration_config=config.requests,
+                request_method=method,
+                request_headers={},
+                query="",
+                request_url="http://host/actual/path/42",
+            ),
+        ) as ctx:
+            span = span_from_context(ctx)
+            assert span.resource == expected
+            assert "/actual/path/42" not in span.resource
+
+
+@pytest.mark.subprocess(env=_OTEL_SUBPROCESS_ENV, err=None)
+def test_a_user_replacing_the_resource_after_start_still_wins():
+    from ddtrace.contrib._events.http_client import HttpClientRequestEvent
+    from ddtrace.contrib.internal import trace_utils
+    from ddtrace.internal import core
+    from ddtrace.internal.settings._config import config
+    from ddtrace.internal.span_bus import span_from_context
+
+    with core.context_with_event(
+        HttpClientRequestEvent(
+            http_operation="requests.request",
+            service="svc",
+            component="requests",
+            resource="GET /actual/path/42",
+            integration_config=config.requests,
+            request_method="GET",
+            request_headers={},
+            query="",
+            request_url="http://host/actual/path/42",
+        ),
+    ) as ctx:
+        span = span_from_context(ctx)
+        assert span.resource == "GET"
+        span.resource = "my custom name"
+        trace_utils.set_http_meta(span, config.requests, method="GET")
+        assert span.resource == "my custom name"
+
+
+@pytest.mark.subprocess(env=_OTEL_SUBPROCESS_ENV, err=None)
+def test_span_start_processor_resource_is_preserved():
+    from ddtrace._trace.processor import SpanProcessor
+    from ddtrace.contrib._events.http_client import HttpClientRequestEvent
+    from ddtrace.internal import core
+    from ddtrace.internal.settings._config import config
+    from ddtrace.internal.span_bus import span_from_context
+
+    class SetResourceAtStart(SpanProcessor):
+        def on_span_start(self, span):
+            span.resource = "processor-owned"
+
+        def on_span_finish(self, span):
+            pass
+
+    processor = SetResourceAtStart()
+    processor.register()
+    try:
+        with core.context_with_event(
+            HttpClientRequestEvent(
+                http_operation="requests.request",
+                service="svc",
+                component="requests",
+                resource="GET /actual/path/42",
+                integration_config=config.requests,
+                request_method="GET",
+                request_headers={},
+                query="",
+                request_url="http://host/actual/path/42",
+            ),
+        ) as ctx:
+            span = span_from_context(ctx)
+            assert span.resource == "processor-owned"
+        assert span.resource == "processor-owned"
+    finally:
+        processor.unregister()
+
+
+@pytest.mark.subprocess(
+    env={
+        **_OTEL_SUBPROCESS_ENV,
+        "DD_TRACE_SAMPLING_RULES": '[{"resource": "GET", "sample_rate": 0.0}]',
+    },
+    err=None,
+)
+def test_a_sampling_rule_matches_the_otel_resource():
+    from ddtrace.constants import USER_REJECT
+    from tests.tracer.test_otel_span_naming import _emit_client_span_through_the_subscriber
+
+    span = _emit_client_span_through_the_subscriber()
+    assert span.resource == "GET"
+    assert span.context.sampling_priority == USER_REJECT
+
+
+@pytest.mark.subprocess(
+    env={
+        **_OTEL_SUBPROCESS_ENV,
+        "DD_TRACE_SAMPLING_RULES": '[{"resource": "GET /actual/path/42", "sample_rate": 0.0}]',
+    },
+    err=None,
+)
+def test_a_sampling_rule_does_not_match_the_pre_rename_resource():
+    from ddtrace.constants import AUTO_KEEP
+    from tests.tracer.test_otel_span_naming import _emit_client_span_through_the_subscriber
+
+    span = _emit_client_span_through_the_subscriber()
+    assert span.context.sampling_priority == AUTO_KEEP

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -1326,3 +1326,227 @@ def test_set_flattened_tags_exclude_policy():
 
     trace_utils.set_flattened_tags(span, d.items(), sep="_", exclude_policy=lambda tag: tag in {"C_A", "C_C"})
     assert span.get_metrics() == e
+
+
+_OTEL_SEMANTICS_SUBPROCESS_ENV = {
+    "DD_TRACE_OTEL_SEMANTICS_ENABLED": "true",
+    "DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED": None,
+}
+
+
+@pytest.mark.subprocess(env=_OTEL_SEMANTICS_SUBPROCESS_ENV)
+def test_otel_semantics_client_attributes():
+    from ddtrace.contrib.internal.trace_utils import set_http_meta
+    from ddtrace.ext import SpanTypes
+    from ddtrace.internal.settings._config import Config
+    from ddtrace.internal.settings.integration import IntegrationConfig
+    from tests.utils import scoped_tracer
+
+    cfg = Config()
+    cfg.myint = IntegrationConfig(cfg, "myint")
+    with scoped_tracer() as tracer, tracer.start_span("http.request", span_type=SpanTypes.HTTP, activate=False) as span:
+        set_http_meta(
+            span,
+            cfg.myint,
+            method="POST",
+            url="https://user:pass@api.example.com:8443/v1/items",
+            target_host="fallback.example.com",
+            status_code=201,
+            request_headers={"user-agent": "client/1.0"},
+        )
+
+        assert span.get_tag("http.request.method") == "POST"
+        assert span.get_tag("url.full") == "https://REDACTED:REDACTED@api.example.com:8443/v1/items"
+        assert span.get_tag("server.address") == "api.example.com"
+        assert span.get_metric("server.port") == 8443
+        assert span.get_metric("http.response.status_code") == 201
+        assert span.get_tag("user_agent.original") == "client/1.0"
+        assert span.error == 0
+
+        for legacy in ("http.method", "http.url", "http.status_code", "http.useragent", "out.host"):
+            assert span.get_tag(legacy) is None, legacy
+
+
+@pytest.mark.subprocess(env=_OTEL_SEMANTICS_SUBPROCESS_ENV)
+def test_otel_semantics_client_trace_query_string_keeps_obfuscated_query():
+    from ddtrace.contrib.internal.trace_utils import set_http_meta
+    from ddtrace.ext import SpanTypes
+    from ddtrace.internal.settings._config import Config
+    from ddtrace.internal.settings.integration import IntegrationConfig
+    from tests.utils import scoped_tracer
+
+    cfg = Config()
+    cfg.myint = IntegrationConfig(cfg, "myint")
+    cfg.myint.http_tag_query_string = False
+    cfg.myint.http.trace_query_string = True
+    with scoped_tracer() as tracer, tracer.start_span("http.request", span_type=SpanTypes.HTTP, activate=False) as span:
+        set_http_meta(
+            span,
+            cfg.myint,
+            url="https://api.example.com/search?token=leaked&page=2",
+            query="token=leaked&page=2",
+        )
+
+        assert span.get_tag("url.full") == "https://api.example.com/search?<redacted>&page=2"
+
+
+@pytest.mark.subprocess(env=_OTEL_SEMANTICS_SUBPROCESS_ENV)
+def test_otel_semantics_client_url_redacts_password_containing_at_sign():
+    from ddtrace.contrib.internal.trace_utils import set_http_meta
+    from ddtrace.ext import SpanTypes
+    from ddtrace.internal.settings._config import Config
+    from ddtrace.internal.settings.integration import IntegrationConfig
+    from tests.utils import scoped_tracer
+
+    cfg = Config()
+    cfg.myint = IntegrationConfig(cfg, "myint")
+    with scoped_tracer() as tracer, tracer.start_span("http.request", span_type=SpanTypes.HTTP, activate=False) as span:
+        set_http_meta(span, cfg.myint, url="https://user:p@ssword@api.example.com/v1/items")
+
+        assert span.get_tag("url.full") == "https://REDACTED:REDACTED@api.example.com/v1/items"
+        assert span.get_tag("server.address") == "api.example.com"
+
+
+@pytest.mark.subprocess(env=_OTEL_SEMANTICS_SUBPROCESS_ENV)
+def test_otel_semantics_client_default_port_from_scheme():
+    from ddtrace.contrib.internal.trace_utils import set_http_meta
+    from ddtrace.ext import SpanTypes
+    from ddtrace.internal.settings._config import Config
+    from ddtrace.internal.settings.integration import IntegrationConfig
+    from tests.utils import scoped_tracer
+
+    cfg = Config()
+    cfg.myint = IntegrationConfig(cfg, "myint")
+    with scoped_tracer() as tracer, tracer.start_span("http.request", span_type=SpanTypes.HTTP, activate=False) as span:
+        set_http_meta(span, cfg.myint, url="https://api.example.com/v1/items")
+
+        assert span.get_tag("server.address") == "api.example.com"
+        assert span.get_metric("server.port") == 443
+
+
+@pytest.mark.subprocess(env=_OTEL_SEMANTICS_SUBPROCESS_ENV)
+def test_otel_semantics_client_method_normalization():
+    from ddtrace.contrib.internal.trace_utils import set_http_meta
+    from ddtrace.ext import SpanTypes
+    from ddtrace.internal.settings._config import Config
+    from ddtrace.internal.settings.integration import IntegrationConfig
+    from tests.utils import scoped_tracer
+
+    cfg = Config()
+    cfg.myint = IntegrationConfig(cfg, "myint")
+    cases = [
+        ("GET", "GET", None),
+        ("get", "GET", "get"),
+        ("Patch", "PATCH", "Patch"),
+        ("QUERY", "QUERY", None),
+        ("FOO", "_OTHER", "FOO"),
+        ("", "_OTHER", ""),
+    ]
+    for raw, expected, expected_original in cases:
+        with (
+            scoped_tracer() as tracer,
+            tracer.start_span("http.request", span_type=SpanTypes.HTTP, activate=False) as span,
+        ):
+            set_http_meta(span, cfg.myint, method=raw)
+            assert span.get_tag("http.request.method") == expected, raw
+            assert span.get_tag("http.request.method_original") == expected_original, raw
+
+
+@pytest.mark.subprocess(
+    env={**_OTEL_SEMANTICS_SUBPROCESS_ENV, "DD_TRACE_HTTP_SERVER_ERROR_STATUSES": "500-501"},
+)
+def test_otel_semantics_client_uses_fixed_error_statuses():
+    from ddtrace.contrib.internal.trace_utils import set_http_meta
+    from ddtrace.ext import SpanTypes
+    from ddtrace.internal.settings._config import Config
+    from ddtrace.internal.settings.integration import IntegrationConfig
+    from tests.utils import scoped_tracer
+
+    cfg = Config()
+    cfg.myint = IntegrationConfig(cfg, "myint")
+    for status_code, expected in ((399, (0, None)), (400, (1, "400")), (599, (1, "599")), (600, (1, "600"))):
+        with (
+            scoped_tracer() as tracer,
+            tracer.start_span("http.request", span_type=SpanTypes.HTTP, activate=False) as span,
+        ):
+            set_http_meta(span, cfg.myint, status_code=status_code)
+            assert (span.error, span.get_tag("error.type")) == expected
+
+
+@pytest.mark.subprocess(env=_OTEL_SEMANTICS_SUBPROCESS_ENV)
+def test_otel_semantics_client_status_does_not_overwrite_exception_error_type():
+    import sys
+
+    from ddtrace.contrib.internal.trace_utils import set_http_meta
+    from ddtrace.ext import SpanTypes
+    from ddtrace.internal.settings._config import Config
+    from ddtrace.internal.settings.integration import IntegrationConfig
+    from tests.utils import scoped_tracer
+
+    cfg = Config()
+    cfg.myint = IntegrationConfig(cfg, "myint")
+    with scoped_tracer() as tracer, tracer.start_span("http.request", span_type=SpanTypes.HTTP, activate=False) as span:
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            span.set_exc_info(*sys.exc_info())
+        set_http_meta(span, cfg.myint, status_code=500)
+
+        assert span.error == 1
+        assert span.get_tag("error.type") == "builtins.ValueError"
+
+
+@pytest.mark.subprocess(
+    env={**_OTEL_SEMANTICS_SUBPROCESS_ENV, "OTEL_TRACES_EXPORTER": "otlp"},
+)
+def test_otel_semantics_client_numeric_attributes_typed_for_otlp():
+    from ddtrace.contrib.internal.trace_utils import set_http_meta
+    from ddtrace.ext import SpanTypes
+    from ddtrace.internal.settings._config import Config
+    from ddtrace.internal.settings.integration import IntegrationConfig
+    from tests.utils import scoped_tracer
+
+    cfg = Config()
+    cfg.myint = IntegrationConfig(cfg, "myint")
+    with scoped_tracer() as tracer, tracer.start_span("http.request", span_type=SpanTypes.HTTP, activate=False) as span:
+        set_http_meta(span, cfg.myint, url="http://localhost:8080/x", status_code=200)
+
+        assert span.get_tag("http.response.status_code") is None
+        assert span.get_metric("http.response.status_code") == 200
+        assert span.get_tag("server.port") is None
+        assert span.get_metric("server.port") == 8080
+
+
+def test_otel_client_semantics_flag_is_read_per_call(int_config):
+    span = Span("http.request", span_type="http")
+
+    with mock.patch.object(config, "_otel_trace_semantics_enabled", False):
+        trace_utils.set_http_meta(span, int_config.myint, method="get")
+        assert span.get_tag("http.method") == "get"
+
+    span = Span("http.request", span_type="http")
+    with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+        trace_utils.set_http_meta(span, int_config.myint, method="get")
+        assert span.get_tag("http.request.method") == "GET"
+
+
+def test_otel_client_semantics_disabled_by_default(int_config):
+    span = Span("http.request", span_type="http")
+    trace_utils.set_http_meta(
+        span,
+        int_config.myint,
+        method="GET",
+        url="http://localhost:8080/users/1",
+        status_code=500,
+    )
+    assert span.get_tag("http.method") == "GET"
+    assert span.get_tag("http.url") == "http://localhost:8080/users/1"
+    assert span.get_tag("http.status_code") == "500"
+    for otel_name in (
+        "http.request.method",
+        "url.full",
+        "http.response.status_code",
+        "server.port",
+        "error.type",
+    ):
+        assert span.get_tag(otel_name) is None, otel_name

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -1363,8 +1363,8 @@ def test_otel_semantics_client_attributes():
         assert span.get_tag("user_agent.original") == "client/1.0"
         assert span.error == 0
 
-        for legacy in ("http.method", "http.url", "http.status_code", "http.useragent", "out.host"):
-            assert span.get_tag(legacy) is None, legacy
+        for datadog_tag in ("http.method", "http.url", "http.status_code", "http.useragent", "out.host"):
+            assert span.get_tag(datadog_tag) is None, datadog_tag
 
 
 @pytest.mark.subprocess(env=_OTEL_SEMANTICS_SUBPROCESS_ENV)


### PR DESCRIPTION
## Description

Second layer of the native three-PR stack replacing [#19501](https://github.com/DataDog/dd-trace-py/pull/19501), based on [#20008](https://github.com/DataDog/dd-trace-py/pull/20008).

- Emits OTel HTTP method, URL, address, port, status, user-agent, and error attributes for outbound client spans when `DD_TRACE_OTEL_SEMANTICS_ENABLED=true`.
- Assigns low-cardinality client resources before sampling and preserves user-owned resources.
- Uses the tracing-layer attribute writer from the foundation layer; contrib code remains responsible for extraction and orchestration.
- Preserves Datadog semantics when the flag is disabled.
- Does not add `DD_TRACE_HTTP_CLIENT_ERROR_STATUSES`; that configuration remains outside this stack's scope.

## Review feedback incorporated

- New OTel span mutations stay under `ddtrace/_trace`.
- Early naming uses the existing tracing subscriber lifecycle, while `set_http_meta` remains the compatibility path for integrations that call it directly.
- Tests name Datadog and OTel semantics explicitly and avoid deprecated-behavior terminology.

## Testing

Validated at `8ebf387985`:

- `scripts/lint checks`: passed.
- Focused tracer tests: 175 passed.
- HTTPX2 integration tests: 45 passed.
- httplib integration tests: 60 passed.
- System tests against [libdatadog#2323](https://github.com/DataDog/libdatadog/pull/2323) head `0ed7fd9bd`: `Test_OtelSemantics_Spans_Http_Client` — 11 passed.

## Risks

Client integrations share `set_http_meta`; the feature flag and focused Datadog/OTel coverage limit the regression surface.

## Stack

Registered as layer 2/3 in GitHub's native stacked pull request UI:

1. [#20008](https://github.com/DataDog/dd-trace-py/pull/20008) — foundation
2. This PR — HTTP client spans
3. [#20010](https://github.com/DataDog/dd-trace-py/pull/20010) — HTTP server/framework/AppSec spans

The original [#19501](https://github.com/DataDog/dd-trace-py/pull/19501) remains open only as the complete historical review and system-test reference.

Made with [Cursor](https://cursor.com)