### PR TITLE
fix(telemetry): avoid multiple flush on app closing

### DIFF
--- a/ddtrace/internal/native/_native.pyi
+++ b/ddtrace/internal/native/_native.pyi
@@ -320,8 +320,14 @@ class TelemetryWorker:
     def stop(self, send_app_closing: bool) -> None:
         """Flush and shut the worker down, waiting briefly for it to drain.
 
-        :param send_app_closing: when ``True`` emit the app-closing event
-            (origin only); when ``False`` just force a final data flush.
+        Emits app-closing (origin process only) and flushes remaining batches
+        during teardown.
+
+        WARNING: send_app_closing is currently ineffective and ignored. Since
+        the migration to libdatadog's telemetry worker, stop() always emits
+        app-closing in the origin process during teardown. If stopping
+        without app-closing is needed again, the behavior must be fixed in
+        libdatadog first (TODO).
         """
         ...
     def flush(self) -> None:

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -858,7 +858,7 @@ class TelemetryWriter:
         if self._worker is not None:
             # The native stop() unconditionally drains the buffer and sends an
             # app-closing event, so there's no need for an additional flush
-            # here (which would incur a hearbeat and an additional separate
+            # here (which would incur a heartbeat and an additional separate
             # request for the final stop).
             self.periodic(force_flush=False)
         self.disable()

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -382,6 +382,9 @@ class TelemetryWriter:
             self._deps_collector = None
         if self._worker is not None:
             try:
+                # NOTE: send_app_closing is currently ignored by the native worker
+                # (it always emits app-closing in the origin process); see
+                # TelemetryWorker.stop in ddtrace/internal/native/_native.pyi.
                 self._worker.stop(send_app_closing=get_parent_runtime_id() is None)
             except Exception:
                 log.debug("Failed to stop the native telemetry worker", exc_info=True)
@@ -853,11 +856,11 @@ class TelemetryWriter:
 
     def app_shutdown(self) -> None:
         if self._worker is not None:
-            # Final dependency/endpoint discovery + FLUSH. force_flush=True is required:
-            # the native Stop lifecycle only emits the observability batch (logs/metrics),
-            # not the app-events batch (dependencies/integrations/configs/endpoints), so the
-            # deps/endpoints discovered here must be flushed before stop() runs.
-            self.periodic(force_flush=True)
+            # The native stop() unconditionally drains the buffer and sends an
+            # app-closing event, so there's no need for an additional flush
+            # here (which would incur a hearbeat and an additional separate
+            # request for the final stop).
+            self.periodic(force_flush=False)
         self.disable()
 
     def set_test_session_token(self, token: Optional[str]) -> None:

--- a/releasenotes/notes/fix-telemetry-shutdown-double-flush-99a9b019d2184804.yaml
+++ b/releasenotes/notes/fix-telemetry-shutdown-double-flush-99a9b019d2184804.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    telemetry: Fixes an issue where an extra, redundant telemetry request was sent at process
+    shutdown, adding avoidable latency to application teardown. The final telemetry payload is
+    now sent as a single request.

--- a/src/native/telemetry.rs
+++ b/src/native/telemetry.rs
@@ -249,8 +249,17 @@ impl TelemetryWorkerPy {
             .map_err(|e| PyValueError::new_err(format!("failed to start telemetry worker: {e}")))
     }
 
-    /// Flush + optionally emit app-closing (in origin process), then tear the worker down.
+    /// Flush + tear the worker down, emitting app-closing (in origin process).
+    ///
+    /// WARNING: `send_app_closing` is currently ineffective and ignored: since the
+    /// migration to libdatadog's telemetry worker, teardown always drains the worker
+    /// and emits app-closing in the origin process. If stopping without an
+    /// app-closing event is needed again, the behavior must be fixed in libdatadog
+    /// (TODO).
     fn stop(&self, py: Python<'_>, send_app_closing: bool) -> PyResult<()> {
+        // Currently a no-op (see doc comment above); kept for API compatibility.
+        let _ = send_app_closing;
+
         self.ensure_runtime_after_fork()?;
         // Take the registration handle; if already stopped, nothing to do.
         let worker_handle = self
@@ -259,12 +268,6 @@ impl TelemetryWorkerPy {
             .unwrap_or_else(|e| e.into_inner())
             .take();
 
-        if send_app_closing {
-            // Flush the app-closing batch first (clears data.started).
-            let _ = self.handle.send_stop();
-        } else {
-            let _ = self.flush(py);
-        }
         if let Some(wh) = worker_handle {
             // Release the GIL while the async teardown runs on the shared
             // runtime. `wh.stop()` pauses the worker then shuts it down.

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -376,6 +376,32 @@ def test_app_closing_event(telemetry_writer, test_agent_session, mock_time):
     validate_request_body(events[0], {}, "app-closing")
 
 
+def test_app_shutdown_sends_a_single_closing_flush(telemetry_writer, test_agent_session, mock_time):
+    """asserts the full lifecycle of an empty app sends exactly two telemetry requests
+
+    Regression test for the shutdown double-flush: app_shutdown() used to force a data flush
+    before stopping the worker, which emitted a spurious heartbeat batch
+    (["app-dependencies-loaded", "app-heartbeat"]) ahead of a separate ["app-closing"] batch.
+    The native stop() drains the buffered events itself, so an empty app must send only:
+      1. ["app-started"], emitted eagerly on start()
+      2. ["app-dependencies-loaded", "app-closing"], drained by stop()
+    """
+    telemetry_writer.app_started()
+    telemetry_writer.app_shutdown()
+
+    # get_requests() returns requests in reverse seq_id order. Restore
+    # chronological order and collapse each request into the list of the event
+    # types it carried.
+    requests = list(reversed(test_agent_session.get_requests(filter_heartbeats=False)))
+    batches = [
+        [payload["request_type"] for payload in req["body"]["payload"]]
+        if req["body"]["request_type"] == "message-batch"
+        else [req["body"]["request_type"]]
+        for req in requests
+    ]
+    assert batches == [["app-started"], ["app-dependencies-loaded", "app-closing"]], batches
+
+
 def test_add_integration(telemetry_writer, test_agent_session, mock_time):
     """asserts that add_integration() queues a valid telemetry request"""
     with override_global_config(dict(_telemetry_dependency_collection=False)):

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -386,8 +386,12 @@ def test_app_shutdown_sends_a_single_closing_flush(telemetry_writer, test_agent_
       1. ["app-started"], emitted eagerly on start()
       2. ["app-dependencies-loaded", "app-closing"], drained by stop()
     """
-    telemetry_writer.app_started()
-    telemetry_writer.app_shutdown()
+    # The ddtrace Test Optimization plugin force-disables telemetry dependency
+    # collection. This test asserts the full app lifecycle including dependency
+    # discovery, so re-enable it for the duration of the test.
+    with mock.patch.object(telemetry_config, "DEPENDENCY_COLLECTION", True):
+        telemetry_writer.app_started()
+        telemetry_writer.app_shutdown()
 
     # get_requests() returns requests in reverse seq_id order. Restore
     # chronological order and collapse each request into the list of the event


### PR DESCRIPTION
## Description

This PR removes unnecessary flushing logic for telemetry happening at app closing. https://github.com/DataDog/dd-trace-py/pull/19368 switched to the native Rust telemetry implementation. I suspect that the previous underlying stop() implementation didn't flush/sent app-closing event automatically, but the new native telemetry worker does on shutdown (both flush and sending `app-closing`), so:

1. It's meaningless to have the `send_app_closing` tweak anymore on `stop()`: unless we change the telemetry worker in libdatadog, we can't opt out of `app-closing`. I kept the parameter because I feel like this ought to be fixed and not just ignored, but it was already ineffective. Happy to do the follow-up work in libdatadog to provide a way to stop the worker without sending the `app-closing` event if requested.
2. It's useless to flush in the Rust wrapping code of dd-trace-py before calling to libdatadog's `stop()`: the worker shutdown code already takes care of the flush
3. It's useless to explicitly flush in the Python implementation before calling to Rust (for the same reason)

The additional flush is creating the following batches for a short-lived app that does nothing:

```
Sent ["app-started"]
Sent ["app-dependencies-loaded", "app-heartbeat"]
Sent ["app-closing"]
```

While the new version does the expected

```
Sent ["app-started"]
Sent ["app-dependencies-loaded", "app-closing"]
```

This has been discovered as part of investigating https://github.com/DataDog/dd-trace-py/issues/19915, and does help getting back a few dozen ms of shutdown time (50 to 100ms locally, once pooling has been enabled - see (https://github.com/DataDog/libdatadog/pull/2440)) by saving one HTTPS request.

## Testing

Tested locally on the repro of https://github.com/DataDog/dd-trace-py/issues/19915. Included a regression test.

## Risks

No major risk identified.

## Additional Notes

See https://datadoghq.atlassian.net/browse/APMS-20441