### PR TITLE
test: unflake module watchdog `first_registered_wins` test

### DIFF
--- a/tests/internal/test_module.py
+++ b/tests/internal/test_module.py
@@ -758,6 +758,10 @@ def test_universal_module_watchdog_first_registered_wins():
             lambda name: name == "tests.submod.stuff", lambda loader, module: calls.append("second")
         )
 
+        # Ensure the module is not already cached from a prior test so that the
+        # import below actually executes the module body and triggers the
+        # pre_exec hooks.
+        sys.modules.pop("tests.submod.stuff", None)
         import tests.submod.stuff  # noqa:F401
 
         assert calls == ["first"]


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-15927

`test_universal_module_watchdog_first_registered_wins` was flaking with failures saying `assert [] == ['first']`.

The problem was that the test registers two pre-exec module hooks and then does `import tests.submod.stuff`, expecting only the first-registered hook to run. Pre-exec hooks only fire when the module body is actually executed. If a previously-run test in the session already imported `tests.submod.stuff` and left it cached in `sys.modules`, this `import` would hit the cache, so the module body never executed and no hook fired, such that `calls` would stay `[]`.
