### PR TITLE
test(profiling): unflake `memalloc` test

### DIFF
--- a/tests/profiling/collector/test_memalloc.py
+++ b/tests/profiling/collector/test_memalloc.py
@@ -34,6 +34,14 @@ PY_313_OR_ABOVE = sys.version_info[:2] >= (3, 13)
 PY_312_OR_ABOVE = sys.version_info[:2] >= (3, 12)
 PY_311_OR_ABOVE = sys.version_info[:2] >= (3, 11)
 
+# Minimum heap-space value at which a live sample attributed to
+# one() is considered as an actual, un-freed one() result object
+# rather than a CPython-internal allocation.
+# The number is chosen to be in the middle of what would be too
+# low and too high to allow some margin against false positives
+# and negatives.
+ONE_RESULT_MIN_ALLOC_SIZE = 1536 if PY_313_OR_ABOVE else 256
+
 
 def _allocate_1k() -> list[object]:
     return [object() for _ in range(1000)]
@@ -657,13 +665,12 @@ def test_memory_collector_python_interface_with_allocation_tracking(tmp_path: Pa
         live_samples = [s for s in final_profile.sample if s.value[heap_space_idx] > 0]
 
         # Check that we have no significant live samples with 'one' in traceback (they were freed).
-        # Small residual allocations (< min_alloc_size) may remain due to CPython internal
-        # caching (type caches, inline bytecode caches, descriptor objects, etc.) that are
-        # allocated while one() is on the call stack and not freed by del + gc.collect().
-        # With aggressive sampling (heap_sample_size=32), these are occasionally sampled.
-        # We only assert on allocations large enough to be the actual one() result object
-        # (bytearray(256) on < 3.13 or (None,)*256 ~= 2096 bytes on 3.13+).
-        min_alloc_size = 256
+        # Small residual allocations may remain due to CPython internal caching (type caches, inline
+        # bytecode caches, descriptor objects, etc.) that are allocated while one() is on the call
+        # stack and not freed by del + gc.collect(). With aggressive sampling (heap_sample_size=32),
+        # these are occasionally sampled. We only assert on allocations large enough to be the actual
+        # one() result object (bytearray(256) on < 3.13 or (None,)*256 ~= 2096 bytes on 3.13+).
+        min_alloc_size = ONE_RESULT_MIN_ALLOC_SIZE
         one_samples_in_final = [
             sample
             for sample in live_samples
@@ -834,7 +841,7 @@ def test_heap_live_samples_drops_after_free(tmp_path: Path) -> None:
         live_after = [s for s in profile_after.sample if s.value[heap_space_idx] > 0]
 
         # 'one' should have no significant live samples (freed)
-        min_alloc_size = 256
+        min_alloc_size = ONE_RESULT_MIN_ALLOC_SIZE
         one_live_after = [
             s
             for s in live_after


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/PROF-15927

`test_memory_collector_python_interface_with_allocation_tracking` was flaky. The problem was a live heap sample attributed to `one()` with `heap-space = 1104`, failing the assertion...

```
Should have no live samples with 'one' in traceback in final_samples, got 1
```

The root cause was that the test tolerates some Python-internal residual allocations (type caches, inline bytecode caches, descriptor objects, etc.) that are made while `one()` is on the call stack, are not released by `del + gc.collect()`, and are occasionally sampled by the aggressive `heap_sample_size=32` profiler. These allocations are always smaller than the actual `one()` result object, and the prior fix (#16671) filtered them out with a flat `heap-space >= 256` cutoff. For a large allocation, `heap-space` (the sampled/weighted size) is approximately the object's own size, so the cutoff is really a size filter.

The problem was that this cutoff was too low for Python 3.13 (and up). In that case, `one(256)` returned `(None,)*256` (so ~2096 bytes), but the residual allocations were ~1104 bytes, so they wrongly counted as a leaked result object. 

The proposed fix is to add a shared constant `ONE_RESULT_MIN_ALLOC_SIZE` = `1536` on Python 3.13+ and `256` otherwise. `1536` is between with some margin.