### PR TITLE
docs: correct DD_AGENTLESS_ENABLED version

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1038,7 +1038,7 @@ Agent
          in agentless mode.
 
      version_added:
-        v4.13.0:
+        v4.15.0:
 
    DD_DOGSTATSD_URL:
      type: URL


### PR DESCRIPTION
## Description

Corrects the documented release version for `DD_AGENTLESS_ENABLED` from 4.13.0 to 4.15.0.

## Testing

`scripts/lint checks`

## Risks

None.

## Additional Notes

None.