### PR TITLE
test(llmobs): fix flaky periodic eval metric test

### DIFF
--- a/tests/llmobs/test_llmobs_evaluator_runner.py
+++ b/tests/llmobs/test_llmobs_evaluator_runner.py
@@ -45,6 +45,13 @@ def test_evaluator_runner_buffer_limit(mock_evaluator_logs):
 def test_evaluator_runner_periodic_enqueues_eval_metric(mock_llmobs_eval_metric_writer, active_evaluator_runner):
     active_evaluator_runner.enqueue({"span_id": "123", "trace_id": "1234"}, DUMMY_SPAN)
     active_evaluator_runner.periodic()
+
+    # periodic() runs each evaluation on a background executor, so the eval metric is
+    # enqueued asynchronously. Wait for that submission to land before asserting.
+    deadline = time.time() + 5
+    while mock_llmobs_eval_metric_writer.enqueue.call_count == 0 and time.time() < deadline:
+        time.sleep(0.01)
+
     mock_llmobs_eval_metric_writer.enqueue.assert_called_once_with(
         _dummy_evaluator_eval_metric_event(span_id="123", trace_id="1234")
     )


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-15927

This test has been constantly failing in all Python versions.

Root cause: `EvaluatorRunner.periodic()` runs each evaluation on a background `ThreadPoolExecutor`. The evaluator's `run_and_submit_evaluation`, which ultimately calls the eval metric writer's `enqueue` therefore executes asynchronously in an executor thread. The test called `periodic()` and then immediately asserted `enqueue.assert_called_once_with(...)` with no wait, so the assertion almost always ran before the executor thread had executed, yielding `AssertionError: Expected 'enqueue' to be called once. Called 0 times.`

<img width="1161" height="462" alt="image" src="https://github.com/user-attachments/assets/185a99c0-e61d-4063-9b04-e36e924d19db" />
