### PR TITLE
fix(agentless): restore some features lost during rebase

### DIFF
--- a/src/native/Cargo.lock
+++ b/src/native/Cargo.lock
@@ -2217,6 +2217,8 @@ dependencies = [
  "serde_json",
  "thin-vec",
  "tracing",
+ "zrip",
+ "zstd",
 ]
 
 [[package]]

--- a/src/native/Cargo.toml
+++ b/src/native/Cargo.toml
@@ -46,7 +46,8 @@ libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "v
 libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
 libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
 libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", features = [
-  "stats-obfuscation"
+  "stats-obfuscation",
+  "compression"
 ] }
 # DEV: `hyper-backend` (rather than the default `reqwest-backend`) avoids
 # hickory-dns, a pure-Rust DNS resolver that mishandles bare, single-label
@@ -56,6 +57,7 @@ libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "v4
 libdd-http-client = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", default-features = false, features = [
   "https",
   "hyper-backend",
+  "hyper-proxy",
 ] }
 libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
 libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", optional = true, features = [


### PR DESCRIPTION
We're missing zstd and hyper-proxy, making the system-tests (under development) for agentless fail.

I missed this when rebasing v43.