### PR TITLE
ci: correct merge order for nightly env

### DIFF
--- a/tests/suitespec.py
+++ b/tests/suitespec.py
@@ -220,10 +220,10 @@ def _variant_settings(
 ) -> tuple[tuple[str, ...], tuple[str, ...], str, tuple[TestRun, ...]]:
     dependencies = _merge_dependencies(DEFAULT_DEPENDENCIES, tuple(variant.get("dependencies", ())))
     environment = DEFAULT_ENVIRONMENT.copy()
-    if "env" in matrix:
-        environment.update(matrix["env"])
     if nightly:
         environment.update(NIGHTLY_ENVIRONMENT)
+    if "env" in matrix:
+        environment.update(matrix["env"])
     if "env" in variant:
         environment.update(variant["env"])
 


### PR DESCRIPTION
## Description

`test_uv_suitespec_matches_riot[py3.13]` was previously flaky and reporting `uv environments missing from Riot`. The failures occurred on nightly pipelines  where the `testing` suite's `matrix.env` `tests/ci_visibility/suitespec.yml` sets `DD_CIVISIBILITY_CODE_COVERAGE_REPORT_UPLOAD_ENABLED: 'false'`.

The problem was that in `tests/suitespec.py`, the environment dict was merged in the order `DEFAULT_ENVIRONMENT` -> `matrix.env` -> `NIGHTLY_ENVIRONMENT` (if nightly) -> `variant.env`. This let the nightly-only coverage flag override the suite's `matrix.env`, so on a nightly build `suitespec` computed `DD_CIVISIBILITY_CODE_COVERAGE_REPORT_UPLOAD_ENABLED=1` for the `testing` suite, while `riotfile.py`'s `_base_env` always applies `NIGHTLY_BUILD` before the per-venv `env` override. The resulting env-var mismatch made every `testing` environment "missing from Riot" in the set comparison whenever `NIGHTLY_BUILD=true`.

The fix flips the merge order so `NIGHTLY_ENVIRONMENT` is applied before `matrix.env` (and `variant.env`), matching `riotfile.py`'s.