### PR TITLE
fix(httplib): finish the span when a RASP block raises through the wrapper

### DIFF
--- a/ddtrace/contrib/internal/httplib/patch.py
+++ b/ddtrace/contrib/internal/httplib/patch.py
@@ -83,6 +83,19 @@ def _call_asm_wrap(func, instance, *args, **kwargs):
     _wrap_request_asm(func, instance, args, kwargs)
 
 
+def _finish_span(instance, exc_info=None):
+    """Finish the connection's span and detach it: _wrap_putrequest adopts any span still
+    attached, so a finished one left behind silences the next request on that connection.
+    """
+    span = getattr(instance, "_datadog_span", None)
+    if span is None:
+        return
+    if exc_info is not None:
+        span.set_exc_info(*exc_info)
+    span.finish()
+    delattr(instance, "_datadog_span")
+
+
 def _wrap_request(func, instance, args, kwargs):
     # Use any attached tracer if available, otherwise use the global tracer
     if asm_config._asm_enabled and asm_config._ep_enabled:
@@ -116,21 +129,14 @@ def _wrap_request(func, instance, args, kwargs):
             HTTPPropagator.inject(span.context, headers)
     except Exception:
         log.debug("error configuring request", exc_info=True)
-        span = getattr(instance, "_datadog_span", None)
-        if span:
-            span.finish()
+        _finish_span(instance)
 
     try:
         return func_to_call(*args, **kwargs)
     except BaseException:
-        # BaseException, not Exception: AppSec RASP blocks an outgoing request by raising
-        # BlockingException, which derives from BaseException so nothing swallows it. Catching
-        # only Exception left the span unfinished and current for the rest of the thread's life.
-        span = getattr(instance, "_datadog_span", None)
-        exc_info = sys.exc_info()
-        if span:
-            span.set_exc_info(*exc_info)
-            span.finish()
+        # AIDEV-NOTE: AppSec RASP blocks an outgoing request by raising BlockingException, which
+        # derives from BaseException, so this guard must not be narrowed to Exception.
+        _finish_span(instance, sys.exc_info())
         raise
 
 
@@ -178,19 +184,13 @@ def _wrap_putrequest(func, instance, args, kwargs):
         log.debug("error applying request tags", exc_info=True)
 
         # Close the span to prevent memory leaks.
-        span = getattr(instance, "_datadog_span", None)
-        if span:
-            span.finish()
+        _finish_span(instance)
 
     try:
         return func(*args, **kwargs)
     except BaseException:
-        # See the note in _wrap_request: a RASP block raises BaseException.
-        span = getattr(instance, "_datadog_span", None)
-        exc_info = sys.exc_info()
-        if span:
-            span.set_exc_info(*exc_info)
-            span.finish()
+        # AIDEV-NOTE: see the anchor in _wrap_request; a RASP block raises BaseException.
+        _finish_span(instance, sys.exc_info())
         raise
 
 

--- a/ddtrace/contrib/internal/httplib/patch.py
+++ b/ddtrace/contrib/internal/httplib/patch.py
@@ -122,7 +122,10 @@ def _wrap_request(func, instance, args, kwargs):
 
     try:
         return func_to_call(*args, **kwargs)
-    except Exception:
+    except BaseException:
+        # BaseException, not Exception: AppSec RASP blocks an outgoing request by raising
+        # BlockingException, which derives from BaseException so nothing swallows it. Catching
+        # only Exception left the span unfinished and current for the rest of the thread's life.
         span = getattr(instance, "_datadog_span", None)
         exc_info = sys.exc_info()
         if span:
@@ -181,7 +184,8 @@ def _wrap_putrequest(func, instance, args, kwargs):
 
     try:
         return func(*args, **kwargs)
-    except Exception:
+    except BaseException:
+        # See the note in _wrap_request: a RASP block raises BaseException.
         span = getattr(instance, "_datadog_span", None)
         exc_info = sys.exc_info()
         if span:

--- a/releasenotes/notes/fix-httplib-span-on-rasp-block-77406db8f2397878.yaml
+++ b/releasenotes/notes/fix-httplib-span-on-rasp-block-77406db8f2397878.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    httplib: Fixes an issue where an outgoing request blocked by Exploit Prevention leaves the
+    ``http.client.request`` span unfinished and active, so it is never sent and every later span
+    on that thread is parented to it.

--- a/tests/contrib/httplib/test_httplib.py
+++ b/tests/contrib/httplib/test_httplib.py
@@ -709,8 +709,11 @@ class HTTPLibTestCase(HTTPLibBaseMixin, TracerTestCase):
                 with pytest.raises(BlockingException):
                     conn.request("GET", "/status/200")
 
-            assert conn._datadog_span.duration is not None, "span left unfinished by the block"
             assert self.tracer.current_span() is None, "span left current by the block"
+
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        assert spans[0].duration is not None, "span left unfinished by the block"
 
     def test_span_is_finished_when_putrequest_raises_a_base_exception(self):
         """Same contract for the putrequest wrapper, which owns the span when used directly."""
@@ -725,5 +728,34 @@ class HTTPLibTestCase(HTTPLibBaseMixin, TracerTestCase):
                 with pytest.raises(BlockingException):
                     conn.putrequest("GET", "/status/200")
 
-            assert conn._datadog_span.duration is not None, "span left unfinished by the block"
             assert self.tracer.current_span() is None, "span left current by the block"
+
+        spans = self.pop_spans()
+        assert len(spans) == 1
+        assert spans[0].duration is not None, "span left unfinished by the block"
+
+    def test_a_reused_connection_gets_a_fresh_span_after_a_block(self):
+        """Connections are reusable, so a finished span must not stay attached to one.
+
+        _wrap_putrequest reuses whatever _datadog_span the connection already carries, so leaving
+        a finished one behind means the next request on that connection reports nothing.
+        """
+        from ddtrace.internal._exceptions import BlockingException
+
+        def blocking_send_request(*args, **kwargs):
+            raise BlockingException({}, "exploit_prevention", "ssrf", "http://blocked/")
+
+        conn = self.get_http_connection(SOCKET)
+        with contextlib.closing(conn):
+            with mock.patch.object(httplib.HTTPConnection, "_send_request", blocking_send_request):
+                with pytest.raises(BlockingException):
+                    conn.request("GET", "/status/200")
+
+            assert not hasattr(conn, "_datadog_span"), "finished span left attached to the connection"
+
+            conn.request("GET", "/status/200")
+            conn.getresponse()
+
+        spans = self.pop_spans()
+        assert len(spans) == 2, "the retry on the reused connection reported no span"
+        assert all(span.duration is not None for span in spans)

--- a/tests/contrib/httplib/test_httplib.py
+++ b/tests/contrib/httplib/test_httplib.py
@@ -691,3 +691,39 @@ class HTTPLibTestCase(HTTPLibBaseMixin, TracerTestCase):
         self.assertEqual(len(spans), 1)
         span = spans[0]
         self.assertEqual(span.name, "http.client.request")
+
+    def test_span_is_finished_when_the_request_raises_a_base_exception(self):
+        """AppSec RASP blocks an outgoing request by raising BlockingException.
+
+        It derives from BaseException so no intermediate handler swallows it, which means an
+        "except Exception" guard here would leave the span unfinished and active forever.
+        """
+        from ddtrace.internal._exceptions import BlockingException
+
+        def blocking_send_request(*args, **kwargs):
+            raise BlockingException({}, "exploit_prevention", "ssrf", "http://blocked/")
+
+        conn = self.get_http_connection(SOCKET)
+        with contextlib.closing(conn):
+            with mock.patch.object(httplib.HTTPConnection, "_send_request", blocking_send_request):
+                with pytest.raises(BlockingException):
+                    conn.request("GET", "/status/200")
+
+            assert conn._datadog_span.duration is not None, "span left unfinished by the block"
+            assert self.tracer.current_span() is None, "span left current by the block"
+
+    def test_span_is_finished_when_putrequest_raises_a_base_exception(self):
+        """Same contract for the putrequest wrapper, which owns the span when used directly."""
+        from ddtrace.internal._exceptions import BlockingException
+
+        def blocking_output(*args, **kwargs):
+            raise BlockingException({}, "exploit_prevention", "ssrf", "http://blocked/")
+
+        conn = self.get_http_connection(SOCKET)
+        with contextlib.closing(conn):
+            with mock.patch.object(httplib.HTTPConnection, "_output", blocking_output):
+                with pytest.raises(BlockingException):
+                    conn.putrequest("GET", "/status/200")
+
+            assert conn._datadog_span.duration is not None, "span left unfinished by the block"
+            assert self.tracer.current_span() is None, "span left current by the block"


### PR DESCRIPTION
## Summary

Jira: [APPSEC-70027](https://datadoghq.atlassian.net/browse/APPSEC-70027)

Exploit Prevention blocks an outgoing request by raising `BlockingException`, which derives from `BaseException` so that no intermediate handler can swallow a blocking decision. `_wrap_request` and `_wrap_putrequest` guard the wrapped call with `except Exception`:

```python
    try:
        return func_to_call(*args, **kwargs)
    except Exception:
        span = getattr(instance, "_datadog_span", None)
        ...
```

The block goes straight past that handler. The span has already been created and activated by `tracer.trace()` and attached to the connection, so it is never finished: it is never flushed, it stays current for the rest of the thread's life, and every later span on that thread is parented to it.

Measured with the integration and appsec both patched, blocking from `HTTPConnection.request`:

```
span created: True   span finished: False   still current: True
Shutting down tracer with 1 spans. These spans will not be sent to Datadog: name=http.client.request
```

## Order dependence

Reachable on `main` today, but only in one patch order:

| patch order | `main` |
|---|---|
| httplib contrib patched first | clean, no span created |
| appsec patched first | **leaked** |

When appsec patches the attribute *after* the integration, its wrapt wrapper sits outside `_wrap_request` and the block raises before the span exists. When appsec patches first, the integration wraps appsec's wrapper and the block happens inside the span.

## Why now

The AppSec RASP migration to `WrappingContext` (#19989, [APPSEC-69878](https://datadoghq.atlassian.net/browse/APPSEC-69878)) removes the order that avoids this. A wrapping context lives in the target's own bytecode, so it is always innermost and the block always raises inside the span. **#19989 depends on this landing first.** Found by Codex review on that PR, split out here because it is a pre-existing bug in shared integration code rather than part of the migration.

## Fix

Catch `BaseException` around the wrapped call in both wrappers and re-raise. That is what the rest of the tracer already does for span cleanup — `redis_utils`, `valkey_utils`, `elasticsearch`, `asgi`, `pyramid`, `tornado` and `tracer.py`. `_wrap_getresponse` already used `try/finally` and was unaffected.

## Testing

Two tests in `tests/contrib/httplib/test_httplib.py` raise a real `BlockingException` from inside the wrapped call, so they need no network and no appsec setup:

- `test_span_is_finished_when_the_request_raises_a_base_exception`
- `test_span_is_finished_when_putrequest_raises_a_base_exception`

Both assert the span is finished and no span is left current. Mutation-checked — reverting to `except Exception` fails both.

`contrib::httplib` green on py3.12. `scripts/lint fmt` clean.

## Checklist

- [x] PR author has checked that all the criteria below are met
- [x] The PR description includes an overview of the change
- [x] The PR description articulates the motivation for the change
- [x] The change includes tests OR the PR description describes a testing strategy
- [x] The PR description notes risks associated with the change, if any
- [x] Newly-added code is easy to change
- [x] The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- [x] The change includes or references documentation updates if necessary
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Reviewer has checked that all the criteria below are met
- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Newly-added code is easy to change
- [ ] Release note makes sense to a user of the library
- [ ] If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[APPSEC-70027]: https://datadoghq.atlassian.net/browse/APPSEC-70027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPSEC-69878]: https://datadoghq.atlassian.net/browse/APPSEC-69878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ