### PR TITLE
feat(anthropic): support Bedrock beta messages

### DIFF
--- a/ddtrace/aiguard/_listener.py
+++ b/ddtrace/aiguard/_listener.py
@@ -400,11 +400,14 @@ def _install_anthropic_wrappers(client: AIGuardClient) -> None:
     ]
     if parse_version(getattr(anthropic, "__version__", "0")) >= (0, 37):
         beta = anthropic.resources.beta.messages.messages
+        bedrock_beta = anthropic.lib.bedrock._beta_messages
         targets += [
             (beta.Messages, "create", sync_wrapper),
             (beta.Messages, "stream", sync_wrapper),
             (beta.AsyncMessages, "stream", sync_wrapper),
             (beta.AsyncMessages, "create", async_wrapper),
+            (bedrock_beta.Messages, "create", sync_wrapper),
+            (bedrock_beta.AsyncMessages, "create", async_wrapper),
         ]
 
     for owner, attr, wrapper in targets:

--- a/ddtrace/contrib/internal/anthropic/patch.py
+++ b/ddtrace/contrib/internal/anthropic/patch.py
@@ -122,7 +122,7 @@ def patch() -> None:
     anthropic._datadog_integration = integration
 
     # AIDEV-NOTE: AI Guard mirrors this wrap-target list in
-    # ddtrace/appsec/_ai_guard/_listener.py::_install_anthropic_wrappers to
+    # ddtrace/aiguard/_listener.py::_install_anthropic_wrappers to
     # install its outermost streaming buffer. If you add/rename a target or
     # change the >= (0, 37) beta gate below, update that list too or the new
     # surface goes unbuffered for stream-response evaluation.
@@ -141,6 +141,14 @@ def patch() -> None:
             traced_async_chat_model_generate,
         )
         wrap("anthropic", "resources.beta.messages.messages.AsyncMessages.stream", traced_chat_model_generate)
+        # Bedrock's beta resource copies the first-party create functions when
+        # anthropic is imported, before this patch replaces those functions.
+        wrap("anthropic", "lib.bedrock._beta_messages.Messages.create", traced_chat_model_generate)
+        wrap(
+            "anthropic",
+            "lib.bedrock._beta_messages.AsyncMessages.create",
+            traced_async_chat_model_generate,
+        )
 
     # Notify AI Guard (and any other plugin) that wrapping is complete so they
     # can install their own outermost wrappers on the same targets.
@@ -166,5 +174,7 @@ def unpatch() -> None:
         unwrap(anthropic.resources.beta.messages.messages.Messages, "stream")
         unwrap(anthropic.resources.beta.messages.messages.AsyncMessages, "create")
         unwrap(anthropic.resources.beta.messages.messages.AsyncMessages, "stream")
+        unwrap(anthropic.lib.bedrock._beta_messages.Messages, "create")
+        unwrap(anthropic.lib.bedrock._beta_messages.AsyncMessages, "create")
 
     delattr(anthropic, "_datadog_integration")

--- a/releasenotes/notes/anthropic-bedrock-beta-messages-7251f91ecc52c226.yaml
+++ b/releasenotes/notes/anthropic-bedrock-beta-messages-7251f91ecc52c226.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    anthropic: Adds APM and LLM Observability tracing support for beta messages API calls through
+    ``AnthropicBedrock`` and ``AsyncAnthropicBedrock``.

--- a/tests/aiguard/anthropic/test_streaming.py
+++ b/tests/aiguard/anthropic/test_streaming.py
@@ -285,6 +285,15 @@ def test_wrappers_installed_when_flag_on(mock_execute_request, anthropic_client_
     list(result)
 
 
+def test_bedrock_beta_wrappers_installed(anthropic_sdk_buffered):
+    """Bedrock beta create methods receive the outer AI Guard streaming wrappers."""
+    from ddtrace.aiguard import _listener
+
+    bedrock_beta = pytest.importorskip("anthropic.lib.bedrock._beta_messages")
+    assert (bedrock_beta.Messages, "create") in _listener._anthropic_wrapped_targets
+    assert (bedrock_beta.AsyncMessages, "create") in _listener._anthropic_wrapped_targets
+
+
 # ---------------------------------------------------------------------------
 # Collision suppression on streaming
 # ---------------------------------------------------------------------------

--- a/tests/contrib/anthropic/test_anthropic_llmobs.py
+++ b/tests/contrib/anthropic/test_anthropic_llmobs.py
@@ -413,6 +413,29 @@ class TestLLMObsAnthropic:
         assert len(spans) == 1
         assert get_llmobs_model_provider(spans[0]) == "amazon"
 
+    @pytest.mark.skipif(ANTHROPIC_VERSION < (0, 37), reason=BETA_SKIP_REASON)
+    @pytest.mark.asyncio
+    @patch("anthropic._base_client.AsyncAPIClient.post", new_callable=mock.AsyncMock)
+    async def test_beta_completion_async_bedrock(
+        self, mock_anthropic_messages_post, anthropic, anthropic_llmobs, test_spans
+    ):
+        """Ensure beta messages through AsyncAnthropicBedrock emit an LLM span."""
+        mock_anthropic_messages_post.return_value = MOCK_MESSAGES_CREATE_REQUEST
+        llm = anthropic.AsyncAnthropicBedrock(
+            aws_access_key="test-access-key",
+            aws_secret_key="test-secret-key",
+            aws_region="us-east-1",
+        )
+        await llm.beta.messages.create(
+            model="claude-3-opus-20240229",
+            max_tokens=15,
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+        spans = [span for trace in test_spans.pop_traces() for span in trace]
+        assert len(spans) == 1
+        assert get_llmobs_span_kind(spans[0]) == "llm"
+        assert get_llmobs_model_provider(spans[0]) == "amazon"
+
     @patch("anthropic._base_client.SyncAPIClient.post")
     def test_completion_vertex_provider(self, mock_anthropic_messages_post, anthropic, anthropic_llmobs, test_spans):
         """model_provider resolves to 'google' for the Vertex base_url (AnthropicVertex)."""

--- a/tests/contrib/anthropic/test_anthropic_patch.py
+++ b/tests/contrib/anthropic/test_anthropic_patch.py
@@ -18,6 +18,8 @@ class TestAnthropicPatch(PatchTestCase.Base):
         if ANTHROPIC_VERSION >= (0, 37):
             self.assert_wrapped(anthropic.resources.beta.messages.messages.Messages.create)
             self.assert_wrapped(anthropic.resources.beta.messages.messages.AsyncMessages.create)
+            self.assert_wrapped(anthropic.lib.bedrock._beta_messages.Messages.create)
+            self.assert_wrapped(anthropic.lib.bedrock._beta_messages.AsyncMessages.create)
 
     def assert_not_module_patched(self, anthropic):
         self.assert_not_wrapped(anthropic.resources.messages.Messages.create)
@@ -25,6 +27,8 @@ class TestAnthropicPatch(PatchTestCase.Base):
         if ANTHROPIC_VERSION >= (0, 37):
             self.assert_not_wrapped(anthropic.resources.beta.messages.messages.Messages.create)
             self.assert_not_wrapped(anthropic.resources.beta.messages.messages.AsyncMessages.create)
+            self.assert_not_wrapped(anthropic.lib.bedrock._beta_messages.Messages.create)
+            self.assert_not_wrapped(anthropic.lib.bedrock._beta_messages.AsyncMessages.create)
 
     def assert_not_module_double_patched(self, anthropic):
         self.assert_not_double_wrapped(anthropic.resources.messages.Messages.create)
@@ -32,3 +36,5 @@ class TestAnthropicPatch(PatchTestCase.Base):
         if ANTHROPIC_VERSION >= (0, 37):
             self.assert_not_double_wrapped(anthropic.resources.beta.messages.messages.Messages.create)
             self.assert_not_double_wrapped(anthropic.resources.beta.messages.messages.AsyncMessages.create)
+            self.assert_not_double_wrapped(anthropic.lib.bedrock._beta_messages.Messages.create)
+            self.assert_not_double_wrapped(anthropic.lib.bedrock._beta_messages.AsyncMessages.create)


### PR DESCRIPTION
## Description

Adds APM and LLM Observability tracing support for beta Messages API calls made through the Anthropic SDK's first-party `AnthropicBedrock` and `AsyncAnthropicBedrock` clients.

The Bedrock beta resource classes capture their own references to the Messages `create` methods during `import anthropic`, before the existing Anthropic instrumentation is installed. This change instruments those Bedrock-specific sync and async methods directly, adds symmetric unpatching, and keeps AI Guard's outer streaming wrappers aligned with the Anthropic integration targets.

Closes #18075.

## Testing

- Added patch lifecycle coverage for the sync and async Bedrock beta Messages methods.
- Added an async LLM Observability regression test that verifies `AsyncAnthropicBedrock.beta.messages.create()` emits an LLM span with Amazon as the model provider.
- Added coverage ensuring AI Guard installs wrappers on both Bedrock beta Messages methods.
- Validated the Anthropic integration against the latest Anthropic SDK on Python 3.13: 23 targeted tests passed.
- Validated backward compatibility with `anthropic~=0.28.0` on Python 3.12: 92 passed, 17 skipped.
- Validated the AI Guard Anthropic streaming suite on Python 3.13: 20 passed.
- Ran `scripts/lint checks` successfully.

## Risks

Low. The new instrumentation targets an Anthropic SDK private module, but it is guarded by the existing `anthropic>=0.37` beta API version check and covered by patch, unpatch, and double-patch tests.