### PR TITLE
ci(system-tests): update system-tests ref to 4f13cf1

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -95,11 +95,11 @@ jobs:
   serverless-system-tests:
     needs: [serverless-system-tests-build-layer]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@72ed6ee7d6b33d2d3a080b939c10a6d3d9077746
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@4f13cf1b6222d42804d012326fd4f6881026ba46
     secrets: inherit
     with:
       library: python_lambda
-      ref: '72ed6ee7d6b33d2d3a080b939c10a6d3d9077746'
+      ref: '4f13cf1b6222d42804d012326fd4f6881026ba46'
       binaries_artifact: serverless_system_tests_binaries
       scenarios_groups: lambda_end_to_end
       skip_empty_scenarios: true
@@ -126,11 +126,11 @@ jobs:
     if: github.event_name != 'schedule' || github.event.repository.fork == false
     needs: [integration-frameworks-combine-wheels]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@72ed6ee7d6b33d2d3a080b939c10a6d3d9077746
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@4f13cf1b6222d42804d012326fd4f6881026ba46
     secrets: inherit
     with:
       library: python
-      ref: '72ed6ee7d6b33d2d3a080b939c10a6d3d9077746'
+      ref: '4f13cf1b6222d42804d012326fd4f6881026ba46'
       scenarios: INTEGRATION_FRAMEWORKS
       binaries_artifact: integration-frameworks-wheels
       push_to_test_optimization: true
@@ -138,10 +138,10 @@ jobs:
   tracer-release:
     needs:
       - download-s3-wheels
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@72ed6ee7d6b33d2d3a080b939c10a6d3d9077746
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@4f13cf1b6222d42804d012326fd4f6881026ba46
     with:
       library: python
-      ref: '72ed6ee7d6b33d2d3a080b939c10a6d3d9077746'
+      ref: '4f13cf1b6222d42804d012326fd4f6881026ba46'
       binaries_artifact: wheels-manylinux_x86_64
       desired_execution_time: 900
       scenarios_groups: tracer-release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "72ed6ee7d6b33d2d3a080b939c10a6d3d9077746"
+  SYSTEM_TESTS_REF: "4f13cf1b6222d42804d012326fd4f6881026ba46"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
   PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v103334885-be1888c-profiling_native"


### PR DESCRIPTION
## Description

Update the DataDog/system-tests pin to commit
4f13cf1b6222d42804d012326fd4f6881026ba46 in both the GitLab SYSTEM_TESTS_REF variable and the GitHub reusable workflow pins.
