### PR TITLE
ci: raise tracer test suite memory to 6Gi and disable VPA

### DIFF
--- a/tests/suitespec.yml
+++ b/tests/suitespec.yml
@@ -281,14 +281,13 @@ suites:
   tracer:
     env:
       DD_TRACE_AGENT_URL: http://localhost:8126
-      # The tracer suite repeatedly OOMKilled at the previously pinned 4Gi
-      # (see #15324, which raised it from 3Gi). Pin 6Gi and disable the VPA —
-      # without DD_DISABLE_VPA the VPA overrides KUBERNETES_MEMORY_* and can
-      # clamp the container back down, which is the likely reason the 4Gi pin
-      # kept not holding.
+      # The tracer suite keeps getting OOMKilled: 3Gi (#15324) -> 4Gi -> 6Gi
+      # were all insufficient. Pin 8Gi and disable the VPA — without
+      # DD_DISABLE_VPA the VPA overrides KUBERNETES_MEMORY_* and can clamp
+      # the container back down below the pinned value.
       DD_DISABLE_VPA: "true"
-      KUBERNETES_MEMORY_REQUEST: "6Gi"
-      KUBERNETES_MEMORY_LIMIT: "6Gi"
+      KUBERNETES_MEMORY_REQUEST: "8Gi"
+      KUBERNETES_MEMORY_LIMIT: "8Gi"
     paths:
       - '@tracing'
       - '@bootstrap'

--- a/tests/suitespec.yml
+++ b/tests/suitespec.yml
@@ -281,8 +281,14 @@ suites:
   tracer:
     env:
       DD_TRACE_AGENT_URL: http://localhost:8126
-      KUBERNETES_MEMORY_REQUEST: "4Gi"
-      KUBERNETES_MEMORY_LIMIT: "4Gi"
+      # The tracer suite repeatedly OOMKilled at the previously pinned 4Gi
+      # (see #15324, which raised it from 3Gi). Pin 6Gi and disable the VPA —
+      # without DD_DISABLE_VPA the VPA overrides KUBERNETES_MEMORY_* and can
+      # clamp the container back down, which is the likely reason the 4Gi pin
+      # kept not holding.
+      DD_DISABLE_VPA: "true"
+      KUBERNETES_MEMORY_REQUEST: "6Gi"
+      KUBERNETES_MEMORY_LIMIT: "6Gi"
     paths:
       - '@tracing'
       - '@bootstrap'


### PR DESCRIPTION
The tracer suite keeps getting OOMKilled. It was previously raised from 3Gi to 4Gi in #15324, but the pin did not hold: without DD_DISABLE_VPA the VPA overrides KUBERNETES_MEMORY_* and can clamp the container back down. Pin 6Gi and disable the VPA so the request actually applies.
