### PR TITLE
feat(tracing): emit OTel HTTP semantics for server spans

### DIFF
--- a/ddtrace/_trace/processor/resource_renaming.py
+++ b/ddtrace/_trace/processor/resource_renaming.py
@@ -1,5 +1,6 @@
 import re
 from typing import Optional
+from typing import Union
 from urllib.parse import urlparse
 
 from ddtrace._trace.processor import SpanProcessor
@@ -11,6 +12,16 @@ from ddtrace.internal.settings._config import config
 
 
 log = get_logger(__name__)
+
+
+def path_source_tag_value(span: Span) -> Optional[str]:
+    """The URL-ish tag an endpoint is computed from, in the active semantics mode.
+
+    Server spans carry url.path and client spans carry url.full under the flag, and
+    SimplifiedEndpointComputer.from_url parses either shape.
+    """
+    path_source_tags = (http.OTEL_URL_PATH, http.OTEL_URL_FULL) if config._otel_trace_semantics_enabled else (http.URL,)
+    return next((value for value in map(span.get_tag, path_source_tags) if value), None)
 
 
 class SimplifiedEndpointComputer:
@@ -74,12 +85,16 @@ class ResourceRenamingProcessor(SpanProcessor):
         if not span._is_top_level or span.span_type not in (SpanTypes.WEB, SpanTypes.HTTP, SpanTypes.SERVERLESS):
             return
 
-        status = span.get_tag(http.STATUS_CODE)
+        status_code_tag = http.OTEL_RESPONSE_STATUS_CODE if config._otel_trace_semantics_enabled else http.STATUS_CODE
+        status: Union[str, int, float, None] = span.get_tag(status_code_tag)
+        if status is None:
+            # under OTLP export the status code is written with its integer type
+            status = span.get_metric(status_code_tag)
         is_404 = status == "404" or status == 404
 
         route = span.get_tag(http.ROUTE)
 
         if not is_404 and (not route or config._trace_resource_renaming_always_simplified_endpoint):
-            url = span.get_tag(http.URL)
+            url = path_source_tag_value(span)
             endpoint = self.simplified_endpoint_computer.from_url(url)
             span._set_attribute(http.ENDPOINT, endpoint)

--- a/ddtrace/_trace/processor/resource_renaming.py
+++ b/ddtrace/_trace/processor/resource_renaming.py
@@ -1,5 +1,6 @@
 import re
 from typing import Optional
+from typing import Protocol
 from typing import Union
 from urllib.parse import urlparse
 
@@ -14,7 +15,11 @@ from ddtrace.internal.settings._config import config
 log = get_logger(__name__)
 
 
-def path_source_tag_value(span: Span) -> Optional[str]:
+class _SpanTagReader(Protocol):
+    def get_tag(self, key: str) -> Optional[str]: ...
+
+
+def path_source_tag_value(span: _SpanTagReader) -> Optional[str]:
     path_source_tags = (http.OTEL_URL_PATH, http.OTEL_URL_FULL) if config._otel_trace_semantics_enabled else (http.URL,)
     return next((value for value in map(span.get_tag, path_source_tags) if value), None)
 

--- a/ddtrace/_trace/processor/resource_renaming.py
+++ b/ddtrace/_trace/processor/resource_renaming.py
@@ -15,11 +15,6 @@ log = get_logger(__name__)
 
 
 def path_source_tag_value(span: Span) -> Optional[str]:
-    """The URL-ish tag an endpoint is computed from, in the active semantics mode.
-
-    Server spans carry url.path and client spans carry url.full under the flag, and
-    SimplifiedEndpointComputer.from_url parses either shape.
-    """
     path_source_tags = (http.OTEL_URL_PATH, http.OTEL_URL_FULL) if config._otel_trace_semantics_enabled else (http.URL,)
     return next((value for value in map(span.get_tag, path_source_tags) if value), None)
 
@@ -88,7 +83,6 @@ class ResourceRenamingProcessor(SpanProcessor):
         status_code_tag = http.OTEL_RESPONSE_STATUS_CODE if config._otel_trace_semantics_enabled else http.STATUS_CODE
         status: Union[str, int, float, None] = span.get_tag(status_code_tag)
         if status is None:
-            # under OTLP export the status code is written with its integer type
             status = span.get_metric(status_code_tag)
         is_404 = status == "404" or status == 404
 

--- a/ddtrace/_trace/processor/resource_renaming.py
+++ b/ddtrace/_trace/processor/resource_renaming.py
@@ -49,7 +49,7 @@ class SimplifiedEndpointComputer:
         try:
             parsed_url = urlparse(url)
         except ValueError as e:
-            log.error("Failed to parse http.url tag when processing span for resource renaming: %s", e)
+            log.error("Failed to parse HTTP URL attribute when processing span for resource renaming: %s", e)
             return "/"
         path = parsed_url.path
         if not path or path == "/":

--- a/ddtrace/_trace/subscribers/web_framework.py
+++ b/ddtrace/_trace/subscribers/web_framework.py
@@ -37,10 +37,8 @@ class WebFrameworkRequestSubscriber(TracingSubscriber):
         if config._otel_trace_semantics_enabled and event.request_method:
             span = span_from_context(ctx)
             set_method_tag(span, event.request_method)
-            # Named here, not just tagged: propagation can force a sampling decision before the
-            # request finishes, and a rule must not match the integration's Datadog resource.
-            # Span-start callbacks have already run. Record ownership only if they left the
-            # event-supplied resource untouched, so their custom names remain user-owned.
+            # Set the final resource before propagation can trigger sampling, while preserving
+            # resources changed by span-start instrumentation.
             record_initial_instrumentation_resource(span, event.resource)
             normalized_method, original_method = normalize_http_method(event.request_method)
             if event.request_route:

--- a/ddtrace/_trace/subscribers/web_framework.py
+++ b/ddtrace/_trace/subscribers/web_framework.py
@@ -1,6 +1,13 @@
 from types import TracebackType
 from typing import Optional
 
+from ddtrace import config
+from ddtrace._trace.http_semantics import normalize_http_method
+from ddtrace._trace.http_semantics import set_method_tag
+from ddtrace._trace.http_semantics import set_query_string_tag
+from ddtrace._trace.otel_http_naming import record_initial_instrumentation_resource
+from ddtrace._trace.otel_http_naming import set_instrumentation_resource
+from ddtrace._trace.otel_http_naming import set_otel_http_resource
 from ddtrace._trace.span import Span
 from ddtrace._trace.subscribers._base import TracingSubscriber
 from ddtrace._trace.trace_handlers import _set_inferred_proxy_tags
@@ -27,6 +34,19 @@ class WebFrameworkRequestSubscriber(TracingSubscriber):
         if event.allow_default_resource:
             event.set_resource = True
 
+        if config._otel_trace_semantics_enabled and event.request_method:
+            span = span_from_context(ctx)
+            set_method_tag(span, event.request_method)
+            # Named here, not just tagged: propagation can force a sampling decision before the
+            # request finishes, and a rule must not match the integration's Datadog resource.
+            # Span-start callbacks have already run. Record ownership only if they left the
+            # event-supplied resource untouched, so their custom names remain user-owned.
+            record_initial_instrumentation_resource(span, event.resource)
+            normalized_method, original_method = normalize_http_method(event.request_method)
+            if event.request_route:
+                span._set_attribute(http.OTEL_ROUTE, event.request_route)
+            set_otel_http_resource(span, normalized_method, original_method, event.request_route)
+
     @classmethod
     def on_ended(
         cls,
@@ -42,9 +62,9 @@ class WebFrameworkRequestSubscriber(TracingSubscriber):
 
         # event.resource can be updated at span finish time
         if event.resource:
-            span.resource = event.resource
+            set_instrumentation_resource(span, event.resource)
         elif event.set_resource and status_code is not None:
-            span.resource = f"{method} {status_code}"
+            set_instrumentation_resource(span, f"{method} {status_code}")
 
         try:
             trace_utils.set_http_meta(
@@ -66,7 +86,7 @@ class WebFrameworkRequestSubscriber(TracingSubscriber):
         # aiohttp supports per-app trace_query_string overrides that may differ from
         # integration_config.trace_query_string.
         if event.trace_query_string and event.query is not None:
-            span._set_attribute(http.QUERY_STRING, event.query)
+            set_query_string_tag(span, event.query)
 
         _set_inferred_proxy_tags(span, status_code)
         for tk, tv in core.get_item("additional_tags", default=dict()).items():

--- a/ddtrace/_trace/subscribers/web_framework.py
+++ b/ddtrace/_trace/subscribers/web_framework.py
@@ -37,8 +37,7 @@ class WebFrameworkRequestSubscriber(TracingSubscriber):
         if config._otel_trace_semantics_enabled and event.request_method:
             span = span_from_context(ctx)
             set_method_tag(span, event.request_method)
-            # Set the final resource before propagation can trigger sampling, while preserving
-            # resources changed by span-start instrumentation.
+            # Set the currently known resource before sampling; preserve span-start callback replacements.
             record_initial_instrumentation_resource(span, event.resource)
             normalized_method, original_method = normalize_http_method(event.request_method)
             if event.request_route:

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -95,6 +95,7 @@ from ddtrace.trace import tracer
 
 log = get_logger(__name__)
 
+_DJANGO_OTEL_ROUTE_APPLIED = "_dd.django_otel_route_applied"
 _WEBSOCKET_LINK_ATTRS_EXECUTED = {SPAN_LINK_KIND: SpanLinkKind.EXECUTED}
 _WEBSOCKET_LINK_ATTRS_RESUMING = {SPAN_LINK_KIND: SpanLinkKind.RESUMING}
 
@@ -746,7 +747,10 @@ def _on_django_func_wrapped(args, _unused2, _unused3, ctx, ignored_excs):
             request_span.span_type == SpanTypes.WEB
             and request_span.get_tag(COMPONENT) == config.django.integration_name
         ):
+            if request_span._get_ctx_item(_DJANGO_OTEL_ROUTE_APPLIED) == route:
+                return
             trace_utils.set_http_meta(request_span, config.django, method=request.method, route=route)
+            request_span._set_ctx_item(_DJANGO_OTEL_ROUTE_APPLIED, route)
             return
         request_span = request_span._parent
 
@@ -788,10 +792,10 @@ def _on_django_after_request_headers_post(
         peer_ip=core.find_item("remote_addr"),
         headers_are_case_sensitive=bool(core.get_item("http.request.headers_case_sensitive")),
         response_cookies=response_cookies,
-        # Forward ``http.route`` so the AppSec normalized-route listener can fire from this hook. ``_set_resolver_tags``
-        # ran earlier inside ``_after_request_tags`` and put the route on the span already. The async path
-        # (``traced_get_response_async``) only reaches this hook — there's no equivalent of the sync
-        # ``django.finalize_response.pre`` dispatch — so without this forward Django/ASGI deployments would miss the
+        # Forward http.route so the AppSec normalized-route listener can fire from this hook. _set_resolver_tags
+        # ran earlier inside _after_request_tags and put the route on the span already. The async path
+        # (traced_get_response_async) only reaches this hook — there's no equivalent of the sync
+        # django.finalize_response.pre dispatch — so without this forward Django/ASGI deployments would miss the
         # tag. Sync requests fire the listener twice (here + finalize_response.pre) with the same value — idempotent.
         route=span.get_tag("http.route"),
     )

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -270,6 +270,7 @@ def _on_web_framework_finish_request(
 def _set_inferred_proxy_tags(span: Span, status_code):
     if span._parent and span._parent.name in INFERRED_SPAN_NAMES:
         inferred_span = span._parent
+        # Proxy spans keep Datadog status attributes; only the source lookup follows active semantics.
         status_code = status_code or span._get_attribute(
             http.OTEL_RESPONSE_STATUS_CODE if config._otel_trace_semantics_enabled else http.STATUS_CODE
         )

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -270,8 +270,6 @@ def _on_web_framework_finish_request(
 def _set_inferred_proxy_tags(span: Span, status_code):
     if span._parent and span._parent.name in INFERRED_SPAN_NAMES:
         inferred_span = span._parent
-        # The inferred proxy span is a Datadog-only construct, so it keeps the Datadog
-        # attribute name. Only the read from the web span follows the semantics mode.
         status_code = status_code or span._get_attribute(
             http.OTEL_RESPONSE_STATUS_CODE if config._otel_trace_semantics_enabled else http.STATUS_CODE
         )
@@ -1918,10 +1916,7 @@ def _on_proxy_request_end(
 
         if request_type == "http":
             if config._otel_trace_semantics_enabled:
-                # This is an inbound request, but the span carries the http span type and no
-                # kind, which the OTel path would otherwise read as a client span and give
-                # client error semantics to. Only set under the flag so the default output
-                # stays unchanged.
+                # Ray omits span.kind for inbound HTTP, which would otherwise be classified as client.
                 span._set_attribute(SPAN_KIND, SpanKind.SERVER)
             trace_utils.set_http_meta(
                 span,

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -20,6 +20,9 @@ from ddtrace._trace._span_link import SpanLinkKind as _SpanLinkKind
 from ddtrace._trace._span_pointer import _SpanPointerDescription
 from ddtrace._trace._span_pointer import _SpanPointerDirection
 from ddtrace._trace._span_pointer import _SpanPointerDirectionName
+from ddtrace._trace.http_semantics import set_url_tags_server
+from ddtrace._trace.otel_http_naming import record_initial_instrumentation_resource
+from ddtrace._trace.otel_http_naming import set_instrumentation_resource
 from ddtrace._trace.span import Span
 from ddtrace._trace.utils import extract_DD_context_from_messages
 from ddtrace.constants import _HOSTNAME_KEY
@@ -47,7 +50,6 @@ from ddtrace.contrib.internal.ray.constants import RAY_APP_NAME
 from ddtrace.contrib.internal.ray.constants import RAY_DEPLOYMENT_ARGS
 from ddtrace.contrib.internal.ray.constants import RAY_DEPLOYMENT_KWARGS
 from ddtrace.contrib.internal.trace_utils import _copy_trace_level_tags
-from ddtrace.contrib.internal.trace_utils import _set_url_tag
 from ddtrace.contrib.internal.trace_utils import set_service_and_source
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanLinkKind
@@ -243,7 +245,7 @@ def _on_web_framework_finish_request(
             status_code = int(status_code)
         except ValueError:
             pass
-        span.resource = f"{method} {status_code}"
+        set_instrumentation_resource(span, f"{method} {status_code}")
     trace_utils.set_http_meta(
         span=span,
         integration_config=int_config,
@@ -267,7 +269,11 @@ def _on_web_framework_finish_request(
 def _set_inferred_proxy_tags(span: Span, status_code):
     if span._parent and span._parent.name in INFERRED_SPAN_NAMES:
         inferred_span = span._parent
-        status_code = status_code or span._get_attribute("http.status_code")
+        # The inferred proxy span is a Datadog-only construct, so it keeps the Datadog
+        # attribute name. Only the read from the web span follows the semantics mode.
+        status_code = status_code or span._get_attribute(
+            http.OTEL_RESPONSE_STATUS_CODE if config._otel_trace_semantics_enabled else http.STATUS_CODE
+        )
         if status_code:
             inferred_span._set_attribute("http.status_code", status_code)
         if span.error == 1:
@@ -403,7 +409,7 @@ def _on_traced_request_context_started_flask(ctx):
     # span before start_response so timed-out workers keep the route resource.
     req_span = ctx.find_item("req_span")
     if req_span is not None and req_span is not current_span:
-        _set_flask_request_route_tags(flask_request, req_span)
+        _set_flask_request_route_tags(flask_request, req_span, flask_config)
     request_span = _start_span(ctx)
     request_span._ignore_exception(ctx.get_item("ignored_exception_type"))
 
@@ -529,7 +535,7 @@ def _set_flask_request_tags(request, span, flask_config):
         if span.name.split(".")[-1] == "request":
             span._set_attribute(SPAN_KIND, SpanKind.SERVER)
 
-        _set_flask_request_route_tags(request, span)
+        _set_flask_request_route_tags(request, span, flask_config)
 
         if not span.get_tag(FLASK_VIEW_ARGS) and request.view_args and flask_config.get("collect_view_args"):
             for k, v in request.view_args.items():
@@ -541,16 +547,23 @@ def _set_flask_request_tags(request, span, flask_config):
         log.debug('failed to set tags for "flask.request" span', exc_info=True)
 
 
-def _set_flask_request_route_tags(request, span):
+def _set_flask_request_route_tags(request, span, flask_config):
     try:
         # DEV: This name will include the blueprint name as well (e.g. `bp.index`)
         if not span.get_tag(FLASK_ENDPOINT) and request.endpoint:
-            span.resource = " ".join((request.method, request.endpoint))
+            set_instrumentation_resource(span, " ".join((request.method, request.endpoint)))
             span._set_attribute(FLASK_ENDPOINT, request.endpoint)
 
         if not span.get_tag(FLASK_URL_RULE) and request.url_rule and request.url_rule.rule:
-            span.resource = " ".join((request.method, request.url_rule.rule))
+            set_instrumentation_resource(span, " ".join((request.method, request.url_rule.rule)))
             span._set_attribute(FLASK_URL_RULE, request.url_rule.rule)
+            if config._otel_trace_semantics_enabled:
+                trace_utils.set_http_meta(
+                    span,
+                    flask_config,
+                    method=request.method,
+                    route=request.url_rule.rule,
+                )
             # Side-channel tag for backend resource remapping; resource itself stays app-local.
             if request.script_root:
                 span._set_attribute(
@@ -573,7 +586,7 @@ def _on_start_response_pre(request, ctx, flask_config, status_code, headers):
     #      we still want `GET /product/<int:product_id>` grouped together,
     #      even if it is a 404
     if not span.get_tag(FLASK_ENDPOINT) and not span.get_tag(FLASK_URL_RULE):
-        span.resource = " ".join((request.method, code))
+        set_instrumentation_resource(span, " ".join((request.method, code)))
 
     response_cookies = _cookies_from_response_headers(headers)
     _on_web_framework_finish_request(
@@ -620,7 +633,7 @@ def _on_request_span_modifier(
     #   POST /save
     # We will override this below in `traced_dispatch_request` when we have a `
     # RequestContext` and possibly a url rule
-    span.resource = " ".join((request.method, request.path))
+    set_instrumentation_resource(span, " ".join((request.method, request.path)))
 
     span._set_attribute(_SPAN_MEASURED_KEY, 1)
 
@@ -712,16 +725,36 @@ def _on_django_cache(
         _finish_span(ctx, exc_info)
 
 
-def _on_django_func_wrapped(_unused1, _unused2, _unused3, ctx, ignored_excs):
+def _on_django_func_wrapped(args, _unused2, _unused3, ctx, ignored_excs):
     if ignored_excs:
         for exc in ignored_excs:
             span_from_context(ctx)._ignore_exception(exc)
+
+    if not config._otel_trace_semantics_enabled or not args:
+        return
+
+    request = args[0]
+    resolver_match = getattr(request, "resolver_match", None)
+    route = getattr(resolver_match, "route", None)
+    if not route:
+        return
+
+    request_spans = getattr(request, "scope", {}).get("datadog", {}).get("request_spans", ())
+    request_span = request_spans[0] if request_spans else span_from_context(ctx)._parent
+    while request_span is not None:
+        if (
+            request_span.span_type == SpanTypes.WEB
+            and request_span.get_tag(COMPONENT) == config.django.integration_name
+        ):
+            trace_utils.set_http_meta(request_span, config.django, method=request.method, route=route)
+            return
+        request_span = request_span._parent
 
 
 def _on_django_block_request(ctx: core.ExecutionContext, metadata: dict[str, str], django_config, url: str, query: str):
     for tk, tv in metadata.items():
         span_from_context(ctx)._set_attribute(tk, tv)
-    _set_url_tag(django_config, span_from_context(ctx), url, query)
+    set_url_tags_server(django_config, span_from_context(ctx), url, query)
 
 
 def _on_django_after_request_headers_post(
@@ -1022,7 +1055,7 @@ def _on_azure_functions_request_span_modifier(ctx, azure_functions_config, req):
     span = span_from_context(ctx)
     parsed_url = parse.urlparse(req.url)
     path = parsed_url.path
-    span.resource = f"{req.method} {path}"
+    set_instrumentation_resource(span, f"{req.method} {path}")
     trace_utils.set_http_meta(
         span,
         azure_functions_config,
@@ -1089,7 +1122,7 @@ def _on_azure_message_modifier(
 def _on_router_match(route):
     req_span = core.get_item("req_span")
     core.set_item("set_resource", False)
-    req_span.resource = f"{route.method} {route.template}"
+    set_instrumentation_resource(req_span, f"{route.method} {route.template}")
 
     MOLTEN_ROUTE = "molten.route"
 
@@ -1351,6 +1384,7 @@ def _on_asgi_request(ctx: core.ExecutionContext) -> None:
 
     span = _start_span(ctx)
     ctx.set_item("req_span", span)
+    record_initial_instrumentation_resource(span, ctx.get_item("resource"))
 
     if "datadog" not in scope:
         scope["datadog"] = {"request_spans": [span]}
@@ -1878,6 +1912,12 @@ def _on_proxy_request_end(
             span._set_attribute("ray.serve.request.type", request_type)
 
         if request_type == "http":
+            if config._otel_trace_semantics_enabled:
+                # This is an inbound request, but the span carries the http span type and no
+                # kind, which the OTel path would otherwise read as a client span and give
+                # client error semantics to. Only set under the flag so the default output
+                # stays unchanged.
+                span._set_attribute(SPAN_KIND, SpanKind.SERVER)
             trace_utils.set_http_meta(
                 span,
                 config.ray,

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -20,6 +20,7 @@ from ddtrace._trace._span_link import SpanLinkKind as _SpanLinkKind
 from ddtrace._trace._span_pointer import _SpanPointerDescription
 from ddtrace._trace._span_pointer import _SpanPointerDirection
 from ddtrace._trace._span_pointer import _SpanPointerDirectionName
+from ddtrace._trace.http_semantics import set_client_address_tags
 from ddtrace._trace.http_semantics import set_url_tags_server
 from ddtrace._trace.otel_http_naming import record_initial_instrumentation_resource
 from ddtrace._trace.otel_http_naming import set_instrumentation_resource
@@ -755,6 +756,10 @@ def _on_django_block_request(ctx: core.ExecutionContext, metadata: dict[str, str
     for tk, tv in metadata.items():
         span_from_context(ctx)._set_attribute(tk, tv)
     set_url_tags_server(django_config, span_from_context(ctx), url, query)
+
+
+def _on_http_set_client_address(span: Span, client_address: str) -> None:
+    set_client_address_tags(span, client_address)
 
 
 def _on_django_after_request_headers_post(
@@ -1957,6 +1962,7 @@ def listen():
     core.on("django.func.wrapped", _on_django_func_wrapped)
     core.on("django.block_request_callback", _on_django_block_request)
     core.on("django.after_request_headers.post", _on_django_after_request_headers_post)
+    core.on("http.set_client_address", _on_http_set_client_address)
     core.on("botocore.patched_api_call.exception", _on_botocore_patched_api_call_exception)
     core.on("botocore.patched_api_call.success", _on_botocore_patched_api_call_success)
     core.on("botocore.patched_kinesis_api_call.success", _on_botocore_patched_api_call_success)

--- a/ddtrace/aiguard/_api_client.py
+++ b/ddtrace/aiguard/_api_client.py
@@ -395,12 +395,7 @@ class AIGuardClient:
                     client_ip = core.find_item(AI_GUARD.CLIENT_IP_CORE_KEY)
                     core.discard_item(AI_GUARD.CLIENT_IP_CORE_KEY)
                     if client_ip:
-                        root_span._set_attribute(
-                            http.OTEL_CLIENT_ADDRESS if otel_semantics else http.CLIENT_IP, client_ip
-                        )
-                        root_span._set_attribute(
-                            net.NETWORK_PEER_ADDRESS if otel_semantics else "network.client.ip", client_ip
-                        )
+                        core.dispatch("http.set_client_address", (root_span, client_ip))
                     # Copy anomaly-detection attributes from the root span onto the
                     # ai_guard span with the `ai_guard.` prefix, so intake processing has them
                     # even when the root span arrives in a later trace chunk.

--- a/ddtrace/aiguard/_api_client.py
+++ b/ddtrace/aiguard/_api_client.py
@@ -18,6 +18,7 @@ from ddtrace.aiguard._types import ImageURL  # noqa:F401
 from ddtrace.aiguard._types import Message
 from ddtrace.aiguard._types import ToolCall  # noqa:F401
 from ddtrace.ext import http
+from ddtrace.ext import net
 from ddtrace.internal import core
 from ddtrace.internal import span_bus
 from ddtrace.internal import telemetry
@@ -383,6 +384,7 @@ class AIGuardClient:
                 self._add_request_to_telemetry(tuple(telemetry_tags))
                 root_span = span_bus.get_root_span()
                 if root_span:
+                    otel_semantics = config._otel_trace_semantics_enabled
                     _aiguard_manual_keep(root_span)
                     root_span.set_tag(AI_GUARD.EVENT_TAG, "true")
                     # Populate client IP on the service-entry span only when an ai_guard span
@@ -393,13 +395,24 @@ class AIGuardClient:
                     client_ip = core.find_item(AI_GUARD.CLIENT_IP_CORE_KEY)
                     core.discard_item(AI_GUARD.CLIENT_IP_CORE_KEY)
                     if client_ip:
-                        root_span._set_attribute(http.CLIENT_IP, client_ip)
-                        root_span._set_attribute("network.client.ip", client_ip)
+                        root_span._set_attribute(
+                            http.OTEL_CLIENT_ADDRESS if otel_semantics else http.CLIENT_IP, client_ip
+                        )
+                        root_span._set_attribute(
+                            net.NETWORK_PEER_ADDRESS if otel_semantics else "network.client.ip", client_ip
+                        )
                     # Copy anomaly-detection attributes from the root span onto the
                     # ai_guard span with the `ai_guard.` prefix, so intake processing has them
                     # even when the root span arrives in a later trace chunk.
                     for tag_name in AI_GUARD.ANOMALY_DETECTION_TAGS:
-                        tag_value = root_span.get_tag(tag_name)
+                        source_tag = tag_name
+                        if otel_semantics:
+                            source_tag = {
+                                http.USER_AGENT: http.OTEL_USER_AGENT_ORIGINAL,
+                                http.CLIENT_IP: http.OTEL_CLIENT_ADDRESS,
+                                "network.client.ip": net.NETWORK_PEER_ADDRESS,
+                            }.get(tag_name, tag_name)
+                        tag_value = root_span.get_tag(source_tag)
                         if tag_value is not None:
                             span.set_tag(f"{AI_GUARD.TAG}.{tag_name}", tag_value)
                 if should_block:

--- a/ddtrace/appsec/_api_security/api_manager.py
+++ b/ddtrace/appsec/_api_security/api_manager.py
@@ -11,6 +11,7 @@ from typing import Union
 
 from ddtrace._trace._limits import MAX_SPAN_META_VALUE_LEN
 from ddtrace._trace.processor.resource_renaming import SimplifiedEndpointComputer
+from ddtrace._trace.processor.resource_renaming import path_source_tag_value
 import ddtrace.appsec._asm_request_context as _asm_request_context
 from ddtrace.appsec._asm_request_context import ASM_Environment
 from ddtrace.appsec._constants import API_SECURITY
@@ -123,9 +124,11 @@ class APIManager(Service):
 
         route = env.waf_addresses.get(SPAN_DATA_NAMES.REQUEST_ROUTE)
         if route is None and env.blocked is None and not is_404:
+            # http.endpoint has no OTel equivalent, so it stays the primary source in both
+            # modes. Only the URL fallback moves, to url.path.
             endpoint = env.entry_span.get_tag(http.ENDPOINT)
             if endpoint is None:
-                url = env.entry_span.get_tag(http.URL)
+                url = path_source_tag_value(env.entry_span)
                 endpoint = self.simplified_endpoint_computer.from_url(url)
             route = endpoint
 

--- a/ddtrace/appsec/_api_security/api_manager.py
+++ b/ddtrace/appsec/_api_security/api_manager.py
@@ -124,8 +124,6 @@ class APIManager(Service):
 
         route = env.waf_addresses.get(SPAN_DATA_NAMES.REQUEST_ROUTE)
         if route is None and env.blocked is None and not is_404:
-            # http.endpoint has no OTel equivalent, so it stays the primary source in both
-            # modes. Only the URL fallback moves, to url.path.
             endpoint = env.entry_span.get_tag(http.ENDPOINT)
             if endpoint is None:
                 url = path_source_tag_value(env.entry_span)

--- a/ddtrace/appsec/_contrib/django/__init__.py
+++ b/ddtrace/appsec/_contrib/django/__init__.py
@@ -16,8 +16,10 @@ from ddtrace.appsec._asm_request_context import call_waf_callback
 from ddtrace.appsec._asm_request_context import get_blocked
 from ddtrace.appsec._asm_request_context import in_asm_context
 from ddtrace.appsec._asm_request_context import set_block_request_callable
+from ddtrace.appsec._asm_request_context import set_waf_address
 from ddtrace.appsec._constants import APPSEC
 from ddtrace.appsec._constants import LOGIN_EVENTS_MODE
+from ddtrace.appsec._constants import SPAN_DATA_NAMES
 from ddtrace.appsec._constants import WAF_ACTIONS
 from ddtrace.appsec._trace_utils import _asm_manual_keep
 from ddtrace.appsec._trace_utils import track_user_login_failure_event
@@ -277,6 +279,22 @@ def _on_traced_get_response_pre(
     set_block_request_callable(block_callable)
 
 
+def _on_django_resolve_request(resolver_match: Any) -> None:
+    if not asm_config._asm_enabled:
+        return
+    path_params = resolver_match.kwargs or resolver_match.args or None
+    if path_params is not None:
+        set_waf_address(SPAN_DATA_NAMES.REQUEST_PATH_PARAMS, path_params)
+        try:
+            _call_waf_first("Django")
+        except BaseException:
+            if block_config := get_blocked():
+                raise BlockingException(block_config)
+            raise
+        if block_config := get_blocked():
+            raise BlockingException(block_config)
+
+
 def listen() -> None:
     core.on("django.login", _on_django_login)
     core.on("django.auth", _on_django_auth, "user")
@@ -291,3 +309,4 @@ def listen() -> None:
 
     core.on("context.ended.django.traced_get_response", _on_context_ended)
     core.on("django.traced_get_response.pre", _on_traced_get_response_pre)
+    core.on("django.resolve_request", _on_django_resolve_request)

--- a/ddtrace/appsec/_contrib/fastapi/__init__.py
+++ b/ddtrace/appsec/_contrib/fastapi/__init__.py
@@ -17,7 +17,7 @@ from ddtrace.contrib.internal.trace_utils_base import set_method_tag
 from ddtrace.contrib.internal.trace_utils_base import set_query_string_tag
 from ddtrace.contrib.internal.trace_utils_base import set_status_code_tag
 from ddtrace.contrib.internal.trace_utils_base import set_url_tags_server
-from ddtrace.contrib.internal.trace_utils_base import user_agent_tag
+from ddtrace.contrib.internal.trace_utils_base import set_user_agent_tag
 from ddtrace.internal import core
 from ddtrace.internal.constants import RESPONSE_HEADERS
 from ddtrace.internal.core import ExecutionContext
@@ -114,7 +114,7 @@ def _asgi_make_block_content(ctx: ExecutionContext[Event], url: str) -> tuple[in
             set_method_tag(req_span, method)
         user_agent = _get_request_header_user_agent(headers, headers_are_case_sensitive=True)
         if user_agent:
-            req_span._set_attribute(user_agent_tag(), user_agent)
+            set_user_agent_tag(req_span, user_agent)
     except Exception as e:
         logger.warning("Could not set some span tags on blocked request: %s", str(e))
     resp_headers.append((b"Content-Length", str(len(content)).encode()))

--- a/ddtrace/appsec/_contrib/fastapi/__init__.py
+++ b/ddtrace/appsec/_contrib/fastapi/__init__.py
@@ -5,6 +5,11 @@ import json
 from typing import Any
 from typing import Optional
 
+from ddtrace._trace.http_semantics import set_method_tag
+from ddtrace._trace.http_semantics import set_query_string_tag
+from ddtrace._trace.http_semantics import set_status_code_tag
+from ddtrace._trace.http_semantics import set_url_tags_server
+from ddtrace._trace.http_semantics import user_agent_tag
 from ddtrace.appsec._asm_request_context import _call_waf
 from ddtrace.appsec._asm_request_context import _call_waf_first
 from ddtrace.appsec._asm_request_context import _on_context_ended
@@ -13,8 +18,6 @@ from ddtrace.appsec._asm_request_context import get_blocked
 from ddtrace.appsec._asm_request_context import iast_disabled_taint_sources
 from ddtrace.appsec._utils import Block_config
 from ddtrace.contrib.internal.trace_utils_base import _get_request_header_user_agent
-from ddtrace.contrib.internal.trace_utils_base import _set_url_tag
-from ddtrace.ext import http
 from ddtrace.internal import core
 from ddtrace.internal.constants import RESPONSE_HEADERS
 from ddtrace.internal.core import ExecutionContext
@@ -101,17 +104,17 @@ def _asgi_make_block_content(ctx: ExecutionContext[Event], url: str) -> tuple[in
     status = block_config.status_code
     try:
         req_span._set_attribute(RESPONSE_HEADERS + ".content-length", str(len(content)))
-        req_span._set_attribute(http.STATUS_CODE, str(status))
+        set_status_code_tag(req_span, status)
         query_string = environ.get("QUERY_STRING")
-        _set_url_tag(middleware.integration_config, req_span, url, query_string)
+        set_url_tags_server(middleware.integration_config, req_span, url, query_string)
         if query_string and middleware._config.trace_query_string:
-            req_span._set_attribute(http.QUERY_STRING, query_string)
+            set_query_string_tag(req_span, query_string)
         method = environ.get("REQUEST_METHOD")
         if method:
-            req_span._set_attribute(http.METHOD, method)
+            set_method_tag(req_span, method)
         user_agent = _get_request_header_user_agent(headers, headers_are_case_sensitive=True)
         if user_agent:
-            req_span._set_attribute(http.USER_AGENT, user_agent)
+            req_span._set_attribute(user_agent_tag(), user_agent)
     except Exception as e:
         logger.warning("Could not set some span tags on blocked request: %s", str(e))
     resp_headers.append((b"Content-Length", str(len(content)).encode()))

--- a/ddtrace/appsec/_contrib/fastapi/__init__.py
+++ b/ddtrace/appsec/_contrib/fastapi/__init__.py
@@ -12,12 +12,7 @@ from ddtrace.appsec._asm_request_context import _set_headers_and_response
 from ddtrace.appsec._asm_request_context import get_blocked
 from ddtrace.appsec._asm_request_context import iast_disabled_taint_sources
 from ddtrace.appsec._utils import Block_config
-from ddtrace.contrib.internal.trace_utils_base import _get_request_header_user_agent
-from ddtrace.contrib.internal.trace_utils_base import set_method_tag
-from ddtrace.contrib.internal.trace_utils_base import set_query_string_tag
-from ddtrace.contrib.internal.trace_utils_base import set_status_code_tag
-from ddtrace.contrib.internal.trace_utils_base import set_url_tags_server
-from ddtrace.contrib.internal.trace_utils_base import set_user_agent_tag
+from ddtrace.contrib import trace_utils
 from ddtrace.internal import core
 from ddtrace.internal.constants import RESPONSE_HEADERS
 from ddtrace.internal.core import ExecutionContext
@@ -104,17 +99,17 @@ def _asgi_make_block_content(ctx: ExecutionContext[Event], url: str) -> tuple[in
     status = block_config.status_code
     try:
         req_span._set_attribute(RESPONSE_HEADERS + ".content-length", str(len(content)))
-        set_status_code_tag(req_span, status)
         query_string = environ.get("QUERY_STRING")
-        set_url_tags_server(middleware.integration_config, req_span, url, query_string)
-        if query_string and middleware._config.trace_query_string:
-            set_query_string_tag(req_span, query_string)
-        method = environ.get("REQUEST_METHOD")
-        if method:
-            set_method_tag(req_span, method)
-        user_agent = _get_request_header_user_agent(headers, headers_are_case_sensitive=True)
-        if user_agent:
-            set_user_agent_tag(req_span, user_agent)
+        trace_utils.set_http_meta(
+            req_span,
+            middleware.integration_config,
+            method=environ.get("REQUEST_METHOD"),
+            url=url,
+            query=query_string,
+            status_code=status,
+            request_headers=headers,
+            headers_are_case_sensitive=True,
+        )
     except Exception as e:
         logger.warning("Could not set some span tags on blocked request: %s", str(e))
     resp_headers.append((b"Content-Length", str(len(content)).encode()))

--- a/ddtrace/appsec/_contrib/fastapi/__init__.py
+++ b/ddtrace/appsec/_contrib/fastapi/__init__.py
@@ -5,11 +5,6 @@ import json
 from typing import Any
 from typing import Optional
 
-from ddtrace._trace.http_semantics import set_method_tag
-from ddtrace._trace.http_semantics import set_query_string_tag
-from ddtrace._trace.http_semantics import set_status_code_tag
-from ddtrace._trace.http_semantics import set_url_tags_server
-from ddtrace._trace.http_semantics import user_agent_tag
 from ddtrace.appsec._asm_request_context import _call_waf
 from ddtrace.appsec._asm_request_context import _call_waf_first
 from ddtrace.appsec._asm_request_context import _on_context_ended
@@ -18,6 +13,11 @@ from ddtrace.appsec._asm_request_context import get_blocked
 from ddtrace.appsec._asm_request_context import iast_disabled_taint_sources
 from ddtrace.appsec._utils import Block_config
 from ddtrace.contrib.internal.trace_utils_base import _get_request_header_user_agent
+from ddtrace.contrib.internal.trace_utils_base import set_method_tag
+from ddtrace.contrib.internal.trace_utils_base import set_query_string_tag
+from ddtrace.contrib.internal.trace_utils_base import set_status_code_tag
+from ddtrace.contrib.internal.trace_utils_base import set_url_tags_server
+from ddtrace.contrib.internal.trace_utils_base import user_agent_tag
 from ddtrace.internal import core
 from ddtrace.internal.constants import RESPONSE_HEADERS
 from ddtrace.internal.core import ExecutionContext

--- a/ddtrace/appsec/_contrib/flask/__init__.py
+++ b/ddtrace/appsec/_contrib/flask/__init__.py
@@ -8,6 +8,11 @@ from typing import MutableMapping
 from typing import Optional
 from typing import cast
 
+from ddtrace._trace.http_semantics import set_method_tag
+from ddtrace._trace.http_semantics import set_query_string_tag
+from ddtrace._trace.http_semantics import set_status_code_tag
+from ddtrace._trace.http_semantics import set_url_tags_server
+from ddtrace._trace.http_semantics import user_agent_tag
 from ddtrace.appsec._asm_request_context import _call_waf_first
 from ddtrace.appsec._asm_request_context import _on_context_ended
 from ddtrace.appsec._asm_request_context import _set_headers_and_response
@@ -22,8 +27,6 @@ from ddtrace.appsec._asm_request_context import set_waf_address
 from ddtrace.appsec._utils import Block_config
 from ddtrace.contrib import trace_utils
 from ddtrace.contrib.internal.trace_utils_base import _get_request_header_user_agent
-from ddtrace.contrib.internal.trace_utils_base import _set_url_tag
-from ddtrace.ext import http
 from ddtrace.internal import core
 from ddtrace.internal.appsec.prototypes import SpanProtocol
 from ddtrace.internal.constants import REQUEST_PATH_PARAMS
@@ -127,20 +130,20 @@ def _on_request_span_modifier(
 
 
 def _on_flask_blocked_request(span: SpanProtocol) -> None:
-    span._set_attribute(http.STATUS_CODE, "403")
+    set_status_code_tag(span, 403)
     request = core.find_item("flask_request")
     try:
         base_url = getattr(request, "base_url", None)
         query_string = getattr(request, "query_string", None)
         if base_url and query_string:
-            _set_url_tag(core.find_item("flask_config"), cast("SpanData", span), base_url, query_string)
+            set_url_tags_server(core.find_item("flask_config"), span, base_url, query_string)
         if query_string and core.find_item("flask_config").trace_query_string:
-            span._set_attribute(http.QUERY_STRING, query_string)
+            set_query_string_tag(span, query_string)
         if request.method is not None:
-            span._set_attribute(http.METHOD, request.method)
+            set_method_tag(span, request.method)
         user_agent = _get_request_header_user_agent(request.headers)
         if user_agent:
-            span._set_attribute(http.USER_AGENT, user_agent)
+            span._set_attribute(user_agent_tag(), user_agent)
     except Exception as e:
         logger.warning("Could not set some span tags on blocked request: %s", str(e))
 
@@ -249,18 +252,18 @@ def _wsgi_make_block_content(
         req_span._set_attribute(RESPONSE_HEADERS + ".content-length", str(len(content)))
         if ctype is not None:
             req_span._set_attribute(RESPONSE_HEADERS + ".content-type", ctype)
-        req_span._set_attribute(http.STATUS_CODE, str(status))
+        set_status_code_tag(req_span, status)
         url = construct_url(environ)
         query_string = environ.get("QUERY_STRING")
-        _set_url_tag(middleware._config, req_span, url, query_string)
+        set_url_tags_server(middleware._config, req_span, url, query_string)
         if query_string and middleware._config.trace_query_string:
-            req_span._set_attribute(http.QUERY_STRING, query_string)
+            set_query_string_tag(req_span, query_string)
         method = environ.get("REQUEST_METHOD")
         if method:
-            req_span._set_attribute(http.METHOD, method)
+            set_method_tag(req_span, method)
         user_agent = _get_request_header_user_agent(headers, headers_are_case_sensitive=True)
         if user_agent:
-            req_span._set_attribute(http.USER_AGENT, user_agent)
+            req_span._set_attribute(user_agent_tag(), user_agent)
     except Exception as e:
         logger.warning("Could not set some span tags on blocked request: %s", str(e))
     resp_headers.append(("Content-Length", str(len(content))))

--- a/ddtrace/appsec/_contrib/flask/__init__.py
+++ b/ddtrace/appsec/_contrib/flask/__init__.py
@@ -26,7 +26,7 @@ from ddtrace.contrib.internal.trace_utils_base import set_method_tag
 from ddtrace.contrib.internal.trace_utils_base import set_query_string_tag
 from ddtrace.contrib.internal.trace_utils_base import set_status_code_tag
 from ddtrace.contrib.internal.trace_utils_base import set_url_tags_server
-from ddtrace.contrib.internal.trace_utils_base import user_agent_tag
+from ddtrace.contrib.internal.trace_utils_base import set_user_agent_tag
 from ddtrace.internal import core
 from ddtrace.internal.appsec.prototypes import SpanProtocol
 from ddtrace.internal.constants import REQUEST_PATH_PARAMS
@@ -143,7 +143,7 @@ def _on_flask_blocked_request(span: SpanProtocol) -> None:
             set_method_tag(span, request.method)
         user_agent = _get_request_header_user_agent(request.headers)
         if user_agent:
-            span._set_attribute(user_agent_tag(), user_agent)
+            set_user_agent_tag(span, user_agent)
     except Exception as e:
         logger.warning("Could not set some span tags on blocked request: %s", str(e))
 
@@ -263,7 +263,7 @@ def _wsgi_make_block_content(
             set_method_tag(req_span, method)
         user_agent = _get_request_header_user_agent(headers, headers_are_case_sensitive=True)
         if user_agent:
-            req_span._set_attribute(user_agent_tag(), user_agent)
+            set_user_agent_tag(req_span, user_agent)
     except Exception as e:
         logger.warning("Could not set some span tags on blocked request: %s", str(e))
     resp_headers.append(("Content-Length", str(len(content))))

--- a/ddtrace/appsec/_contrib/flask/__init__.py
+++ b/ddtrace/appsec/_contrib/flask/__init__.py
@@ -1,7 +1,6 @@
 from collections.abc import Mapping
 import io
 import json
-from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import MutableMapping
@@ -21,12 +20,6 @@ from ddtrace.appsec._asm_request_context import set_block_request_callable
 from ddtrace.appsec._asm_request_context import set_waf_address
 from ddtrace.appsec._utils import Block_config
 from ddtrace.contrib import trace_utils
-from ddtrace.contrib.internal.trace_utils_base import _get_request_header_user_agent
-from ddtrace.contrib.internal.trace_utils_base import set_method_tag
-from ddtrace.contrib.internal.trace_utils_base import set_query_string_tag
-from ddtrace.contrib.internal.trace_utils_base import set_status_code_tag
-from ddtrace.contrib.internal.trace_utils_base import set_url_tags_server
-from ddtrace.contrib.internal.trace_utils_base import set_user_agent_tag
 from ddtrace.internal import core
 from ddtrace.internal.appsec.prototypes import SpanProtocol
 from ddtrace.internal.constants import REQUEST_PATH_PARAMS
@@ -42,9 +35,6 @@ from ddtrace.internal.utils.http import MediaType
 from ddtrace.internal.utils.http import classify_media_type
 import ddtrace.vendor.xmltodict as xmltodict
 
-
-if TYPE_CHECKING:
-    from ddtrace.internal.native._native import SpanData
 
 logger = get_logger(__name__)
 
@@ -130,20 +120,17 @@ def _on_request_span_modifier(
 
 
 def _on_flask_blocked_request(span: SpanProtocol) -> None:
-    set_status_code_tag(span, 403)
     request = core.find_item("flask_request")
     try:
-        base_url = getattr(request, "base_url", None)
-        query_string = getattr(request, "query_string", None)
-        if base_url and query_string:
-            set_url_tags_server(core.find_item("flask_config"), span, base_url, query_string)
-        if query_string and core.find_item("flask_config").trace_query_string:
-            set_query_string_tag(span, query_string)
-        if request.method is not None:
-            set_method_tag(span, request.method)
-        user_agent = _get_request_header_user_agent(request.headers)
-        if user_agent:
-            set_user_agent_tag(span, user_agent)
+        trace_utils.set_http_meta(
+            cast(Any, span),
+            core.find_item("flask_config"),
+            method=getattr(request, "method", None),
+            url=getattr(request, "base_url", None),
+            query=getattr(request, "query_string", None),
+            status_code=403,
+            request_headers=getattr(request, "headers", None),
+        )
     except Exception as e:
         logger.warning("Could not set some span tags on blocked request: %s", str(e))
 
@@ -252,18 +239,18 @@ def _wsgi_make_block_content(
         req_span._set_attribute(RESPONSE_HEADERS + ".content-length", str(len(content)))
         if ctype is not None:
             req_span._set_attribute(RESPONSE_HEADERS + ".content-type", ctype)
-        set_status_code_tag(req_span, status)
         url = construct_url(environ)
         query_string = environ.get("QUERY_STRING")
-        set_url_tags_server(middleware._config, req_span, url, query_string)
-        if query_string and middleware._config.trace_query_string:
-            set_query_string_tag(req_span, query_string)
-        method = environ.get("REQUEST_METHOD")
-        if method:
-            set_method_tag(req_span, method)
-        user_agent = _get_request_header_user_agent(headers, headers_are_case_sensitive=True)
-        if user_agent:
-            set_user_agent_tag(req_span, user_agent)
+        trace_utils.set_http_meta(
+            req_span,
+            middleware._config,
+            method=environ.get("REQUEST_METHOD"),
+            url=url,
+            query=query_string,
+            status_code=status,
+            request_headers=headers,
+            headers_are_case_sensitive=True,
+        )
     except Exception as e:
         logger.warning("Could not set some span tags on blocked request: %s", str(e))
     resp_headers.append(("Content-Length", str(len(content))))

--- a/ddtrace/appsec/_contrib/flask/__init__.py
+++ b/ddtrace/appsec/_contrib/flask/__init__.py
@@ -8,11 +8,6 @@ from typing import MutableMapping
 from typing import Optional
 from typing import cast
 
-from ddtrace._trace.http_semantics import set_method_tag
-from ddtrace._trace.http_semantics import set_query_string_tag
-from ddtrace._trace.http_semantics import set_status_code_tag
-from ddtrace._trace.http_semantics import set_url_tags_server
-from ddtrace._trace.http_semantics import user_agent_tag
 from ddtrace.appsec._asm_request_context import _call_waf_first
 from ddtrace.appsec._asm_request_context import _on_context_ended
 from ddtrace.appsec._asm_request_context import _set_headers_and_response
@@ -27,6 +22,11 @@ from ddtrace.appsec._asm_request_context import set_waf_address
 from ddtrace.appsec._utils import Block_config
 from ddtrace.contrib import trace_utils
 from ddtrace.contrib.internal.trace_utils_base import _get_request_header_user_agent
+from ddtrace.contrib.internal.trace_utils_base import set_method_tag
+from ddtrace.contrib.internal.trace_utils_base import set_query_string_tag
+from ddtrace.contrib.internal.trace_utils_base import set_status_code_tag
+from ddtrace.contrib.internal.trace_utils_base import set_url_tags_server
+from ddtrace.contrib.internal.trace_utils_base import user_agent_tag
 from ddtrace.internal import core
 from ddtrace.internal.appsec.prototypes import SpanProtocol
 from ddtrace.internal.constants import REQUEST_PATH_PARAMS

--- a/ddtrace/contrib/internal/asgi/middleware.py
+++ b/ddtrace/contrib/internal/asgi/middleware.py
@@ -297,7 +297,7 @@ class TraceMiddleware:
                     url = f"{url}?{query_string}"
                 if raw_url:
                     raw_url = f"{raw_url}?{query_string}"
-            if not self.integration_config.trace_query_string:
+            if not config._otel_trace_semantics_enabled and not self.integration_config.trace_query_string:
                 query_string = None
             # Body parsing is HTTP-only: sub-apps skip it (parent already handled it),
             # and websocket scopes must not have their receive() consumed here.
@@ -592,7 +592,11 @@ class TraceMiddleware:
         if span and message.get("type") == "http.response.start" and "status" in message:
             cookies = _parse_response_cookies(response_headers)
             status_code = message["status"]
-            if self.integration_config.obfuscate_404_resource and status_code == 404:
+            if (
+                self.integration_config.obfuscate_404_resource
+                and status_code == 404
+                and not config._otel_trace_semantics_enabled
+            ):
                 set_instrumentation_resource(span, " ".join((method, "404")))
 
             trace_utils.set_http_meta(

--- a/ddtrace/contrib/internal/asgi/middleware.py
+++ b/ddtrace/contrib/internal/asgi/middleware.py
@@ -7,6 +7,8 @@ from typing import Optional
 from urllib import parse
 
 from ddtrace import config
+from ddtrace._trace.http_semantics import set_status_code_tag
+from ddtrace._trace.otel_http_naming import set_instrumentation_resource
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
 from ddtrace.contrib.internal.asgi.utils import bytes_to_str
@@ -97,7 +99,7 @@ def _extract_versions_from_scope(scope: Mapping[str, Any], integration_config: M
 
 def _default_handle_exception_span(exc, span):
     """Default handler for exception for span"""
-    span._set_attribute(http.STATUS_CODE, "500")
+    set_status_code_tag(span, 500)
 
 
 def span_from_scope(scope: Mapping[str, Any]) -> Optional[Span]:
@@ -591,7 +593,7 @@ class TraceMiddleware:
             cookies = _parse_response_cookies(response_headers)
             status_code = message["status"]
             if self.integration_config.obfuscate_404_resource and status_code == 404:
-                span.resource = " ".join((method, "404"))
+                set_instrumentation_resource(span, " ".join((method, "404")))
 
             trace_utils.set_http_meta(
                 span,

--- a/ddtrace/contrib/internal/cherrypy/patch.py
+++ b/ddtrace/contrib/internal/cherrypy/patch.py
@@ -8,8 +8,11 @@ import cherrypy
 from cherrypy.lib.httputil import valid_status
 
 from ddtrace import config
+from ddtrace._trace.http_semantics import normalize_http_method
 from ddtrace._trace.http_semantics import set_method_tag
+from ddtrace._trace.otel_http_naming import record_initial_instrumentation_resource
 from ddtrace._trace.otel_http_naming import set_instrumentation_resource
+from ddtrace._trace.otel_http_naming import set_otel_http_resource
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
@@ -92,7 +95,10 @@ class TraceTool(cherrypy.Tool):
                 config.cherrypy,
             )
             set_method_tag(req_span, cherrypy.request.method)
-            set_instrumentation_resource(req_span, req_span.resource)
+            record_initial_instrumentation_resource(req_span, SPAN_NAME)
+            if config._otel_trace_semantics_enabled:
+                normalized_method, original_method = normalize_http_method(cherrypy.request.method)
+                set_otel_http_resource(req_span, normalized_method, original_method)
 
             ctx.set_item("req_span", req_span)
             core.dispatch("web.request.start", (ctx, config.cherrypy))

--- a/ddtrace/contrib/internal/cherrypy/patch.py
+++ b/ddtrace/contrib/internal/cherrypy/patch.py
@@ -8,6 +8,8 @@ import cherrypy
 from cherrypy.lib.httputil import valid_status
 
 from ddtrace import config
+from ddtrace._trace.http_semantics import set_method_tag
+from ddtrace._trace.otel_http_naming import set_instrumentation_resource
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import ERROR_STACK
 from ddtrace.constants import ERROR_TYPE
@@ -89,6 +91,8 @@ class TraceTool(cherrypy.Tool):
                 trace_utils.int_service(None, config.cherrypy, default="cherrypy"),
                 config.cherrypy,
             )
+            set_method_tag(req_span, cherrypy.request.method)
+            set_instrumentation_resource(req_span, req_span.resource)
 
             ctx.set_item("req_span", req_span)
             core.dispatch("web.request.start", (ctx, config.cherrypy))
@@ -133,7 +137,7 @@ class TraceTool(cherrypy.Tool):
             #   GET /
             #   POST /save
             resource = "{} {}".format(cherrypy.request.method, cherrypy.request.path_info)
-            span.resource = str(resource)
+            set_instrumentation_resource(span, str(resource))
 
         url = str(cherrypy.request.base + cherrypy.request.path_info)
         status_code, _, _ = valid_status(cherrypy.response.status)

--- a/ddtrace/contrib/internal/django/patch.py
+++ b/ddtrace/contrib/internal/django/patch.py
@@ -11,6 +11,7 @@ import asyncio
 from inspect import getmro
 from inspect import iscoroutinefunction
 from inspect import unwrap
+from typing import Any
 from typing import cast
 
 import wrapt
@@ -42,6 +43,8 @@ from ddtrace.vendor.packaging.version import parse as parse_version
 
 
 log = get_logger(__name__)
+
+_legacy_resolve_request_enabled = False
 
 DJANGO_TRACING_MINIMAL = asbool(_get_config("DD_DJANGO_TRACING_MINIMAL", default=True))
 
@@ -235,6 +238,11 @@ def traced_load_middleware(django, pin, func, instance, args, kwargs):
 
     ret = func(*args, **kwargs)
 
+    if django.VERSION < (3, 1):
+        # AIDEV-NOTE: Django <3.1 resolves routes inline in _get_response. A first-position view middleware is the
+        # only post-resolution, pre-application hook that avoids invoking custom path converters a second time.
+        instance._view_middleware.insert(0, _dispatch_resolved_request)
+
     # Building a BaseHandler is the earliest reliable signal that this process serves HTTP, so the URLconf import
     # forced here is one the first request would pay anyway. Dynamic per-tenant urlconfs still come from response.py.
     try:
@@ -245,6 +253,16 @@ def traced_load_middleware(django, pin, func, instance, args, kwargs):
         log.debug("Error collecting Django routes for endpoint discovery", exc_info=True)
 
     return ret
+
+
+def _dispatch_resolved_request(
+    request: Any, _callback: Any, _callback_args: tuple[Any, ...], _callback_kwargs: dict[str, Any]
+) -> None:
+    if not _legacy_resolve_request_enabled:
+        return
+    resolver_match = getattr(request, "resolver_match", None)
+    if resolver_match is not None:
+        core.dispatch("django.resolve_request", (resolver_match,), allow_raise=True)
 
 
 def instrument_view(django, view):
@@ -527,12 +545,15 @@ def wrap_wsgi_environ(wrapped, _instance, args, kwargs):
 
 
 def patch():
+    global _legacy_resolve_request_enabled
+
     import django
 
     if getattr(django, "_datadog_patch", False):
         return
     _patch(django)
 
+    _legacy_resolve_request_enabled = True
     django._datadog_patch = True
 
 
@@ -566,11 +587,14 @@ def _unpatch(django):
 
 
 def unpatch():
+    global _legacy_resolve_request_enabled
+
     import django
 
     if not getattr(django, "_datadog_patch", False):
         return
 
+    _legacy_resolve_request_enabled = False
     _unpatch(django)
 
     django._datadog_patch = False

--- a/ddtrace/contrib/internal/django/patch.py
+++ b/ddtrace/contrib/internal/django/patch.py
@@ -239,7 +239,8 @@ def traced_load_middleware(django, pin, func, instance, args, kwargs):
     ret = func(*args, **kwargs)
 
     if django.VERSION < (3, 1):
-        # AIDEV-NOTE: This post-resolution hook avoids rerunning custom converters on Django <3.1.
+        # AIDEV-NOTE: First-position view middleware is Django <3.1's only post-resolution,
+        # pre-application hook that does not rerun custom converters.
         instance._view_middleware.insert(0, _dispatch_resolved_request)
 
     # Building a BaseHandler is the earliest reliable signal that this process serves HTTP, so the URLconf import

--- a/ddtrace/contrib/internal/django/patch.py
+++ b/ddtrace/contrib/internal/django/patch.py
@@ -44,7 +44,7 @@ from ddtrace.vendor.packaging.version import parse as parse_version
 
 log = get_logger(__name__)
 
-_legacy_resolve_request_enabled = False
+_pre_31_resolve_request_enabled = False
 
 DJANGO_TRACING_MINIMAL = asbool(_get_config("DD_DJANGO_TRACING_MINIMAL", default=True))
 
@@ -239,8 +239,7 @@ def traced_load_middleware(django, pin, func, instance, args, kwargs):
     ret = func(*args, **kwargs)
 
     if django.VERSION < (3, 1):
-        # AIDEV-NOTE: Django <3.1 resolves routes inline in _get_response. A first-position view middleware is the
-        # only post-resolution, pre-application hook that avoids invoking custom path converters a second time.
+        # AIDEV-NOTE: This post-resolution hook avoids rerunning custom converters on Django <3.1.
         instance._view_middleware.insert(0, _dispatch_resolved_request)
 
     # Building a BaseHandler is the earliest reliable signal that this process serves HTTP, so the URLconf import
@@ -258,7 +257,7 @@ def traced_load_middleware(django, pin, func, instance, args, kwargs):
 def _dispatch_resolved_request(
     request: Any, _callback: Any, _callback_args: tuple[Any, ...], _callback_kwargs: dict[str, Any]
 ) -> None:
-    if not _legacy_resolve_request_enabled:
+    if not _pre_31_resolve_request_enabled:
         return
     resolver_match = getattr(request, "resolver_match", None)
     if resolver_match is not None:
@@ -545,7 +544,7 @@ def wrap_wsgi_environ(wrapped, _instance, args, kwargs):
 
 
 def patch():
-    global _legacy_resolve_request_enabled
+    global _pre_31_resolve_request_enabled
 
     import django
 
@@ -553,7 +552,7 @@ def patch():
         return
     _patch(django)
 
-    _legacy_resolve_request_enabled = True
+    _pre_31_resolve_request_enabled = True
     django._datadog_patch = True
 
 
@@ -587,14 +586,14 @@ def _unpatch(django):
 
 
 def unpatch():
-    global _legacy_resolve_request_enabled
+    global _pre_31_resolve_request_enabled
 
     import django
 
     if not getattr(django, "_datadog_patch", False):
         return
 
-    _legacy_resolve_request_enabled = False
+    _pre_31_resolve_request_enabled = False
     _unpatch(django)
 
     django._datadog_patch = False

--- a/ddtrace/contrib/internal/django/response.py
+++ b/ddtrace/contrib/internal/django/response.py
@@ -10,6 +10,8 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 
 from ddtrace import config
+from ddtrace._trace.http_semantics import http_block_metadata
+from ddtrace._trace.otel_http_naming import record_initial_instrumentation_resource
 from ddtrace._trace.pin import Pin
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib.internal import trace_utils
@@ -21,7 +23,6 @@ from ddtrace.contrib.internal.django.utils import _after_request_tags
 from ddtrace.contrib.internal.django.utils import _before_request_tags
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
-from ddtrace.ext import http
 from ddtrace.internal import core
 from ddtrace.internal._exceptions import BlockingException
 from ddtrace.internal._exceptions import find_exception
@@ -51,17 +52,21 @@ config_django: IntegrationConfig = cast(IntegrationConfig, config.django)
 
 def _gather_block_metadata(request, request_headers, ctx: core.ExecutionContext):
     url: Optional[str] = None
-    metadata: dict[str, str] = {}
+    metadata: dict[str, Any] = {}
     query: str = ""
     try:
-        metadata = {http.STATUS_CODE: "403", http.METHOD: request.method}
+        # The dispatch below applies these to the request span as-is, so they are already
+        # spelled and shaped for whichever semantics mode is active. Built from the method and
+        # status alone first, so a failure in the calls below still leaves those on the span.
+        metadata = http_block_metadata(request.method, 403)
         url = utils.get_request_uri(request)
         query = request.META.get("QUERY_STRING", "")
-        if query and config_django.trace_query_string:
-            metadata[http.QUERY_STRING] = query
-        user_agent = trace_utils._get_request_header_user_agent(request_headers)
-        if user_agent:
-            metadata[http.USER_AGENT] = user_agent
+        metadata = http_block_metadata(
+            request.method,
+            403,
+            query=query if config_django.trace_query_string else None,
+            user_agent=trace_utils._get_request_header_user_agent(request_headers),
+        )
     except Exception as e:
         log.warning("Could not gather some metadata on blocked request: %s", str(e))
     core.dispatch("django.block_request_callback", (ctx, metadata, config_django, url, query))
@@ -73,6 +78,13 @@ def _block_request_callable(request, request_headers, ctx: core.ExecutionContext
     set_blocked()
     _gather_block_metadata(request, request_headers, ctx)
     raise PermissionDenied()
+
+
+def traced_resolve_request(func: FunctionType, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+    """Publish Django's resolved route before view middleware and application code run."""
+    resolver_match = func(*args, **kwargs)
+    core.dispatch("django.resolve_request", (resolver_match,), allow_raise=True)
+    return resolver_match
 
 
 def traced_get_response(func: FunctionType, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
@@ -92,6 +104,8 @@ def traced_get_response(func: FunctionType, args: tuple[Any, ...], kwargs: dict[
     request_headers = utils._get_request_headers(request)
 
     pin = Pin.get_from(instance)
+    otel_resource = utils._initial_otel_resource(request)
+    span_tags = {COMPONENT: config_django.integration_name, SPAN_KIND: SpanKind.SERVER}
 
     with core.context_with_data(
         "django.traced_get_response",
@@ -99,14 +113,16 @@ def traced_get_response(func: FunctionType, args: tuple[Any, ...], kwargs: dict[
         headers=request_headers,
         headers_case_sensitive=True,
         span_name=schematize_url_operation("django.request", protocol="http", direction=SpanDirection.INBOUND),
-        resource=utils.REQUEST_DEFAULT_RESOURCE,
+        resource=otel_resource or utils.REQUEST_DEFAULT_RESOURCE,
         service=trace_utils.int_service(pin, config_django),
         span_type=SpanTypes.WEB,
-        tags={COMPONENT: config_django.integration_name, SPAN_KIND: SpanKind.SERVER},
+        tags=span_tags,
         integration_config=config_django,
         distributed_headers=request_headers,
         activate_distributed_headers=True,
     ) as ctx:
+        if otel_resource is not None:
+            record_initial_instrumentation_resource(span_from_context(ctx), otel_resource)
         core.dispatch(
             "django.traced_get_response.pre",
             (
@@ -199,8 +215,10 @@ async def traced_get_response_async(
     if span is None:
         return await func(*args, **kwargs)
 
-    # Reset the span resource so we can know if it was modified during the request or not
-    span.resource = REQUEST_DEFAULT_RESOURCE
+    # The ASGI subscriber already published the OTel method resource. Keep it stable while
+    # application code runs so nested propagation samples the same name that will be exported.
+    if not config._otel_trace_semantics_enabled:
+        span.resource = REQUEST_DEFAULT_RESOURCE
     _before_request_tags(pin, span, request)
     response = None
     try:
@@ -222,6 +240,12 @@ def instrument_module(django: ModuleType, django_core_handlers_base: ModuleType)
         )
 
     if django.VERSION >= (3, 1):
+        if not is_wrapped_with(django_core_handlers_base.BaseHandler.resolve_request, traced_resolve_request):
+            wrap(
+                django_core_handlers_base.BaseHandler.resolve_request,
+                traced_resolve_request,
+            )
+
         # DEV: We cannot use bytecode wrappers here, otherwise in Python 3.13+ we'll trigger:
         #      `ValueError: coroutine already executing`
         if not trace_utils.iswrapped(django_core_handlers_base.BaseHandler, "get_response_async"):
@@ -236,6 +260,12 @@ def uninstrument_module(django: ModuleType, django_core_handlers_base: ModuleTyp
         )
 
     if django.VERSION >= (3, 1):
+        if is_wrapped_with(django_core_handlers_base.BaseHandler.resolve_request, traced_resolve_request):
+            unwrap(
+                django_core_handlers_base.BaseHandler.resolve_request,
+                traced_resolve_request,
+            )
+
         # DEV: We cannot use bytecode wrappers here, otherwise in Python 3.13+ we'll trigger:
         #      `ValueError: coroutine already executing`
         if trace_utils.iswrapped(django_core_handlers_base.BaseHandler, "get_response_async"):

--- a/ddtrace/contrib/internal/django/response.py
+++ b/ddtrace/contrib/internal/django/response.py
@@ -55,9 +55,6 @@ def _gather_block_metadata(request, request_headers, ctx: core.ExecutionContext)
     metadata: dict[str, Any] = {}
     query: str = ""
     try:
-        # The dispatch below applies these to the request span as-is, so they are already
-        # spelled and shaped for whichever semantics mode is active. Built from the method and
-        # status alone first, so a failure in the calls below still leaves those on the span.
         metadata = http_block_metadata(request.method, 403)
         url = utils.get_request_uri(request)
         query = request.META.get("QUERY_STRING", "")
@@ -81,7 +78,6 @@ def _block_request_callable(request, request_headers, ctx: core.ExecutionContext
 
 
 def traced_resolve_request(func: FunctionType, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
-    """Publish Django's resolved route before view middleware and application code run."""
     resolver_match = func(*args, **kwargs)
     core.dispatch("django.resolve_request", (resolver_match,), allow_raise=True)
     return resolver_match
@@ -215,8 +211,7 @@ async def traced_get_response_async(
     if span is None:
         return await func(*args, **kwargs)
 
-    # The ASGI subscriber already published the OTel method resource. Keep it stable while
-    # application code runs so nested propagation samples the same name that will be exported.
+    # Preserve the final resource while application code can trigger sampling.
     if not config._otel_trace_semantics_enabled:
         span.resource = REQUEST_DEFAULT_RESOURCE
     _before_request_tags(pin, span, request)

--- a/ddtrace/contrib/internal/django/response.py
+++ b/ddtrace/contrib/internal/django/response.py
@@ -55,6 +55,7 @@ def _gather_block_metadata(request, request_headers, ctx: core.ExecutionContext)
     metadata: dict[str, Any] = {}
     query: str = ""
     try:
+        # Preserve method and status if later request extraction fails.
         metadata = http_block_metadata(request.method, 403)
         url = utils.get_request_uri(request)
         query = request.META.get("QUERY_STRING", "")
@@ -211,7 +212,7 @@ async def traced_get_response_async(
     if span is None:
         return await func(*args, **kwargs)
 
-    # Preserve the final resource while application code can trigger sampling.
+    # Preserve the method-only OTel resource while application code can trigger sampling.
     if not config._otel_trace_semantics_enabled:
         span.resource = REQUEST_DEFAULT_RESOURCE
     _before_request_tags(pin, span, request)

--- a/ddtrace/contrib/internal/django/response.py
+++ b/ddtrace/contrib/internal/django/response.py
@@ -80,6 +80,11 @@ def _block_request_callable(request, request_headers, ctx: core.ExecutionContext
 
 def traced_resolve_request(func: FunctionType, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
     resolver_match = func(*args, **kwargs)
+    request = get_argument_value(args, kwargs, 1, "request")
+    if request is not None:
+        # The AppSec callback can block during this dispatch. Store Django's resolved
+        # value first so final tagging does not invoke application converters again.
+        request.resolver_match = resolver_match
     core.dispatch("django.resolve_request", (resolver_match,), allow_raise=True)
     return resolver_match
 
@@ -156,7 +161,7 @@ def traced_get_response(func: FunctionType, args: tuple[Any, ...], kwargs: dict[
                 if uri is not None and query:
                     uri += "?" + query
 
-                # The listener pulls ``request_path_params`` itself via ``utils._request_path_params(request)``.
+                # The listener pulls request_path_params itself via utils._request_path_params(request).
                 core.dispatch(
                     "django.start_response", (ctx, request, utils._extract_body, utils._remake_body, query, uri)
                 )

--- a/ddtrace/contrib/internal/django/utils.py
+++ b/ddtrace/contrib/internal/django/utils.py
@@ -2,6 +2,7 @@ import io
 import json
 from typing import Any  # noqa:F401
 from typing import Mapping  # noqa:F401
+from typing import Optional
 from typing import Text  # noqa:F401
 from typing import Union  # noqa:F401
 import uuid
@@ -11,6 +12,11 @@ from django.utils.functional import SimpleLazyObject
 from wrapt import FunctionWrapper
 
 from ddtrace import config
+from ddtrace._trace.http_semantics import normalize_http_method
+from ddtrace._trace.otel_http_naming import INSTRUMENTATION_HTTP_RESOURCE
+from ddtrace._trace.otel_http_naming import RESOURCE_SET_BY_USER
+from ddtrace._trace.otel_http_naming import otel_http_resource
+from ddtrace._trace.otel_http_naming import set_instrumentation_resource
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.contrib import trace_utils
 from ddtrace.contrib.internal.django.compat import get_resolver
@@ -183,6 +189,9 @@ def _set_resolver_tags(pin, span, request):
             # The request quite likely failed (e.g. 404) so we do the resolution anyway.
             resolver = get_resolver(getattr(request, "urlconf", None))
             resolver_match = resolver.resolve(request.path_info)
+            # Preserve the result for downstream consumers such as AppSec. In particular,
+            # an early blocked request never reaches Django's own resolver assignment.
+            request.resolver_match = resolver_match
 
         if hasattr(resolver_match[0], "view_class"):
             # In django==4.0, view.__name__ defaults to <module>.views.view
@@ -237,8 +246,24 @@ def _set_resolver_tags(pin, span, request):
     finally:
         # Only update the resource name if it was not explicitly set
         # by anyone during the request lifetime
-        if span.resource == REQUEST_DEFAULT_RESOURCE:
+        otel_resource = span._get_ctx_item(INSTRUMENTATION_HTTP_RESOURCE)
+        if span.resource == REQUEST_DEFAULT_RESOURCE or (otel_resource is not None and span.resource == otel_resource):
             span.resource = resource
+            if config._otel_trace_semantics_enabled:
+                span._set_ctx_item(INSTRUMENTATION_HTTP_RESOURCE, span.resource)
+        else:
+            # set_http_meta otherwise renames the span from its attributes and would undo
+            # the user's choice.
+            span._set_ctx_item(RESOURCE_SET_BY_USER, True)
+
+
+def _initial_otel_resource(request: Any) -> Optional[str]:
+    """Return the method-only resource used until Django resolves the application route."""
+    if not config._otel_trace_semantics_enabled:
+        return None
+
+    normalized_method, _ = normalize_http_method(request.method)
+    return otel_http_resource(normalized_method, None)
 
 
 def _before_request_tags(pin, span, request):
@@ -421,23 +446,20 @@ def _after_request_tags(pin, span: Span, request, response):
             core.dispatch("django.after_request_headers.finalize", (content, None))
     finally:
         if span.resource == REQUEST_DEFAULT_RESOURCE:
-            span.resource = request.method
+            set_instrumentation_resource(span, request.method)
 
 
 def _request_path_params(request):
     """Polymorphic Django path-params extraction.
 
-    Returns ``resolver_match.kwargs`` (named captures), else ``resolver_match.args`` (unnamed captures), else ``None``.
-    Pre-view hooks may run before Django sets ``request.resolver_match``; we fall back to a fresh resolve in that
-    case. The broad try/except shields request tagging from raising third-party ``ResolverMatch`` subclasses.
+    Returns resolver_match.kwargs (named captures), else resolver_match.args (unnamed captures),
+    else None. Pre-view hooks must not resolve the route themselves because converters are
+    application code and Django will invoke them during its own resolution.
     """
     try:
         resolver_match = getattr(request, "resolver_match", None)
         if resolver_match is None:
-            resolver = get_resolver(getattr(request, "urlconf", None))
-            if resolver is None:
-                return None
-            resolver_match = resolver.resolve(request.path_info)
+            return None
         return resolver_match.kwargs or resolver_match.args or None
     except Exception:
         log.debug("Django request_path_params extraction failed", exc_info=True)

--- a/ddtrace/contrib/internal/django/utils.py
+++ b/ddtrace/contrib/internal/django/utils.py
@@ -189,8 +189,7 @@ def _set_resolver_tags(pin, span, request):
             # The request quite likely failed (e.g. 404) so we do the resolution anyway.
             resolver = get_resolver(getattr(request, "urlconf", None))
             resolver_match = resolver.resolve(request.path_info)
-            # Preserve the result for downstream consumers such as AppSec. In particular,
-            # an early blocked request never reaches Django's own resolver assignment.
+            # Early AppSec blocking bypasses Django's resolver assignment.
             request.resolver_match = resolver_match
 
         if hasattr(resolver_match[0], "view_class"):
@@ -252,13 +251,11 @@ def _set_resolver_tags(pin, span, request):
             if config._otel_trace_semantics_enabled:
                 span._set_ctx_item(INSTRUMENTATION_HTTP_RESOURCE, span.resource)
         else:
-            # set_http_meta otherwise renames the span from its attributes and would undo
-            # the user's choice.
+            # Prevent final HTTP tagging from replacing a user-owned resource.
             span._set_ctx_item(RESOURCE_SET_BY_USER, True)
 
 
 def _initial_otel_resource(request: Any) -> Optional[str]:
-    """Return the method-only resource used until Django resolves the application route."""
     if not config._otel_trace_semantics_enabled:
         return None
 

--- a/ddtrace/contrib/internal/django/utils.py
+++ b/ddtrace/contrib/internal/django/utils.py
@@ -181,6 +181,7 @@ def get_request_uri(request):
 def _set_resolver_tags(pin, span, request):
     # Default to just the HTTP method when we cannot determine a reasonable resource
     resource = request.method
+    route = None
 
     try:
         # Get resolver match result and build resource name pieces
@@ -199,7 +200,6 @@ def _set_resolver_tags(pin, span, request):
         else:
             handler = func_name(resolver_match[0])
 
-        route = None
         # In Django >= 2.2.0 we can access the original route or regex pattern
         # TODO: Validate if `resolver.pattern.regex.pattern` is available on django<2.2
         if DJANGO22:
@@ -243,6 +243,10 @@ def _set_resolver_tags(pin, span, request):
             exc_info=True,
         )
     finally:
+        if config._otel_trace_semantics_enabled:
+            normalized_method, _ = normalize_http_method(request.method)
+            resource = otel_http_resource(normalized_method, route)
+
         # Only update the resource name if it was not explicitly set
         # by anyone during the request lifetime
         otel_resource = span._get_ctx_item(INSTRUMENTATION_HTTP_RESOURCE)

--- a/ddtrace/contrib/internal/falcon/middleware.py
+++ b/ddtrace/contrib/internal/falcon/middleware.py
@@ -1,6 +1,7 @@
 import sys
 
 from ddtrace import config
+from ddtrace._trace.otel_http_naming import set_instrumentation_resource
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
 from ddtrace.internal.schema import SpanDirection
@@ -56,7 +57,7 @@ class TraceMiddleware(object):
         span = tracer.current_span()
         if not span:
             return  # unexpected
-        span.resource = "%s %s" % (req.method, _name(resource))
+        set_instrumentation_resource(span, "%s %s" % (req.method, _name(resource)))
 
     def process_response(self, req, resp, resource, req_succeeded=None):
         # req_succeded is not a kwarg in the API, but we need that to support
@@ -72,7 +73,7 @@ class TraceMiddleware(object):
         # here.
         if resource is None:
             status = "404"
-            span.resource = "%s 404" % req.method
+            set_instrumentation_resource(span, "%s 404" % req.method)
             core.dispatch("web.request.finish", (span, config.falcon, None, None, status, None, None, None, None, True))
             return
 

--- a/ddtrace/contrib/internal/sanic/patch.py
+++ b/ddtrace/contrib/internal/sanic/patch.py
@@ -5,6 +5,7 @@ import wrapt
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.otel_http_naming import record_initial_instrumentation_resource
 from ddtrace._trace.otel_http_naming import set_instrumentation_resource
 from ddtrace._trace.pin import Pin
 from ddtrace.contrib import trace_utils
@@ -119,7 +120,11 @@ async def patch_run_request_middleware(wrapped, instance, args, kwargs):
     request = args[0]
     span = _get_current_span(request)
     if span is not None:
-        set_instrumentation_resource(span, "{} {}".format(request.method, _get_path(request)))
+        route = _get_path(request)
+        if config._otel_trace_semantics_enabled:
+            trace_utils.set_http_meta(span, config.sanic, method=request.method, route=route)
+        else:
+            set_instrumentation_resource(span, "{} {}".format(request.method, route))
     return await wrapped(*args, **kwargs)
 
 
@@ -219,6 +224,7 @@ def _create_sanic_request_span(request):
         headers_case_sensitive=True,
     ) as ctx:
         req_span = span_from_context(ctx)
+        record_initial_instrumentation_resource(req_span, resource)
 
         ctx.set_item("req_span", req_span)
         core.dispatch("web.request.start", (ctx, config.sanic))
@@ -254,7 +260,10 @@ async def sanic_http_routing_after(request, route, kwargs, handler):
     if route.regex:
         pattern = route.pattern
 
-    set_instrumentation_resource(span, "{} {}".format(request.method, pattern))
+    if config._otel_trace_semantics_enabled:
+        trace_utils.set_http_meta(span, config.sanic, method=request.method, route=pattern)
+    else:
+        set_instrumentation_resource(span, "{} {}".format(request.method, pattern))
     span._set_attribute("sanic.route.name", route.name)
 
 

--- a/ddtrace/contrib/internal/sanic/patch.py
+++ b/ddtrace/contrib/internal/sanic/patch.py
@@ -5,6 +5,7 @@ import wrapt
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.otel_http_naming import set_instrumentation_resource
 from ddtrace._trace.pin import Pin
 from ddtrace.contrib import trace_utils
 from ddtrace.ext import SpanTypes
@@ -118,7 +119,7 @@ async def patch_run_request_middleware(wrapped, instance, args, kwargs):
     request = args[0]
     span = _get_current_span(request)
     if span is not None:
-        span.resource = "{} {}".format(request.method, _get_path(request))
+        set_instrumentation_resource(span, "{} {}".format(request.method, _get_path(request)))
     return await wrapped(*args, **kwargs)
 
 
@@ -253,7 +254,7 @@ async def sanic_http_routing_after(request, route, kwargs, handler):
     if route.regex:
         pattern = route.pattern
 
-    span.resource = "{} {}".format(request.method, pattern)
+    set_instrumentation_resource(span, "{} {}".format(request.method, pattern))
     span._set_attribute("sanic.route.name", route.name)
 
 

--- a/ddtrace/contrib/internal/starlette/patch.py
+++ b/ddtrace/contrib/internal/starlette/patch.py
@@ -20,6 +20,7 @@ from ddtrace.contrib.internal.asgi.middleware import _DD_ROUTE_RESOURCE_RESOLVER
 from ddtrace.contrib.internal.asgi.middleware import TraceMiddleware
 from ddtrace.contrib.internal.trace_utils import with_traced_module
 from ddtrace.ext import http
+from ddtrace.ext import net
 from ddtrace.internal import core
 from ddtrace.internal._exceptions import BlockingException
 from ddtrace.internal.compat import is_wrapted
@@ -272,6 +273,26 @@ def _set_route_resource(span: Span, method: Optional[str], route: str) -> None:
         set_otel_http_resource(span, normalized_method, original_method, route)
 
 
+def _copy_server_url_attributes(source: Span, destination: Span) -> None:
+    if not config._otel_trace_semantics_enabled:
+        url_tag = server_url_tag()
+        destination.set_tag(url_tag, source.get_tag(url_tag))
+        return
+
+    for key in (
+        http.OTEL_URL_SCHEME,
+        http.OTEL_URL_PATH,
+        http.OTEL_URL_QUERY,
+        net.SERVER_ADDRESS,
+        net.SERVER_PORT,
+    ):
+        value = source.get_tag(key)
+        if value is None:
+            value = source.get_metric(key)
+        if value is not None:
+            destination._set_attribute(key, value)
+
+
 def traced_handler(wrapped, instance, args, kwargs):
     # Since handle can be called multiple times for one request, we take the path of each instance
     # Then combine them at the end to get the correct resource names
@@ -363,8 +384,7 @@ def traced_handler(wrapped, instance, args, kwargs):
 
     # https://github.com/encode/starlette/issues/1336
     if _STARLETTE_VERSION_LTE_0_33_0 and len(request_spans) > 1:
-        url_tag = server_url_tag()
-        request_spans[-1].set_tag(url_tag, request_spans[0].get_tag(url_tag))
+        _copy_server_url_attributes(request_spans[0], request_spans[-1])
 
     return wrapped(*args, **kwargs)
 

--- a/ddtrace/contrib/internal/starlette/patch.py
+++ b/ddtrace/contrib/internal/starlette/patch.py
@@ -10,6 +10,10 @@ from starlette.middleware import Middleware
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
+from ddtrace._trace.http_semantics import normalize_http_method
+from ddtrace._trace.http_semantics import server_url_tag
+from ddtrace._trace.otel_http_naming import set_instrumentation_resource
+from ddtrace._trace.otel_http_naming import set_otel_http_resource
 from ddtrace._trace.pin import Pin
 from ddtrace.contrib import trace_utils
 from ddtrace.contrib.internal.asgi.middleware import _DD_ROUTE_RESOURCE_RESOLVER
@@ -149,7 +153,7 @@ def _resolve_route_resource(scope: Mapping[str, Any], span: Span) -> None:
 
     path, is_route = route_match
     method = scope.get("method")
-    span.resource = "{} {}".format(method, path) if method else path
+    _set_route_resource(span, method, path)
     if is_route:
         span._set_attribute(http.ROUTE, path)
 
@@ -260,6 +264,14 @@ def _get_fastapi_effective_path(scope: dict) -> Optional[str]:
     return getattr(effective_route_context, "path_format", None)
 
 
+def _set_route_resource(span: Span, method: Optional[str], route: str) -> None:
+    resource = f"{method} {route}" if method else route
+    set_instrumentation_resource(span, resource)
+    if config._otel_trace_semantics_enabled and method:
+        normalized_method, original_method = normalize_http_method(method)
+        set_otel_http_resource(span, normalized_method, original_method, route)
+
+
 def traced_handler(wrapped, instance, args, kwargs):
     # Since handle can be called multiple times for one request, we take the path of each instance
     # Then combine them at the end to get the correct resource names
@@ -296,7 +308,7 @@ def traced_handler(wrapped, instance, args, kwargs):
 
     if full_path is not None:
         if request_spans:
-            request_spans[0].resource = "{} {}".format(scope["method"], full_path)
+            _set_route_resource(request_spans[0], scope.get("method"), full_path)
             request_spans[0]._set_attribute(http.ROUTE, full_path)
     elif len(request_spans) == len(resource_paths):
         # Iterate through the request_spans and assign the correct resource name to each
@@ -307,20 +319,14 @@ def traced_handler(wrapped, instance, args, kwargs):
             # Second request span gets /hello/{name}
             path = "".join(resource_paths[index:])
 
-            if scope.get("method"):
-                span.resource = "{} {}".format(scope["method"], path)
-            else:
-                span.resource = path
+            _set_route_resource(span, scope.get("method"), path)
             # route should only be in the root span
             if index == 0:
                 span._set_attribute(http.ROUTE, path)
-    # at least always update the root asgi span resource name request_spans[0].resource = "".join(resource_paths)
+    # At least always update the root ASGI span when only part of the route tree is available.
     elif request_spans and resource_paths:
         route = "".join(resource_paths)
-        if scope.get("method"):
-            request_spans[0].resource = "{} {}".format(scope["method"], route)
-        else:
-            request_spans[0].resource = route
+        _set_route_resource(request_spans[0], scope.get("method"), route)
         request_spans[0]._set_attribute(http.ROUTE, route)
     else:
         log.debug(
@@ -358,7 +364,8 @@ def traced_handler(wrapped, instance, args, kwargs):
 
     # https://github.com/encode/starlette/issues/1336
     if _STARLETTE_VERSION_LTE_0_33_0 and len(request_spans) > 1:
-        request_spans[-1].set_tag(http.URL, request_spans[0].get_tag(http.URL))
+        url_tag = server_url_tag()
+        request_spans[-1].set_tag(url_tag, request_spans[0].get_tag(url_tag))
 
     return wrapped(*args, **kwargs)
 

--- a/ddtrace/contrib/internal/starlette/patch.py
+++ b/ddtrace/contrib/internal/starlette/patch.py
@@ -323,7 +323,6 @@ def traced_handler(wrapped, instance, args, kwargs):
             # route should only be in the root span
             if index == 0:
                 span._set_attribute(http.ROUTE, path)
-    # At least always update the root ASGI span when only part of the route tree is available.
     elif request_spans and resource_paths:
         route = "".join(resource_paths)
         _set_route_resource(request_spans[0], scope.get("method"), route)

--- a/ddtrace/contrib/internal/tornado/handlers.py
+++ b/ddtrace/contrib/internal/tornado/handlers.py
@@ -5,6 +5,7 @@ from tornado.routing import PathMatches
 from tornado.web import HTTPError
 
 from ddtrace import config
+from ddtrace._trace.otel_http_naming import set_instrumentation_resource
 from ddtrace.contrib.internal import trace_utils
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
@@ -263,7 +264,7 @@ def on_finish(func, handler, args, kwargs):
         # default handler class will be used so we don't pollute the resource
         # space here
         klass = handler.__class__
-        request_span.resource = "{}.{}".format(klass.__module__, klass.__name__)
+        set_instrumentation_resource(request_span, "{}.{}".format(klass.__module__, klass.__name__))
         core.dispatch(
             "web.request.finish",
             (

--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -419,6 +419,28 @@ def set_service_and_source(
         span.service = service
 
 
+def _should_collect_client_ip() -> bool:
+    # We always collect the IP if appsec is enabled to report it on potential vulnerabilities.
+    # https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2118779066/Client+IP+addresses+resolution
+    return asm_config._asm_enabled or config._retrieve_client_ip
+
+
+def _resolve_client_ip(
+    request_headers: Optional[Mapping[str, str]], peer_ip: Optional[str], headers_are_case_sensitive: bool
+) -> Optional[str]:
+    """Resolve the client IP the same way in both semantics modes.
+
+    AppSec depends on this resolution, so the OTel path reuses it verbatim and only changes
+    the key the result is written under.
+    """
+    # Retrieve the IP if it was calculated on AppSecProcessor.on_span_start
+    request_ip = core.find_item("http.request.remote_ip")
+    if not request_ip:
+        # Not calculated: framework does not support IP blocking or testing env
+        request_ip = _get_request_header_client_ip(request_headers, peer_ip, headers_are_case_sensitive) or peer_ip
+    return request_ip
+
+
 def set_http_meta(
     span: Span,
     integration_config: "IntegrationConfig",
@@ -459,10 +481,12 @@ def set_http_meta(
         ``{name: value}`` for frameworks that bind named parameters (Django ``resolver_match.kwargs``, Flask
         ``view_args``, ...), or a positional sequence of values for regex routes with only unnamed captures (Django
         ``resolver_match.args``, Tornado ``path_args``).
+
+    Both the Datadog and the OpenTelemetry HTTP conventions are written from here, so the
+    shared work (headers, cookies, client IP, the AppSec dispatch) exists once and only the
+    attribute names and value shapes differ between them.
     """
     otel_http = OTelHTTPSpanAttributes(span, integration_config) if config._otel_trace_semantics_enabled else None
-    if otel_http is not None and not otel_http.is_client:
-        otel_http = None
 
     if method is not None:
         if otel_http is not None:
@@ -474,6 +498,7 @@ def set_http_meta(
         otel_http.set_url(
             url,
             query=query,
+            raw_uri=raw_uri,
             server_address=server_address,
             fallback_server_address=target_host,
         )
@@ -481,7 +506,6 @@ def set_http_meta(
         if url is not None:
             url = _sanitized_url(url)
             _set_url_tag(integration_config, span, url, query)
-
         if target_host is not None:
             span._set_attribute(net.TARGET_HOST, target_host)
 
@@ -528,21 +552,15 @@ def set_http_meta(
             is the DD standardized tag for user-agent"""
             _store_request_headers(dict(request_headers), span, integration_config)
 
-    # We always collect the IP if appsec is enabled to report it on potential vulnerabilities.
-    # https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2118779066/Client+IP+addresses+resolution
-    if asm_config._asm_enabled or config._retrieve_client_ip:
-        # Retrieve the IP if it was calculated on AppSecProcessor.on_span_start
-        request_ip = core.find_item("http.request.remote_ip")
-
-        if not request_ip:
-            # Not calculated: framework does not support IP blocking or testing env
-            request_ip = _get_request_header_client_ip(request_headers, peer_ip, headers_are_case_sensitive) or peer_ip
-
-        if request_ip:
-            span._set_attribute(http.CLIENT_IP, request_ip)
-
-        if peer_ip:
-            span._set_attribute("network.client.ip", peer_ip)
+    if _should_collect_client_ip():
+        request_ip = _resolve_client_ip(request_headers, peer_ip, headers_are_case_sensitive)
+        if otel_http is not None:
+            otel_http.set_client_addresses(request_ip, peer_ip)
+        else:
+            if request_ip:
+                span._set_attribute(http.CLIENT_IP, request_ip)
+            if peer_ip:
+                span._set_attribute("network.client.ip", peer_ip)
 
     if response_headers is not None and integration_config.is_header_tracing_configured:
         _store_response_headers(response_headers, span, integration_config)
@@ -572,6 +590,7 @@ def set_http_meta(
     )
 
     if route is not None:
+        # http.route is spelled the same in both conventions
         span._set_attribute(http.ROUTE, route)
 
     if otel_http is not None:

--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -420,23 +420,14 @@ def set_service_and_source(
 
 
 def _should_collect_client_ip() -> bool:
-    # We always collect the IP if appsec is enabled to report it on potential vulnerabilities.
-    # https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2118779066/Client+IP+addresses+resolution
     return asm_config._asm_enabled or config._retrieve_client_ip
 
 
 def _resolve_client_ip(
     request_headers: Optional[Mapping[str, str]], peer_ip: Optional[str], headers_are_case_sensitive: bool
 ) -> Optional[str]:
-    """Resolve the client IP the same way in both semantics modes.
-
-    AppSec depends on this resolution, so the OTel path reuses it verbatim and only changes
-    the key the result is written under.
-    """
-    # Retrieve the IP if it was calculated on AppSecProcessor.on_span_start
     request_ip = core.find_item("http.request.remote_ip")
     if not request_ip:
-        # Not calculated: framework does not support IP blocking or testing env
         request_ip = _get_request_header_client_ip(request_headers, peer_ip, headers_are_case_sensitive) or peer_ip
     return request_ip
 
@@ -482,9 +473,6 @@ def set_http_meta(
         ``view_args``, ...), or a positional sequence of values for regex routes with only unnamed captures (Django
         ``resolver_match.args``, Tornado ``path_args``).
 
-    Both the Datadog and the OpenTelemetry HTTP conventions are written from here, so the
-    shared work (headers, cookies, client IP, the AppSec dispatch) exists once and only the
-    attribute names and value shapes differ between them.
     """
     otel_http = OTelHTTPSpanAttributes(span, integration_config) if config._otel_trace_semantics_enabled else None
 
@@ -590,7 +578,6 @@ def set_http_meta(
     )
 
     if route is not None:
-        # http.route is spelled the same in both conventions
         span._set_attribute(http.ROUTE, route)
 
     if otel_http is not None:

--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -469,10 +469,9 @@ def set_http_meta(
     :param response_headers: the HTTP response headers
     :param raw_uri: the full raw HTTP URI (including ports and query)
     :param request_cookies: the HTTP request cookies as a dict
-    :param request_path_params: the parameters of the HTTP URL as set by the framework. Polymorphic: a mapping of
-        ``{name: value}`` for frameworks that bind named parameters (Django ``resolver_match.kwargs``, Flask
-        ``view_args``, ...), or a positional sequence of values for regex routes with only unnamed captures (Django
-        ``resolver_match.args``, Tornado ``path_args``).
+    request_path_params accepts a mapping of named parameters (for example,
+    Django resolver_match.kwargs or Flask view_args) or a positional sequence
+    for regex routes with unnamed captures.
 
     """
     otel_http = OTelHTTPSpanAttributes(span, integration_config) if config._otel_trace_semantics_enabled else None

--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -426,6 +426,7 @@ def _should_collect_client_ip() -> bool:
 def _resolve_client_ip(
     request_headers: Optional[Mapping[str, str]], peer_ip: Optional[str], headers_are_case_sensitive: bool
 ) -> Optional[str]:
+    # Both semantics modes reuse AppSec resolution; only the emitted attribute names differ.
     request_ip = core.find_item("http.request.remote_ip")
     if not request_ip:
         request_ip = _get_request_header_client_ip(request_headers, peer_ip, headers_are_case_sensitive) or peer_ip

--- a/ddtrace/contrib/internal/wsgi/wsgi.py
+++ b/ddtrace/contrib/internal/wsgi/wsgi.py
@@ -354,6 +354,8 @@ def get_request_headers(environ: Mapping[str, str]) -> Mapping[str, str]:
 
 
 def default_wsgi_span_modifier(span, environ):
+    if config._otel_trace_semantics_enabled:
+        return
     set_instrumentation_resource(span, "{} {}".format(environ["REQUEST_METHOD"], environ["PATH_INFO"]))
 
 

--- a/ddtrace/contrib/internal/wsgi/wsgi.py
+++ b/ddtrace/contrib/internal/wsgi/wsgi.py
@@ -5,6 +5,7 @@ from typing import Callable
 from typing import Iterable
 from typing import Optional
 
+from ddtrace._trace.otel_http_naming import set_instrumentation_resource
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.internal.span_bus import span_from_context
 
@@ -353,7 +354,7 @@ def get_request_headers(environ: Mapping[str, str]) -> Mapping[str, str]:
 
 
 def default_wsgi_span_modifier(span, environ):
-    span.resource = "{} {}".format(environ["REQUEST_METHOD"], environ["PATH_INFO"])
+    set_instrumentation_resource(span, "{} {}".format(environ["REQUEST_METHOD"], environ["PATH_INFO"]))
 
 
 class DDWSGIMiddleware(_DDWSGIMiddlewareBase):

--- a/releasenotes/notes/otel-http-semantics-43cca3d1860400ba.yaml
+++ b/releasenotes/notes/otel-http-semantics-43cca3d1860400ba.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    tracing: Adds support for the OpenTelemetry HTTP semantic conventions on HTTP client and
+    server spans, enabled with ``DD_TRACE_OTEL_SEMANTICS_ENABLED=true``. The default remains
+    the existing Datadog behavior. See
+    https://docs.datadoghq.com/tracing/trace_collection/otel_instrumentation/ for details.

--- a/releasenotes/notes/otel-http-semantics-43cca3d1860400ba.yaml
+++ b/releasenotes/notes/otel-http-semantics-43cca3d1860400ba.yaml
@@ -1,7 +1,7 @@
 ---
 features:
   - |
-    tracing: Adds support for the OpenTelemetry HTTP semantic conventions on HTTP client and
-    server spans, enabled with ``DD_TRACE_OTEL_SEMANTICS_ENABLED=true``. The default remains
-    the existing Datadog behavior. See
-    https://docs.datadoghq.com/tracing/trace_collection/otel_instrumentation/ for details.
+    tracing: Adds support for OpenTelemetry HTTP semantic conventions on HTTP server spans,
+    enabled with ``DD_TRACE_OTEL_SEMANTICS_ENABLED=true``. When enabled, server spans use
+    OpenTelemetry attribute names, route-based resource names, and error classification; the
+    default remains the existing Datadog behavior.

--- a/tests/appsec/contrib_appsec/test_django.py
+++ b/tests/appsec/contrib_appsec/test_django.py
@@ -35,6 +35,7 @@ def isolated_database(tmp_path_factory):
         from django.db import connections
 
         connections.close_all()
+        importlib.import_module(_FLAT_URLCONF).DB.close()
         settings.DATABASES["default"]["NAME"] = original_database_name
 
 
@@ -64,7 +65,10 @@ class _Test_Django_Base:
         settings.ROOT_URLCONF = request.param
         clear_url_caches()
         endpoint_collection.reset()
-        importlib.reload(importlib.import_module(request.param))
+        urlconf = importlib.import_module(request.param)
+        if request.param == _FLAT_URLCONF:
+            urlconf.DB.close()
+        importlib.reload(urlconf)
 
         client = Client(
             f"http://localhost:{self.SERVER_PORT}",
@@ -162,6 +166,44 @@ class Test_Django(_Test_Django_Base, utils.Contrib_TestClass_For_Threats):
         # `<path:name>` matches one or more URL segments; substitute a non-empty multi-segment value so it resolves.
         path = re.sub(r"<path:[a-z_]+>", "a/b/c", path)
         return path if path.startswith("/") else ("/" + path)
+
+    def test_path_params_block_before_view(self, interface):
+        from django.http import HttpResponse
+        from django.urls import path
+
+        from tests.utils import override_global_config
+
+        view_calls = []
+        view_middleware_calls = []
+
+        def blocked_view(_request, value):
+            view_calls.append(value)
+            return HttpResponse("view ran")
+
+        def process_view(_request, _view_func, _view_args, _view_kwargs):
+            view_middleware_calls.append(True)
+
+        if django.VERSION >= (3, 1):
+            interface.client.handler.load_middleware(is_async=False)
+        else:
+            interface.client.handler.load_middleware()
+        interface.client.handler._view_middleware.append(process_view)
+
+        urlconf = importlib.import_module(settings.ROOT_URLCONF)
+        pattern = path("block-before-view/<str:value>/", blocked_view)
+        urlconf.urlpatterns.insert(0, pattern)
+        clear_url_caches()
+        try:
+            with override_global_config(dict(_asm_enabled=True, _asm_static_rule_file=utils.rules.RULES_SRB)):
+                self.update_tracer(interface)
+                response = interface.client.get("/block-before-view/AiKfOeRcvG45/")
+
+            assert self.status(response) == 403
+            assert view_middleware_calls == []
+            assert view_calls == []
+        finally:
+            urlconf.urlpatterns.remove(pattern)
+            clear_url_caches()
 
     @pytest.mark.skipif(django.VERSION < (3, 1, 0), reason="Django ASGI requires Django 3.1+")
     def test_normalized_route_asgi(self, interface: utils.Interface, get_entry_span_tag):

--- a/tests/contrib/asgi/test_asgi.py
+++ b/tests/contrib/asgi/test_asgi.py
@@ -3,11 +3,13 @@ from functools import partial
 import logging
 import os
 import random
+from unittest import mock
 
 from asgiref.testing import ApplicationCommunicator
 import httpx
 import pytest
 
+from ddtrace import config
 from ddtrace.constants import _SAMPLING_PRIORITY_KEY
 from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import USER_KEEP
@@ -17,6 +19,7 @@ from ddtrace.contrib.internal.asgi.middleware import span_from_scope
 from ddtrace.propagation import http as http_propagation
 from tests.conftest import DEFAULT_DDTRACE_SUBPROCESS_TEST_SERVICE_NAME
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
+from tests.utils import override_config
 from tests.utils import override_global_config
 from tests.utils import override_http_config
 
@@ -180,6 +183,30 @@ async def test_basic_asgi(scope, test_spans):
     assert request_span.get_tag("component") == "asgi"
     assert request_span.get_tag("span.kind") == "server"
     _check_span_tags(scope, request_span)
+
+
+def test_otel_semantics_does_not_replace_resource_with_404():
+    from ddtrace._trace.otel_http_naming import INSTRUMENTATION_HTTP_RESOURCE
+    from ddtrace.ext import SpanTypes
+    from ddtrace.trace import Span
+
+    middleware = TraceMiddleware(basic_app)
+    span = Span("asgi.request", resource="GET /items/{id}", span_type=SpanTypes.WEB)
+    span._set_ctx_item(INSTRUMENTATION_HTTP_RESOURCE, span.resource)
+
+    with (
+        mock.patch.object(config, "_otel_trace_semantics_enabled", True),
+        override_config("asgi", dict(obfuscate_404_resource=True)),
+    ):
+        middleware._handle_http_response(
+            {},
+            {"type": "http.response.start", "status": 404},
+            span,
+            "GET",
+            {},
+        )
+
+    assert span.resource == "GET /items/{id}"
 
 
 @pytest.mark.asyncio
@@ -366,6 +393,20 @@ async def test_query_string(scope, test_spans):
         assert request_span.get_tag("component") == "asgi"
         assert request_span.get_tag("span.kind") == "server"
         _check_span_tags(scope, request_span)
+
+
+@pytest.mark.asyncio
+async def test_otel_semantics_preserves_query_without_datadog_query_tracing(scope, test_spans):
+    scope["query_string"] = b"q=public"
+    with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+        app = TraceMiddleware(basic_app)
+        instance = ApplicationCommunicator(app, scope)
+        await instance.send_input({"type": "http.request", "body": b""})
+        await instance.receive_output(1)
+        await instance.receive_output(1)
+
+    request_span = test_spans.pop_traces()[0][0]
+    assert request_span.get_tag("url.query") == "q=public"
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/cherrypy/test_middleware.py
+++ b/tests/contrib/cherrypy/test_middleware.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import time
+from unittest import mock
 from urllib.parse import quote as url_quote
 
 import cherrypy
@@ -59,7 +60,7 @@ class TestCherrypy(TracerTestCase, helper.CPWebCase):
         from ddtrace.contrib.internal.cherrypy.patch import get_version
 
         version = get_version()
-        assert type(version) == str
+        assert isinstance(version, str)
         assert version != ""
 
         emit_integration_and_version_to_test_agent("cherrypy", version)
@@ -364,6 +365,27 @@ class TestCherrypy(TracerTestCase, helper.CPWebCase):
         assert s.get_tag(http.METHOD) == "GET"
         assert s.get_tag("component") == "cherrypy"
         assert s.get_tag("span.kind") == "server"
+
+    def test_otel_semantics_preserves_custom_span_resource(self):
+        with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+            self.getPage("/custom_span")
+            time.sleep(0.1)
+
+        self.assertStatus("200 OK")
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        assert spans[0].resource == "overridden"
+
+    def test_otel_semantics_sets_method_resource_before_in_handler_sampling(self):
+        with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+            self.getPage("/sampled_resource")
+            time.sleep(0.1)
+
+        self.assertStatus("200 OK")
+        self.assertBody("GET")
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        assert spans[0].resource == "GET"
 
     def test_http_request_header_tracing(self):
         config.cherrypy.http.trace_headers(["Host", "my-header"])

--- a/tests/contrib/cherrypy/web.py
+++ b/tests/contrib/cherrypy/web.py
@@ -74,6 +74,14 @@ class StubApp:
         return "hiya"
 
     @cherrypy.expose
+    def sampled_resource(self):
+        span = tracer.current_root_span()
+        assert span
+        resource = span.resource
+        tracer.sample(span)
+        return resource
+
+    @cherrypy.expose
     def response_headers(self):
         cherrypy.response.headers["my-response-header"] = "my_response_value"
         return "Hello CherryPy"

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -45,7 +45,6 @@ from tests.utils import override_http_config
 
 @pytest.mark.subprocess(env={"DD_TRACE_OTEL_SEMANTICS_ENABLED": "true"})
 def test_otel_semantics_names_the_request_span_from_the_route():
-    """A real request names the root span {method} {http.route}, not the URI path."""
     from django.test import Client
 
     from tests.contrib.django.utils import setup_django_test_spans
@@ -62,7 +61,6 @@ def test_otel_semantics_names_the_request_span_from_the_route():
 
 @pytest.mark.subprocess(env={"DD_TRACE_OTEL_SEMANTICS_ENABLED": "true"})
 def test_otel_semantics_substitutes_an_unaccepted_method_in_the_span_name():
-    """_OTHER is reported in http.request.method, but the span name uses HTTP."""
     from django.test import Client
 
     from tests.contrib.django.utils import setup_django_test_spans
@@ -163,7 +161,6 @@ def test_otel_semantics_keeps_async_request_resource_stable_during_application()
 
 @pytest.mark.subprocess(env={"DD_TRACE_OTEL_SEMANTICS_ENABLED": "false"})
 def test_default_semantics_keep_the_datadog_request_span_name():
-    """Flag off, the resource and attribute names are unchanged."""
     from django.test import Client
 
     from tests.contrib.django.utils import setup_django_test_spans

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -26,6 +26,7 @@ from ddtrace.constants import ERROR_TYPE
 from ddtrace.constants import USER_KEEP
 from ddtrace.contrib.internal.django.patch import instrument_view
 from ddtrace.contrib.internal.django.response import traced_get_response
+from ddtrace.contrib.internal.django.response import traced_resolve_request
 from ddtrace.contrib.internal.django.utils import get_request_uri
 from ddtrace.ext import http
 from ddtrace.ext import user
@@ -41,6 +42,19 @@ from tests.utils import override_config
 from tests.utils import override_env
 from tests.utils import override_global_config
 from tests.utils import override_http_config
+
+
+def test_resolver_match_is_stored_before_appsec_dispatch():
+    request = mock.Mock()
+    resolver_match = mock.Mock()
+
+    def assert_match_is_available(*args, **kwargs):
+        assert request.resolver_match is resolver_match
+        raise RuntimeError("blocked")
+
+    with mock.patch("ddtrace.contrib.internal.django.response.core.dispatch", side_effect=assert_match_is_available):
+        with pytest.raises(RuntimeError, match="blocked"):
+            traced_resolve_request(lambda *_args, **_kwargs: resolver_match, (mock.Mock(), request), {})
 
 
 @pytest.mark.subprocess(env={"DD_TRACE_OTEL_SEMANTICS_ENABLED": "true"})
@@ -71,6 +85,25 @@ def test_otel_semantics_substitutes_an_unaccepted_method_in_the_span_name():
         assert root.get_tag("http.request.method") == "_OTHER"
         assert root.get_tag("http.request.method_original") == "PROPFIND"
         assert root.resource == "HTTP ^fn-view/$"
+
+
+@pytest.mark.subprocess(env={"DD_TRACE_OTEL_SEMANTICS_ENABLED": "true"})
+def test_otel_semantics_normalizes_resource_when_response_creation_aborts():
+    from django.test import Client
+    from django.test import override_settings
+    import pytest
+
+    from tests.contrib.django.utils import setup_django_test_spans
+
+    with setup_django_test_spans() as test_spans:
+        with override_settings(DEBUG_PROPAGATE_EXCEPTIONS=True):
+            with pytest.raises(Exception, match="Error 500"):
+                Client().generic("PROPFIND", "/error-500/")
+
+        root = test_spans.get_root_span()
+        assert root.get_tag("http.request.method") == "_OTHER"
+        assert root.get_tag("http.route") == "^error-500/$"
+        assert root.resource == "HTTP ^error-500/$"
 
 
 @pytest.mark.subprocess(env={"DD_TRACE_OTEL_SEMANTICS_ENABLED": "true"})

--- a/tests/contrib/django/test_django.py
+++ b/tests/contrib/django/test_django.py
@@ -43,6 +43,138 @@ from tests.utils import override_global_config
 from tests.utils import override_http_config
 
 
+@pytest.mark.subprocess(env={"DD_TRACE_OTEL_SEMANTICS_ENABLED": "true"})
+def test_otel_semantics_names_the_request_span_from_the_route():
+    """A real request names the root span {method} {http.route}, not the URI path."""
+    from django.test import Client
+
+    from tests.contrib.django.utils import setup_django_test_spans
+
+    with setup_django_test_spans() as test_spans:
+        assert Client().get("/fn-view/").status_code == 200
+        root = test_spans.get_root_span()
+        assert root.get_tag("http.request.method") == "GET"
+        assert root.get_tag("http.route") == "^fn-view/$"
+        assert root.get_metric("http.response.status_code") == 200
+        assert root.get_tag("http.response.status_code") is None
+        assert root.resource == "GET ^fn-view/$"
+
+
+@pytest.mark.subprocess(env={"DD_TRACE_OTEL_SEMANTICS_ENABLED": "true"})
+def test_otel_semantics_substitutes_an_unaccepted_method_in_the_span_name():
+    """_OTHER is reported in http.request.method, but the span name uses HTTP."""
+    from django.test import Client
+
+    from tests.contrib.django.utils import setup_django_test_spans
+
+    with setup_django_test_spans() as test_spans:
+        Client().generic("PROPFIND", "/fn-view/")
+        root = test_spans.get_root_span()
+        assert root.get_tag("http.request.method") == "_OTHER"
+        assert root.get_tag("http.request.method_original") == "PROPFIND"
+        assert root.resource == "HTTP ^fn-view/$"
+
+
+@pytest.mark.subprocess(env={"DD_TRACE_OTEL_SEMANTICS_ENABLED": "true"})
+def test_otel_semantics_does_not_resolve_custom_converter_twice():
+    from tests.contrib.django.utils import setup_django
+    from tests.contrib.django.utils import setup_django_test_spans
+
+    setup_django()
+
+    from django.http import HttpResponse
+    from django.test import Client
+    from django.urls import clear_url_caches
+    from django.urls import path
+    from django.urls import register_converter
+
+    from ddtrace.trace import tracer
+    from tests.contrib.django.django_app import urls
+
+    converted = []
+    captured = {}
+
+    class RecordingConverter:
+        regex = "[^/]+"
+
+        def to_python(self, value):
+            converted.append(value)
+            return value
+
+        def to_url(self, value):
+            return value
+
+    def converted_view(request, value):
+        captured["resource"] = tracer.current_root_span().resource
+        return HttpResponse(value)
+
+    register_converter(RecordingConverter, "recording")
+    urls.urlpatterns.insert(0, path("converted/<recording:value>/", converted_view))
+    clear_url_caches()
+
+    with setup_django_test_spans():
+        assert Client().get("/converted/value/").status_code == 200
+
+    assert converted == ["value"], converted
+    assert captured["resource"] == "GET converted/<recording:value>/", captured
+
+
+@pytest.mark.subprocess(env={"DD_TRACE_OTEL_SEMANTICS_ENABLED": "true"}, err=None)
+def test_otel_semantics_keeps_async_request_resource_stable_during_application():
+    import asyncio
+
+    import mock
+
+    from ddtrace._trace.otel_http_naming import INSTRUMENTATION_HTTP_RESOURCE
+    from ddtrace._trace.pin import Pin
+    from ddtrace.contrib.internal.django import response as django_response
+    from ddtrace.ext import SpanTypes
+    from ddtrace.trace import tracer
+
+    captured = {}
+
+    class Handler:
+        pass
+
+    class Request:
+        pass
+
+    handler = Handler()
+    Pin().onto(handler)
+
+    with tracer.start_span("django.request", resource="GET", span_type=SpanTypes.WEB) as span:
+        span._set_ctx_item(INSTRUMENTATION_HTTP_RESOURCE, "GET")
+        request = Request()
+        request.scope = {"datadog": {"request_spans": [span]}}
+
+        async def application(request):
+            captured["resource"] = span.resource
+            return object()
+
+        with (
+            mock.patch.object(django_response, "_before_request_tags"),
+            mock.patch.object(django_response, "_after_request_tags"),
+            mock.patch.object(django_response, "get_resolver", return_value=None),
+        ):
+            asyncio.run(django_response.traced_get_response_async(application, handler, (request,), {}))
+
+    assert captured["resource"] == "GET"
+
+
+@pytest.mark.subprocess(env={"DD_TRACE_OTEL_SEMANTICS_ENABLED": "false"})
+def test_default_semantics_keep_the_datadog_request_span_name():
+    """Flag off, the resource and attribute names are unchanged."""
+    from django.test import Client
+
+    from tests.contrib.django.utils import setup_django_test_spans
+
+    with setup_django_test_spans() as test_spans:
+        assert Client().get("/fn-view/").status_code == 200
+        root = test_spans.get_root_span()
+        assert root.get_tag("http.method") == "GET"
+        assert root.get_tag("http.request.method") is None
+
+
 @pytest.fixture(autouse=True)
 def cleanup_connections():
     yield
@@ -1651,7 +1783,8 @@ def test_cached_view():
             "component": "django",
             "django.cache.backend": "django.core.cache.backends.locmem.LocMemCache",
             "django.cache.key": (
-                "views.decorators.cache.cache_page..GET.03cdc1cc4aab71b038a6764e5fcabb82.d41d8cd98f00b204e9800998ecf8..."
+                "views.decorators.cache.cache_page..GET.03cdc1cc4aab71b038a6764e5fcabb82."
+                "d41d8cd98f00b204e9800998ecf8..."
             ),
             "_dd.base_service": "ddtrace_subprocess_dir",
         }

--- a/tests/contrib/django/test_django_request_path_params.py
+++ b/tests/contrib/django/test_django_request_path_params.py
@@ -1,9 +1,3 @@
-"""Unit tests for ``_request_path_params``.
-
-Covers the polymorphic ``kwargs or args or None`` extraction used by the Django ``set_http_meta`` callsites. Tests run
-against ``SimpleNamespace`` mocks so the helper's logic is exercised without spinning up a real Django app.
-"""
-
 from types import SimpleNamespace
 
 import pytest
@@ -12,14 +6,12 @@ from ddtrace.contrib.internal.django.utils import _request_path_params
 
 
 def _request(resolver_match):
-    """Build a minimal ``request``-like object with a ``resolver_match`` attribute."""
     return SimpleNamespace(resolver_match=resolver_match)
 
 
 @pytest.mark.parametrize(
     ("resolver_match", "expected"),
     [
-        # No resolver match yet — Django has not resolved the route.
         (None, None),
         # Both empty — route with no captures (static-only path or ``^$``).
         (SimpleNamespace(kwargs={}, args=()), None),

--- a/tests/contrib/django/test_django_request_path_params.py
+++ b/tests/contrib/django/test_django_request_path_params.py
@@ -1,8 +1,7 @@
 """Unit tests for ``_request_path_params``.
 
-Covers the polymorphic ``kwargs or args or None`` resolution and the no-resolver-match fallback used by the Django
-``set_http_meta`` callsites. Tests run against ``SimpleNamespace`` mocks so the helper's logic is exercised without
-spinning up a real Django app — the fresh-resolve fallback is integration-tested via the contrib_appsec suite.
+Covers the polymorphic ``kwargs or args or None`` extraction used by the Django ``set_http_meta`` callsites. Tests run
+against ``SimpleNamespace`` mocks so the helper's logic is exercised without spinning up a real Django app.
 """
 
 from types import SimpleNamespace
@@ -20,8 +19,7 @@ def _request(resolver_match):
 @pytest.mark.parametrize(
     ("resolver_match", "expected"),
     [
-        # No resolver match yet — pre-view dispatches fall here. The fallback resolve only fires when the helper
-        # can re-import Django; in this unit-test context the fallback raises and the helper returns None.
+        # No resolver match yet — Django has not resolved the route.
         (None, None),
         # Both empty — route with no captures (static-only path or ``^$``).
         (SimpleNamespace(kwargs={}, args=()), None),

--- a/tests/contrib/django/test_django_snapshots.py
+++ b/tests/contrib/django/test_django_snapshots.py
@@ -309,7 +309,6 @@ def test_djangoq_dd_trace_methods(dd_trace_methods, error_expected):
 @pytest.mark.skipif(django.VERSION < (2, 0), reason="")
 @snapshot(ignores=SNAPSHOT_IGNORES)
 def test_otel_semantics_request(client):
-    """A request under OTel semantics: the whole span, not just the tags a unit test picks."""
     from unittest import mock
 
     from ddtrace.internal.settings._config import config
@@ -321,7 +320,6 @@ def test_otel_semantics_request(client):
 @pytest.mark.skipif(django.VERSION < (2, 0), reason="")
 @snapshot(ignores=SNAPSHOT_IGNORES)
 def test_otel_semantics_request_unaccepted_method(client):
-    """An unaccepted method is reported as _OTHER but named HTTP."""
     from unittest import mock
 
     from ddtrace.internal.settings._config import config

--- a/tests/contrib/django/test_django_snapshots.py
+++ b/tests/contrib/django/test_django_snapshots.py
@@ -304,3 +304,27 @@ def test_djangoq_dd_trace_methods(dd_trace_methods, error_expected):
 
     _, stderr = proc.communicate(timeout=10)
     assert (b"error configuring Datadog tracing" in stderr) == error_expected
+
+
+@pytest.mark.skipif(django.VERSION < (2, 0), reason="")
+@snapshot(ignores=SNAPSHOT_IGNORES)
+def test_otel_semantics_request(client):
+    """A request under OTel semantics: the whole span, not just the tags a unit test picks."""
+    from unittest import mock
+
+    from ddtrace.internal.settings._config import config
+
+    with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+        assert client.get("/fn-view/", timeout=5).status_code == 200
+
+
+@pytest.mark.skipif(django.VERSION < (2, 0), reason="")
+@snapshot(ignores=SNAPSHOT_IGNORES)
+def test_otel_semantics_request_unaccepted_method(client):
+    """An unaccepted method is reported as _OTHER but named HTTP."""
+    from unittest import mock
+
+    from ddtrace.internal.settings._config import config
+
+    with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+        client.generic("PROPFIND", "/fn-view/", timeout=5)

--- a/tests/contrib/falcon/test_suite.py
+++ b/tests/contrib/falcon/test_suite.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from ddtrace import config
 from ddtrace.constants import ERROR_TYPE
 from ddtrace.constants import USER_KEEP
@@ -132,6 +134,15 @@ class FalconTestCase(FalconTestMixin):
 
     def test_route_reporting_200(self):
         return self.make_route_reporting_test("/200", 200, "/200")
+
+    def test_otel_semantics_refines_resource_from_route(self):
+        with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+            self.make_test_call("/200", expected_status_code=200)
+
+        span = self.pop_traces()[0][0]
+        assert span.get_tag(httpx.OTEL_REQUEST_METHOD) == "GET"
+        assert span.get_tag(httpx.ROUTE) == "/200"
+        assert span.resource == "GET /200"
 
     def test_route_reporting_dynamic_match(self):
         return self.make_route_reporting_test("/hello/foo", 200, "/hello/{name}")

--- a/tests/contrib/flask/test_request.py
+++ b/tests/contrib/flask/test_request.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 import time
+from unittest import mock
 
 import flask
 from flask import abort
@@ -15,6 +16,7 @@ from ddtrace.constants import ERROR_MSG
 from ddtrace.constants import USER_KEEP
 from ddtrace.contrib.internal.flask.patch import flask_version
 from ddtrace.ext import http
+from ddtrace.internal.settings._config import config
 from ddtrace.propagation.http import HTTP_HEADER_PARENT_ID
 from ddtrace.propagation.http import HTTP_HEADER_TRACE_ID
 from tests.conftest import DEFAULT_DDTRACE_SUBPROCESS_TEST_SERVICE_NAME
@@ -108,6 +110,47 @@ class FlaskRequestTestCase(BaseFlaskTestCase):
         self.assertEqual(handler_span.name, "tests.contrib.flask.test_request.index")
         self.assertEqual(handler_span.resource, "/")
         self.assertEqual(req_span.error, 0)
+
+    def test_otel_semantics_replaces_flask_route_resource(self):
+        @self.app.route("/users/<int:user_id>")
+        def user(user_id):
+            return str(user_id)
+
+        with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+            response = self.client.get("/users/42")
+
+        self.assertEqual(response.status_code, 200)
+        request_span = self.get_spans()[0]
+        self.assertEqual(request_span.resource, "GET /users/<int:user_id>")
+
+    def test_otel_semantics_replaces_flask_method_not_allowed_resource(self):
+        @self.app.route("/")
+        def index():
+            return "Hello Flask"
+
+        with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+            response = self.client.open("/", method="PROPFIND")
+
+        self.assertEqual(response.status_code, 405)
+        request_span = self.get_spans()[0]
+        self.assertEqual(request_span.resource, "HTTP")
+
+    def test_otel_semantics_normalizes_route_resource_before_view(self):
+        from ddtrace.trace import tracer
+
+        captured = {}
+
+        @self.app.route("/items/<int:item_id>", methods=["PROPFIND"])
+        def item(item_id):
+            captured["resource"] = tracer.current_root_span().resource
+            return str(item_id)
+
+        with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+            response = self.client.open("/items/42", method="PROPFIND")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(captured["resource"], "HTTP /items/<int:item_id>")
+        self.assertEqual(self.get_spans()[0].resource, "HTTP /items/<int:item_id>")
 
     def test_route_params_request(self):
         """

--- a/tests/contrib/sanic/test_sanic.py
+++ b/tests/contrib/sanic/test_sanic.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import random
 import re
+from unittest import mock
 
 import pytest
 from sanic import Sanic
@@ -272,6 +273,23 @@ async def test_resource_name(tracer, client, url, expected_json, expected_resour
     spans = test_spans.pop_traces()
     request_span = spans[0][0]
     assert request_span.resource == expected_resource
+
+
+@pytest.mark.asyncio
+async def test_otel_semantics_sets_complete_request_metadata(client, test_spans):
+    with (
+        mock.patch.object(config, "_otel_trace_semantics_enabled", True),
+        mock.patch("ddtrace._trace.http_semantics.otel_number", side_effect=lambda value: value),
+    ):
+        response = await client.get("/hello/foo")
+
+    assert _response_status(response) == 200
+    request_span = test_spans.pop_traces()[0][0]
+    assert request_span.get_tag("http.request.method") == "GET"
+    assert request_span.get_tag("http.route") == "/hello/<first_name>"
+    assert request_span.get_metric("http.response.status_code") == 200
+    assert request_span.get_tag("url.path") == "/hello/foo"
+    assert request_span.resource == "GET /hello/<first_name>"
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/starlette/test_starlette.py
+++ b/tests/contrib/starlette/test_starlette.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+from unittest import mock
 
 import httpx
 import pytest
@@ -15,6 +16,7 @@ from ddtrace.contrib.internal.sqlalchemy.patch import patch as sql_patch
 from ddtrace.contrib.internal.sqlalchemy.patch import unpatch as sql_unpatch
 from ddtrace.contrib.internal.starlette.patch import patch as starlette_patch
 from ddtrace.contrib.internal.starlette.patch import unpatch as starlette_unpatch
+from ddtrace.internal.settings._config import config
 from ddtrace.propagation import http as http_propagation
 from tests.contrib.starlette.app import get_app
 from tests.tracer.utils_inferred_spans.test_helpers import assert_web_and_inferred_aws_api_gateway_span_data
@@ -646,6 +648,21 @@ def test_inferred_spans_api_gateway(client, test_spans):
             url="https://local/",
             start=1736973768,
         )
+
+
+def test_otel_semantics_replaces_starlette_route_resource(tracer, test_spans):
+    async def endpoint(request):
+        return PlainTextResponse("ok")
+
+    app = Starlette(routes=[Route("/items/{item_id}", endpoint=endpoint, methods=["PROPFIND"])])
+
+    with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+        with TestClient(app) as client:
+            response = client.request("PROPFIND", "/items/42")
+
+    assert response.status_code == 200
+    request_span = next(test_spans.filter_spans(name="starlette.request"))
+    assert request_span.resource == "HTTP /items/{item_id}"
 
 
 def test_cors_preflight_span_resource_uses_route_pattern(tracer, test_spans):

--- a/tests/contrib/starlette/test_starlette.py
+++ b/tests/contrib/starlette/test_starlette.py
@@ -665,6 +665,28 @@ def test_otel_semantics_replaces_starlette_route_resource(tracer, test_spans):
     assert request_span.resource == "HTTP /items/{item_id}"
 
 
+def test_otel_semantics_copies_complete_url_for_old_starlette_nested_span():
+    from ddtrace.contrib.internal.starlette.patch import _copy_server_url_attributes
+    from ddtrace.trace import Span
+
+    outer = Span("starlette.request")
+    inner = Span("starlette.request")
+    outer._set_attribute("url.scheme", "https")
+    outer._set_attribute("url.path", "/items/42")
+    outer._set_attribute("url.query", "view=full")
+    outer._set_attribute("server.address", "example.com")
+    outer._set_attribute("server.port", 8443)
+
+    with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+        _copy_server_url_attributes(outer, inner)
+
+    assert inner.get_tag("url.scheme") == "https"
+    assert inner.get_tag("url.path") == "/items/42"
+    assert inner.get_tag("url.query") == "view=full"
+    assert inner.get_tag("server.address") == "example.com"
+    assert inner.get_metric("server.port") == 8443
+
+
 def test_cors_preflight_span_resource_uses_route_pattern(tracer, test_spans):
     """CORSMiddleware short-circuits OPTIONS preflight before the router runs.
 

--- a/tests/contrib/wsgi/test_wsgi.py
+++ b/tests/contrib/wsgi/test_wsgi.py
@@ -1,4 +1,5 @@
 import os
+from unittest import mock
 
 import pytest
 from webtest import TestApp
@@ -8,6 +9,7 @@ from ddtrace.contrib.internal.wsgi.wsgi import DDWSGIMiddleware
 from ddtrace.contrib.internal.wsgi.wsgi import _DDWSGIMiddlewareBase
 from ddtrace.contrib.internal.wsgi.wsgi import construct_url
 from ddtrace.contrib.internal.wsgi.wsgi import get_request_headers
+from ddtrace.trace import tracer as global_tracer
 from tests.utils import override_config
 from tests.utils import override_http_config
 from tests.utils import snapshot
@@ -99,6 +101,27 @@ def test_middleware(tracer, test_spans):
     spans = test_spans.pop()
     assert len(spans) == 2
     assert spans[0].error == 1
+
+
+def test_otel_semantics_keeps_method_resource_before_response_on_exception(tracer, test_spans):
+    observed_resources = []
+
+    def failing_application(environ, start_response):
+        root_span = global_tracer.current_root_span()
+        assert root_span is not None
+        observed_resources.append(root_span.resource)
+        global_tracer.sample(root_span)
+        raise RuntimeError("before start_response")
+
+    with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+        app = TestApp(DDWSGIMiddleware(failing_application, tracer=tracer))
+        with pytest.raises(RuntimeError, match="before start_response"):
+            app.get("/users/12345")
+
+    spans = test_spans.pop()
+    request_span = next(span for span in spans if span.name == "wsgi.request")
+    assert observed_resources == ["GET"]
+    assert request_span.resource == "GET"
 
 
 def test_distributed_tracing(tracer, test_spans):

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_otel_semantics_request.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_otel_semantics_request.json
@@ -1,0 +1,466 @@
+[[
+  {
+    "name": "django.request",
+    "service": "django",
+    "resource": "GET ^fn-view/$",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.contrib.django",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "6a8fc5a300000000",
+      "_dd.svc_src": "django",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.django",
+      "component": "django",
+      "django.request.class": "django.core.handlers.wsgi.WSGIRequest",
+      "django.response.class": "django.http.response.HttpResponse",
+      "django.user.is_authenticated": "False",
+      "django.view": "fn-view",
+      "http.request.method": "GET",
+      "http.response.status_code": "200",
+      "http.route": "^fn-view/$",
+      "runtime-id": "a5fe4f9751674c999e0d6e33b994fa6a",
+      "server.address": "testserver",
+      "server.port": "80",
+      "span.kind": "server",
+      "url.path": "/fn-view/",
+      "url.scheme": "http"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 477.0
+    },
+    "duration": 2504042,
+    "start": 1787807139036052805
+  },
+     {
+       "name": "django.middleware",
+       "service": "django",
+       "resource": "django.contrib.sessions.middleware.SessionMiddleware.__call__",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "_dd.base_service": "tests.contrib.django",
+         "_dd.svc_src": "django",
+         "component": "django"
+       },
+       "duration": 2050833,
+       "start": 1787807139036269514
+     },
+        {
+          "name": "django.middleware",
+          "service": "django",
+          "resource": "django.contrib.sessions.middleware.SessionMiddleware.process_request",
+          "trace_id": 0,
+          "span_id": 3,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "_dd.base_service": "tests.contrib.django",
+            "_dd.svc_src": "django",
+            "component": "django"
+          },
+          "duration": 44041,
+          "start": 1787807139036324639
+        },
+        {
+          "name": "django.middleware",
+          "service": "django",
+          "resource": "django.middleware.common.CommonMiddleware.__call__",
+          "trace_id": 0,
+          "span_id": 4,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "_dd.base_service": "tests.contrib.django",
+            "_dd.svc_src": "django",
+            "component": "django"
+          },
+          "duration": 1807792,
+          "start": 1787807139036404472
+        },
+           {
+             "name": "django.middleware",
+             "service": "django",
+             "resource": "django.middleware.common.CommonMiddleware.process_request",
+             "trace_id": 0,
+             "span_id": 6,
+             "parent_id": 4,
+             "type": "",
+             "error": 0,
+             "meta": {
+               "_dd.base_service": "tests.contrib.django",
+               "_dd.svc_src": "django",
+               "component": "django"
+             },
+             "duration": 48958,
+             "start": 1787807139036446347
+           },
+           {
+             "name": "django.middleware",
+             "service": "django",
+             "resource": "django.middleware.csrf.CsrfViewMiddleware.__call__",
+             "trace_id": 0,
+             "span_id": 7,
+             "parent_id": 4,
+             "type": "",
+             "error": 0,
+             "meta": {
+               "_dd.base_service": "tests.contrib.django",
+               "_dd.svc_src": "django",
+               "component": "django"
+             },
+             "duration": 1493667,
+             "start": 1787807139036552097
+           },
+              {
+                "name": "django.middleware",
+                "service": "django",
+                "resource": "django.middleware.csrf.CsrfViewMiddleware.process_request",
+                "trace_id": 0,
+                "span_id": 9,
+                "parent_id": 7,
+                "type": "",
+                "error": 0,
+                "meta": {
+                  "_dd.base_service": "tests.contrib.django",
+                  "_dd.svc_src": "django",
+                  "component": "django"
+                },
+                "duration": 36417,
+                "start": 1787807139036609722
+              },
+              {
+                "name": "django.middleware",
+                "service": "django",
+                "resource": "django.contrib.auth.middleware.AuthenticationMiddleware.__call__",
+                "trace_id": 0,
+                "span_id": 10,
+                "parent_id": 7,
+                "type": "",
+                "error": 0,
+                "meta": {
+                  "_dd.base_service": "tests.contrib.django",
+                  "_dd.svc_src": "django",
+                  "component": "django"
+                },
+                "duration": 1292500,
+                "start": 1787807139036678889
+              },
+                 {
+                   "name": "django.middleware",
+                   "service": "django",
+                   "resource": "django.contrib.auth.middleware.AuthenticationMiddleware.process_request",
+                   "trace_id": 0,
+                   "span_id": 12,
+                   "parent_id": 10,
+                   "type": "",
+                   "error": 0,
+                   "meta": {
+                     "_dd.base_service": "tests.contrib.django",
+                     "_dd.svc_src": "django",
+                     "component": "django"
+                   },
+                   "duration": 34791,
+                   "start": 1787807139036723639
+                 },
+                 {
+                   "name": "django.middleware",
+                   "service": "django",
+                   "resource": "django.contrib.messages.middleware.MessageMiddleware.__call__",
+                   "trace_id": 0,
+                   "span_id": 13,
+                   "parent_id": 10,
+                   "type": "",
+                   "error": 0,
+                   "meta": {
+                     "_dd.base_service": "tests.contrib.django",
+                     "_dd.svc_src": "django",
+                     "component": "django"
+                   },
+                   "duration": 1142500,
+                   "start": 1787807139036811139
+                 },
+                    {
+                      "name": "django.middleware",
+                      "service": "django",
+                      "resource": "django.contrib.messages.middleware.MessageMiddleware.process_request",
+                      "trace_id": 0,
+                      "span_id": 14,
+                      "parent_id": 13,
+                      "type": "",
+                      "error": 0,
+                      "meta": {
+                        "_dd.base_service": "tests.contrib.django",
+                        "_dd.svc_src": "django",
+                        "component": "django"
+                      },
+                      "duration": 137958,
+                      "start": 1787807139036906597
+                    },
+                    {
+                      "name": "django.middleware",
+                      "service": "django",
+                      "resource": "django.middleware.clickjacking.XFrameOptionsMiddleware.__call__",
+                      "trace_id": 0,
+                      "span_id": 15,
+                      "parent_id": 13,
+                      "type": "",
+                      "error": 0,
+                      "meta": {
+                        "_dd.base_service": "tests.contrib.django",
+                        "_dd.svc_src": "django",
+                        "component": "django"
+                      },
+                      "duration": 776375,
+                      "start": 1787807139037106097
+                    },
+                       {
+                         "name": "django.middleware",
+                         "service": "django",
+                         "resource": "django.middleware.security.SecurityMiddleware.__call__",
+                         "trace_id": 0,
+                         "span_id": 17,
+                         "parent_id": 15,
+                         "type": "",
+                         "error": 0,
+                         "meta": {
+                           "_dd.base_service": "tests.contrib.django",
+                           "_dd.svc_src": "django",
+                           "component": "django"
+                         },
+                         "duration": 617167,
+                         "start": 1787807139037165097
+                       },
+                          {
+                            "name": "django.middleware",
+                            "service": "django",
+                            "resource": "django.middleware.security.SecurityMiddleware.process_request",
+                            "trace_id": 0,
+                            "span_id": 19,
+                            "parent_id": 17,
+                            "type": "",
+                            "error": 0,
+                            "meta": {
+                              "_dd.base_service": "tests.contrib.django",
+                              "_dd.svc_src": "django",
+                              "component": "django"
+                            },
+                            "duration": 25625,
+                            "start": 1787807139037206514
+                          },
+                          {
+                            "name": "django.middleware",
+                            "service": "django",
+                            "resource": "tests.contrib.django.middleware.ClsMiddleware.__call__",
+                            "trace_id": 0,
+                            "span_id": 20,
+                            "parent_id": 17,
+                            "type": "",
+                            "error": 0,
+                            "meta": {
+                              "_dd.base_service": "tests.contrib.django",
+                              "_dd.svc_src": "django",
+                              "component": "django"
+                            },
+                            "duration": 425000,
+                            "start": 1787807139037264930
+                          },
+                             {
+                               "name": "django.middleware",
+                               "service": "django",
+                               "resource": "tests.contrib.django.middleware.fn_middleware",
+                               "trace_id": 0,
+                               "span_id": 22,
+                               "parent_id": 20,
+                               "type": "",
+                               "error": 0,
+                               "meta": {
+                                 "_dd.base_service": "tests.contrib.django",
+                                 "_dd.svc_src": "django",
+                                 "component": "django"
+                               },
+                               "duration": 367083,
+                               "start": 1787807139037304764
+                             },
+                                {
+                                  "name": "django.middleware",
+                                  "service": "django",
+                                  "resource": "tests.contrib.django.middleware.EverythingMiddleware.__call__",
+                                  "trace_id": 0,
+                                  "span_id": 23,
+                                  "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
+                                  "meta": {
+                                    "_dd.base_service": "tests.contrib.django",
+                                    "_dd.svc_src": "django",
+                                    "component": "django"
+                                  },
+                                  "duration": 304459,
+                                  "start": 1787807139037349555
+                                },
+                                   {
+                                     "name": "django.middleware",
+                                     "service": "django",
+                                     "resource": "django.middleware.csrf.CsrfViewMiddleware.process_view",
+                                     "trace_id": 0,
+                                     "span_id": 24,
+                                     "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
+                                     "meta": {
+                                       "_dd.base_service": "tests.contrib.django",
+                                       "_dd.svc_src": "django",
+                                       "component": "django"
+                                     },
+                                     "duration": 31959,
+                                     "start": 1787807139037433430
+                                   },
+                                   {
+                                     "name": "django.middleware",
+                                     "service": "django",
+                                     "resource": "tests.contrib.django.middleware.EverythingMiddleware.process_view",
+                                     "trace_id": 0,
+                                     "span_id": 25,
+                                     "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
+                                     "meta": {
+                                       "_dd.base_service": "tests.contrib.django",
+                                       "_dd.svc_src": "django",
+                                       "component": "django"
+                                     },
+                                     "duration": 28042,
+                                     "start": 1787807139037494597
+                                   },
+                                   {
+                                     "name": "django.view",
+                                     "service": "django",
+                                     "resource": "tests.contrib.django.views.function_view",
+                                     "trace_id": 0,
+                                     "span_id": 26,
+                                     "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
+                                     "meta": {
+                                       "_dd.base_service": "tests.contrib.django",
+                                       "_dd.svc_src": "django",
+                                       "component": "django"
+                                     },
+                                     "duration": 55042,
+                                     "start": 1787807139037571472
+                                   },
+                          {
+                            "name": "django.middleware",
+                            "service": "django",
+                            "resource": "django.middleware.security.SecurityMiddleware.process_response",
+                            "trace_id": 0,
+                            "span_id": 21,
+                            "parent_id": 17,
+                            "type": "",
+                            "error": 0,
+                            "meta": {
+                              "_dd.base_service": "tests.contrib.django",
+                              "_dd.svc_src": "django",
+                              "component": "django"
+                            },
+                            "duration": 39292,
+                            "start": 1787807139037721722
+                          },
+                       {
+                         "name": "django.middleware",
+                         "service": "django",
+                         "resource": "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response",
+                         "trace_id": 0,
+                         "span_id": 18,
+                         "parent_id": 15,
+                         "type": "",
+                         "error": 0,
+                         "meta": {
+                           "_dd.base_service": "tests.contrib.django",
+                           "_dd.svc_src": "django",
+                           "component": "django"
+                         },
+                         "duration": 49750,
+                         "start": 1787807139037813555
+                       },
+                    {
+                      "name": "django.middleware",
+                      "service": "django",
+                      "resource": "django.contrib.messages.middleware.MessageMiddleware.process_response",
+                      "trace_id": 0,
+                      "span_id": 16,
+                      "parent_id": 13,
+                      "type": "",
+                      "error": 0,
+                      "meta": {
+                        "_dd.base_service": "tests.contrib.django",
+                        "_dd.svc_src": "django",
+                        "component": "django"
+                      },
+                      "duration": 26792,
+                      "start": 1787807139037909722
+                    },
+              {
+                "name": "django.middleware",
+                "service": "django",
+                "resource": "django.middleware.csrf.CsrfViewMiddleware.process_response",
+                "trace_id": 0,
+                "span_id": 11,
+                "parent_id": 7,
+                "type": "",
+                "error": 0,
+                "meta": {
+                  "_dd.base_service": "tests.contrib.django",
+                  "_dd.svc_src": "django",
+                  "component": "django"
+                },
+                "duration": 27291,
+                "start": 1787807139038001389
+              },
+           {
+             "name": "django.middleware",
+             "service": "django",
+             "resource": "django.middleware.common.CommonMiddleware.process_response",
+             "trace_id": 0,
+             "span_id": 8,
+             "parent_id": 4,
+             "type": "",
+             "error": 0,
+             "meta": {
+               "_dd.base_service": "tests.contrib.django",
+               "_dd.svc_src": "django",
+               "component": "django"
+             },
+             "duration": 73167,
+             "start": 1787807139038072430
+           },
+        {
+          "name": "django.middleware",
+          "service": "django",
+          "resource": "django.contrib.sessions.middleware.SessionMiddleware.process_response",
+          "trace_id": 0,
+          "span_id": 5,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "_dd.base_service": "tests.contrib.django",
+            "_dd.svc_src": "django",
+            "component": "django"
+          },
+          "duration": 45375,
+          "start": 1787807139038257014
+        }]]

--- a/tests/snapshots/tests.contrib.django.test_django_snapshots.test_otel_semantics_request_unaccepted_method.json
+++ b/tests/snapshots/tests.contrib.django.test_django_snapshots.test_otel_semantics_request_unaccepted_method.json
@@ -1,0 +1,467 @@
+[[
+  {
+    "name": "django.request",
+    "service": "django",
+    "resource": "HTTP ^fn-view/$",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "web",
+    "error": 0,
+    "meta": {
+      "_dd.base_service": "tests.contrib.django",
+      "_dd.p.dm": "-0",
+      "_dd.p.tid": "6a8fc5a300000000",
+      "_dd.svc_src": "django",
+      "_dd.tags.process": "entrypoint.name:pytest,entrypoint.type:script,entrypoint.workdir:project,svc.auto:tests.contrib.django",
+      "component": "django",
+      "django.request.class": "django.core.handlers.wsgi.WSGIRequest",
+      "django.response.class": "django.http.response.HttpResponse",
+      "django.user.is_authenticated": "False",
+      "django.view": "fn-view",
+      "http.request.method": "_OTHER",
+      "http.request.method_original": "PROPFIND",
+      "http.response.status_code": "200",
+      "http.route": "^fn-view/$",
+      "runtime-id": "a5fe4f9751674c999e0d6e33b994fa6a",
+      "server.address": "testserver",
+      "server.port": "80",
+      "span.kind": "server",
+      "url.path": "/fn-view/",
+      "url.scheme": "http"
+    },
+    "metrics": {
+      "_dd.measured": 1.0,
+      "_dd.top_level": 1.0,
+      "_dd.tracer_kr": 1.0,
+      "_sampling_priority_v1": 1.0,
+      "process_id": 477.0
+    },
+    "duration": 9453750,
+    "start": 1787807139012091472
+  },
+     {
+       "name": "django.middleware",
+       "service": "django",
+       "resource": "django.contrib.sessions.middleware.SessionMiddleware.__call__",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "",
+       "error": 0,
+       "meta": {
+         "_dd.base_service": "tests.contrib.django",
+         "_dd.svc_src": "django",
+         "component": "django"
+       },
+       "duration": 8211958,
+       "start": 1787807139012861847
+     },
+        {
+          "name": "django.middleware",
+          "service": "django",
+          "resource": "django.contrib.sessions.middleware.SessionMiddleware.process_request",
+          "trace_id": 0,
+          "span_id": 3,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "_dd.base_service": "tests.contrib.django",
+            "_dd.svc_src": "django",
+            "component": "django"
+          },
+          "duration": 909208,
+          "start": 1787807139012939139
+        },
+        {
+          "name": "django.middleware",
+          "service": "django",
+          "resource": "django.middleware.common.CommonMiddleware.__call__",
+          "trace_id": 0,
+          "span_id": 4,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "_dd.base_service": "tests.contrib.django",
+            "_dd.svc_src": "django",
+            "component": "django"
+          },
+          "duration": 7000500,
+          "start": 1787807139013984347
+        },
+           {
+             "name": "django.middleware",
+             "service": "django",
+             "resource": "django.middleware.common.CommonMiddleware.process_request",
+             "trace_id": 0,
+             "span_id": 6,
+             "parent_id": 4,
+             "type": "",
+             "error": 0,
+             "meta": {
+               "_dd.base_service": "tests.contrib.django",
+               "_dd.svc_src": "django",
+               "component": "django"
+             },
+             "duration": 1146125,
+             "start": 1787807139014045680
+           },
+           {
+             "name": "django.middleware",
+             "service": "django",
+             "resource": "django.middleware.csrf.CsrfViewMiddleware.__call__",
+             "trace_id": 0,
+             "span_id": 7,
+             "parent_id": 4,
+             "type": "",
+             "error": 0,
+             "meta": {
+               "_dd.base_service": "tests.contrib.django",
+               "_dd.svc_src": "django",
+               "component": "django"
+             },
+             "duration": 5663833,
+             "start": 1787807139015245222
+           },
+              {
+                "name": "django.middleware",
+                "service": "django",
+                "resource": "django.middleware.csrf.CsrfViewMiddleware.process_request",
+                "trace_id": 0,
+                "span_id": 9,
+                "parent_id": 7,
+                "type": "",
+                "error": 0,
+                "meta": {
+                  "_dd.base_service": "tests.contrib.django",
+                  "_dd.svc_src": "django",
+                  "component": "django"
+                },
+                "duration": 40709,
+                "start": 1787807139015294680
+              },
+              {
+                "name": "django.middleware",
+                "service": "django",
+                "resource": "django.contrib.auth.middleware.AuthenticationMiddleware.__call__",
+                "trace_id": 0,
+                "span_id": 10,
+                "parent_id": 7,
+                "type": "",
+                "error": 0,
+                "meta": {
+                  "_dd.base_service": "tests.contrib.django",
+                  "_dd.svc_src": "django",
+                  "component": "django"
+                },
+                "duration": 5475500,
+                "start": 1787807139015365680
+              },
+                 {
+                   "name": "django.middleware",
+                   "service": "django",
+                   "resource": "django.contrib.auth.middleware.AuthenticationMiddleware.process_request",
+                   "trace_id": 0,
+                   "span_id": 12,
+                   "parent_id": 10,
+                   "type": "",
+                   "error": 0,
+                   "meta": {
+                     "_dd.base_service": "tests.contrib.django",
+                     "_dd.svc_src": "django",
+                     "component": "django"
+                   },
+                   "duration": 36042,
+                   "start": 1787807139015422347
+                 },
+                 {
+                   "name": "django.middleware",
+                   "service": "django",
+                   "resource": "django.contrib.messages.middleware.MessageMiddleware.__call__",
+                   "trace_id": 0,
+                   "span_id": 13,
+                   "parent_id": 10,
+                   "type": "",
+                   "error": 0,
+                   "meta": {
+                     "_dd.base_service": "tests.contrib.django",
+                     "_dd.svc_src": "django",
+                     "component": "django"
+                   },
+                   "duration": 5332917,
+                   "start": 1787807139015491222
+                 },
+                    {
+                      "name": "django.middleware",
+                      "service": "django",
+                      "resource": "django.contrib.messages.middleware.MessageMiddleware.process_request",
+                      "trace_id": 0,
+                      "span_id": 14,
+                      "parent_id": 13,
+                      "type": "",
+                      "error": 0,
+                      "meta": {
+                        "_dd.base_service": "tests.contrib.django",
+                        "_dd.svc_src": "django",
+                        "component": "django"
+                      },
+                      "duration": 4192459,
+                      "start": 1787807139015536055
+                    },
+                    {
+                      "name": "django.middleware",
+                      "service": "django",
+                      "resource": "django.middleware.clickjacking.XFrameOptionsMiddleware.__call__",
+                      "trace_id": 0,
+                      "span_id": 15,
+                      "parent_id": 13,
+                      "type": "",
+                      "error": 0,
+                      "meta": {
+                        "_dd.base_service": "tests.contrib.django",
+                        "_dd.svc_src": "django",
+                        "component": "django"
+                      },
+                      "duration": 946417,
+                      "start": 1787807139019795680
+                    },
+                       {
+                         "name": "django.middleware",
+                         "service": "django",
+                         "resource": "django.middleware.security.SecurityMiddleware.__call__",
+                         "trace_id": 0,
+                         "span_id": 17,
+                         "parent_id": 15,
+                         "type": "",
+                         "error": 0,
+                         "meta": {
+                           "_dd.base_service": "tests.contrib.django",
+                           "_dd.svc_src": "django",
+                           "component": "django"
+                         },
+                         "duration": 799958,
+                         "start": 1787807139019858139
+                       },
+                          {
+                            "name": "django.middleware",
+                            "service": "django",
+                            "resource": "django.middleware.security.SecurityMiddleware.process_request",
+                            "trace_id": 0,
+                            "span_id": 19,
+                            "parent_id": 17,
+                            "type": "",
+                            "error": 0,
+                            "meta": {
+                              "_dd.base_service": "tests.contrib.django",
+                              "_dd.svc_src": "django",
+                              "component": "django"
+                            },
+                            "duration": 29042,
+                            "start": 1787807139019902805
+                          },
+                          {
+                            "name": "django.middleware",
+                            "service": "django",
+                            "resource": "tests.contrib.django.middleware.ClsMiddleware.__call__",
+                            "trace_id": 0,
+                            "span_id": 20,
+                            "parent_id": 17,
+                            "type": "",
+                            "error": 0,
+                            "meta": {
+                              "_dd.base_service": "tests.contrib.django",
+                              "_dd.svc_src": "django",
+                              "component": "django"
+                            },
+                            "duration": 589167,
+                            "start": 1787807139019966847
+                          },
+                             {
+                               "name": "django.middleware",
+                               "service": "django",
+                               "resource": "tests.contrib.django.middleware.fn_middleware",
+                               "trace_id": 0,
+                               "span_id": 22,
+                               "parent_id": 20,
+                               "type": "",
+                               "error": 0,
+                               "meta": {
+                                 "_dd.base_service": "tests.contrib.django",
+                                 "_dd.svc_src": "django",
+                                 "component": "django"
+                               },
+                               "duration": 532709,
+                               "start": 1787807139020007055
+                             },
+                                {
+                                  "name": "django.middleware",
+                                  "service": "django",
+                                  "resource": "tests.contrib.django.middleware.EverythingMiddleware.__call__",
+                                  "trace_id": 0,
+                                  "span_id": 23,
+                                  "parent_id": 22,
+                                  "type": "",
+                                  "error": 0,
+                                  "meta": {
+                                    "_dd.base_service": "tests.contrib.django",
+                                    "_dd.svc_src": "django",
+                                    "component": "django"
+                                  },
+                                  "duration": 476375,
+                                  "start": 1787807139020044972
+                                },
+                                   {
+                                     "name": "django.middleware",
+                                     "service": "django",
+                                     "resource": "django.middleware.csrf.CsrfViewMiddleware.process_view",
+                                     "trace_id": 0,
+                                     "span_id": 24,
+                                     "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
+                                     "meta": {
+                                       "_dd.base_service": "tests.contrib.django",
+                                       "_dd.svc_src": "django",
+                                       "component": "django"
+                                     },
+                                     "duration": 60750,
+                                     "start": 1787807139020133222
+                                   },
+                                   {
+                                     "name": "django.middleware",
+                                     "service": "django",
+                                     "resource": "tests.contrib.django.middleware.EverythingMiddleware.process_view",
+                                     "trace_id": 0,
+                                     "span_id": 25,
+                                     "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
+                                     "meta": {
+                                       "_dd.base_service": "tests.contrib.django",
+                                       "_dd.svc_src": "django",
+                                       "component": "django"
+                                     },
+                                     "duration": 24042,
+                                     "start": 1787807139020223680
+                                   },
+                                   {
+                                     "name": "django.view",
+                                     "service": "django",
+                                     "resource": "tests.contrib.django.views.function_view",
+                                     "trace_id": 0,
+                                     "span_id": 26,
+                                     "parent_id": 23,
+                                     "type": "",
+                                     "error": 0,
+                                     "meta": {
+                                       "_dd.base_service": "tests.contrib.django",
+                                       "_dd.svc_src": "django",
+                                       "component": "django"
+                                     },
+                                     "duration": 91042,
+                                     "start": 1787807139020305555
+                                   },
+                          {
+                            "name": "django.middleware",
+                            "service": "django",
+                            "resource": "django.middleware.security.SecurityMiddleware.process_response",
+                            "trace_id": 0,
+                            "span_id": 21,
+                            "parent_id": 17,
+                            "type": "",
+                            "error": 0,
+                            "meta": {
+                              "_dd.base_service": "tests.contrib.django",
+                              "_dd.svc_src": "django",
+                              "component": "django"
+                            },
+                            "duration": 46375,
+                            "start": 1787807139020589389
+                          },
+                       {
+                         "name": "django.middleware",
+                         "service": "django",
+                         "resource": "django.middleware.clickjacking.XFrameOptionsMiddleware.process_response",
+                         "trace_id": 0,
+                         "span_id": 18,
+                         "parent_id": 15,
+                         "type": "",
+                         "error": 0,
+                         "meta": {
+                           "_dd.base_service": "tests.contrib.django",
+                           "_dd.svc_src": "django",
+                           "component": "django"
+                         },
+                         "duration": 35000,
+                         "start": 1787807139020690555
+                       },
+                    {
+                      "name": "django.middleware",
+                      "service": "django",
+                      "resource": "django.contrib.messages.middleware.MessageMiddleware.process_response",
+                      "trace_id": 0,
+                      "span_id": 16,
+                      "parent_id": 13,
+                      "type": "",
+                      "error": 0,
+                      "meta": {
+                        "_dd.base_service": "tests.contrib.django",
+                        "_dd.svc_src": "django",
+                        "component": "django"
+                      },
+                      "duration": 34334,
+                      "start": 1787807139020772680
+                    },
+              {
+                "name": "django.middleware",
+                "service": "django",
+                "resource": "django.middleware.csrf.CsrfViewMiddleware.process_response",
+                "trace_id": 0,
+                "span_id": 11,
+                "parent_id": 7,
+                "type": "",
+                "error": 0,
+                "meta": {
+                  "_dd.base_service": "tests.contrib.django",
+                  "_dd.svc_src": "django",
+                  "component": "django"
+                },
+                "duration": 26375,
+                "start": 1787807139020867055
+              },
+           {
+             "name": "django.middleware",
+             "service": "django",
+             "resource": "django.middleware.common.CommonMiddleware.process_response",
+             "trace_id": 0,
+             "span_id": 8,
+             "parent_id": 4,
+             "type": "",
+             "error": 0,
+             "meta": {
+               "_dd.base_service": "tests.contrib.django",
+               "_dd.svc_src": "django",
+               "component": "django"
+             },
+             "duration": 32167,
+             "start": 1787807139020936347
+           },
+        {
+          "name": "django.middleware",
+          "service": "django",
+          "resource": "django.contrib.sessions.middleware.SessionMiddleware.process_response",
+          "trace_id": 0,
+          "span_id": 5,
+          "parent_id": 2,
+          "type": "",
+          "error": 0,
+          "meta": {
+            "_dd.base_service": "tests.contrib.django",
+            "_dd.svc_src": "django",
+            "component": "django"
+          },
+          "duration": 45750,
+          "start": 1787807139021011264
+        }]]

--- a/tests/tracer/test_otel_span_naming.py
+++ b/tests/tracer/test_otel_span_naming.py
@@ -230,3 +230,187 @@ def test_a_sampling_rule_does_not_match_the_pre_rename_resource():
 
     span = _emit_client_span_through_the_subscriber()
     assert span.context.sampling_priority == AUTO_KEEP
+
+
+def _server_name(method=None, route=None, resource=_INTEGRATION_RESOURCE, span_hook=None, kind="server"):
+    with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+        with tracer.start_span("django.request", span_type=SpanTypes.WEB, activate=False) as span:
+            if resource is not None:
+                span.resource = resource
+                span._set_ctx_item(INSTRUMENTATION_HTTP_RESOURCE, resource)
+            if kind is not None:
+                span._set_attribute(SPAN_KIND, kind)
+            if span_hook is not None:
+                span_hook(span)
+            trace_utils.set_http_meta(span, _integration_config(), method=method, route=route)
+            return span.resource
+
+
+def test_server_with_route():
+    assert _server_name(method="GET", route="/users/<int:id>") == "GET /users/<int:id>"
+
+
+def test_server_without_route_is_bare_method():
+    assert _server_name(method="GET") == "GET"
+
+
+def test_server_without_route_ignores_the_uri_path():
+    assert _server_name(method="GET", resource="GET /users/12345") == "GET"
+
+
+@pytest.mark.parametrize(("route", "expected"), [(None, "HTTP"), ("/ping", "HTTP /ping")])
+def test_server_unaccepted_method_substitutes_only_the_method_token(route, expected):
+    assert _server_name(method="FROBNICATE", route=route) == expected
+
+
+def test_server_raw_method_never_leaks_into_the_name():
+    assert _server_name(method="get") == "GET"
+
+
+def test_server_user_set_resource_is_preserved():
+    def claim(span):
+        span._set_ctx_item(RESOURCE_SET_BY_USER, True)
+
+    assert _server_name(method="GET", route="/users", span_hook=claim) == _INTEGRATION_RESOURCE
+
+
+def test_server_resource_replaced_by_user_code_is_detected_and_kept():
+    def replace(span):
+        span.resource = "my custom name"
+
+    assert _server_name(method="GET", route="/users", resource=None, span_hook=replace) == "my custom name"
+
+
+def test_websocket_handshake_is_left_alone():
+    assert _server_name(method="websocket") == _INTEGRATION_RESOURCE
+
+
+def test_server_span_without_a_method_is_left_alone():
+    assert _server_name(method=None) == _INTEGRATION_RESOURCE
+
+
+def test_server_span_with_no_kind_gets_the_bare_method():
+    assert _server_name(method="GET", kind=None) == "GET"
+
+
+def test_server_method_and_route_attributes_are_still_written():
+    from ddtrace.ext import http
+
+    with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+        with tracer.start_span("web.request", span_type=SpanTypes.WEB, activate=False) as span:
+            span._set_attribute(SPAN_KIND, "server")
+            trace_utils.set_http_meta(span, _integration_config(), method="get", route="/x")
+            assert span.get_tag(http.OTEL_REQUEST_METHOD) == "GET"
+            assert span.get_tag(http.OTEL_REQUEST_METHOD_ORIGINAL) == "get"
+            assert span.get_tag(http.OTEL_ROUTE) == "/x"
+
+
+def test_server_span_is_named_at_start_not_left_as_the_integration_resource():
+    with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+        with tracer.start_span("aiohttp.request", span_type=SpanTypes.WEB, activate=False) as span:
+            span.resource = "aiohttp.request"
+            span._set_attribute(SPAN_KIND, "server")
+            normalized, original = normalize_http_method("GET")
+            set_otel_http_resource(span, normalized, original)
+            assert span.resource == "GET"
+            trace_utils.set_http_meta(span, _integration_config(), method="GET", route="/users/{id}")
+            assert span.resource == "GET /users/{id}"
+
+
+def test_a_later_call_refines_the_server_name_with_a_route():
+    with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+        with tracer.start_span("web.request", span_type=SpanTypes.WEB, activate=False) as span:
+            span.resource = _INTEGRATION_RESOURCE
+            span._set_ctx_item(INSTRUMENTATION_HTTP_RESOURCE, _INTEGRATION_RESOURCE)
+            span._set_attribute(SPAN_KIND, "server")
+            integration_config = _integration_config()
+            trace_utils.set_http_meta(span, integration_config, method="GET")
+            assert span.resource == "GET"
+            trace_utils.set_http_meta(span, integration_config, method="GET", route="/users/<int:id>")
+            assert span.resource == "GET /users/<int:id>"
+
+
+def test_a_user_resource_set_between_server_calls_stops_the_rename():
+    with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+        with tracer.start_span("web.request", span_type=SpanTypes.WEB, activate=False) as span:
+            span.resource = _INTEGRATION_RESOURCE
+            span._set_ctx_item(INSTRUMENTATION_HTTP_RESOURCE, _INTEGRATION_RESOURCE)
+            span._set_attribute(SPAN_KIND, "server")
+            integration_config = _integration_config()
+            trace_utils.set_http_meta(span, integration_config, method="GET")
+            span.resource = "my custom name"
+            trace_utils.set_http_meta(span, integration_config, method="GET", route="/users")
+            assert span.resource == "my custom name"
+            assert span._get_ctx_item(RESOURCE_SET_BY_USER) is True
+
+
+@pytest.mark.subprocess(env=_OTEL_SUBPROCESS_ENV, err=None)
+def test_web_resource_replaced_during_request_is_preserved_at_finish():
+    from ddtrace.contrib._events.web_framework import WebFrameworkRequestEvent
+    from ddtrace.internal import core
+    from ddtrace.internal.settings._config import config
+    from ddtrace.internal.span_bus import span_from_context
+
+    event = WebFrameworkRequestEvent(
+        http_operation="aiohttp.request",
+        service="svc",
+        component="aiohttp",
+        resource="GET /users/42",
+        integration_config=config.aiohttp,
+        request_method="GET",
+        request_headers={},
+        query="",
+        request_url="http://host/users/42",
+        request_route="/users/{id}",
+        headers_case_sensitive=False,
+    )
+    with core.context_with_event(event) as ctx:
+        span = span_from_context(ctx)
+        assert span.resource == "GET /users/{id}"
+        span.resource = "user-owned"
+
+    assert span.resource == "user-owned"
+
+
+def _emit_server_trace_sampled_during_client_propagation():
+    from ddtrace.contrib._events.web_framework import WebFrameworkRequestEvent
+    from ddtrace.internal import core
+    from ddtrace.internal.span_bus import span_from_context
+
+    with core.context_with_event(
+        WebFrameworkRequestEvent(
+            http_operation="django.request",
+            service="server",
+            component="django",
+            resource="GET /actual/path/42",
+            integration_config=config.django,
+            request_method="GET",
+            request_headers={},
+            query="",
+            request_url="http://server/actual/path/42",
+            headers_case_sensitive=False,
+        ),
+    ) as server_ctx:
+        server_span = span_from_context(server_ctx)
+        assert server_span.resource == "GET"
+
+        with core.context_with_event(_client_event(method="POST")):
+            pass
+
+    return server_span
+
+
+@pytest.mark.subprocess(
+    env={
+        **_OTEL_SUBPROCESS_ENV,
+        "DD_TRACE_SAMPLING_RULES": '[{"resource": "GET", "sample_rate": 0.0}]',
+    },
+    err=None,
+)
+def test_server_rule_matches_when_client_propagation_forces_the_decision():
+    from ddtrace.constants import USER_REJECT
+    from tests.tracer.test_otel_span_naming import _emit_server_trace_sampled_during_client_propagation
+
+    span = _emit_server_trace_sampled_during_client_propagation()
+    assert span.resource == "GET"
+    assert span.context.sampling_priority == USER_REJECT

--- a/tests/tracer/test_resource_renaming.py
+++ b/tests/tracer/test_resource_renaming.py
@@ -1,9 +1,12 @@
+from unittest import mock
+
 import pytest
 
 from ddtrace._trace.processor.resource_renaming import ResourceRenamingProcessor
 from ddtrace._trace.processor.resource_renaming import SimplifiedEndpointComputer
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import http
+from ddtrace.internal.settings._config import config
 from ddtrace.trace import Context
 from ddtrace.trace import Span
 from tests.utils import override_global_config
@@ -109,6 +112,31 @@ class TestResourceRenaming:
         processor.on_span_finish(span)
         assert span.get_tag(http.ENDPOINT) == "/api/users/{param:int}"
 
+    def test_processor_route_less_404(self):
+        processor = ResourceRenamingProcessor()
+        span = Span("test", context=Context(), span_type=SpanTypes.WEB)
+        span.set_tag(http.URL, "https://example.com/missing")
+        span.set_tag(http.STATUS_CODE, 404)
+
+        processor.on_span_finish(span)
+
+        assert span.get_tag(http.ENDPOINT) is None
+
+    def test_processor_reads_semantics_flag_per_call(self):
+        processor = ResourceRenamingProcessor()
+
+        with mock.patch.object(config, "_otel_trace_semantics_enabled", False):
+            span = Span("test", context=Context(), span_type=SpanTypes.WEB)
+            span.set_tag(http.URL, "https://example.com/legacy/123")
+            processor.on_span_finish(span)
+            assert span.get_tag(http.ENDPOINT) == "/legacy/{param:int}"
+
+        with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
+            span = Span("test", context=Context(), span_type=SpanTypes.WEB)
+            span.set_tag(http.OTEL_URL_PATH, "/otel/123")
+            processor.on_span_finish(span)
+            assert span.get_tag(http.ENDPOINT) == "/otel/{param:int}"
+
     def test_processor_always_simplified_endpoint(self):
         processor = ResourceRenamingProcessor()
         with override_global_config(dict(_trace_resource_renaming_always_simplified_endpoint=True)):
@@ -119,3 +147,27 @@ class TestResourceRenaming:
             processor.on_span_finish(span)
         # Should use simplified endpoint even when route exists
         assert span.get_tag(http.ENDPOINT) == "/api/users/{param:int}"
+
+
+@pytest.mark.subprocess(env={"DD_TRACE_OTEL_SEMANTICS_ENABLED": "true"})
+def test_processor_reads_the_otel_tag_names():
+    from ddtrace._trace.processor.resource_renaming import ResourceRenamingProcessor
+    from ddtrace.ext import SpanTypes
+    from ddtrace.ext import http
+    from ddtrace.trace import Span
+
+    processor = ResourceRenamingProcessor()
+
+    # The path and the status come from the OTel names once the Datadog ones are gone.
+    span = Span("test", span_type=SpanTypes.WEB)
+    span.set_tag(http.OTEL_URL_PATH, "/api/users/123")
+    span.set_tag(http.OTEL_RESPONSE_STATUS_CODE, 200)
+    processor.on_span_finish(span)
+    assert span.get_tag(http.ENDPOINT) == "/api/users/{param:int}"
+
+    # A route-less 404 is still left alone, exactly as with the flag off.
+    span = Span("test", span_type=SpanTypes.WEB)
+    span.set_tag(http.OTEL_URL_PATH, "/missing")
+    span.set_tag(http.OTEL_RESPONSE_STATUS_CODE, 404)
+    processor.on_span_finish(span)
+    assert span.get_tag(http.ENDPOINT) is None

--- a/tests/tracer/test_resource_renaming.py
+++ b/tests/tracer/test_resource_renaming.py
@@ -127,9 +127,9 @@ class TestResourceRenaming:
 
         with mock.patch.object(config, "_otel_trace_semantics_enabled", False):
             span = Span("test", context=Context(), span_type=SpanTypes.WEB)
-            span.set_tag(http.URL, "https://example.com/legacy/123")
+            span.set_tag(http.URL, "https://example.com/datadog/123")
             processor.on_span_finish(span)
-            assert span.get_tag(http.ENDPOINT) == "/legacy/{param:int}"
+            assert span.get_tag(http.ENDPOINT) == "/datadog/{param:int}"
 
         with mock.patch.object(config, "_otel_trace_semantics_enabled", True):
             span = Span("test", context=Context(), span_type=SpanTypes.WEB)
@@ -158,14 +158,12 @@ def test_processor_reads_the_otel_tag_names():
 
     processor = ResourceRenamingProcessor()
 
-    # The path and the status come from the OTel names once the Datadog ones are gone.
     span = Span("test", span_type=SpanTypes.WEB)
     span.set_tag(http.OTEL_URL_PATH, "/api/users/123")
     span.set_tag(http.OTEL_RESPONSE_STATUS_CODE, 200)
     processor.on_span_finish(span)
     assert span.get_tag(http.ENDPOINT) == "/api/users/{param:int}"
 
-    # A route-less 404 is still left alone, exactly as with the flag off.
     span = Span("test", span_type=SpanTypes.WEB)
     span.set_tag(http.OTEL_URL_PATH, "/missing")
     span.set_tag(http.OTEL_RESPONSE_STATUS_CODE, 404)

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -1335,6 +1335,68 @@ _OTEL_SEMANTICS_SUBPROCESS_ENV = {
 
 
 @pytest.mark.subprocess(env=_OTEL_SEMANTICS_SUBPROCESS_ENV)
+def test_otel_semantics_server_attributes():
+    from ddtrace.contrib.internal.trace_utils import set_http_meta
+    from ddtrace.ext import SpanTypes
+    from ddtrace.internal.settings._config import Config
+    from ddtrace.internal.settings.integration import IntegrationConfig
+    from tests.utils import scoped_tracer
+
+    cfg = Config()
+    cfg.myint = IntegrationConfig(cfg, "myint")
+    with scoped_tracer() as tracer, tracer.start_span("web.request", span_type=SpanTypes.WEB, activate=False) as span:
+        set_http_meta(
+            span,
+            cfg.myint,
+            method="GET",
+            url="http://localhost:8080/users/1?q=1",
+            query="q=1",
+            status_code=200,
+            request_headers={"user-agent": "curl/8.0"},
+            route="/users/<id>",
+        )
+
+        assert span.get_tag("http.request.method") == "GET"
+        assert span.get_tag("http.request.method_original") is None
+        assert span.get_tag("url.scheme") == "http"
+        assert span.get_tag("url.path") == "/users/1"
+        assert span.get_tag("url.query") == "q=1"
+        assert span.get_tag("server.address") == "localhost"
+        assert span.get_metric("server.port") == 8080
+        assert span.get_tag("user_agent.original") == "curl/8.0"
+        assert span.get_metric("http.response.status_code") == 200
+        assert span.get_tag("http.route") == "/users/<id>"
+        assert span.get_tag("error.type") is None
+        assert span.error == 0
+
+        for legacy in ("http.method", "http.url", "http.query.string", "http.useragent", "http.status_code"):
+            assert span.get_tag(legacy) is None, legacy
+
+
+@pytest.mark.subprocess(env=_OTEL_SEMANTICS_SUBPROCESS_ENV)
+def test_otel_semantics_server_prefers_encoded_raw_uri_path():
+    from ddtrace.contrib.internal.trace_utils import set_http_meta
+    from ddtrace.ext import SpanTypes
+    from ddtrace.internal.settings._config import Config
+    from ddtrace.internal.settings.integration import IntegrationConfig
+    from tests.utils import scoped_tracer
+
+    cfg = Config()
+    cfg.myint = IntegrationConfig(cfg, "myint")
+    with scoped_tracer() as tracer, tracer.start_span("web.request", span_type=SpanTypes.WEB, activate=False) as span:
+        set_http_meta(
+            span,
+            cfg.myint,
+            url="http://localhost/users/a/b?token=leaked&page=2",
+            raw_uri="/users/a%2Fb?token=leaked&page=2",
+            query="token=leaked&page=2",
+        )
+
+        assert span.get_tag("url.path") == "/users/a%2Fb"
+        assert span.get_tag("url.query") == "<redacted>&page=2"
+
+
+@pytest.mark.subprocess(env=_OTEL_SEMANTICS_SUBPROCESS_ENV)
 def test_otel_semantics_client_attributes():
     from ddtrace.contrib.internal.trace_utils import set_http_meta
     from ddtrace.ext import SpanTypes
@@ -1474,6 +1536,54 @@ def test_otel_semantics_client_uses_fixed_error_statuses():
 
 
 @pytest.mark.subprocess(env=_OTEL_SEMANTICS_SUBPROCESS_ENV)
+def test_otel_semantics_error_statuses_defaults():
+    from ddtrace.contrib.internal.trace_utils import set_http_meta
+    from ddtrace.ext import SpanTypes
+    from ddtrace.internal.settings._config import Config
+    from ddtrace.internal.settings.integration import IntegrationConfig
+    from tests.utils import scoped_tracer
+
+    cfg = Config()
+    cfg.myint = IntegrationConfig(cfg, "myint")
+
+    def tag(span_type, status_code):
+        with scoped_tracer() as tracer, tracer.start_span("request", span_type=span_type, activate=False) as span:
+            set_http_meta(span, cfg.myint, status_code=status_code)
+            return span.error, span.get_tag("error.type")
+
+    assert tag(SpanTypes.WEB, 404) == (0, None)
+    assert tag(SpanTypes.WEB, 499) == (0, None)
+    assert tag(SpanTypes.WEB, 500) == (1, "500")
+    assert tag(SpanTypes.HTTP, 399) == (0, None)
+    assert tag(SpanTypes.HTTP, 404) == (1, "404")
+    assert tag(SpanTypes.HTTP, 503) == (1, "503")
+    assert tag(SpanTypes.HTTP, 302) == (0, None)
+    for status_code in (599, 600, 999):
+        assert tag(SpanTypes.WEB, status_code) == (1, str(status_code))
+        assert tag(SpanTypes.HTTP, status_code) == (1, str(status_code))
+
+
+@pytest.mark.subprocess(env={**_OTEL_SEMANTICS_SUBPROCESS_ENV, "DD_TRACE_HTTP_SERVER_ERROR_STATUSES": "404-412"})
+def test_otel_semantics_server_error_statuses_configured():
+    from ddtrace.contrib.internal.trace_utils import set_http_meta
+    from ddtrace.ext import SpanTypes
+    from ddtrace.internal.settings._config import Config
+    from ddtrace.internal.settings.integration import IntegrationConfig
+    from tests.utils import scoped_tracer
+
+    cfg = Config()
+    cfg.myint = IntegrationConfig(cfg, "myint")
+    for status_code, expected_error, expected_type in ((405, 1, "405"), (500, 0, None), (600, 0, None)):
+        with (
+            scoped_tracer() as tracer,
+            tracer.start_span("web.request", span_type=SpanTypes.WEB, activate=False) as span,
+        ):
+            set_http_meta(span, cfg.myint, status_code=status_code)
+            assert span.error == expected_error
+            assert span.get_tag("error.type") == expected_type
+
+
+@pytest.mark.subprocess(env=_OTEL_SEMANTICS_SUBPROCESS_ENV)
 def test_otel_semantics_client_status_does_not_overwrite_exception_error_type():
     import sys
 
@@ -1496,6 +1606,51 @@ def test_otel_semantics_client_status_does_not_overwrite_exception_error_type():
         assert span.get_tag("error.type") == "builtins.ValueError"
 
 
+@pytest.mark.subprocess(env=_OTEL_SEMANTICS_SUBPROCESS_ENV)
+def test_otel_semantics_url_query_is_obfuscated():
+    from ddtrace.contrib.internal.trace_utils import set_http_meta
+    from ddtrace.ext import SpanTypes
+    from ddtrace.internal.settings._config import Config
+    from ddtrace.internal.settings.integration import IntegrationConfig
+    from tests.utils import scoped_tracer
+
+    cfg = Config()
+    cfg.myint = IntegrationConfig(cfg, "myint")
+    with scoped_tracer() as tracer, tracer.start_span("web.request", span_type=SpanTypes.WEB, activate=False) as span:
+        set_http_meta(
+            span,
+            cfg.myint,
+            url="http://localhost/login?token=leaked&page=2",
+            query="token=leaked&page=2",
+        )
+        assert span.get_tag("url.query") == "<redacted>&page=2"
+        assert span.get_tag("url.path") == "/login"
+
+
+@pytest.mark.subprocess(env={**_OTEL_SEMANTICS_SUBPROCESS_ENV, "DD_TRACE_CLIENT_IP_ENABLED": "true"})
+def test_otel_semantics_client_ip_attributes():
+    from ddtrace.contrib.internal.trace_utils import set_http_meta
+    from ddtrace.ext import SpanTypes
+    from ddtrace.internal.settings._config import Config
+    from ddtrace.internal.settings.integration import IntegrationConfig
+    from tests.utils import scoped_tracer
+
+    cfg = Config()
+    cfg.myint = IntegrationConfig(cfg, "myint")
+    with scoped_tracer() as tracer, tracer.start_span("web.request", span_type=SpanTypes.WEB, activate=False) as span:
+        set_http_meta(
+            span,
+            cfg.myint,
+            request_headers={"x-forwarded-for": "8.8.8.8"},
+            peer_ip="10.0.0.1",
+        )
+
+        assert span.get_tag("client.address") == "8.8.8.8"
+        assert span.get_tag("network.peer.address") == "10.0.0.1"
+        assert span.get_tag("http.client_ip") is None
+        assert span.get_tag("network.client.ip") is None
+
+
 @pytest.mark.subprocess(
     env={**_OTEL_SEMANTICS_SUBPROCESS_ENV, "OTEL_TRACES_EXPORTER": "otlp"},
 )
@@ -1509,6 +1664,27 @@ def test_otel_semantics_client_numeric_attributes_typed_for_otlp():
     cfg = Config()
     cfg.myint = IntegrationConfig(cfg, "myint")
     with scoped_tracer() as tracer, tracer.start_span("http.request", span_type=SpanTypes.HTTP, activate=False) as span:
+        set_http_meta(span, cfg.myint, url="http://localhost:8080/x", status_code=200)
+
+        assert span.get_tag("http.response.status_code") is None
+        assert span.get_metric("http.response.status_code") == 200
+        assert span.get_tag("server.port") is None
+        assert span.get_metric("server.port") == 8080
+
+
+@pytest.mark.subprocess(
+    env={**_OTEL_SEMANTICS_SUBPROCESS_ENV, "OTEL_TRACES_EXPORTER": "otlp"},
+)
+def test_otel_semantics_server_numeric_attributes_typed_for_otlp():
+    from ddtrace.contrib.internal.trace_utils import set_http_meta
+    from ddtrace.ext import SpanTypes
+    from ddtrace.internal.settings._config import Config
+    from ddtrace.internal.settings.integration import IntegrationConfig
+    from tests.utils import scoped_tracer
+
+    cfg = Config()
+    cfg.myint = IntegrationConfig(cfg, "myint")
+    with scoped_tracer() as tracer, tracer.start_span("web.request", span_type=SpanTypes.WEB, activate=False) as span:
         set_http_meta(span, cfg.myint, url="http://localhost:8080/x", status_code=200)
 
         assert span.get_tag("http.response.status_code") is None
@@ -1545,6 +1721,28 @@ def test_otel_client_semantics_disabled_by_default(int_config):
     for otel_name in (
         "http.request.method",
         "url.full",
+        "http.response.status_code",
+        "server.port",
+        "error.type",
+    ):
+        assert span.get_tag(otel_name) is None, otel_name
+
+
+def test_otel_server_semantics_disabled_by_default(int_config):
+    span = Span("web.request", span_type="web")
+    trace_utils.set_http_meta(
+        span,
+        int_config.myint,
+        method="GET",
+        url="http://localhost:8080/users/1",
+        status_code=500,
+    )
+    assert span.get_tag("http.method") == "GET"
+    assert span.get_tag("http.url") == "http://localhost:8080/users/1"
+    assert span.get_tag("http.status_code") == "500"
+    for otel_name in (
+        "http.request.method",
+        "url.path",
         "http.response.status_code",
         "server.port",
         "error.type",

--- a/tests/tracer/test_trace_utils.py
+++ b/tests/tracer/test_trace_utils.py
@@ -1369,8 +1369,8 @@ def test_otel_semantics_server_attributes():
         assert span.get_tag("error.type") is None
         assert span.error == 0
 
-        for legacy in ("http.method", "http.url", "http.query.string", "http.useragent", "http.status_code"):
-            assert span.get_tag(legacy) is None, legacy
+        for datadog_tag in ("http.method", "http.url", "http.query.string", "http.useragent", "http.status_code"):
+            assert span.get_tag(datadog_tag) is None, datadog_tag
 
 
 @pytest.mark.subprocess(env=_OTEL_SEMANTICS_SUBPROCESS_ENV)


### PR DESCRIPTION
## Description

Final layer of the native three-PR stack replacing [#19501](https://github.com/DataDog/dd-trace-py/pull/19501), based on [#20009](https://github.com/DataDog/dd-trace-py/pull/20009).

- Emits OTel HTTP semantics and route-based resources for inbound server/framework spans.
- Updates framework lifecycle hooks, resource renaming, blocked-response metadata, and AI Guard consumers without adding security-product dependencies on tracing modules.
- Publishes Django routes before sampling and AppSec blocking; Django <3.1 uses a first-position view-middleware hook that avoids a second custom-converter invocation.
- Includes the customer-facing release note and completes the intended behavior from #19501 with Emmett's requested tracing ownership boundary.
- Uses Datadog-versus-OTel terminology throughout; Datadog semantics remain supported and are not deprecated behavior.

## Review feedback incorporated

- The large original change is split into independently reviewable foundation, client, and server layers.
- Span attribute mutation is owned by `ddtrace/_trace`; contrib integrations extract and orchestrate.
- Direct tracing dependencies were removed from AppSec and AI Guard consumers through existing neutral helpers and core events.
- Redundant explanatory comments were removed; concise lifecycle, sampling, ownership, and failure-ordering invariants remain.
- Every original review thread, including resolved and outdated threads, was reconciled against the cumulative stack; no functional review fix was lost.

## Testing

Validated at `f7f533d426`:

- `scripts/lint checks`: passed.
- Final-head focused tracer suite: 252 passed.
- Final-head Django 2.2 suite: 141 passed, 10 skipped.
- Final-head Django 4.2 suite, including snapshots: 201 passed, 10 skipped, 1 expected xfail.
- Django snapshots and AppSec early-blocking integration coverage: passed.
- Flask, Starlette, FastAPI blocked-response, and AI Guard client-address coverage: passed.
- Circular-import and dependency-direction analyses: passed.

System tests built from server behavior commit `c7ca8ca20c` with [libdatadog#2323](https://github.com/DataDog/libdatadog/pull/2323) head `0ed7fd9bd`. The remaining commits through final head `f7f533d426` only restore concise comments and adjust one log message; the final-head suites above validate that exact revision:

- HTTP server + client semantics: 30 passed, 1 skipped.
- Sampling-rule semantics: 2 passed.
- OTLP trace metrics: 4 passed.
- Django AppSec pre-view blocking regressions: 2 passed.
- Custom error statuses under the manifest: 2 server assertions xpassed; 2 client assertions xfailed because `DD_TRACE_HTTP_CLIENT_ERROR_STATUSES` is not implemented and is explicitly outside this stack's scope. Forced execution confirmed those same two client-only failures and both server assertions passed.

## Risks

This layer touches shared server-framework lifecycle paths and AppSec blocked responses. The feature remains gated, Datadog semantics are covered, and both Django resolution paths were exercised.

## Stack

Registered as layer 3/3 in GitHub's native stacked pull request UI:

1. [#20008](https://github.com/DataDog/dd-trace-py/pull/20008) — foundation
2. [#20009](https://github.com/DataDog/dd-trace-py/pull/20009) — HTTP client spans
3. This PR — HTTP server/framework/AppSec spans

The original [#19501](https://github.com/DataDog/dd-trace-py/pull/19501) remains open only as the complete historical review and system-test reference.

Made with [Cursor](https://cursor.com)