### PR TITLE
fix(internal): fix crash at finalisation

### DIFF
--- a/releasenotes/notes/fix-exporter-gil-finalize-abort-fbb593d14b8c1493.yaml
+++ b/releasenotes/notes/fix-exporter-gil-finalize-abort-fbb593d14b8c1493.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    tracing: Resolved a rare crash that could occur during interpreter shutdown.

--- a/src/native/data_pipeline/mod.rs
+++ b/src/native/data_pipeline/mod.rs
@@ -4,31 +4,13 @@ use libdd_data_pipeline::trace_exporter::{
     TraceExporterInputFormat, TraceExporterOutputFormat,
 };
 use libdd_shared_runtime::ForkSafeRuntime;
-use pyo3::{exceptions::PyValueError, ffi, prelude::*, pybacked::PyBackedBytes};
+use pyo3::{exceptions::PyValueError, prelude::*, pybacked::PyBackedBytes};
 use std::time::Duration;
 mod agent_response;
 mod exceptions;
+use crate::gil::detach_or_hang_on_finalize;
 use crate::shared_runtime::SharedRuntimePy;
 use exceptions::TraceExporterErrorPy;
-
-// CPython < 3.13 does not expose the public Py_IsFinalizing; use the private symbol,
-// which returns the finalizing thread state (non-null once finalization has started).
-#[cfg(not(Py_3_13))]
-extern "C" {
-    fn _Py_IsFinalizing() -> *mut ffi::PyThreadState;
-}
-
-// Report whether the interpreter has started finalizing. Safe to call without the GIL.
-fn interpreter_is_finalizing() -> bool {
-    #[cfg(Py_3_13)]
-    {
-        unsafe { ffi::Py_IsFinalizing() != 0 }
-    }
-    #[cfg(not(Py_3_13))]
-    {
-        unsafe { !_Py_IsFinalizing().is_null() }
-    }
-}
 
 /// A wrapper around [TraceExporterBuilder]
 ///
@@ -328,17 +310,10 @@ impl TraceExporterPy {
     /// The payload is passed as an immutable `bytes` object to be able to release the GIL while
     /// sending the traces.
     fn send(&self, py: Python<'_>, data: PyBackedBytes) -> PyResult<String> {
-        // Release the GIL for the blocking network send. We manage the thread state by
-        // hand instead of Python::detach so that, if the interpreter starts finalizing
-        // while the GIL is released, we can hang this thread instead of re-acquiring the
-        // GIL. Re-acquiring during finalization drives CPython's take_gil into
-        // PyThread_exit_thread -> pthread_exit, whose forced unwind aborts through
-        // this native worker thread's extern "C"/noexcept frames. CPython 3.14
-        // hangs the thread instead (gh-87135); we replicate that for older runtimes.
-        let _ = py; // proves the GIL is held on entry, as PyEval_SaveThread requires.
-        let save = unsafe { ffi::PyEval_SaveThread() };
-
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // Release the GIL for the blocking network send. If the interpreter starts
+        // finalizing while the GIL is released, this (non-main) thread hangs instead of
+        // re-acquiring the GIL, which would abort the process (see the gil module).
+        detach_or_hang_on_finalize(py, move || {
             match self
                 .inner
                 .as_ref()
@@ -353,22 +328,7 @@ impl TraceExporterPy {
                 },
                 Err(e) => Err(TraceExporterErrorPy::from(e).into()),
             }
-        }));
-
-        if interpreter_is_finalizing() {
-            // Do not re-acquire the GIL: take_gil would exit this thread via pthread_exit
-            // and abort. Park until the process exits (matches CPython 3.14 gh-87135).
-            loop {
-                std::thread::sleep(Duration::from_secs(3600));
-            }
-        }
-
-        unsafe { ffi::PyEval_RestoreThread(save) };
-
-        match result {
-            Ok(value) => value,
-            Err(payload) => std::panic::resume_unwind(payload),
-        }
+        })
     }
 
     /// Report `trace_api.*` health metrics through an externally-owned telemetry worker.

--- a/src/native/data_pipeline/mod.rs
+++ b/src/native/data_pipeline/mod.rs
@@ -4,12 +4,31 @@ use libdd_data_pipeline::trace_exporter::{
     TraceExporterInputFormat, TraceExporterOutputFormat,
 };
 use libdd_shared_runtime::ForkSafeRuntime;
-use pyo3::{exceptions::PyValueError, prelude::*, pybacked::PyBackedBytes};
+use pyo3::{exceptions::PyValueError, ffi, prelude::*, pybacked::PyBackedBytes};
 use std::time::Duration;
 mod agent_response;
 mod exceptions;
 use crate::shared_runtime::SharedRuntimePy;
 use exceptions::TraceExporterErrorPy;
+
+// CPython < 3.13 does not expose the public Py_IsFinalizing; use the private symbol,
+// which returns the finalizing thread state (non-null once finalization has started).
+#[cfg(not(Py_3_13))]
+extern "C" {
+    fn _Py_IsFinalizing() -> *mut ffi::PyThreadState;
+}
+
+// Report whether the interpreter has started finalizing. Safe to call without the GIL.
+fn interpreter_is_finalizing() -> bool {
+    #[cfg(Py_3_13)]
+    {
+        unsafe { ffi::Py_IsFinalizing() != 0 }
+    }
+    #[cfg(not(Py_3_13))]
+    {
+        unsafe { !_Py_IsFinalizing().is_null() }
+    }
+}
 
 /// A wrapper around [TraceExporterBuilder]
 ///
@@ -309,7 +328,17 @@ impl TraceExporterPy {
     /// The payload is passed as an immutable `bytes` object to be able to release the GIL while
     /// sending the traces.
     fn send(&self, py: Python<'_>, data: PyBackedBytes) -> PyResult<String> {
-        py.detach(move || {
+        // Release the GIL for the blocking network send. We manage the thread state by
+        // hand instead of Python::detach so that, if the interpreter starts finalizing
+        // while the GIL is released, we can hang this thread instead of re-acquiring the
+        // GIL. Re-acquiring during finalization drives CPython's take_gil into
+        // PyThread_exit_thread -> pthread_exit, whose forced unwind aborts through
+        // this native worker thread's extern "C"/noexcept frames. CPython 3.14
+        // hangs the thread instead (gh-87135); we replicate that for older runtimes.
+        let _ = py; // proves the GIL is held on entry, as PyEval_SaveThread requires.
+        let save = unsafe { ffi::PyEval_SaveThread() };
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             match self
                 .inner
                 .as_ref()
@@ -324,7 +353,22 @@ impl TraceExporterPy {
                 },
                 Err(e) => Err(TraceExporterErrorPy::from(e).into()),
             }
-        })
+        }));
+
+        if interpreter_is_finalizing() {
+            // Do not re-acquire the GIL: take_gil would exit this thread via pthread_exit
+            // and abort. Park until the process exits (matches CPython 3.14 gh-87135).
+            loop {
+                std::thread::sleep(Duration::from_secs(3600));
+            }
+        }
+
+        unsafe { ffi::PyEval_RestoreThread(save) };
+
+        match result {
+            Ok(value) => value,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
     }
 
     /// Report `trace_api.*` health metrics through an externally-owned telemetry worker.

--- a/src/native/debugger.rs
+++ b/src/native/debugger.rs
@@ -22,6 +22,7 @@ use pyo3::exceptions::{PyException, PyValueError};
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedBytes;
 
+use crate::gil::detach_or_hang_on_finalize;
 use crate::shared_runtime::SharedRuntimePy;
 
 create_exception!(
@@ -137,7 +138,7 @@ where
     F: std::future::Future<Output = anyhow::Result<()>> + Send,
 {
     let runtime = runtime.clone();
-    let result = py.detach(move || {
+    let result = detach_or_hang_on_finalize(py, move || {
         runtime.block_on(async move {
             match tokio::time::timeout(timeout, future).await {
                 Ok(result) => result,

--- a/src/native/gil.rs
+++ b/src/native/gil.rs
@@ -1,0 +1,105 @@
+//! Finalization-safe GIL release for native worker threads.
+//!
+//! dd-trace-py runs blocking work (trace/telemetry/remote-config sends) on native
+//! background threads that release the GIL and re-acquire it when the work returns.
+//! If the interpreter starts finalizing while the GIL is released, CPython's take_gil
+//! forces the (non-main) thread out via PyThread_exit_thread -> pthread_exit. That
+//! forced unwind runs without the GIL and cannot cross our extern "C"/noexcept frames,
+//! so the process aborts with SIGABRT.
+//!
+//! CPython 3.14 fixes this by hanging such threads instead of exiting them
+//! (gh-87135 / python/cpython#105805). We replicate that here for older runtimes:
+//! after the blocking call, a non-main thread that finds the interpreter finalizing
+//! hangs instead of re-acquiring the GIL. The finalizing thread itself (approximated
+//! by the main thread) re-acquires normally, so shutdown flushes still complete.
+
+use pyo3::marker::Ungil;
+use pyo3::{ffi, Python};
+use std::os::raw::c_ulong;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Duration;
+
+// CPython < 3.13 has no public Py_IsFinalizing(); use the private symbol, which
+// returns nonzero once finalization has started. It is removed on 3.13+.
+#[cfg(not(Py_3_13))]
+extern "C" {
+    fn _Py_IsFinalizing() -> std::os::raw::c_int;
+}
+
+extern "C" {
+    // Public, stable, and callable without the GIL: the calling OS thread's Python
+    // identifier. Not exposed by pyo3-ffi, so we declare it ourselves.
+    fn PyThread_get_thread_ident() -> c_ulong;
+}
+
+static MAIN_THREAD_IDENT: AtomicU64 = AtomicU64::new(0);
+static MAIN_THREAD_SET: AtomicBool = AtomicBool::new(false);
+
+/// Record the interpreter's main thread. Call once from the module init function,
+/// which runs on the importing thread (normally the main thread) with the GIL held.
+pub(crate) fn record_main_thread() {
+    MAIN_THREAD_IDENT.store(current_thread_ident(), Ordering::Relaxed);
+    MAIN_THREAD_SET.store(true, Ordering::Release);
+}
+
+fn current_thread_ident() -> u64 {
+    unsafe { PyThread_get_thread_ident() as u64 }
+}
+
+fn interpreter_is_finalizing() -> bool {
+    #[cfg(Py_3_13)]
+    {
+        unsafe { ffi::Py_IsFinalizing() != 0 }
+    }
+    #[cfg(not(Py_3_13))]
+    {
+        unsafe { _Py_IsFinalizing() != 0 }
+    }
+}
+
+/// Whether re-acquiring the GIL on this thread would be fatal: the interpreter is
+/// finalizing and this is not the finalizing thread (approximated by the recorded
+/// main thread). Only non-main threads are forced out by take_gil during
+/// finalization; the finalizing thread can re-acquire safely.
+fn must_hang_instead_of_reattach() -> bool {
+    if !interpreter_is_finalizing() {
+        return false;
+    }
+    // If the main thread was never recorded, do not hang: the worst case is the
+    // pre-existing abort, whereas hanging the finalizing thread would deadlock exit.
+    if !MAIN_THREAD_SET.load(Ordering::Acquire) {
+        return false;
+    }
+    current_thread_ident() != MAIN_THREAD_IDENT.load(Ordering::Relaxed)
+}
+
+/// Run `f` with the GIL released, like [`Python::detach`], but if the interpreter
+/// starts finalizing while the GIL is released, hang this (non-main) thread instead
+/// of re-acquiring the GIL. See the module docs for why.
+pub(crate) fn detach_or_hang_on_finalize<T, F>(py: Python<'_>, f: F) -> T
+where
+    F: Ungil + FnOnce() -> T,
+    T: Ungil,
+{
+    let _ = py; // The GIL is held on entry, which PyEval_SaveThread requires.
+    let save = unsafe { ffi::PyEval_SaveThread() };
+
+    // Guard against a panic in f so we never unwind across the ffi boundary before
+    // restoring (or deliberately not restoring) the thread state.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+
+    if must_hang_instead_of_reattach() {
+        // Do not re-acquire the GIL: take_gil would exit this thread via pthread_exit
+        // and abort. Park until the process exits (matches CPython 3.14 gh-87135).
+        loop {
+            std::thread::sleep(Duration::from_secs(3600));
+        }
+    }
+
+    unsafe { ffi::PyEval_RestoreThread(save) };
+
+    match result {
+        Ok(value) => value,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}

--- a/src/native/http_client/client.rs
+++ b/src/native/http_client/client.rs
@@ -79,6 +79,7 @@ fn ensure_crypto_provider() {
     });
 }
 
+use crate::gil::detach_or_hang_on_finalize;
 use crate::http_client::{errors::http_error_to_pyerr, response::HttpResponsePy};
 use crate::shared_runtime::SharedRuntimePy;
 
@@ -152,8 +153,9 @@ impl HttpClientPy {
         //
         // DEV: `req` is cloned per attempt so the call can be retried by
         // `block_on_resilient`; `HttpRequest` is a cheap, plain-data value.
-        let result =
-            py.detach(move || block_on_resilient(|| runtime.block_on(client.send(req.clone()))));
+        let result = detach_or_hang_on_finalize(py, move || {
+            block_on_resilient(|| runtime.block_on(client.send(req.clone())))
+        });
         match result {
             Ok(Ok(resp)) => Ok(HttpResponsePy::from(resp)),
             Ok(Err(e)) => Err(http_error_to_pyerr(py, e)),

--- a/src/native/lib.rs
+++ b/src/native/lib.rs
@@ -16,6 +16,7 @@ mod debugger;
 mod event_hub;
 #[cfg(feature = "ffe")]
 mod ffe;
+mod gil;
 mod http_client;
 mod library_config;
 mod log;
@@ -40,6 +41,10 @@ pub extern "C" fn ddtrace_force_export_for_windows() {}
 
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Runs on the importing (main) thread with the GIL held: capture the thread that
+    // may safely re-acquire the GIL during interpreter finalization. See gil module.
+    gil::record_main_thread();
+
     #[cfg(feature = "stats")]
     {
         m.add_class::<ddsketch::DDSketchPy>()?;

--- a/src/native/remote_config.rs
+++ b/src/native/remote_config.rs
@@ -33,6 +33,7 @@ use pyo3::types::PyBytes;
 
 use native_proc_macro::ConvertToPyO3Enum;
 
+use crate::gil::detach_or_hang_on_finalize;
 use crate::rc_shm::{ShmReader, ShmStorage};
 use crate::shared_runtime::SharedRuntimePy;
 
@@ -302,7 +303,7 @@ impl RemoteConfigClient {
         // Unwrap the PyO3 mirror to the libdatadog enum before releasing the GIL.
         let products: Vec<RemoteConfigProductNative> =
             products.into_iter().map(Into::into).collect();
-        let result: Result<Vec<ChangeRecord>, String> = py.detach(move || {
+        let result: Result<Vec<ChangeRecord>, String> = detach_or_hang_on_finalize(py, move || {
             let mut inner = self.lock();
 
             let rc_capabilities: Vec<RemoteConfigCapabilitiesNative> =
@@ -421,7 +422,7 @@ impl RemoteConfigReader {
     /// Returns `True` if woken by a notification, `False` on timeout. On Linux
     /// this is a futex wait on the manifest's generation word; elsewhere it polls.
     fn wait_for_change(&self, py: Python<'_>, timeout_ms: u64) -> bool {
-        py.detach(move || {
+        detach_or_hang_on_finalize(py, move || {
             let mut reader = self.reader.lock().unwrap_or_else(|e| e.into_inner());
             reader.wait_for_change(Duration::from_millis(timeout_ms))
         })
@@ -437,7 +438,7 @@ impl RemoteConfigReader {
     #[pyo3(signature = (enabled_products))]
     fn read(&self, py: Python<'_>, enabled_products: Vec<String>) -> PyResult<Vec<ChangeRecord>> {
         let enabled: HashSet<String> = enabled_products.into_iter().collect();
-        let changes = py.detach(move || {
+        let changes = detach_or_hang_on_finalize(py, move || {
             let mut reader = self.reader.lock().unwrap_or_else(|e| e.into_inner());
             reader.read(enabled)
         });

--- a/src/native/telemetry.rs
+++ b/src/native/telemetry.rs
@@ -24,6 +24,7 @@ use native_proc_macro::ConvertToPyO3Enum;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
+use crate::gil::detach_or_hang_on_finalize;
 use crate::shared_runtime::{ensure_after_fork_child, SharedRuntimePy};
 
 /// An opaque, registered metric context handle returned by
@@ -271,7 +272,7 @@ impl TelemetryWorkerPy {
         if let Some(wh) = worker_handle {
             // Release the GIL while the async teardown runs on the shared
             // runtime. `wh.stop()` pauses the worker then shuts it down.
-            py.detach(|| {
+            detach_or_hang_on_finalize(py, || {
                 let _ = self.shared_runtime.block_on(async {
                     let _ = wh.stop().await;
                 });
@@ -293,7 +294,7 @@ impl TelemetryWorkerPy {
         // (FlushMetricAggr), otherwise FlushData would send no metrics — the
         // worker normally does this on its own 10s cadence, but a forced flush
         // must do it inline so metrics added since the last cadence are sent.
-        py.detach(|| {
+        detach_or_hang_on_finalize(py, || {
             let _ = self.shared_runtime.block_on(async {
                 let _ = self
                     .handle

--- a/src/native/tracer_flare.rs
+++ b/src/native/tracer_flare.rs
@@ -2,6 +2,8 @@ use libdd_remote_config::config::{agent_config, agent_task};
 use libdd_tracer_flare::{error::FlareError, FlareAction, TracerFlareManager};
 use pyo3::{create_exception, exceptions::PyException, prelude::*, Bound, PyErr};
 
+use crate::gil::detach_or_hang_on_finalize;
+
 create_exception!(
     tracer_flare_exceptions,
     ListeningError,
@@ -215,7 +217,7 @@ impl TracerFlareManagerPy {
         directory: &str,
         send_action: FlareActionPy,
     ) -> PyResult<()> {
-        py.detach(move || {
+        detach_or_hang_on_finalize(py, move || {
             let manager = &self.manager;
             manager
                 .zip_and_send_sync(vec![directory.to_string()], send_action.inner)


### PR DESCRIPTION
## Description

This fixes a crash that can happen at interpreter finalisation before Python 3.14. Python 3.14 fixed this in https://github.com/python/cpython/issues/87135 but previous versions are still sensitive to the issue. We fix it in the Python tracer by replicating https://github.com/python/cpython/pull/105805, where threads trying to acquire the GIL at finalisation time are hanged rather than properly exited.

This happens because the exporter runs on a thread that is not joined at shutdown. (The PR fixes the bug for all native threads, not only the exporter.)

```
Error UnixSignal: Process terminated with SI_TKILL (SIGABRT)
#0   0x0000f4f997842038 __pthread_kill_implementation (nptl/nptl/pthread_kill.c:44)
#1   0x0000f4f9977fa83c __GI_raise (sysdeps/posix/raise.c:27)
#2   0x0000f4f9977e7134 __GI_abort (stdlib/stdlib/abort.c:81)
#3   0x0000f4f99784909c  
#4   0x0000f4f997841344 __pthread_exit (nptl/nptl/pthread_exit.c:30)
#5   0x0000ba94a70708a4 _PyThread_at_fork_reinit (/usr/src/python/Python/thread_pthread.h:727)
#6   0x0000ba94a71036b0 take_gil (/usr/src/python/Python/ceval_gil.c:452)
#7   0x0000ba94a7103adc PyEval_RestoreThread (/usr/src/python/Python/ceval_gil.c:710)
#8   0x0000f4f99660b768 _native::data_pipeline::TraceExporterPy::__pymethod_send__ 
#9   0x0000f4f9965d2a74 pyo3::impl_::trampoline::fastcall_cfunction_with_keywords::inner 
#10  0x0000f4f9965d2310 pyo3::impl_::trampoline::fastcall_cfunction_with_keywords 
#11  0x0000ba94a70ed1d8 _PyEval_EvalFrameDefault (/usr/src/python/Python/bytecodes.c:3123)
#12  0x0000000000000000 _PyObject_VectorcallTstate (/usr/src/python/Include/internal/pycore_call.h:93)
#13  0x0000ba94a70bc9cc _PyObject_VectorcallTstate (/usr/src/python/Include/internal/pycore_call.h:93)
#14  0x0000ba94a70bc9cc method_vectorcall (/usr/src/python/Objects/classobject.c:69)
#15  0x0000ba94a70bae50 _PyObject_VectorcallTstate (/usr/src/python/Include/internal/pycore_call.h:93)
#16  0x0000f4f996ef5184 std::thread::_State_impl<std::thread::_Invoker<std::tuple<_PeriodicThread_do_start(periodic_thread*, bool)::{lambda()#1}> > >::_M_run() 
#17  0x0000f4f996ef5e9c execute_native_thread_routine 
#18  0x0000f4f9978403c8 start_thread (nptl/nptl/pthread_create.c:442)
```