### PR TITLE
fix(selenium): pop the wrapping context storage on the normal return path

### DIFF
--- a/ddtrace/contrib/internal/selenium/patch.py
+++ b/ddtrace/contrib/internal/selenium/patch.py
@@ -82,16 +82,19 @@ class SeleniumWrappingContextBase(WrappingContext):
         except Exception:  # noqa: E722
             log.debug("Error handling instrumentation return", exc_info=True)
 
-        return value
+        # super(), not a bare return: the base __return__ is what pops this call's storage off
+        # the context variable, and returning value directly leaks one dict per wrapped call.
+        return t.cast(T, super().__return__(value))
 
 
 class SeleniumGetWrappingContext(SeleniumWrappingContextBase):
     def _handle_return(self) -> None:
         root_span = tracer.current_root_span()
-        test_trace_id = root_span.trace_id
 
         if root_span is None or root_span.get_tag("type") != "test":
             return
+
+        test_trace_id = root_span.trace_id
 
         webdriver_instance = self._get_webdriver_instance()
 

--- a/releasenotes/notes/fix-selenium-wrapping-storage-leak-489bc7a20b958d4c.yaml
+++ b/releasenotes/notes/fix-selenium-wrapping-storage-leak-489bc7a20b958d4c.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    selenium: Fixes a memory leak where memory usage grows over the lifetime of a browser
+    test session, proportionally to the number of ``WebDriver.get``, ``WebDriver.quit`` and
+    ``WebDriver.close`` calls made.

--- a/tests/contrib/selenium/test_selenium_wrapping_context.py
+++ b/tests/contrib/selenium/test_selenium_wrapping_context.py
@@ -1,0 +1,78 @@
+"""Storage lifecycle of the selenium wrapping contexts.
+
+No browser and no selenium import: the contexts are exercised over a plain function, which is all
+that is needed to observe what they leave behind on the context variable.
+"""
+
+import pytest
+
+from ddtrace.contrib.internal.selenium.patch import SeleniumWrappingContextBase
+from ddtrace.internal.wrapping.context import _STORAGE_PREV
+
+
+def _chain_depth(context) -> int:
+    """How many per-call storage dicts the context still holds on its context variable."""
+    depth = 0
+    storage = context._storage.get()
+    while storage is not None:
+        depth += 1
+        storage = storage.get(_STORAGE_PREV)
+    return depth
+
+
+class _RecordingContext(SeleniumWrappingContextBase):
+    def __init__(self, f):
+        super().__init__(f)
+        self.returns = 0
+        self.raise_on_return = False
+
+    def _handle_return(self) -> None:
+        self.returns += 1
+        if self.raise_on_return:
+            raise ValueError("instrumentation is broken")
+
+
+def _target(value):
+    if value == "boom":
+        raise RuntimeError("boom")
+    return value
+
+
+@pytest.fixture
+def context():
+    ctx = _RecordingContext(_target)
+    ctx.wrap()
+    try:
+        yield ctx
+    finally:
+        ctx.unwrap()
+
+
+def test_a_successful_call_leaves_no_storage_behind(context):
+    assert _target("ok") == "ok"
+
+    assert context.returns == 1
+    assert _chain_depth(context) == 0
+
+
+def test_repeated_calls_do_not_accumulate_storage(context):
+    for _ in range(50):
+        _target("ok")
+
+    # Regression: __return__ used to return the value without chaining to super(), so every
+    # successful call chained another dict onto the context variable for the thread's lifetime.
+    assert _chain_depth(context) == 0
+
+
+def test_a_failing_call_leaves_no_storage_behind(context):
+    with pytest.raises(RuntimeError):
+        _target("boom")
+
+    assert _chain_depth(context) == 0
+
+
+def test_failing_instrumentation_neither_leaks_nor_reaches_the_caller(context):
+    context.raise_on_return = True
+
+    assert _target("ok") == "ok"
+    assert _chain_depth(context) == 0


### PR DESCRIPTION
## Summary

`SeleniumWrappingContextBase.__return__` returns the value directly instead of chaining to `super().__return__(value)`:

```python
def __return__(self, value: T) -> T:
    """Always return the original value no matter what our instrumentation does"""
    try:
        self._handle_return()
    except Exception:  # noqa: E722
        log.debug("Error handling instrumentation return", exc_info=True)

    return value
```

`BaseWrappingContext.__return__` ([context.py:521](https://github.com/DataDog/dd-trace-py/blob/main/ddtrace/internal/wrapping/context.py#L521)) is what calls `_pop_storage()`, so on a normal return the per-call storage dict pushed by `__enter__` is never popped. The next call sees it as its `prev` and chains onto it, so the context variable grows by one dict per wrapped call for the lifetime of the thread.

All three wrapped methods are affected — `WebDriver.get`, `WebDriver.quit` and `WebDriver.close` — and `get` is the one that matters in practice, since a browser test session navigates repeatedly.

The exception path was already correct: `__exit__` is not overridden, so it inherits the base implementation and pops.

Measured with the context wrapped around a plain function:

| | chain depth after 50 successful calls |
|---|---|
| before | 50 |
| after | 0 |

### Severity

Low-to-moderate. Each leaked dict is small (two entries) and holds no frame — these contexts never call `self.set()`, and the `__frame__` reference lives on the universal context's storage, which is popped correctly. So this is unbounded growth of small objects, not frame retention. It is nonetheless unbounded and proportional to browser navigations in a test session.

Same class of bug as APPSEC-69960 (storage not released on the AppSec blocking path), but on the return path rather than the exception path. Found while auditing the three products that use `WrappingContext` — AppSec RASP, Dynamic Instrumentation and selenium — for a consistent lifecycle. `ddtrace/debugging/_debugger.py` is the reference: it guards its own work in each hook *and* always chains to `super()`.

### Drive-by

`SeleniumGetWrappingContext._handle_return` read `root_span.trace_id` on the line *before* the `if root_span is None` check, so the check was dead and the method raised `AttributeError` whenever there was no root span. The blanket `except Exception` in `__return__` swallowed it, which is why it went unnoticed — the observable behaviour matched the intended early return. The read now sits after the check.

## Ownership

`ddtrace/contrib/internal/selenium/` is Test Optimization's code; I came at it from the AppSec side. Happy to hand this over or close it if you would rather own the fix. No Jira ticket linked yet — filing one under SD - Test Optimization was blocked on my side, so please attach the right key.

## Testing

New `tests/contrib/selenium/test_selenium_wrapping_context.py`. It drives the context over a plain function, so it needs neither a browser nor the selenium package, and asserts the context variable is empty:

- after a successful call
- after 50 successful calls (the regression)
- after a call that raises (guards the already-correct exception path)
- when the instrumentation itself raises

Mutation-checked — reverting `__return__` to `return value` fails 3 of the 4:

```
3 failed, 1 passed
```

`ci_visibility::selenium` on py3.12: 4 passed. `scripts/lint fmt`, `typing`, `spelling` and `suitespec-check` clean.

## Checklist

- [x] PR author has checked that all the criteria below are met
- [x] The PR description includes an overview of the change
- [x] The PR description articulates the motivation for the change
- [x] The change includes tests OR the PR description describes a testing strategy
- [x] The PR description notes risks associated with the change, if any
- [x] Newly-added code is easy to change
- [x] The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- [x] The change includes or references documentation updates if necessary
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Reviewer has checked that all the criteria below are met
- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Newly-added code is easy to change
- [ ] Release note makes sense to a user of the library
- [ ] If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
