### PR TITLE
test: harden `azure_functions` test fixtures

### DIFF
--- a/tests/contrib/azure_functions_cosmos/conftest.py
+++ b/tests/contrib/azure_functions_cosmos/conftest.py
@@ -1,0 +1,90 @@
+from io import BufferedRandom
+import os
+import signal
+import subprocess
+import tempfile
+import time
+from typing import Generator
+from typing import Union
+
+import pytest
+
+from tests.webclient import Client
+
+
+AZURE_FUNCTIONS_PORT = 7071
+AZURE_FUNCTION_APP_DIR = os.path.join(os.path.dirname(__file__), "azure_function_app")
+
+
+def _read_log(log_file: BufferedRandom) -> str:
+    log_file.seek(0)
+    return log_file.read().decode("utf-8", errors="replace")
+
+
+def _start_azure_functions_server(extra_env: Union[dict[str, str], None] = None) -> tuple[subprocess.Popen, Client]:
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+
+    port = AZURE_FUNCTIONS_PORT
+    env["AZURE_FUNCTIONS_TEST_PORT"] = str(port)
+    env["DD_TRACE_STATS_COMPUTATION_ENABLED"] = "False"  # disable stats computation to avoid potential flakes in tests
+
+    # Use temp files instead of PIPE to capture logs without deadlocking when func is verbose.
+    stdout_log = tempfile.TemporaryFile(mode="w+b")
+    stderr_log = tempfile.TemporaryFile(mode="w+b")
+
+    # webservers might exec or fork into another process, so we need to os.setsid() to create a process group
+    # (all of which will listen to signals sent to the parent) so that we can kill the whole application.
+    proc = subprocess.Popen(
+        ["func", "start", "--port", str(port)],
+        stdout=stdout_log,
+        stderr=stderr_log,
+        close_fds=True,
+        env=env,
+        preexec_fn=os.setsid,
+        cwd=AZURE_FUNCTION_APP_DIR,
+    )
+    client = Client("http://0.0.0.0:%d" % port)
+    try:
+        client.wait(delay=0.5, initial_wait=2.0)
+    except Exception as e:
+        stdout = _read_log(stdout_log)
+        stderr = _read_log(stderr_log)
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.wait()
+        stdout_log.close()
+        stderr_log.close()
+        raise TimeoutError(
+            "Azure Functions host failed to start\n======STDOUT=====%s\n\n======STDERR=====%s\n" % (stdout, stderr)
+        ) from e
+    else:
+        stdout_log.close()
+        stderr_log.close()
+    return proc, client
+
+
+@pytest.fixture()
+def azure_functions_client(request: pytest.FixtureRequest) -> Generator[Client, None, None]:
+    env_vars = getattr(request, "param", {})
+
+    # Snapshot tests set a unique X-Datadog-Test-Session-Token per test via os.environ.
+    # The func worker reads that token at startup, so we must start a fresh host per test.
+    proc, client = _start_azure_functions_server(env_vars or None)
+    try:
+        yield client
+        # At this point the traces have been sent to the test agent
+        # but the test agent hasn't necessarily finished processing
+        # the traces (race condition) so wait just a bit for that
+        # processing to complete.
+
+        # The Cosmos emulator is much slower than the HTTP trigger
+        # used by the other Azure Functions suites, so we need a
+        # longer delay here than for other suites.
+        time.sleep(10)
+    finally:
+        os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait()

--- a/tests/contrib/azure_functions_cosmos/test_azure_functions_snapshot.py
+++ b/tests/contrib/azure_functions_cosmos/test_azure_functions_snapshot.py
@@ -1,8 +1,3 @@
-import os
-import signal
-import subprocess
-import time
-
 from azure.cosmos import CosmosClient
 from azure.cosmos import PartitionKey
 import pytest
@@ -19,7 +14,7 @@ COSMOS_CONTAINER_NAME = "documents"
 
 
 @pytest.fixture(autouse=True)
-def setup_cosmos_resources():
+def setup_cosmos_resources() -> None:
     client = CosmosClient.from_connection_string(CONNECTION_STRING, connection_verify=False)
     try:
         client.delete_database(COSMOS_DATABASE_NAME)
@@ -27,49 +22,6 @@ def setup_cosmos_resources():
         pass
     database = client.create_database_if_not_exists(COSMOS_DATABASE_NAME)
     database.create_container_if_not_exists(id=COSMOS_CONTAINER_NAME, partition_key=PartitionKey(path="/title"))
-
-
-@pytest.fixture()
-def azure_functions_client(request):
-    env_vars = getattr(request, "param", {})
-
-    # Copy the env to get the correct PYTHONPATH and such
-    # from the virtualenv.
-    env = os.environ.copy()
-    env.update(env_vars)
-
-    port = 7071
-    env["AZURE_FUNCTIONS_TEST_PORT"] = str(port)
-    env["DD_TRACE_STATS_COMPUTATION_ENABLED"] = "False"  # disable stats computation to avoid potential flakes in tests
-
-    # webservers might exec or fork into another process, so we need to os.setsid() to create a process group
-    # (all of which will listen to signals sent to the parent) so that we can kill the whole application.
-    proc = subprocess.Popen(
-        ["func", "start", "--port", str(port)],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        close_fds=True,
-        env=env,
-        preexec_fn=os.setsid,
-        cwd=os.path.join(os.path.dirname(__file__), "azure_function_app"),
-    )
-    try:
-        client = Client(f"http://0.0.0.0:{port}")
-        # Wait for the server to start up
-        try:
-            client.wait(delay=0.5)
-            yield client
-            client.get_ignored("/shutdown")
-        except Exception:
-            pass
-        # At this point the traces have been sent to the test agent
-        # but the test agent hasn't necessarily finished processing
-        # the traces (race condition) so wait just a bit for that
-        # processing to complete.
-        time.sleep(10)
-    finally:
-        os.killpg(proc.pid, signal.SIGKILL)
-        proc.wait()
 
 
 @pytest.mark.snapshot(ignores=SNAPSHOT_IGNORES)

--- a/tests/contrib/azure_functions_eventhubs/conftest.py
+++ b/tests/contrib/azure_functions_eventhubs/conftest.py
@@ -1,0 +1,86 @@
+from io import BufferedRandom
+import os
+import signal
+import subprocess
+import tempfile
+import time
+from typing import Generator
+from typing import Union
+
+import pytest
+
+from tests.webclient import Client
+
+
+AZURE_FUNCTIONS_PORT = 7071
+AZURE_FUNCTION_APP_DIR = os.path.join(os.path.dirname(__file__), "azure_function_app")
+
+
+def _read_log(log_file: BufferedRandom) -> str:
+    log_file.seek(0)
+    return log_file.read().decode("utf-8", errors="replace")
+
+
+def _start_azure_functions_server(extra_env: Union[dict[str, str], None] = None) -> tuple[subprocess.Popen, Client]:
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+
+    port = AZURE_FUNCTIONS_PORT
+    env["AZURE_FUNCTIONS_TEST_PORT"] = str(port)
+    env["DD_TRACE_STATS_COMPUTATION_ENABLED"] = "False"  # disable stats computation to avoid potential flakes in tests
+
+    # Use temp files instead of PIPE to capture logs without deadlocking when func is verbose.
+    stdout_log = tempfile.TemporaryFile(mode="w+b")
+    stderr_log = tempfile.TemporaryFile(mode="w+b")
+
+    # webservers might exec or fork into another process, so we need to os.setsid() to create a process group
+    # (all of which will listen to signals sent to the parent) so that we can kill the whole application.
+    proc = subprocess.Popen(
+        ["func", "start", "--port", str(port)],
+        stdout=stdout_log,
+        stderr=stderr_log,
+        close_fds=True,
+        env=env,
+        preexec_fn=os.setsid,
+        cwd=AZURE_FUNCTION_APP_DIR,
+    )
+    client = Client("http://0.0.0.0:%d" % port)
+    try:
+        client.wait(delay=0.5, initial_wait=2.0)
+    except Exception as e:
+        stdout = _read_log(stdout_log)
+        stderr = _read_log(stderr_log)
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.wait()
+        stdout_log.close()
+        stderr_log.close()
+        raise TimeoutError(
+            "Azure Functions host failed to start\n======STDOUT=====%s\n\n======STDERR=====%s\n" % (stdout, stderr)
+        ) from e
+    else:
+        stdout_log.close()
+        stderr_log.close()
+    return proc, client
+
+
+@pytest.fixture
+def azure_functions_client(request: pytest.FixtureRequest) -> Generator[Client, None, None]:
+    env_vars = getattr(request, "param", {})
+
+    # Snapshot tests set a unique X-Datadog-Test-Session-Token per test via os.environ.
+    # The func worker reads that token at startup, so we must start a fresh host per test.
+    proc, client = _start_azure_functions_server(env_vars or None)
+    try:
+        yield client
+        # At this point the traces have been sent to the test agent
+        # but the test agent hasn't necessarily finished processing
+        # the traces (race condition) so wait just a bit for that
+        # processing to complete.
+        time.sleep(1)
+    finally:
+        os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait()

--- a/tests/contrib/azure_functions_eventhubs/test_azure_functions_snapshot.py
+++ b/tests/contrib/azure_functions_eventhubs/test_azure_functions_snapshot.py
@@ -1,8 +1,4 @@
 import itertools
-import os
-import signal
-import subprocess
-import time
 
 from azure.core.exceptions import ResourceNotFoundError
 from azure.storage.blob import BlobServiceClient
@@ -39,51 +35,8 @@ params = [
 param_ids, param_values = zip(*params)
 
 
-@pytest.fixture
-def azure_functions_client(request):
-    env_vars = getattr(request, "param", {})
-
-    # Copy the env to get the correct PYTHONPATH and such
-    # from the virtualenv.
-    env = os.environ.copy()
-    env.update(env_vars)
-
-    port = 7071
-    env["AZURE_FUNCTIONS_TEST_PORT"] = str(port)
-    env["DD_TRACE_STATS_COMPUTATION_ENABLED"] = "False"  # disable stats computation to avoid potential flakes in tests
-
-    # webservers might exec or fork into another process, so we need to os.setsid() to create a process group
-    # (all of which will listen to signals sent to the parent) so that we can kill the whole application.
-    proc = subprocess.Popen(
-        ["func", "start", "--port", str(port)],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        close_fds=True,
-        env=env,
-        preexec_fn=os.setsid,
-        cwd=os.path.join(os.path.dirname(__file__), "azure_function_app"),
-    )
-    try:
-        client = Client(f"http://0.0.0.0:{port}")
-        # Wait for the server to start up
-        try:
-            client.wait(delay=0.5)
-            yield client
-            client.get_ignored("/shutdown")
-        except Exception:
-            pass
-        # At this point the traces have been sent to the test agent
-        # but the test agent hasn't necessarily finished processing
-        # the traces (race condition) so wait just a bit for that
-        # processing to complete.
-        time.sleep(1)
-    finally:
-        os.killpg(proc.pid, signal.SIGKILL)
-        proc.wait()
-
-
 @pytest.fixture(autouse=True)
-def cleanup_checkpoints():
+def cleanup_checkpoints() -> None:
     connection_string = BLOB_CONNECTION_STRING
     container_name = "azure-webjobs-eventhub"
 
@@ -106,5 +59,5 @@ def cleanup_checkpoints():
     indirect=["azure_functions_client"],
 )
 @pytest.mark.snapshot(ignores=SNAPSHOT_IGNORES)
-def test_event_hubs_trigger(azure_functions_client: Client, payload_type) -> None:
+def test_event_hubs_trigger(azure_functions_client: Client, payload_type: str) -> None:
     assert azure_functions_client.post(f"/api/sendevent{payload_type}", headers=DEFAULT_HEADERS).status_code == 200

--- a/tests/contrib/azure_functions_servicebus/conftest.py
+++ b/tests/contrib/azure_functions_servicebus/conftest.py
@@ -1,0 +1,86 @@
+from io import BufferedRandom
+import os
+import signal
+import subprocess
+import tempfile
+import time
+from typing import Generator
+from typing import Union
+
+import pytest
+
+from tests.webclient import Client
+
+
+AZURE_FUNCTIONS_PORT = 7071
+AZURE_FUNCTION_APP_DIR = os.path.join(os.path.dirname(__file__), "azure_function_app")
+
+
+def _read_log(log_file: BufferedRandom) -> str:
+    log_file.seek(0)
+    return log_file.read().decode("utf-8", errors="replace")
+
+
+def _start_azure_functions_server(extra_env: Union[dict[str, str], None] = None) -> tuple[subprocess.Popen, Client]:
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+
+    port = AZURE_FUNCTIONS_PORT
+    env["AZURE_FUNCTIONS_TEST_PORT"] = str(port)
+    env["DD_TRACE_STATS_COMPUTATION_ENABLED"] = "False"  # disable stats computation to avoid potential flakes in tests
+
+    # Use temp files instead of PIPE to capture logs without deadlocking when func is verbose.
+    stdout_log = tempfile.TemporaryFile(mode="w+b")
+    stderr_log = tempfile.TemporaryFile(mode="w+b")
+
+    # webservers might exec or fork into another process, so we need to os.setsid() to create a process group
+    # (all of which will listen to signals sent to the parent) so that we can kill the whole application.
+    proc = subprocess.Popen(
+        ["func", "start", "--port", str(port)],
+        stdout=stdout_log,
+        stderr=stderr_log,
+        close_fds=True,
+        env=env,
+        preexec_fn=os.setsid,
+        cwd=AZURE_FUNCTION_APP_DIR,
+    )
+    client = Client("http://0.0.0.0:%d" % port)
+    try:
+        client.wait(delay=0.5, initial_wait=2.0)
+    except Exception as e:
+        stdout = _read_log(stdout_log)
+        stderr = _read_log(stderr_log)
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.wait()
+        stdout_log.close()
+        stderr_log.close()
+        raise TimeoutError(
+            "Azure Functions host failed to start\n======STDOUT=====%s\n\n======STDERR=====%s\n" % (stdout, stderr)
+        ) from e
+    else:
+        stdout_log.close()
+        stderr_log.close()
+    return proc, client
+
+
+@pytest.fixture
+def azure_functions_client(request: pytest.FixtureRequest) -> Generator[Client, None, None]:
+    env_vars = getattr(request, "param", {})
+
+    # Snapshot tests set a unique X-Datadog-Test-Session-Token per test via os.environ.
+    # The func worker reads that token at startup, so we must start a fresh host per test.
+    proc, client = _start_azure_functions_server(env_vars or None)
+    try:
+        yield client
+        # At this point the traces have been sent to the test agent
+        # but the test agent hasn't necessarily finished processing
+        # the traces (race condition) so wait just a bit for that
+        # processing to complete.
+        time.sleep(1)
+    finally:
+        os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait()

--- a/tests/contrib/azure_functions_servicebus/test_azure_functions_snapshot.py
+++ b/tests/contrib/azure_functions_servicebus/test_azure_functions_snapshot.py
@@ -1,8 +1,4 @@
 import itertools
-import os
-import signal
-import subprocess
-import time
 
 import pytest
 
@@ -37,49 +33,6 @@ params = [
 param_ids, param_values = zip(*params)
 
 
-@pytest.fixture
-def azure_functions_client(request):
-    env_vars = getattr(request, "param", {})
-
-    # Copy the env to get the correct PYTHONPATH and such
-    # from the virtualenv.
-    env = os.environ.copy()
-    env.update(env_vars)
-
-    port = 7071
-    env["AZURE_FUNCTIONS_TEST_PORT"] = str(port)
-    env["DD_TRACE_STATS_COMPUTATION_ENABLED"] = "False"  # disable stats computation to avoid potential flakes in tests
-
-    # webservers might exec or fork into another process, so we need to os.setsid() to create a process group
-    # (all of which will listen to signals sent to the parent) so that we can kill the whole application.
-    proc = subprocess.Popen(
-        ["func", "start", "--port", str(port)],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        close_fds=True,
-        env=env,
-        preexec_fn=os.setsid,
-        cwd=os.path.join(os.path.dirname(__file__), "azure_function_app"),
-    )
-    try:
-        client = Client(f"http://0.0.0.0:{port}")
-        # Wait for the server to start up
-        try:
-            client.wait(delay=0.5)
-            yield client
-            client.get_ignored("/shutdown")
-        except Exception:
-            pass
-        # At this point the traces have been sent to the test agent
-        # but the test agent hasn't necessarily finished processing
-        # the traces (race condition) so wait just a bit for that
-        # processing to complete.
-        time.sleep(1)
-    finally:
-        os.killpg(proc.pid, signal.SIGKILL)
-        proc.wait()
-
-
 @pytest.mark.parametrize(
     "azure_functions_client, entity, payload_type",
     param_values,
@@ -87,7 +40,7 @@ def azure_functions_client(request):
     indirect=["azure_functions_client"],
 )
 @pytest.mark.snapshot(ignores=SNAPSHOT_IGNORES)
-def test_service_bus_trigger(azure_functions_client: Client, entity, payload_type) -> None:
+def test_service_bus_trigger(azure_functions_client: Client, entity: str, payload_type: str) -> None:
     assert (
         azure_functions_client.post(f"/api/{entity}sendmessage{payload_type}", headers=DEFAULT_HEADERS).status_code
         == 200


### PR DESCRIPTION
## Description

[datadoghq.atlassian.net/browse/PROF-15927](https://datadoghq.atlassian.net/browse/PROF-15927)

The `servicebus`, `eventhubs`, and `cosmos` test suites from `contrib/azure_functions` were causing CI flakes on a regular basis. `test_service_bus_trigger`, `test_event_hubs_trigger`, and `test_cosmos_trigger` failures were caused by the Azure Functions host (`func start`) not being ready when the `azure_functions_client` fixture started polling it. 

The root cause was that each of those suites defined its own inline `azure_functions_client` fixture inside `test_azure_functions_snapshot.py` that:
- polled for readiness immediately with no startup grace period (`client.wait(delay=0.5)`),
- discarded the host's stdout/stderr (`subprocess.DEVNULL`),
- silently swallowed startup failures (`except Exception: pass`), such that a host that failed to boot surfaced only as the unhelpful "did not yield a value".

This was already partially fixed in #19119, but it was not applied to the servicebus/eventhubs/cosmos suites. 

