### PR TITLE
ci(profiling): fix fuzz linker error

### DIFF
--- a/ddtrace/internal/datadog/profiling/stack/fuzz/CMakeLists.txt
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/CMakeLists.txt
@@ -18,6 +18,7 @@ set(FUZZ_ECHION_SOURCES
     ../src/echion/strings.cc
     ../src/echion/tasks.cc
     ../src/echion/threads.cc
+    ../src/gc_frame_tracker.cpp
     ../src/origin_task_links.cpp
     ../src/stack_renderer.cpp
     ../src/sampler.cpp


### PR DESCRIPTION
## Description

Fuzzing is failing again because one of our `CMakeLists` wasn't updated after a recent change. This fixes it.

