### PR TITLE
ci: retry `rdfind` install in oci package job

### DIFF
--- a/.gitlab/prepare-oci-package.sh
+++ b/.gitlab/prepare-oci-package.sh
@@ -46,7 +46,17 @@ cp -r ../pywheels-dep/site-packages* sources/ddtrace_pkgs
 cp ../lib-injection/sources/* sources/
 
 if ! type rdfind &> /dev/null; then
-  clean-apt install rdfind
+  for attempt in 1 2 3; do
+    if clean-apt install rdfind; then
+      break
+    fi
+    if [ "$attempt" -eq 3 ]; then
+      echo "clean-apt install rdfind failed after 3 attempts" >&2
+      exit 1
+    fi
+    echo "clean-apt install rdfind failed (attempt $attempt/3), retrying in 5s..."
+    sleep 5
+  done
 fi
 echo "Deduplicating package files"
 cd ./sources


### PR DESCRIPTION
## Description

The `package-oci` job installs `rdfind` via `clean-apt install rdfind` in `.gitlab/prepare-oci-package.sh` while deduplicating package files for the OCI artifact. This install has no retry logic, so a transient failure from the Ubuntu apt mirror (e.g. a `503 Service Unavailable`, which tends to happen) fails the whole job outright, even though a retry a few seconds later would typically succeed.

This wraps the `rdfind` install in a small retry loop (3 attempts, 5s backoff) so transient mirror flakiness doesn't fail the pipeline.

