### PR TITLE
ci(system-tests): allow failure for parametric scenario

### DIFF
--- a/.gitlab/system-tests.yml
+++ b/.gitlab/system-tests.yml
@@ -78,6 +78,7 @@
 
 system-tests parametric:
   extends: .system-tests-base
+  allow_failure: true
   script:
     - echo -e "\e[0Ksection_start:`date +%s`:run_parametric\r\e[0KRunning PARAMETRIC scenario"
     - cd ${CI_PROJECT_DIR}/system-tests


### PR DESCRIPTION
## Description

The PARAMETRIC system tests scenario is failing consistently while the root cause is being investigated.

This PR marks the GitLab job allow_failure so it reports as a warning and does not block the pipeline.

## Additional Notes

Temporary: remove once the root cause is fixed.
