### PR TITLE
ci: bump pip retries and timeout for ci installs

### DIFF
--- a/.gitlab/testrunner.yml
+++ b/.gitlab/testrunner.yml
@@ -21,6 +21,8 @@ variables:
     # Default to 4 when `-n auto` is used
     # DEV: auto/logical doesn't work well in k8s so we manually set it
     PYTEST_XDIST_AUTO_NUM_WORKERS: "4"
+    PIP_RETRIES: "10"
+    PIP_DEFAULT_TIMEOUT: "60"
   artifacts:
     when: always
     paths:


### PR DESCRIPTION
## Description

PyTorch jobs fail pretty often on all branches due to PyTorch being absolutely _huge_ to install (like 300MB). I'm adding this so that intermittent failures don't make the job fail/don't force us to re-run the whole job.


Example error from a job

```
ERROR: Exception:
Traceback (most recent call last):
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py31115_deps/lib/python3.11/site-packages/pip/_vendor/urllib3/response.py", line 438, in _error_catcher
    yield
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py31115_deps/lib/python3.11/site-packages/pip/_vendor/urllib3/response.py", line 561, in read
    data = self._fp_read(amt) if not fp_closed else b""
           ^^^^^^^^^^^^^^^^^^
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py31115_deps/lib/python3.11/site-packages/pip/_vendor/urllib3/response.py", line 527, in _fp_read
    return self._fp.read(amt) if amt is not None else self._fp.read()
           ^^^^^^^^^^^^^^^^^^
  File "/go/src/github.com/DataDog/apm-reliability/dd-trace-py/.riot/venv_py31115_deps/lib/python3.11/site-packages/pip/_vendor/cachecontrol/filewrapper.py", line 100, in read
    data: bytes = self.__fp.read(amt)
                  ^^^^^^^^^^^^^^^^^^^
  File "/home/bits/.pyenv/versions/3.11.15/lib/python3.11/http/client.py", line 478, in read
    s = self.fp.read(amt)
        ^^^^^^^^^^^^^^^^^
  File "/home/bits/.pyenv/versions/3.11.15/lib/python3.11/socket.py", line 718, in readinto
    return self._sock.recv_into(b)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bits/.pyenv/versions/3.11.15/lib/python3.11/ssl.py", line 1314, in recv_into
    return self.read(nbytes, buffer)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bits/.pyenv/versions/3.11.15/lib/python3.11/ssl.py", line 1166, in read
    return self._sslobj.read(len, buffer)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
BrokenPipeError: [Errno 32] Broken pipe
```