### PR TITLE
ci: pull-only pytorch pip cache and riot venv install retry

### DIFF
--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -40,7 +40,7 @@ include:
       do
         echo "Running riot hash: ${hash}"
         riot list "${hash}"
-        ${RIOT_RUN_CMD} "${hash}" -- --ddtrace
+        ./scripts/riot_run_with_install_retry.py ${RIOT_RUN_CMD} "${hash}" -- --ddtrace
       done
       ./scripts/check-diff ".riot/requirements/" \
         "Changes detected after running riot. Consider deleting changed files, running scripts/compile-and-prune-test-requirements and committing the result."

--- a/mypy.ini
+++ b/mypy.ini
@@ -85,6 +85,21 @@ ignore_errors = true
 [mypy-tests.webclient]
 ignore_errors = true
 
+# scripts/gen_gitlab_config.py is a uv script, not in files=. Pre-commit passes
+# it explicitly and then follows imports into these modules.
+
+[mypy-gen_gitlab_config]
+ignore_errors = true
+
+[mypy-needs_testrun]
+ignore_errors = true
+
+[mypy-suitespec]
+ignore_errors = true
+
+[mypy-tests.suitespec]
+ignore_errors = true
+
 # ── Modules not yet compliant with strict mode ────────────────────────────────
 # Generated against mypy 1.15.
 # To clean up a module: remove its section, fix all errors, re-run mypy.

--- a/scripts/gen_gitlab_config.py
+++ b/scripts/gen_gitlab_config.py
@@ -23,7 +23,7 @@ import datetime
 import hashlib
 import os
 import re
-import subprocess
+import subprocess  # nosec B404
 import typing as t
 
 
@@ -73,6 +73,9 @@ class JobSpec:
     only: t.Optional[set[str]] = None  # ignored
     gpu: bool = False
     type: str = "test"  # ignored
+    # Pull the riot pip cache but skip the S3 upload. Torch CUDA wheels are too
+    # large to push; omitting the cache block (the old skip_pip_cache behavior)
+    # also dropped downloads. GitLab policy: pull is download-only.
     skip_pip_cache: bool = False
     suite: t.Optional[str] = None
     uses_uv: bool = False
@@ -150,13 +153,19 @@ class JobSpec:
         if not self.uses_uv:
             env["PIP_CACHE_DIR"] = "${CI_PROJECT_DIR}/.cache/pip"
             env["PIP_CACHE_KEY"] = (
-                subprocess.check_output([".gitlab/scripts/get-riot-pip-cache-key.sh", suite_name]).decode().strip()
+                subprocess.check_output(  # nosec B603
+                    [".gitlab/scripts/get-riot-pip-cache-key.sh", suite_name]
+                )
+                .decode()
+                .strip()
             )
-        if not self.uses_uv and not self.skip_pip_cache:
+        if not self.uses_uv:
             lines.append("  cache:")
             lines.append(f"    key: v1-pip-${'{PIP_CACHE_KEY}'}-{TESTRUNNER_IMAGE_HASH}-cache")
             lines.append("    paths:")
             lines.append("      - .cache")
+            if self.skip_pip_cache:
+                lines.append("    policy: pull")
 
         lines.append("  variables:")
         for key, value in env.items():

--- a/scripts/riot_run_with_install_retry.py
+++ b/scripts/riot_run_with_install_retry.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Retry riot venv installs that fail with CmdFailure / BrokenPipe.
+
+Riot has no pip --retries hook. GitLab testrunner retry is 0 and must stay that
+way: this wrapper retries only when riot reports a venv-dependency install
+failure, not when pytest fails.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Mapping
+from collections.abc import Sequence
+import os
+import subprocess  # nosec B404
+import sys
+from typing import IO
+
+
+DEFAULT_INSTALL_ATTEMPTS: int = 3
+_ENV_ATTEMPTS: str = "RIOT_INSTALL_RETRIES"
+_VENV_INSTALL_FAILURE: str = "Failed to install venv dependencies"
+_BROKEN_PIPE: str = "BrokenPipeError"
+
+
+def attempts_from_env(env: Mapping[str, str]) -> int:
+    raw: str = env.get(_ENV_ATTEMPTS, str(DEFAULT_INSTALL_ATTEMPTS))
+    try:
+        parsed: int = int(raw)
+    except ValueError:
+        return DEFAULT_INSTALL_ATTEMPTS
+    return max(1, parsed)
+
+
+def is_retryable_venv_install_failure(output: str) -> bool:
+    # Riot wraps pip CmdFailure as this message. Test failures use
+    # "Test failed with exit code" and must not retry (testrunner retry: 0).
+    if "Test failed with exit code" in output:
+        return False
+    return _VENV_INSTALL_FAILURE in output or _BROKEN_PIPE in output
+
+
+def run_command(argv: Sequence[str]) -> tuple[int, str]:
+    proc: subprocess.Popen[str] = subprocess.Popen(  # nosec B603
+        list(argv),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    chunks: list[str] = []
+    stdout_pipe: IO[str] | None = proc.stdout
+    if stdout_pipe is None:
+        returncode: int = proc.wait()
+        return returncode, ""
+    for line in stdout_pipe:
+        chunks.append(line)
+        sys.stdout.write(line)
+        sys.stdout.flush()
+    finished: int = proc.wait()
+    return finished, "".join(chunks)
+
+
+def run_with_install_retry(
+    argv: Sequence[str],
+    *,
+    attempts: int,
+    run: Callable[[Sequence[str]], tuple[int, str]] = run_command,
+) -> int:
+    last_code: int = 1
+    for attempt in range(1, attempts + 1):
+        result: tuple[int, str] = run(argv)
+        last_code = result[0]
+        output: str = result[1]
+        if last_code == 0:
+            return 0
+        retryable: bool = is_retryable_venv_install_failure(output)
+        if not retryable or attempt == attempts:
+            return last_code
+        print(
+            f"riot venv install failed (attempt {attempt}/{attempts}); retrying",
+            file=sys.stderr,
+        )
+    return last_code
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args: list[str] = list(sys.argv[1:] if argv is None else argv)
+    if not args:
+        print(f"usage: {sys.argv[0]} <command>...", file=sys.stderr)
+        return 2
+    attempts: int = attempts_from_env(os.environ)
+    return run_with_install_retry(args, attempts=attempts)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/contrib/suitespec.yml
+++ b/tests/contrib/suitespec.yml
@@ -1143,6 +1143,7 @@ suites:
     snapshot: true
   pytorch:
     venvs_per_job: 1
+    # Pull-only: restore cache download, skip uploading large torch CUDA wheels.
     skip_pip_cache: true
     paths:
       - '@bootstrap'

--- a/tests/internal/test_gen_gitlab_config.py
+++ b/tests/internal/test_gen_gitlab_config.py
@@ -128,3 +128,28 @@ def test_unmigrated_jobs_keep_using_riot(gen_gitlab_config_mod):
     assert "  extends: .test_base_riot" in config
     assert "    PIP_CACHE_KEY: pip-key" in config
     assert "TEST_ENVIRONMENTS_" not in config
+
+
+def test_jobspec_default_pip_cache_is_pull_push(gen_gitlab_config_mod) -> None:
+    with mock.patch.object(gen_gitlab_config_mod.subprocess, "check_output", return_value=b"pip-key\n"):
+        config: str = str(gen_gitlab_config_mod.JobSpec(name="suite", stage="core"))
+
+    assert "  cache:" in config
+    assert "      - .cache" in config
+    assert "    policy: pull" not in config
+
+
+def test_jobspec_skip_pip_cache_is_pull_only(gen_gitlab_config_mod) -> None:
+    with mock.patch.object(gen_gitlab_config_mod.subprocess, "check_output", return_value=b"pip-key\n"):
+        config: str = str(gen_gitlab_config_mod.JobSpec(name="pytorch", stage="contrib", skip_pip_cache=True))
+
+    assert "  cache:" in config
+    assert "      - .cache" in config
+    assert "    policy: pull" in config
+
+
+def test_jobspec_uv_jobs_omit_pip_cache(gen_gitlab_config_mod) -> None:
+    config: str = str(gen_gitlab_config_mod.JobSpec(name="tracer", stage="core", suite="tracer", uses_uv=True))
+
+    assert "  cache:" not in config
+    assert "PIP_CACHE_KEY" not in config

--- a/tests/internal/test_riot_run_with_install_retry.py
+++ b/tests/internal/test_riot_run_with_install_retry.py
@@ -1,0 +1,89 @@
+"""Tests for scripts/riot_run_with_install_retry.py."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from importlib.machinery import ModuleSpec
+import importlib.util
+import pathlib
+from types import ModuleType
+
+import pytest
+
+
+_SCRIPT_PATH = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "riot_run_with_install_retry.py"
+_TESTS_YML = pathlib.Path(__file__).resolve().parents[2] / ".gitlab" / "tests.yml"
+
+
+@pytest.fixture(scope="module")
+def retry_mod() -> ModuleType:
+    spec: ModuleSpec | None = importlib.util.spec_from_file_location("riot_run_with_install_retry", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module: ModuleType = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_riot_jobs_use_install_retry_wrapper() -> None:
+    text: str = _TESTS_YML.read_text()
+    assert "riot_run_with_install_retry.py" in text
+    assert "${RIOT_RUN_CMD}" in text
+
+
+def test_attempts_from_env_defaults_and_clamps(retry_mod: ModuleType) -> None:
+    assert retry_mod.attempts_from_env({}) == 3
+    assert retry_mod.attempts_from_env({"RIOT_INSTALL_RETRIES": "5"}) == 5
+    assert retry_mod.attempts_from_env({"RIOT_INSTALL_RETRIES": "0"}) == 1
+    assert retry_mod.attempts_from_env({"RIOT_INSTALL_RETRIES": "nope"}) == 3
+
+
+def test_install_failure_is_retryable_test_failure_is_not(retry_mod: ModuleType) -> None:
+    install_output: str = "Failed to install venv dependencies torch~=2.11.0\nBrokenPipeError"
+    assert retry_mod.is_retryable_venv_install_failure(install_output) is True
+    assert retry_mod.is_retryable_venv_install_failure("BrokenPipeError: [Errno 32] Broken pipe") is True
+    assert retry_mod.is_retryable_venv_install_failure("Test failed with exit code 1") is False
+    mixed: str = "Failed to install venv dependencies foo\nTest failed with exit code 1"
+    assert retry_mod.is_retryable_venv_install_failure(mixed) is False
+
+
+def test_retries_venv_install_failure_then_succeeds(retry_mod: ModuleType) -> None:
+    calls: list[int] = []
+
+    def fake_run(argv: Sequence[str]) -> tuple[int, str]:
+        calls.append(1)
+        if len(calls) < 2:
+            return 1, "Failed to install venv dependencies torch~=2.11.0"
+        return 0, "ok"
+
+    code: int = retry_mod.run_with_install_retry(["riot", "run", "abc"], attempts=3, run=fake_run)
+    assert code == 0
+    assert len(calls) == 2
+
+
+def test_does_not_retry_test_failure(retry_mod: ModuleType) -> None:
+    calls: list[int] = []
+
+    def fake_run(argv: Sequence[str]) -> tuple[int, str]:
+        calls.append(1)
+        return 1, "Test failed with exit code 1"
+
+    code: int = retry_mod.run_with_install_retry(["riot", "run", "abc"], attempts=3, run=fake_run)
+    assert code == 1
+    assert len(calls) == 1
+
+
+def test_exhausts_install_retries(retry_mod: ModuleType) -> None:
+    calls: list[int] = []
+
+    def fake_run(argv: Sequence[str]) -> tuple[int, str]:
+        calls.append(1)
+        return 1, "Failed to install venv dependencies nvidia_nccl_cu13"
+
+    code: int = retry_mod.run_with_install_retry(["riot", "run", "abc"], attempts=3, run=fake_run)
+    assert code == 1
+    assert len(calls) == 3
+
+
+def test_main_requires_a_command(retry_mod: ModuleType) -> None:
+    code: int = retry_mod.main([])
+    assert code == 2

--- a/tests/suitespec.yml
+++ b/tests/suitespec.yml
@@ -224,6 +224,7 @@ suites:
       - '@vendor'
       - ddtrace/internal/*
       - scripts/gen_gitlab_config.py
+      - scripts/riot_run_with_install_retry.py
       - tests/internal/*
       - tests/submod/*
       - tests/cache/*


### PR DESCRIPTION
## Description

`skip_pip_cache` on `contrib/pytorch` omitted the GitLab pip cache block, so riot cold-pulled `torch==2.11.0` / `nvidia_nccl_cu13` and died on pip BrokenPipe (job 2009197825). #18519's text said `policy: pull`; the merged code skipped cache entirely.

Riot jobs now emit that cache with `policy: pull` (download only; no S3 upload of CUDA wheels). `scripts/riot_run_with_install_retry.py` retries a riot hash up to 3 times only when output contains `Failed to install venv dependencies` or `BrokenPipeError`. Pytest `Test failed with exit code` is not retried. Testrunner `retry: 0` and torch pins are unchanged.

## Testing

Generator tests pin pull-only vs default pull-push vs uv (no pip cache). Helper tests pin install retry, no retry on test failure, and that `.gitlab/tests.yml` invokes the wrapper.

## Risks

Pull-only never warms a new cache key (testrunner image hash is in the key), so the first pipeline after a key change still hits PyPI; the install retry covers that.