### PR TITLE
chore(aiguard): report redaction errors as ai_guard.error type:redaction_error

### DIFF
--- a/.cursor/rules/ai-guard.mdc
+++ b/.cursor/rules/ai-guard.mdc
@@ -146,7 +146,10 @@ plain dicts *or* SDK objects.
 3. Applies any `redaction_replacements` from the response, then truncates to
    `DD_AI_GUARD_MAX_MESSAGES_LENGTH` / `DD_AI_GUARD_MAX_CONTENT_SIZE` and
    attaches the result as a meta-struct. The service always receives the
-   originals; only what is reported is redacted.
+   originals; only what is reported is redacted. A replacement that cannot be
+   applied (malformed, unresolvable, or conflicting for one path) is skipped
+   and counted on `ai_guard.error` with `type:redaction_error`; it never fails
+   the evaluation.
 4. Tags the span with the action/reason, marks the root span
    (`_aiguard_manual_keep`, `ai_guard` event tag, client IP), and emits
    telemetry.

--- a/ddtrace/aiguard/_api_client.py
+++ b/ddtrace/aiguard/_api_client.py
@@ -149,9 +149,9 @@ class AIGuardClient:
         telemetry.telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.AI_GUARD, AI_GUARD.REQUESTS_METRIC, 1, tags)
 
     @staticmethod
-    def _add_error_to_telemetry(error_type: str, call_path_tags: tuple[tuple[str, str], ...]) -> None:
+    def _add_error_to_telemetry(error_type: str, call_path_tags: tuple[tuple[str, str], ...], count: int = 1) -> None:
         telemetry.telemetry_writer.add_count_metric(
-            TELEMETRY_NAMESPACE.AI_GUARD, AI_GUARD.ERROR_METRIC, 1, (("type", error_type),) + call_path_tags
+            TELEMETRY_NAMESPACE.AI_GUARD, AI_GUARD.ERROR_METRIC, count, (("type", error_type),) + call_path_tags
         )
 
     @staticmethod
@@ -345,7 +345,11 @@ class AIGuardClient:
                     redacted_messages = messages
                     redaction_enabled = aiguard_config._ai_guard_redaction_enabled
                     if redaction_enabled and redaction_replacements:
-                        redacted_messages = redact_messages(messages, redaction_replacements)
+                        redacted_messages, redaction_errors = redact_messages(messages, redaction_replacements)
+                        # A replacement we cannot apply is reported and then forgotten: redaction is
+                        # best effort and must never fail the evaluation it rode in on.
+                        if redaction_errors:
+                            self._add_error_to_telemetry(AI_GUARD.ERROR_REDACTION, call_path_tags, redaction_errors)
                     # redact_messages returns the very same list when nothing was applied.
                     redacted = redacted_messages is not messages
                     if redaction_enabled:

--- a/ddtrace/aiguard/_api_client.py
+++ b/ddtrace/aiguard/_api_client.py
@@ -323,8 +323,8 @@ class AIGuardClient:
                         sds_findings = attributes.get("sds_findings") or []
                         blocking_enabled = attributes.get("is_blocking_enabled", False)
                         tag_probs = attributes.get("tag_probs")
-                        # Presence of a non-empty array is the signal to redact; sds_findings are
-                        # detection metadata only and never drive redaction.
+                        # Presence of the field is the signal to redact; sds_findings are detection
+                        # metadata only and never drive redaction.
                         redaction_replacements = attributes.get("redaction_replacements")
                     except Exception as e:
                         error_type = AI_GUARD.ERROR_BAD_RESPONSE
@@ -344,7 +344,8 @@ class AIGuardClient:
                     span.set_tag(AI_GUARD.ACTION_TAG, action)
                     redacted_messages = messages
                     redaction_enabled = aiguard_config._ai_guard_redaction_enabled
-                    if redaction_enabled and redaction_replacements:
+                    # Not truthiness: a present but malformed payload has redaction errors to report.
+                    if redaction_enabled and redaction_replacements is not None:
                         redacted_messages, redaction_errors = redact_messages(messages, redaction_replacements)
                         # A replacement we cannot apply is reported and then forgotten: redaction is
                         # best effort and must never fail the evaluation it rode in on.

--- a/ddtrace/aiguard/_constants.py
+++ b/ddtrace/aiguard/_constants.py
@@ -49,6 +49,9 @@ class AI_GUARD(metaclass=Constant_Class):
     ERROR_CLIENT: Literal["client_error"] = "client_error"
     ERROR_BAD_STATUS: Literal["bad_status"] = "bad_status"
     ERROR_BAD_RESPONSE: Literal["bad_response"] = "bad_response"
+    # A replacement the service asked for could not be applied. Reported per affected path, and
+    # never fails the evaluation, see the redaction errors addendum of the AI Guard redaction RFC.
+    ERROR_REDACTION: Literal["redaction_error"] = "redaction_error"
 
     # Values of the "source" tag: which call path reached the evaluation. sdk means the
     # customer called evaluate() directly, auto means our AI package instrumentation did.

--- a/ddtrace/aiguard/_redaction.py
+++ b/ddtrace/aiguard/_redaction.py
@@ -158,11 +158,14 @@ def redact_messages(messages: list[Message], replacements: object) -> RedactionR
     Copy-on-write: the caller's messages are never mutated, and the very same list object is returned
     when nothing was applied, so callers can use identity to detect whether anything changed.
     """
-    try:
-        # Absent or empty is the service saying there is nothing to redact, not a malformed response.
-        if not replacements:
-            return RedactionResult(messages, 0)
+    # An absent field is the service saying there is nothing to redact. Anything else that is
+    # present, an empty array included, is classified by _collect_replacements.
+    if replacements is None:
+        return RedactionResult(messages, 0)
 
+    errors = 0
+    by_path: dict[str, str] = {}
+    try:
         by_path, errors = _collect_replacements(replacements)
         if not by_path:
             return RedactionResult(messages, errors)
@@ -170,15 +173,18 @@ def redact_messages(messages: list[Message], replacements: object) -> RedactionR
         result = deepcopy(messages)
         root = {"messages": result}
         applied = 0
+        skipped = 0
         for path, replacement in by_path.items():
             # A path that is missing, malformed or not pointing at a redactable string is skipped
             # fail-safe, and reported rather than silently dropped.
             if _set_string_at_path(root, path, replacement):
                 applied += 1
             else:
-                errors += 1
+                skipped += 1
 
-        return RedactionResult(result if applied else messages, errors)
+        return RedactionResult(result if applied else messages, errors + skipped)
     except Exception:
         logger.debug("AI Guard redaction failed", exc_info=True)
-        return RedactionResult(messages, 1)
+        # Nothing is delivered when the pass dies, so every collected path is one more replacement
+        # we failed to apply, on top of the entries that were already unusable.
+        return RedactionResult(messages, max(errors + len(by_path), 1))

--- a/ddtrace/aiguard/_redaction.py
+++ b/ddtrace/aiguard/_redaction.py
@@ -2,6 +2,7 @@
 
 The service returns the fully redacted string per location path, so applying it is a verbatim
 overwrite. Never raises: a malformed response degrades to a skip that leaves the message untouched.
+Every skip is counted so the caller can report it, see the redaction errors addendum of the RFC.
 """
 
 from collections.abc import Mapping
@@ -9,6 +10,7 @@ from collections.abc import MutableMapping
 from copy import deepcopy
 import re
 from typing import Any
+from typing import NamedTuple
 from typing import Optional
 from typing import Union
 
@@ -26,12 +28,16 @@ _SEGMENT_RE = re.compile(r"^(?P<name>[A-Za-z0-9_]+)(?:\[(?P<index>[0-9]+)\])?\Z"
 # pointing at an image locator, a role or a tool name can never overwrite it.
 _REDACTABLE_TERMINALS = frozenset({"content", "text", "arguments"})
 
-# Marks a path the backend sent conflicting replacements for: it is skipped rather than guessed.
-_SKIP = object()
-
 Segment = tuple[str, Optional[int]]
 # What a replacement can be written into: everything else resolves read-only.
 Writable = Union[MutableMapping[str, Any], list[Any]]
+
+
+class RedactionResult(NamedTuple):
+    """Messages to use downstream, plus how many replacements could not be applied."""
+
+    messages: list[Message]
+    errors: int
 
 
 def _split_segments(path: str) -> Optional[list[Segment]]:
@@ -112,31 +118,42 @@ def _set_string_at_path(root: dict[str, Any], path: str, value: str) -> bool:
     return True
 
 
-def _collect_replacements(replacements: object) -> dict[str, object]:
-    """Collect one authoritative replacement per path, or _SKIP when the backend contradicts itself."""
-    if not isinstance(replacements, list):
-        return {}
+def _collect_replacements(replacements: object) -> tuple[dict[str, str], int]:
+    """Collect one authoritative replacement per path, plus the number of entries that are unusable.
 
-    by_path: dict[str, object] = {}
+    A path the backend sends contradicting values for is dropped rather than guessed, and counted
+    once however many entries disagree. Identical duplicates agree, so they are not errors.
+    """
+    if not isinstance(replacements, list):
+        # Not even an array: nothing can be applied, so the whole payload counts as one error.
+        return {}, 1
+
+    errors = 0
+    by_path: dict[str, str] = {}
+    conflicting: set[str] = set()
     for entry in replacements:
         if not isinstance(entry, Mapping):
+            errors += 1
             continue
         path = entry.get("path")
         replacement = entry.get("replacement")
         # An empty replacement is valid: it is the customer's "remove" placeholder. A non-string one
         # is not, and would break serialization further down the line.
         if not path or not isinstance(path, str) or not isinstance(replacement, str):
+            errors += 1
             continue
         previous = by_path.get(path)
         if previous is not None and previous != replacement:
-            by_path[path] = _SKIP
-            continue
+            conflicting.add(path)
         by_path[path] = replacement
-    return by_path
+
+    for path in conflicting:
+        del by_path[path]
+    return by_path, errors + len(conflicting)
 
 
-def redact_messages(messages: list[Message], replacements: object) -> list[Message]:
-    """Apply the replacements to the messages and return the redacted list.
+def redact_messages(messages: list[Message], replacements: object) -> RedactionResult:
+    """Apply the replacements to the messages and return them along with the redaction error count.
 
     Copy-on-write: the caller's messages are never mutated, and the very same list object is returned
     when nothing was applied, so callers can use identity to detect whether anything changed.
@@ -144,22 +161,24 @@ def redact_messages(messages: list[Message], replacements: object) -> list[Messa
     try:
         # Absent or empty is the service saying there is nothing to redact, not a malformed response.
         if not replacements:
-            return messages
+            return RedactionResult(messages, 0)
 
-        by_path = _collect_replacements(replacements)
+        by_path, errors = _collect_replacements(replacements)
         if not by_path:
-            return messages
+            return RedactionResult(messages, errors)
 
         result = deepcopy(messages)
         root = {"messages": result}
         applied = 0
         for path, replacement in by_path.items():
-            # _SKIP is not a str, so a contradicted path is skipped along with any path that is
-            # missing, malformed or not pointing at a redactable string.
-            if isinstance(replacement, str) and _set_string_at_path(root, path, replacement):
+            # A path that is missing, malformed or not pointing at a redactable string is skipped
+            # fail-safe, and reported rather than silently dropped.
+            if _set_string_at_path(root, path, replacement):
                 applied += 1
+            else:
+                errors += 1
 
-        return result if applied else messages
+        return RedactionResult(result if applied else messages, errors)
     except Exception:
         logger.debug("AI Guard redaction failed", exc_info=True)
-        return messages
+        return RedactionResult(messages, 1)

--- a/tests/aiguard/api/redaction_scenarios.json
+++ b/tests/aiguard/api/redaction_scenarios.json
@@ -1122,6 +1122,26 @@
       "expected_messages": "SAME",
       "expected_errors": 1
     },
+    {
+      "id": "skip/payload/is-an-empty-object",
+      "description": "Empty but still the wrong type: unlike an empty array, that is a malformed payload.",
+      "messages": [
+        {"role": "user", "content": "My SSN is 123-45-6789"}
+      ],
+      "redaction_replacements": {},
+      "expected_messages": "SAME",
+      "expected_errors": 1
+    },
+    {
+      "id": "skip/payload/is-false",
+      "description": "A falsy payload is still a payload: being present and not an array is the error.",
+      "messages": [
+        {"role": "user", "content": "My SSN is 123-45-6789"}
+      ],
+      "redaction_replacements": false,
+      "expected_messages": "SAME",
+      "expected_errors": 1
+    },
 
     {
       "id": "skip/conflict/two-different-values",

--- a/tests/aiguard/api/redaction_scenarios.json
+++ b/tests/aiguard/api/redaction_scenarios.json
@@ -2,7 +2,8 @@
   "comment": [
     "Cross-tracer corpus for AI Guard sensitive data redaction, kept language-neutral on purpose.",
     "Fields: redaction_replacements null means the service omitted the field; expected_messages 'SAME'",
-    "means the identical list object must come back"
+    "means the identical list object must come back; expected_errors is how many replacements could",
+    "not be applied, each reported as one ai_guard.error with type:redaction_error"
   ],
   "cases": [
     {
@@ -13,7 +14,8 @@
         {"role": "user", "content": "My SSN is 123-45-6789"}
       ],
       "redaction_replacements": null,
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 0
     },
     {
       "id": "noop/replacements-empty",
@@ -22,7 +24,8 @@
         {"role": "user", "content": "My SSN is 123-45-6789"}
       ],
       "redaction_replacements": [],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 0
     },
     {
       "id": "noop/all-entries-invalid",
@@ -34,7 +37,8 @@
         {"path": "messages[0].content"},
         {"replacement": "orphan"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 2
     },
 
     {
@@ -50,7 +54,8 @@
       "expected_messages": [
         {"role": "system", "content": "You are a helpful assistant. Contact <REDACTED>"},
         {"role": "user", "content": "hello"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/content/user-message",
@@ -65,7 +70,8 @@
       "expected_messages": [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "My SSN is <REDACTED>"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/content/middle-message",
@@ -82,7 +88,8 @@
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "My email is <REDACTED>"},
         {"role": "assistant", "content": "Noted."}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/content/assistant-response",
@@ -97,7 +104,8 @@
       "expected_messages": [
         {"role": "user", "content": "what is my account number?"},
         {"role": "assistant", "content": "Your account is <REDACTED>"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/content/tool-result",
@@ -118,7 +126,8 @@
           {"id": "call_1", "function": {"name": "lookup", "arguments": "{\"who\":\"me\"}"}}
         ]},
         {"role": "tool", "tool_call_id": "call_1", "content": "Account <REDACTED>, balance 42"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/content/last-message",
@@ -137,7 +146,8 @@
         {"role": "user", "content": "hi"},
         {"role": "assistant", "content": "hello"},
         {"role": "user", "content": "my passport is <REDACTED>"}
-      ]
+      ],
+      "expected_errors": 0
     },
 
     {
@@ -151,7 +161,8 @@
       ],
       "expected_messages": [
         {"role": "user", "content": "card <REDACTED>"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/placeholder/category-specific",
@@ -164,7 +175,8 @@
       ],
       "expected_messages": [
         {"role": "user", "content": "SSN <US_SSN> email <EMAIL_ADDRESS>"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/placeholder/stars",
@@ -177,7 +189,8 @@
       ],
       "expected_messages": [
         {"role": "user", "content": "my pin is ****"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/placeholder/empty-string-removes-everything",
@@ -190,7 +203,8 @@
       ],
       "expected_messages": [
         {"role": "user", "content": ""}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/no-placeholder/value-dropped-inline",
@@ -203,7 +217,8 @@
       ],
       "expected_messages": [
         {"role": "user", "content": "My SSN is  thanks"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/no-placeholder/partial-hash",
@@ -216,7 +231,8 @@
       ],
       "expected_messages": [
         {"role": "user", "content": "card ************1111"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/no-placeholder/full-hash",
@@ -229,7 +245,8 @@
       ],
       "expected_messages": [
         {"role": "user", "content": "My SSN is 5e884898da280471"}
-      ]
+      ],
+      "expected_errors": 0
     },
 
     {
@@ -243,7 +260,8 @@
       ],
       "expected_messages": [
         {"role": "user", "content": "ssn <A-VERY-LONG-REDACTION-PLACEHOLDER>"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/shape/shorter-replacement",
@@ -256,7 +274,8 @@
       ],
       "expected_messages": [
         {"role": "user", "content": "x"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/shape/identical-replacement",
@@ -269,7 +288,8 @@
       ],
       "expected_messages": [
         {"role": "user", "content": "nothing sensitive here"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/shape/astral-plane",
@@ -282,7 +302,8 @@
       ],
       "expected_messages": [
         {"role": "user", "content": "🙂 ssn <REDACTED> 𝔘 ok"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/shape/replacement-looks-like-a-path",
@@ -295,7 +316,8 @@
       ],
       "expected_messages": [
         {"role": "user", "content": "messages[0].content[1].text"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/shape/multiline",
@@ -308,7 +330,8 @@
       ],
       "expected_messages": [
         {"role": "user", "content": "line1\nssn <REDACTED>\n\"quoted\""}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/path/leading-zero-index",
@@ -323,7 +346,8 @@
       "expected_messages": [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "My SSN is <REDACTED>"}
-      ]
+      ],
+      "expected_errors": 0
     },
 
     {
@@ -343,7 +367,8 @@
           {"type": "input_text", "text": "here is my card <REDACTED>"},
           {"type": "input_image", "image_url": {"url": "https://example.com/card.png"}}
         ]}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/content-part/text-after-image",
@@ -362,7 +387,8 @@
           {"type": "input_image", "image_url": {"url": "https://example.com/card.png"}},
           {"type": "input_text", "text": "my email is <REDACTED>"}
         ]}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/content-part/both-text-parts",
@@ -382,7 +408,8 @@
           {"type": "input_text", "text": "ssn <REDACTED>"},
           {"type": "input_text", "text": "email <REDACTED>"}
         ]}
-      ]
+      ],
+      "expected_errors": 0
     },
 
     {
@@ -402,7 +429,8 @@
         {"role": "assistant", "tool_calls": [
           {"id": "call_1", "function": {"name": "send_email", "arguments": "{\"to\":\"john@acme.io\",\"ssn\":\"<REDACTED>\"}"}}
         ]}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/tool-calls/arguments-second-call",
@@ -421,7 +449,8 @@
           {"id": "call_1", "function": {"name": "noop", "arguments": "{}"}},
           {"id": "call_2", "function": {"name": "lookup", "arguments": "{\"account\":\"<REDACTED>\"}"}}
         ]}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/tool-calls/both-calls",
@@ -441,7 +470,8 @@
           {"id": "call_1", "function": {"name": "send_email", "arguments": "{\"to\":\"<REDACTED>\"}"}},
           {"id": "call_2", "function": {"name": "lookup", "arguments": "{\"account\":\"<REDACTED>\"}"}}
         ]}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/tool-calls/nested-json-arguments",
@@ -458,7 +488,8 @@
         {"role": "assistant", "tool_calls": [
           {"id": "call_1", "function": {"name": "pay", "arguments": "{\"user\":{\"iban\":\"<REDACTED>\"},\"amount\":10}"}}
         ]}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/tool-calls/emptied-arguments",
@@ -475,7 +506,8 @@
         {"role": "assistant", "tool_calls": [
           {"id": "call_1", "function": {"name": "pay", "arguments": "{}"}}
         ]}
-      ]
+      ],
+      "expected_errors": 0
     },
 
     {
@@ -492,7 +524,8 @@
       "expected_messages": [
         {"role": "system", "content": "escalate to <REDACTED>"},
         {"role": "user", "content": "My SSN is <REDACTED>"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/multi/all-three-target-kinds",
@@ -519,7 +552,8 @@
           {"id": "call_1", "function": {"name": "pay", "arguments": "{\"iban\":\"<REDACTED>\"}"}}
         ]},
         {"role": "tool", "tool_call_id": "call_1", "content": "paid from <REDACTED>"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/multi/several-spans-one-string",
@@ -532,7 +566,8 @@
       ],
       "expected_messages": [
         {"role": "user", "content": "SSN <REDACTED> email <REDACTED> card <REDACTED>"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/multi/duplicate-identical-entries",
@@ -546,7 +581,8 @@
       ],
       "expected_messages": [
         {"role": "user", "content": "My SSN is <REDACTED>"}
-      ]
+      ],
+      "expected_errors": 0
     },
 
     {
@@ -567,7 +603,8 @@
         {"role": "user", "content": "My SSN is <REDACTED>"},
         {"role": "assistant", "content": "Your SSN is <REDACTED>."},
         {"role": "user", "content": "my email is <REDACTED>"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/conversation/every-role",
@@ -586,7 +623,8 @@
         {"role": "system", "content": "You are the support bot for account <REDACTED>."},
         {"role": "user", "content": "My SSN is <REDACTED>"},
         {"role": "assistant", "content": "I sent the details to <REDACTED>"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/conversation/history-only",
@@ -605,7 +643,8 @@
         {"role": "user", "content": "What is on file for me?"},
         {"role": "assistant", "content": "Your card is <REDACTED>"},
         {"role": "user", "content": "Thanks, what are your opening hours?"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/conversation/several-turns",
@@ -632,7 +671,8 @@
         {"role": "user", "content": "Also my card <REDACTED>"},
         {"role": "assistant", "content": "I filed it under <REDACTED>"},
         {"role": "user", "content": "My phone is <REDACTED>"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/conversation/tool-turn-in-history",
@@ -659,7 +699,8 @@
         ]},
         {"role": "tool", "tool_call_id": "call_1", "content": "paid from <REDACTED>"},
         {"role": "user", "content": "Send the receipt to <REDACTED>"}
-      ]
+      ],
+      "expected_errors": 0
     },
     {
       "id": "apply/conversation/content-parts-across-turns",
@@ -689,7 +730,8 @@
         {"role": "user", "content": [
           {"type": "input_text", "text": "and my SSN is <REDACTED>"}
         ]}
-      ]
+      ],
+      "expected_errors": 0
     },
 
     {
@@ -701,7 +743,8 @@
       "redaction_replacements": [
         {"path": "messages[99].content", "replacement": "X"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/path/unknown-field",
@@ -712,7 +755,8 @@
       "redaction_replacements": [
         {"path": "messages[0].foo", "replacement": "X"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/path/content-is-a-list",
@@ -725,7 +769,8 @@
       "redaction_replacements": [
         {"path": "messages[0].content", "replacement": "X"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/path/index-into-a-string",
@@ -736,7 +781,8 @@
       "redaction_replacements": [
         {"path": "messages[0].content[0]", "replacement": "X"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/path/content-part-out-of-range",
@@ -749,7 +795,8 @@
       "redaction_replacements": [
         {"path": "messages[0].content[9].text", "replacement": "X"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/path/tool-call-out-of-range",
@@ -762,7 +809,8 @@
       "redaction_replacements": [
         {"path": "messages[0].tool_calls[9].function.arguments", "replacement": "X"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/path/target-is-a-message",
@@ -773,7 +821,8 @@
       "redaction_replacements": [
         {"path": "messages[0]", "replacement": "X"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/path/target-is-the-array",
@@ -784,7 +833,8 @@
       "redaction_replacements": [
         {"path": "messages", "replacement": "X"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/path/image-locator",
@@ -798,7 +848,8 @@
       "redaction_replacements": [
         {"path": "messages[0].content[1].image_url.url", "replacement": "https://example.com/<REDACTED>"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/path/role",
@@ -809,7 +860,8 @@
       "redaction_replacements": [
         {"path": "messages[0].role", "replacement": "system"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/path/tool-function-name",
@@ -822,7 +874,8 @@
       "redaction_replacements": [
         {"path": "messages[0].tool_calls[0].function.name", "replacement": "<REDACTED>"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/path/tool-call-id",
@@ -833,7 +886,8 @@
       "redaction_replacements": [
         {"path": "messages[0].tool_call_id", "replacement": "<REDACTED>"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/path/malformed-segment-hyphen",
@@ -844,7 +898,8 @@
       "redaction_replacements": [
         {"path": "messages[0].con-tent", "replacement": "X"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/path/negative-index",
@@ -856,7 +911,8 @@
       "redaction_replacements": [
         {"path": "messages[-1].content", "replacement": "X"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/path/trailing-space",
@@ -867,7 +923,8 @@
       "redaction_replacements": [
         {"path": "messages[0].content ", "replacement": "X"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/path/trailing-dot",
@@ -878,7 +935,8 @@
       "redaction_replacements": [
         {"path": "messages[0].content.", "replacement": "X"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/path/not-rooted-at-messages",
@@ -889,7 +947,8 @@
       "redaction_replacements": [
         {"path": "foo[0].content", "replacement": "X"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/path/bare-terminal",
@@ -900,7 +959,8 @@
       "redaction_replacements": [
         {"path": "content", "replacement": "X"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/path/missing-message-index",
@@ -911,7 +971,8 @@
       "redaction_replacements": [
         {"path": "messages.content", "replacement": "X"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
 
     {
@@ -923,7 +984,8 @@
       "redaction_replacements": [
         {"replacement": "My SSN is <REDACTED>"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/entry/null-path",
@@ -934,7 +996,8 @@
       "redaction_replacements": [
         {"path": null, "replacement": "My SSN is <REDACTED>"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/entry/empty-path",
@@ -945,7 +1008,8 @@
       "redaction_replacements": [
         {"path": "", "replacement": "My SSN is <REDACTED>"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/entry/path-not-a-string",
@@ -956,7 +1020,8 @@
       "redaction_replacements": [
         {"path": 0, "replacement": "My SSN is <REDACTED>"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/entry/no-replacement",
@@ -967,7 +1032,8 @@
       "redaction_replacements": [
         {"path": "messages[0].content"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/entry/null-replacement",
@@ -978,7 +1044,8 @@
       "redaction_replacements": [
         {"path": "messages[0].content", "replacement": null}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/entry/replacement-not-a-string",
@@ -989,7 +1056,8 @@
       "redaction_replacements": [
         {"path": "messages[0].content", "replacement": 42}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/entry/replacement-is-an-object",
@@ -1000,7 +1068,8 @@
       "redaction_replacements": [
         {"path": "messages[0].content", "replacement": {"value": "X"}}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/entry/entry-is-a-string",
@@ -1009,7 +1078,8 @@
         {"role": "user", "content": "My SSN is 123-45-6789"}
       ],
       "redaction_replacements": ["messages[0].content"],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/entry/entry-is-null",
@@ -1018,7 +1088,8 @@
         {"role": "user", "content": "My SSN is 123-45-6789"}
       ],
       "redaction_replacements": [null],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
 
     {
@@ -1028,7 +1099,8 @@
         {"role": "user", "content": "My SSN is 123-45-6789"}
       ],
       "redaction_replacements": {"path": "messages[0].content", "replacement": "X"},
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/payload/is-a-string",
@@ -1037,7 +1109,8 @@
         {"role": "user", "content": "My SSN is 123-45-6789"}
       ],
       "redaction_replacements": "messages[0].content",
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/payload/is-a-number",
@@ -1046,7 +1119,8 @@
         {"role": "user", "content": "My SSN is 123-45-6789"}
       ],
       "redaction_replacements": 42,
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
 
     {
@@ -1059,7 +1133,8 @@
         {"path": "messages[0].content", "replacement": "My SSN is <A>"},
         {"path": "messages[0].content", "replacement": "My SSN is <B>"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
     {
       "id": "skip/conflict/sticky",
@@ -1072,7 +1147,8 @@
         {"path": "messages[0].content", "replacement": "My SSN is <B>"},
         {"path": "messages[0].content", "replacement": "My SSN is <A>"}
       ],
-      "expected_messages": "SAME"
+      "expected_messages": "SAME",
+      "expected_errors": 1
     },
 
     {
@@ -1089,7 +1165,8 @@
       "expected_messages": [
         {"role": "system", "content": "escalate to <REDACTED>"},
         {"role": "user", "content": "My SSN is 123-45-6789"}
-      ]
+      ],
+      "expected_errors": 1
     },
     {
       "id": "mixed/applied-and-conflict",
@@ -1106,7 +1183,8 @@
       "expected_messages": [
         {"role": "system", "content": "escalate to <REDACTED>"},
         {"role": "user", "content": "My SSN is 123-45-6789"}
-      ]
+      ],
+      "expected_errors": 1
     },
     {
       "id": "mixed/applied-and-missing-replacement",
@@ -1122,7 +1200,8 @@
       "expected_messages": [
         {"role": "user", "content": "My SSN is <REDACTED>"},
         {"role": "assistant", "content": "noted"}
-      ]
+      ],
+      "expected_errors": 1
     },
     {
       "id": "mixed/every-outcome-at-once",
@@ -1152,7 +1231,8 @@
         {"role": "assistant", "tool_calls": [
           {"id": "call_1", "function": {"name": "pay", "arguments": "{\"ssn\":\"<REDACTED>\"}"}}
         ]}
-      ]
+      ],
+      "expected_errors": 3
     },
     {
       "id": "mixed/conversation/history-applied-latest-skipped",
@@ -1173,7 +1253,8 @@
         {"role": "user", "content": "My SSN is <REDACTED>"},
         {"role": "assistant", "content": "Noted."},
         {"role": "user", "content": "My phone is 415-555-0132"}
-      ]
+      ],
+      "expected_errors": 1
     }
   ]
 }

--- a/tests/aiguard/api/test_redaction.py
+++ b/tests/aiguard/api/test_redaction.py
@@ -220,19 +220,37 @@ def test_redacted_is_reported_per_turn(
     assert redacted_tags == ["true", "false"]
 
 
-def test_redaction_never_raises() -> None:
+class Undeepcopyable:
+    """Blows up the copy-on-write step, so the whole redaction pass fails."""
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> Any:
+        raise RuntimeError("boom")
+
+
+@pytest.mark.parametrize(
+    "replacements,expected_errors",
+    [
+        pytest.param([{"path": "messages[0].content", "replacement": "redacted"}], 1, id="one unapplied path"),
+        # Nothing is delivered, so the two unusable entries and the path we never got to all count.
+        pytest.param(
+            [
+                {"path": "messages[0].content", "replacement": "redacted"},
+                {"path": "messages[0].content"},
+                {"replacement": "orphan"},
+            ],
+            3,
+            id="entries already counted are not lost",
+        ),
+    ],
+)
+def test_redaction_never_raises(replacements: list[dict[str, Any]], expected_errors: int) -> None:
     """An unexpected failure degrades to the original messages instead of breaking the caller."""
-
-    class Undeepcopyable:
-        def __deepcopy__(self, memo: dict[int, Any]) -> Any:
-            raise RuntimeError("boom")
-
     messages: list[Any] = [{"role": "user", "content": "My SSN is 123-45-6789", "extra": Undeepcopyable()}]
 
-    result, errors = redact_messages(messages, [{"path": "messages[0].content", "replacement": "redacted"}])
+    result, errors = redact_messages(messages, replacements)
 
     assert result is messages
-    assert errors == 1, "a failed pass is one redaction error, not a silent no-op"
+    assert errors == expected_errors, "a failed pass is at least one redaction error, not a silent no-op"
 
 
 @pytest.mark.parametrize(

--- a/tests/aiguard/api/test_redaction.py
+++ b/tests/aiguard/api/test_redaction.py
@@ -55,6 +55,15 @@ def _metrics(add_count_metric: Mock, metric: str) -> list[tuple[Any, Any]]:
     ]
 
 
+def _redaction_errors(add_count_metric: Mock) -> int:
+    """How many redaction errors the evaluation reported on the ai_guard.error metric."""
+    return sum(
+        value
+        for value, tags in _metrics(add_count_metric, AI_GUARD.ERROR_METRIC)
+        if dict(tags).get("type") == AI_GUARD.ERROR_REDACTION
+    )
+
+
 def _meta_struct(test_spans: TracerSpanContainer) -> dict[str, Any]:
     struct = find_ai_guard_span(test_spans)._get_struct_tag(AI_GUARD.TAG)
     assert struct is not None
@@ -67,9 +76,10 @@ def test_redact_messages_corpus(case: dict[str, Any]) -> None:
     messages = deepcopy(case["messages"])
     untouched = deepcopy(messages)
 
-    result = redact_messages(messages, case["redaction_replacements"])
+    result, errors = redact_messages(messages, case["redaction_replacements"])
 
     assert messages == untouched, "the caller's messages must never be mutated"
+    assert errors == case["expected_errors"]
     if case["expected_messages"] == "SAME":
         assert result is messages, "nothing applied: the original list object must come back"
     else:
@@ -78,9 +88,11 @@ def test_redact_messages_corpus(case: dict[str, Any]) -> None:
 
 
 @pytest.mark.parametrize("case", _corpus_params())
+@patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
 @patch("ddtrace.aiguard._api_client.AIGuardClient._execute_request")
 def test_evaluate_applies_corpus(
     mock_execute_request: Mock,
+    add_count_metric: Mock,
     ai_guard_client: AIGuardClient,
     test_spans: TracerSpanContainer,
     case: dict[str, Any],
@@ -100,6 +112,7 @@ def test_evaluate_applies_corpus(
     if case["expected_messages"] == "SAME":
         assert result["messages"] is messages
     assert _meta_struct(test_spans)["messages"] == expected
+    assert _redaction_errors(add_count_metric) == case["expected_errors"]
     # The service must always receive the originals: it needs the raw text to compute the replacements.
     payload = mock_execute_request.call_args[0][1]
     assert payload["data"]["attributes"]["messages"] == sent
@@ -216,9 +229,10 @@ def test_redaction_never_raises() -> None:
 
     messages: list[Any] = [{"role": "user", "content": "My SSN is 123-45-6789", "extra": Undeepcopyable()}]
 
-    result = redact_messages(messages, [{"path": "messages[0].content", "replacement": "redacted"}])
+    result, errors = redact_messages(messages, [{"path": "messages[0].content", "replacement": "redacted"}])
 
     assert result is messages
+    assert errors == 1, "a failed pass is one redaction error, not a silent no-op"
 
 
 @pytest.mark.parametrize(
@@ -450,3 +464,82 @@ def test_kill_switch_keeps_findings_and_evaluation(
     assert result["messages"] is messages
     assert _meta_struct(test_spans)["messages"] == SIMPLE
     assert _meta_struct(test_spans)["sds"] == findings
+
+
+@patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
+@patch("ddtrace.aiguard._api_client.AIGuardClient._execute_request")
+def test_redaction_errors_are_reported_once_with_the_call_path(
+    mock_execute_request: Mock,
+    add_count_metric: Mock,
+    ai_guard_client: AIGuardClient,
+    test_spans: TracerSpanContainer,
+) -> None:
+    """Every unusable replacement is counted, and the whole turn reports them in a single metric."""
+    messages = deepcopy(SIMPLE)
+    mock_execute_request.return_value = mock_evaluate_response(
+        "ALLOW",
+        redaction_replacements=[
+            {"path": "messages[1].content", "replacement": "My SSN is <REDACTED>"},
+            {"path": "messages[9].content", "replacement": "out of range"},
+            {"path": "messages[0].role", "replacement": "not a redactable target"},
+            {"replacement": "no path at all"},
+        ],
+    )
+
+    result = ai_guard_client.evaluate(messages, source=AI_GUARD.SOURCE_AUTO, integration=AI_GUARD.INTEGRATION_OPENAI)
+
+    assert result["messages"] == REDACTED, "the valid replacement is still applied"
+    assert _metrics(add_count_metric, AI_GUARD.ERROR_METRIC) == [
+        (
+            3,
+            (
+                ("type", AI_GUARD.ERROR_REDACTION),
+                ("source", AI_GUARD.SOURCE_AUTO),
+                ("integration", AI_GUARD.INTEGRATION_OPENAI),
+            ),
+        )
+    ]
+
+
+@patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
+@patch("ddtrace.aiguard._api_client.AIGuardClient._execute_request")
+def test_redaction_errors_do_not_fail_the_evaluation(
+    mock_execute_request: Mock,
+    add_count_metric: Mock,
+    ai_guard_client: AIGuardClient,
+    test_spans: TracerSpanContainer,
+) -> None:
+    """A turn whose replacements all fail is still a successful, non-redacting evaluation."""
+    messages = deepcopy(SIMPLE)
+    mock_execute_request.return_value = mock_evaluate_response(
+        "ALLOW", redaction_replacements=[{"path": "messages[0].role", "replacement": "system"}]
+    )
+
+    result = ai_guard_client.evaluate(messages)
+
+    assert result["action"] == "ALLOW"
+    assert result["messages"] is messages
+    assert find_ai_guard_span(test_spans).get_tag(AI_GUARD.REDACTED_TAG) == "false"
+    [(_, request_tags)] = _metrics(add_count_metric, AI_GUARD.REQUESTS_METRIC)
+    assert dict(request_tags)["error"] == "false"
+    assert _redaction_errors(add_count_metric) == 1
+
+
+@patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
+@patch("ddtrace.aiguard._api_client.AIGuardClient._execute_request")
+def test_no_redaction_error_when_the_kill_switch_is_off(
+    mock_execute_request: Mock,
+    add_count_metric: Mock,
+    ai_guard_client: AIGuardClient,
+    test_spans: TracerSpanContainer,
+) -> None:
+    """No redaction work is attempted with the kill switch off, so a broken payload is not reported."""
+    messages = deepcopy(SIMPLE)
+    mock_execute_request.return_value = mock_evaluate_response(
+        "ALLOW", redaction_replacements=[{"path": "messages[0].role", "replacement": "system"}]
+    )
+
+    with override_ai_guard_config(dict(_ai_guard_redaction_enabled=False)):
+        ai_guard_client.evaluate(messages)
+
+    assert _metrics(add_count_metric, AI_GUARD.ERROR_METRIC) == []


### PR DESCRIPTION
## Description

Implements the **Redaction errors** addendum of the AI Guard redaction RFC (same contract being
discussed in [dd-trace-java#12394](https://github.com/DataDog/dd-trace-java/pull/12394)).

Replacements the service asks for but that we cannot apply are now counted and reported on the
`ai_guard.error` count metric with `type:redaction_error`, alongside the usual `source` /
`integration` call-path tags.

- `redact_messages` returns a `RedactionResult(messages, errors)` instead of a bare list.
- One error is counted for: a malformed entry (not an object, missing/empty/non-string `path`,
  non-string `replacement`), a path that does not resolve to a supported string target, and a
  `redaction_replacements` payload that is not an array at all.
- A path the backend sends **conflicting** values for is skipped and counted **once**, however
  many entries disagree. Identical duplicate entries agree, so they are not errors.
- Errors never fail the evaluation: other valid, non-conflicting replacements are still applied
  and `ai_guard.requests` keeps `error:false`. The metric is emitted before the blocking
  decision, so a blocked turn still reports it.
- With `DD_AI_GUARD_REDACTION_ENABLED=false` no redaction work is attempted and no metric is
  emitted.

Internally this also drops the `_SKIP` sentinel from `_collect_replacements`: conflicting paths
are now removed from the map before resolution, which makes the value type a plain `str`.

Jira: https://datadoghq.atlassian.net/browse/APPSEC-69387

## Testing

The cross-tracer scenario corpus (`tests/aiguard/api/redaction_scenarios.json`, 80 cases) gains an
`expected_errors` field, asserted both against `redact_messages` directly and end to end through
`evaluate()`, so the other tracers can drive the same counts.

Three new tests cover the telemetry itself:
- a mixed turn (1 applied, 3 unusable) emits a single `ai_guard.error` valued `3` with
  `type:redaction_error` plus the `source`/`integration` tags,
- a turn whose only replacement fails is still a successful, non-redacting evaluation
  (`ai_guard.redacted:false`, `ai_guard.requests` `error:false`),
- with the kill switch off, a broken payload emits no error metric at all.

`scripts/run-tests --venv f63a4f0` (aiguard::ai_guard_api, py3.12): 239 passed.
`scripts/lint fmt` and `scripts/lint typing` clean for the changed files.

## Risks

Low. Telemetry-only: no change to which messages are redacted or to what is reported on the span.
The `redact_messages` signature change is contained to `ddtrace/aiguard/`, which is private.

## Additional Notes

No release note — internal telemetry, no customer-visible behavior change, so
`changelog/no-changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)