### PR TITLE
ci: detect and remove duplicate/dead suites

### DIFF
--- a/scripts/find_duplicate_suites.py
+++ b/scripts/find_duplicate_suites.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Detect suitespec suites that are duplicates, dead, or latently skipped.
+
+The suitespec system maps each suite to a set of test executions via a regex
+pattern (default: the suite name). The repo is mid-migration from riot to uv:
+most suites still resolve to riot venvs (riotfile.venv.instances()), while the
+suites in UV_TEST_SUITES resolve to uv environments declared in suitespec.yml
+(see tests.suitespec.get_test_environments). This tool handles both, mirroring
+the split in scripts/gen_gitlab_config.py.
+
+Three kinds of structural bugs hide here:
+
+Duplicates — two active suites in the same runner (riot or uv) resolve to the
+exact same set of executions and share the same job context (snapshot,
+services, env, gpu), so a single PR runs the same tests twice. They differ
+only in trigger paths. Suites that share a venv-set but differ in
+snapshot/services/env/gpu are NOT duplicates — snapshot:true adds the
+testagent (without which @snapshot tests fail), and differing services/env/gpu
+change what passes — so they're left out of this category.
+
+Dead suites — a suite resolves to no executions at all, so it can never emit a
+job (gen_gitlab_config warns "No riot venvs found" / no uv envs). Often a
+typo'd or colliding pattern, e.g. an unanchored urllib that was meant to
+target a stdlib integration but silently matches the unrelated urllib3 venv —
+or a webbrowser pattern with no matching venv.
+
+Skipped-but-functional suites — skip:true suppresses the job but the suite
+would otherwise run; listed so latent pattern collisions are visible.
+
+Usage:
+    python scripts/find_duplicate_suites.py            # report
+    python scripts/find_duplicate_suites.py --paths    # also print trigger paths
+
+Dev/diagnostic tool; not wired into CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from pathlib import Path
+import re
+import sys
+
+
+# Ensure we import THIS worktree's tests.suitespec/riotfile, not whatever an
+# ambient PYTHONPATH happens to point at.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT))
+
+import riot  # noqa: F401, E402
+
+import riotfile  # noqa: F401, E402  -- imported for side effects (defines riot.venv)
+import tests.suitespec as spec  # noqa: E402
+
+
+def _suite_pattern(suite: str, config: dict) -> str:
+    return config.get("pattern", suite)
+
+
+def _is_uv_suite(suite: str, config: dict) -> bool:
+    """Whether a suite is emitted as a uv job (not riot).
+
+    Mirrors gen_gitlab_config.py's emit logic: a UV_TEST_SUITES member is run
+    via the uv runner regardless of ddtest (ddtest+UV suites use runner=uv,
+    environments = info.uv_venvs). Non-UV_TEST_SUITES suites use riot. So
+    membership in UV_TEST_SUITES alone determines the runner.
+    """
+    return suite in spec.UV_TEST_SUITES
+
+
+def _matching_riot_venvs(suite_regexes: dict[str, re.Pattern]) -> dict[str, frozenset[tuple[str, str]]]:
+    """Map each riot suite to the frozenset of (name, short_hash) venvs it matches."""
+    matched: dict[str, set[tuple[str, str]]] = {s: set() for s in suite_regexes}
+    for inst in riotfile.venv.instances():  # type: ignore[attr-defined]
+        if not inst.name:
+            continue
+        key = (inst.name, inst.short_hash)  # type: ignore[attr-defined]
+        for suite, regex in suite_regexes.items():
+            if inst.matches_pattern(regex):  # type: ignore[attr-defined]
+                matched[suite].add(key)
+    return {s: frozenset(v) for s, v in matched.items()}
+
+
+def _job_context_key(config: dict) -> tuple:
+    """Job-level dimensions that change what runs / what passes, not just how.
+
+    Two suites matching the same venvs are only true duplicates when they also
+    share these: snapshot (adds the testagent — @snapshot tests fail without
+    it), services (backing services like mysql/httpbin), env (environment
+    variables that alter behavior), and gpu (changes the base template, container
+    image, runner tags, and resources). parallelism/retry/timeout only affect
+    how a suite runs, so they're intentionally excluded.
+    """
+    snapshot = bool(config.get("snapshot", False))
+    services = tuple(config.get("services") or [])
+    env = tuple(sorted((config.get("env") or {}).items()))
+    gpu = bool(config.get("gpu", False))
+    return (snapshot, services, env, gpu)
+
+
+def _execution_key(execution_set: frozenset, config: dict) -> tuple:
+    """Full identity: the matched executions plus their job context."""
+    return (execution_set, _job_context_key(config))
+
+
+def _uv_env_key(env) -> tuple:
+    """Hashable identity for a uv TestEnvironment, excluding the suite name.
+
+    Two suites are duplicates when their environments match on variant name,
+    Python, dependencies, and commands — the suite field itself is what differs
+    between duplicate suites, so it must be excluded.
+    """
+    return (env.name, env.python, env.direct_dependencies, tuple(env.runs))
+
+
+def _matching_uv_envs(uv_suites: dict[str, dict]) -> dict[str, frozenset[tuple]]:
+    """Map each uv suite to the frozenset of its environment identities."""
+    nightly = False
+    try:
+        envs = spec.get_test_environments(nightly=nightly)
+    except Exception as exc:  # noqa: BLE001
+        print(f"# WARNING: failed to load uv test environments: {exc}")
+        return {s: frozenset() for s in uv_suites}
+    return {s: frozenset(_uv_env_key(e) for e in envs.get(s, ())) for s in uv_suites}
+
+
+def _print_suite(suite: str, cfg: dict, show_paths: bool) -> None:
+    skip = " [skip]" if cfg.get("skip") else ""
+    runner = "uv" if _is_uv_suite(suite, cfg) else "riot"
+    print(
+        f"  - {suite}  (runner={runner}, pattern={_suite_pattern(suite, cfg)!r}, "
+        f"parallelism={cfg.get('parallelism')}, snapshot={cfg.get('snapshot', False)}){skip}"
+    )
+    if show_paths:
+        for p in cfg.get("paths", []):
+            print(f"      {p}")
+
+
+def _report_duplicates(label: str, by_key: dict[tuple, list[str]], suites: dict[str, dict], show_paths: bool) -> bool:
+    """Print duplicate groups sharing the same non-empty execution identity.
+
+    Return True only if a group has >=2 active (non-skipped) members — i.e.
+    real CI waste. Groups whose extra members are all skipped are latent
+    (skipped suites emit no job) and don't fail the gate; they're still printed
+    so collisions are visible.
+    """
+    print(f"## Duplicate {label} suites (same venvs + snapshot/services/env)")
+    found_active = False
+    any_shown = False
+    for key, group in sorted(by_key.items(), key=lambda kv: (-len(kv[1]), sorted(kv[1]))):
+        # key = (execution_set, (snapshot, services, env)); skip empty execution sets
+        exec_set = key[0]
+        if not exec_set or len(group) < 2:
+            continue
+        active = [s for s in group if not suites[s].get("skip")]
+        if len(active) >= 2:
+            note = f"  ({len(active)} active — wasted CI)"
+            found_active = True
+        else:
+            note = "  (only one active — skipped members would collide if un-skipped)"
+        any_shown = True
+        print(f"### {len(group)} suites share the same {len(exec_set)} execution(s){note}")
+        for suite in sorted(group):
+            _print_suite(suite, suites[suite], show_paths)
+        print()
+    if not any_shown:
+        print("(none)\n")
+    return found_active
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--paths", action="store_true", help="also print each suite's trigger paths")
+    args = parser.parse_args()
+
+    suites = spec.get_suites()
+
+    # Benchmark suites (type contains "benchmark") use a separate runner
+    # (BenchmarkSpec -> benchmarks/<name>/scenario.py) and do NOT execute the
+    # riot venvs / uv environments their pattern happens to match. Excluding
+    # them avoids false positives where a benchmark shares a name with a test.
+    test_suites = {s: c for s, c in suites.items() if "benchmark" not in c.get("type", "test")}
+
+    riot_suites = {s: c for s, c in test_suites.items() if not _is_uv_suite(s, c)}
+    uv_suites = {s: c for s, c in test_suites.items() if _is_uv_suite(s, c)}
+
+    # --- riot: match patterns against riotfile venvs ---
+    riot_regexes: dict[str, re.Pattern] = {}
+    invalid_patterns: list[str] = []
+    for suite, config in riot_suites.items():
+        pattern = _suite_pattern(suite, config)
+        try:
+            riot_regexes[suite] = re.compile(pattern)
+        except re.error:
+            print(f"# WARNING: invalid pattern for suite {suite!r}: {pattern}")
+            invalid_patterns.append(suite)
+    riot_matched = _matching_riot_venvs(riot_regexes)
+
+    # --- uv: resolve environments declared in suitespec ---
+    uv_matched = _matching_uv_envs(uv_suites)
+
+    n_skipped = sum(1 for c in test_suites.values() if c.get("skip"))
+    n_benchmarks = len(suites) - len(test_suites)
+    print(
+        f"# {len(test_suites)} test suites ({n_benchmarks} benchmark suites skipped), "
+        f"{n_skipped} skipped, {len(riot_suites)} riot, {len(uv_suites)} uv"
+    )
+    print()
+
+    # --- Category 1: duplicates, per runner ---
+    # Group by the full execution identity (matched executions + job context:
+    # snapshot/services/env). Two suites sharing only a venv-set but differing
+    # in snapshot/services are NOT duplicates — they run different outcomes.
+    riot_by_key: dict[tuple, list[str]] = defaultdict(list)
+    for suite, exec_set in riot_matched.items():
+        riot_by_key[_execution_key(exec_set, riot_suites[suite])].append(suite)
+    dup_riot = _report_duplicates("riot", riot_by_key, riot_suites, args.paths)
+
+    uv_by_key: dict[tuple, list[str]] = defaultdict(list)
+    for suite, exec_set in uv_matched.items():
+        uv_by_key[_execution_key(exec_set, uv_suites[suite])].append(suite)
+    dup_uv = _report_duplicates("uv", uv_by_key, uv_suites, args.paths)
+
+    # --- Category 2: dead suites (no executions in their runner) ---
+    dead_riot = sorted(s for s, k in riot_matched.items() if not k)
+    dead_uv = sorted(s for s, k in uv_matched.items() if not k)
+    print("## Dead suites (resolve to no executions — would emit zero jobs)")
+    if dead_riot or dead_uv:
+        for suite in dead_riot:
+            _print_suite(suite, riot_suites[suite], args.paths)
+        for suite in dead_uv:
+            _print_suite(suite, uv_suites[suite], args.paths)
+        print()
+    else:
+        print("(none)\n")
+
+    # --- Category 3: skipped suites that would run if un-skipped (latent) ---
+    latent_riot = sorted(s for s in riot_matched if riot_suites[s].get("skip") and riot_matched[s])
+    latent_uv = sorted(s for s in uv_matched if uv_suites[s].get("skip") and uv_matched[s])
+    print("## Skipped suites (latent: would run if un-skipped)")
+    if latent_riot or latent_uv:
+        for suite in latent_riot:
+            cfg = riot_suites[suite]
+            print(
+                f"  - {suite}  (runner=riot, pattern={_suite_pattern(suite, cfg)!r}, "
+                f"matches {len(riot_matched[suite])} venv(s))"
+            )
+            if args.paths:
+                for p in cfg.get("paths", []):
+                    print(f"      {p}")
+        for suite in latent_uv:
+            cfg = uv_suites[suite]
+            print(
+                f"  - {suite}  (runner=uv, pattern={_suite_pattern(suite, cfg)!r}, "
+                f"matches {len(uv_matched[suite])} env(s))"
+            )
+            if args.paths:
+                for p in cfg.get("paths", []):
+                    print(f"      {p}")
+        print()
+    else:
+        print("(none)\n")
+
+    # Exit non-zero on real bugs (active duplicates, active dead suites, invalid
+    # patterns) so this can gate CI. Skipped-latent suites are informational
+    # only — a skipped suite that would run is not a bug until someone un-skips
+    # it. UV environments are resolved with nightly=False because this gate runs
+    # on PR prechecks, not the nightly pipeline.
+    has_dup = dup_riot or dup_uv
+    has_active_dead = any(not riot_suites[s].get("skip") for s in dead_riot) or any(
+        not uv_suites[s].get("skip") for s in dead_uv
+    )
+    has_invalid = bool(invalid_patterns)
+    return 1 if (has_dup or has_active_dead or has_invalid) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gen_gitlab_config.py
+++ b/scripts/gen_gitlab_config.py
@@ -773,6 +773,11 @@ def gen_pre_checks() -> None:
         paths={"*"},
     )
     check(
+        name="Check suitespec duplicates",
+        command="scripts/lint suitespec-duplicates",
+        paths={"*"},
+    )
+    check(
         name="Check ddtrace error logs",
         command="scripts/lint error-log-check",
         paths={"ddtrace/*", "scripts/check_constant_log_message.py", "scripts/lint"},

--- a/scripts/lint
+++ b/scripts/lint
@@ -58,6 +58,7 @@ case "$cmd" in
     "$SCRIPT_DIR/lint" riot
     "$SCRIPT_DIR/lint" security
     "$SCRIPT_DIR/lint" suitespec-check
+    "$SCRIPT_DIR/lint" suitespec-duplicates
     "$SCRIPT_DIR/lint" profiling-native-check
     "$SCRIPT_DIR/lint" error-log-check
     "$SCRIPT_DIR/lint" supported-config-check
@@ -95,6 +96,9 @@ case "$cmd" in
     ;;
   suitespec-check)
     uv_lint python scripts/check_suitespec_coverage.py "$@"
+    ;;
+  suitespec-duplicates)
+    uv_lint python scripts/find_duplicate_suites.py "$@"
     ;;
   profiling-native-check)
     uv_lint python scripts/check_profiling_native_coverage.py "$@"
@@ -177,6 +181,7 @@ Subcommands:
   riot [args]               python -m doctest riotfile.py
   fmt-snapshots [path]      ddapm-test-agent-fmt
   suitespec-check           Check suitespec coverage
+  suitespec-duplicates      Check for duplicate/dead suitespec suites
   profiling-native-check    Check profiling native coverage
   error-log-check           Check constant log messages
   supported-config-check    Check supported-configurations.json is in sync and complete

--- a/tests/suitespec.yml
+++ b/tests/suitespec.yml
@@ -218,11 +218,6 @@ suites:
       - tests/snapshots/tests.integration.*
     pattern: integration-snapshot*
     snapshot: true
-  integration_registry:
-    parallelism: 1
-    paths:
-      - '@contrib'
-      - scripts/integration_registry/*
   internal:
     retry: 2
     venvs_per_job: 2


### PR DESCRIPTION
   ## Description

   Remove a duplicate suitespec suite and add a CI gate that prevents regressions.

   Duplicate suite (ran identical tests, differed only in trigger paths):
   - `integration_registry` (root) vs `contrib::integration_registry`: both
     resolved to the same single riot venv (`pytest tests/contrib/integration_registry`)
     with a strict-subset trigger set, both `snapshot:false`, no services/env.
     Both born duplicated in #13215 (`6c9d61451f`). Removed the redundant root
     suite; `contrib::integration_registry` already covers every trigger.

   ## Testing

   New CI gate (`scripts/find_duplicate_suites.py`, ~1s):
   - Mirrors `gen_gitlab_config.py`'s riot/uv split so migrated suites aren't
     falsely flagged dead during the riot→uv migration.
   - Duplicate identity = same matched venvs/envs AND same job context
     (`snapshot`, `services`, `env`). `snapshot:true` adds the testagent (without
     it `@snapshot` tests fail), so two suites sharing a venv but differing in
     snapshot/services/env are NOT duplicates — they run different outcomes.
   - Reports three categories: duplicate suites (same venvs + snapshot/services/
     env, ≥2 active), dead suites (resolve to no executions), skipped-latent.
   - Gates on *active* waste only: exits non-zero on ≥2 active duplicates or a
     non-skipped dead suite. Skipped suites are latent (emit no job) — reported
     but not failing. This avoids blocking on intentionally-disabled suites
     (`contrib::vertica`, `llmobs::vllm`, `runtime`, `contrib::mysqlpython`)
     and on the skipped `appsec::urllib` pattern collision (handled separately
     in the follow-up PR).
   - Wired as `scripts/lint suitespec-duplicates` and a `Check suitespec
     duplicates` precheck job (`paths={'*'}`), matching `suitespec-check`.

   Verified: `suitespec-check` + `suitespec-duplicates` pass on this branch
   (0 active dups, 0 active dead; reports `appsec::webbrowser` as a skipped
   dead suite and `appsec::urllib` as a skipped pattern collision — both
   informational, exit 0). Against the pre-fix tree the gate exits 1 and flags
   the `integration_registry` duplicate ("2 active — wasted CI").
   `lint fmt/style/spelling` clean; suitespec doctests pass.

   ## Risks

   Low. The new precheck runs on every PR (`paths={'*'}`) but is ~1s with no
   network. The riot/uv split in the detector may need a revisit once the
   migration completes and `riotfile.py` is removed. The skipped
   `appsec::urllib`/`appsec::webbrowser` suites are left untouched here — they
   conflate the IAST SSRF taint sink with the RASP exploit-prevention bridge and
   are handled in a dedicated follow-up PR for AppSec review.