### PR TITLE
fix: synchronize post-fork worker restarts

### DIFF
--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -191,7 +191,7 @@ class Tracer(object):
         forksafe.register(self._child_after_fork)
 
         self._shutdown_lock = Lock()
-
+        self._post_fork_lock = forksafe.Lock()
         self._new_process = False
 
         self._store_metadata()
@@ -428,6 +428,17 @@ class Tracer(object):
         if active is not None:
             core.dispatch("ddtrace.context_provider.activate", (self.context_provider, active))
 
+    def _ensure_post_fork_writer(self) -> bool:
+        """Recreate the inherited writer once after a fork."""
+        if not self._new_process:
+            return False
+        with self._post_fork_lock:
+            if not self._new_process:
+                return False
+            self._recreate(reset_buffer=False, flush_writer=False)
+            self._new_process = False
+            return True
+
     def _recreate(
         self,
         trace_processors: Optional[list[TraceProcessor]] = None,
@@ -499,10 +510,9 @@ class Tracer(object):
         Note: be sure to finish all spans to avoid memory leaks and incorrect
         parenting of spans.
         """
-        if self._new_process:
-            self._recreate(reset_buffer=False, flush_writer=False)
-            self._new_process = False
-
+        # PERF: keep the normal span-start path to the existing flag check; avoid a helper call
+        # unless this process actually forked.
+        if self._new_process and self._ensure_post_fork_writer():
             # The spans remaining in the context can not and will not be
             # finished in this new process. So to avoid memory leaks the
             # strong span reference (which will never be finished) is replaced
@@ -805,6 +815,7 @@ class Tracer(object):
 
     def flush(self):
         """Flush the buffer of the trace writer. This does nothing if an unbuffered trace writer is used."""
+        self._ensure_post_fork_writer()
         self._span_aggregator.writer.flush_queue()
 
     def _wrap_generator(

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -193,6 +193,7 @@ class Tracer(object):
 
         self._shutdown_lock = Lock()
         self._post_fork_lock = forksafe.Lock()
+        self._post_fork_writer_pending = False
         self._new_process = False
 
         self._store_metadata()
@@ -426,6 +427,7 @@ class Tracer(object):
         # at-fork callbacks return. Recreating the native writer here would start Tokio early
         # enough for those descriptor sweeps to invalidate its I/O driver.
         self._span_aggregator.reset_trace_buffer_after_fork()
+        self._post_fork_writer_pending = True
         self._new_process = True
         self._store_metadata()
         # Re-dispatch activation post-fork: native code clears profiler span links; inherited context is unchanged.
@@ -435,13 +437,13 @@ class Tracer(object):
 
     def _ensure_post_fork_writer(self) -> bool:
         """Recreate the inherited writer once after a fork."""
-        if not self._new_process:
+        if not self._post_fork_writer_pending:
             return False
         with self._post_fork_lock:
-            if not self._new_process:
+            if not self._post_fork_writer_pending:
                 return False
             self._recreate(reset_buffer=False, flush_writer=False)
-            self._new_process = False
+            self._post_fork_writer_pending = False
             return True
 
     def _recreate(
@@ -515,9 +517,11 @@ class Tracer(object):
         Note: be sure to finish all spans to avoid memory leaks and incorrect
         parenting of spans.
         """
-        # PERF: keep the normal span-start path to the existing flag check; avoid a helper call
-        # unless this process actually forked.
-        if self._new_process and self._ensure_post_fork_writer():
+        # PERF: avoid a helper call on the normal span-start path.
+        if self._post_fork_writer_pending:
+            self._ensure_post_fork_writer()
+        if self._new_process:
+            self._new_process = False
             # The spans remaining in the context can not and will not be
             # finished in this new process. So to avoid memory leaks the
             # strong span reference (which will never be finished) is replaced
@@ -1021,6 +1025,7 @@ class Tracer(object):
         try:
             # Do not recreate an inherited writer only to shut it down. The span aggregator
             # discards its buffered traces during shutdown.
+            self._post_fork_writer_pending = False
             self._new_process = False
             for processor in chain(self._span_processors, SpanProcessor.__processors__, [self._span_aggregator]):
                 if processor:

--- a/ddtrace/internal/threads.py
+++ b/ddtrace/internal/threads.py
@@ -164,7 +164,7 @@ def _after_fork_child():
 
     _forking = False
 
-    # AIDEV-NOTE: Clean up child-ineligible workers now and remove them from the pending set.
+    # Clean up child-ineligible workers now and remove them from the pending set.
     # A nested fork may promote the timer to the parent-side force policy, which must only apply
     # to workers that were actually running in that intermediate parent.
     for thread in _threads_to_restart_after_fork.copy():

--- a/ddtrace/internal/threads.py
+++ b/ddtrace/internal/threads.py
@@ -164,6 +164,19 @@ def _after_fork_child():
 
     _forking = False
 
+    # AIDEV-NOTE: Clean up child-ineligible workers now and remove them from the pending set.
+    # A nested fork may promote the timer to the parent-side force policy, which must only apply
+    # to workers that were actually running in that intermediate parent.
+    for thread in _threads_to_restart_after_fork.copy():
+        if not getattr(thread, "__autorestart__", True):
+            log.debug("Cleaning up non-restartable thread %s after fork in child", thread.name)
+            try:
+                thread._after_fork()
+            except Exception as e:
+                log.error("failed to clean up periodic thread %s after fork: %s", thread.name, e)
+            finally:
+                _threads_to_restart_after_fork.discard(thread)
+
     # Process managers can close inherited file descriptors after Python's at-fork callbacks
     # return. Delay autorestarting periodic threads so none of them rebuilds a native runtime
     # before that cleanup completes. ThreadRestartTimer forces eligible child threads to restart

--- a/releasenotes/notes/fix-post-fork-worker-races-9f86448ace3317e1.yaml
+++ b/releasenotes/notes/fix-post-fork-worker-races-9f86448ace3317e1.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    internal: Fixes race conditions after process forks that can cause telemetry recording to stall
+    or background workers to restart incorrectly when multiple threads resume concurrently or forks
+    are nested.

--- a/src/native/shared_runtime/mod.rs
+++ b/src/native/shared_runtime/mod.rs
@@ -20,6 +20,8 @@ static ATFORK_RUNTIME: OnceCell<Arc<SharedRuntimeState>> = OnceCell::new();
 static CHILD_RESTART_PENDING: AtomicBool = AtomicBool::new(false);
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 static CHILD_RESTART_DEFERRED: AtomicBool = AtomicBool::new(false);
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+static CHILD_RESTART_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 
 struct SharedRuntimeState {
     runtime: RwLock<Arc<ForkSafeRuntime>>,
@@ -42,6 +44,10 @@ fn atfork_runtime() -> Option<&'static Arc<SharedRuntimeState>> {
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 unsafe extern "C" fn before_fork() {
+    CHILD_RESTART_DEFERRED.store(true, Ordering::Release);
+    while CHILD_RESTART_IN_PROGRESS.load(Ordering::Acquire) {
+        std::thread::yield_now();
+    }
     if let Some(state) = atfork_runtime() {
         let runtime = state.current();
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -58,6 +64,7 @@ unsafe extern "C" fn after_fork_parent() {
             let _ = runtime.after_fork_parent();
         }));
     }
+    CHILD_RESTART_DEFERRED.store(false, Ordering::Release);
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -65,7 +72,49 @@ unsafe extern "C" fn after_fork_child() {
     // AIDEV-NOTE: Do not rebuild Tokio here. This callback also runs in fork+exec children,
     // where exec closes the new runtime's descriptors while its worker thread is using them.
     // The next Python-facing runtime or telemetry operation performs the restart instead.
+    CHILD_RESTART_IN_PROGRESS.store(false, Ordering::Release);
     CHILD_RESTART_PENDING.store(true, Ordering::Release);
+    CHILD_RESTART_DEFERRED.store(false, Ordering::Release);
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+struct ChildRestartGuard;
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+impl Drop for ChildRestartGuard {
+    fn drop(&mut self) {
+        CHILD_RESTART_IN_PROGRESS.store(false, Ordering::Release);
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn acquire_child_restart() -> PyResult<Option<ChildRestartGuard>> {
+    loop {
+        if !CHILD_RESTART_PENDING.load(Ordering::Acquire) {
+            return Ok(None);
+        }
+        if CHILD_RESTART_DEFERRED.load(Ordering::Acquire) {
+            return Err(PyRuntimeError::new_err(
+                "native runtime restart is deferred until child fork hooks complete",
+            ));
+        }
+        if CHILD_RESTART_IN_PROGRESS
+            .compare_exchange_weak(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            let guard = ChildRestartGuard;
+            if !CHILD_RESTART_PENDING.load(Ordering::Acquire) {
+                return Ok(None);
+            }
+            if CHILD_RESTART_DEFERRED.load(Ordering::Acquire) {
+                return Err(PyRuntimeError::new_err(
+                    "native runtime restart is deferred until child fork hooks complete",
+                ));
+            }
+            return Ok(Some(guard));
+        }
+        std::thread::yield_now();
+    }
 }
 
 #[pyclass(name = "SharedRuntime", subclass)]
@@ -88,19 +137,14 @@ pub(crate) fn ensure_after_fork_child(runtime: &Arc<ForkSafeRuntime>) -> PyResul
         if !CHILD_RESTART_PENDING.load(Ordering::Acquire) {
             return Ok(());
         }
-        if CHILD_RESTART_DEFERRED.load(Ordering::Acquire) {
-            return Err(PyRuntimeError::new_err(
-                "native runtime restart is deferred until child fork hooks complete",
-            ));
-        }
-        if CHILD_RESTART_PENDING.swap(false, Ordering::AcqRel) {
+        if let Some(_restart_guard) = acquire_child_restart()? {
             if let Err(e) = runtime.after_fork_child() {
-                CHILD_RESTART_PENDING.store(true, Ordering::Release);
                 return Err(shared_runtime_error_to_pyerr(e));
             }
             if let Some(state) = atfork_runtime() {
                 state.pid.store(std::process::id(), Ordering::Release);
             }
+            CHILD_RESTART_PENDING.store(false, Ordering::Release);
         } else if let Some(state) = atfork_runtime() {
             if state.pid.load(Ordering::Acquire) != std::process::id() {
                 return Err(PyRuntimeError::new_err(
@@ -121,11 +165,7 @@ fn ensure_shared_runtime_after_fork(
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    if CHILD_RESTART_DEFERRED.load(Ordering::Acquire) {
-        return Err(PyRuntimeError::new_err(
-            "native runtime restart is deferred until child fork hooks complete",
-        ));
-    }
+    let restart_guard = acquire_child_restart()?;
 
     let mut runtime = state.runtime.write().unwrap_or_else(|e| e.into_inner());
     if state.pid.load(Ordering::Acquire) == current_pid {
@@ -133,12 +173,12 @@ fn ensure_shared_runtime_after_fork(
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    if CHILD_RESTART_PENDING.swap(false, Ordering::AcqRel) {
+    if restart_guard.is_some() {
         if let Err(e) = runtime.after_fork_child() {
-            CHILD_RESTART_PENDING.store(true, Ordering::Release);
             return Err(shared_runtime_error_to_pyerr(e));
         }
         state.pid.store(current_pid, Ordering::Release);
+        CHILD_RESTART_PENDING.store(false, Ordering::Release);
         return Ok(runtime.clone());
     }
 

--- a/tests/internal/test_periodic.py
+++ b/tests/internal/test_periodic.py
@@ -605,6 +605,63 @@ def test_autorestart_false_service_restarts_in_parent_after_fork():
     )
 
 
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
+@pytest.mark.subprocess
+def test_nested_fork_preserves_periodic_thread_restart_policy():
+    """A nested fork must not force-restart workers inherited by the intermediate child."""
+    import os
+    from threading import Event
+    from time import sleep
+
+    from ddtrace.internal import periodic
+
+    inherited_ran = Event()
+
+    class InheritedService(periodic.PeriodicService):
+        def periodic(self):
+            inherited_ran.set()
+
+    inherited = InheritedService(interval=0.05, autorestart=False)
+    inherited.start()
+    assert inherited_ran.wait(timeout=2)
+    inherited_ran.clear()
+
+    pid = os.fork()
+    if pid == 0:
+        local_ran = Event()
+
+        class LocalService(periodic.PeriodicService):
+            def periodic(self):
+                local_ran.set()
+
+        local = LocalService(interval=0.05, autorestart=False)
+        local.start()
+        assert local_ran.wait(timeout=2)
+        local_ran.clear()
+
+        grandchild_pid = os.fork()
+        if grandchild_pid == 0:
+            os._exit(0)
+        _, grandchild_status = os.waitpid(grandchild_pid, 0)
+        assert os.waitstatus_to_exitcode(grandchild_status) == 0
+
+        # The nested-fork parent timer must resume workers that were active locally, while
+        # leaving the autorestart=False worker inherited from the root process stopped.
+        sleep(0.5)
+        if local._worker is not None:
+            local._worker.awake()
+        assert local_ran.wait(timeout=2)
+        assert not inherited_ran.is_set()
+        local.stop()
+        local.join()
+        os._exit(0)
+
+    _, status = os.waitpid(pid, 0)
+    inherited.stop()
+    inherited.join()
+    assert os.waitstatus_to_exitcode(status) == 0
+
+
 def test_periodic_service_no_immediate_run_after_fork():
     periodic_ran = Event()
 

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -905,3 +905,87 @@ time.sleep(1.5)
         assert any(d["name"] == "xmltodict" for d in extended_deps), extended_deps
     else:
         assert extended_deps == [], extended_deps
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires a native fork")
+def test_concurrent_metric_collection_after_native_fork(test_agent_session, run_python_code_in_subprocess):
+    """Concurrent child operations wait for the native runtime restart to finish."""
+    code = """
+import ctypes
+import os
+import signal
+import sys
+import threading
+import time
+import types
+
+# Reproduce ddtrace-run loading ddtrace before uWSGI has populated uwsgi.opt.
+sys.modules["uwsgi"] = types.SimpleNamespace()
+import ddtrace
+from ddtrace.internal.native import MetricNamespace
+from ddtrace.internal.native import MetricType
+from ddtrace.internal.telemetry import telemetry_writer
+
+
+worker = telemetry_writer._worker
+assert worker is not None
+context = worker.register_metric_context(
+    MetricNamespace.tracers,
+    "concurrent_native_fork",
+    MetricType.count,
+    [],
+    True,
+)
+
+libc = ctypes.CDLL(None)
+libc.fork.restype = ctypes.c_int
+pid = libc.fork()
+if pid == 0:
+    barrier = threading.Barrier(8)
+    errors = []
+
+    def produce_metrics():
+        try:
+            barrier.wait(timeout=2)
+            for _ in range(512):
+                worker.add_point(context, 1)
+                worker.add_point_with_tags(context, 1, ["fork:child"])
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=produce_metrics) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+    assert all(not thread.is_alive() for thread in threads)
+    assert errors == []
+    telemetry_writer.periodic(force_flush=True)
+    os._exit(0)
+
+deadline = time.monotonic() + 5
+while True:
+    waited, status = os.waitpid(pid, os.WNOHANG)
+    if waited:
+        break
+    if time.monotonic() >= deadline:
+        os.kill(pid, signal.SIGKILL)
+        os.waitpid(pid, 0)
+        raise AssertionError("metric producer blocked during the native runtime restart")
+    time.sleep(0.01)
+
+assert os.waitstatus_to_exitcode(status) == 0
+"""
+
+    _, stderr, status, _ = run_python_code_in_subprocess(code)
+
+    assert status == 0, stderr
+    child_metrics = [
+        metric
+        for event in test_agent_session.get_events("generate-metrics")
+        for metric in event["payload"]["series"]
+        if metric["metric"] == "concurrent_native_fork" and metric["tags"] == ["fork:child"]
+    ]
+    assert len(child_metrics) == 1, child_metrics
+    assert child_metrics[0]["type"] == "count"
+    assert child_metrics[0]["points"][0][1] == 4096

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -762,6 +762,63 @@ class TracerTestCases(TracerTestCase):
             reset_trace_buffer.assert_called_once_with()
             flush_queue.assert_not_called()
 
+    def test_tracer_flush_recreates_writer_after_fork(self):
+        inherited_writer = self.tracer._span_aggregator.writer
+        with (
+            mock.patch.object(self.tracer, "_recreate", wraps=self.tracer._recreate) as recreate,
+            mock.patch.object(inherited_writer, "flush_queue", wraps=inherited_writer.flush_queue) as inherited_flush,
+        ):
+            self.tracer._child_after_fork()
+            self.tracer.flush()
+
+        recreate.assert_called_once_with(reset_buffer=False, flush_writer=False)
+        inherited_flush.assert_not_called()
+        assert self.tracer._span_aggregator.writer is not inherited_writer
+        assert not self.tracer._new_process
+
+    def test_tracer_post_fork_writer_recreation_is_single_flight(self):
+        self.tracer._child_after_fork()
+        recreate_entered = threading.Event()
+        release_recreate = threading.Event()
+        second_thread_started = threading.Event()
+        recreate_calls = []
+        errors = []
+        recreate = self.tracer._recreate
+
+        def blocking_recreate(*args, **kwargs):
+            recreate_calls.append(1)
+            recreate_entered.set()
+            assert release_recreate.wait(timeout=2)
+            recreate(*args, **kwargs)
+
+        def start_span(started=None):
+            if started is not None:
+                started.set()
+            try:
+                self.tracer.start_span("post-fork-concurrent").finish()
+            except Exception as e:
+                errors.append(e)
+
+        with mock.patch.object(self.tracer, "_recreate", side_effect=blocking_recreate):
+            first = threading.Thread(target=start_span)
+            first.start()
+            assert recreate_entered.wait(timeout=2)
+
+            second = threading.Thread(target=start_span, args=(second_thread_started,))
+            second.start()
+            assert second_thread_started.wait(timeout=2)
+            time.sleep(0.05)
+            release_recreate.set()
+
+            first.join(timeout=2)
+            second.join(timeout=2)
+
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert errors == []
+        assert len(recreate_calls) == 1
+        assert not self.tracer._new_process
+
     def test_tracer_shutdown_after_fork_does_not_recreate_writer(self):
         writer = self.tracer._span_aggregator.writer
         with mock.patch.object(self.tracer, "_recreate", wraps=self.tracer._recreate) as recreate:

--- a/tests/tracer/test_tracer.py
+++ b/tests/tracer/test_tracer.py
@@ -774,7 +774,23 @@ class TracerTestCases(TracerTestCase):
         recreate.assert_called_once_with(reset_buffer=False, flush_writer=False)
         inherited_flush.assert_not_called()
         assert self.tracer._span_aggregator.writer is not inherited_writer
+        assert not self.tracer._post_fork_writer_pending
+        assert self.tracer._new_process
+
+    def test_tracer_flush_preserves_inherited_context_cleanup_after_fork(self):
+        parent = self.tracer.trace("parent")
+        self.tracer._child_after_fork()
+
+        self.tracer.flush()
+        child = self.tracer.trace("child")
+
+        assert child.parent_id == parent.span_id
+        assert child._parent is None
+        assert child._local_root is child
         assert not self.tracer._new_process
+
+        child.finish()
+        self.tracer.context_provider.activate(None)
 
     def test_tracer_post_fork_writer_recreation_is_single_flight(self):
         self.tracer._child_after_fork()


### PR DESCRIPTION
## Description

Several post-fork lifecycle paths could run concurrently:

- native telemetry operations could observe the runtime as ready while another thread was still restarting it;
- multiple application threads could recreate the tracer writer simultaneously; and
- nested forks could lose the periodic-thread restart policy selected for the outer fork.

This change serializes lazy native runtime restart, makes tracer writer recreation single-flight, guards `flush()` against an inherited writer, and preserves periodic-thread restart policy across nested forks.

## Testing

- `cargo check --manifest-path src/native/Cargo.toml --all-features`
- Targeted tracer, telemetry, and periodic-thread fork regressions: 8 passed
- Full repository lint checks
- `fork_time` benchmark against the exact pre-change `main` commit:
  - unconfigured: 757 ± 54 µs → 740 ± 62 µs
  - configured: 4.33 ± 0.39 ms → 4.37 ± 0.34 ms
  - neither difference was statistically significant

## Risks

Native restart synchronization runs only after a fork. The normal telemetry metric path remains a single read-only atomic check, and tracer span startup retains its existing fast-path flag check.

