### PR TITLE
fix(llmobs): remove evaluator import cycle

### DIFF
--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -56,6 +56,7 @@ from ddtrace.internal.native import rand64bits
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs._constants import DD_SITE_STAGING
 from ddtrace.llmobs._constants import DD_SITES_NEEDING_APP_SUBDOMAIN
+from ddtrace.llmobs._integration_api import get_llmobs_service
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import convert_tags_dict_to_list
 from ddtrace.llmobs._utils import get_asyncio
@@ -489,9 +490,9 @@ class RemoteEvaluator(BaseEvaluator):
         self._eval_name = eval_name.strip()
         self._transform_fn = transform_fn if transform_fn is not None else _default_context_transform
 
-        from ddtrace.llmobs import LLMObs
-
-        self._llmobs_service = LLMObs
+        # AIDEV-NOTE: Use the registered class to avoid importing the public package back
+        # from the experiment engine, while still following LLMObs._instance replacements.
+        self._llmobs_service = get_llmobs_service()
 
     def evaluate(self, context: EvaluatorContext) -> Union[JSONType, EvaluatorResult]:
         """Evaluate using the remote LLM-as-Judge evaluator.

--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -490,7 +490,7 @@ class RemoteEvaluator(BaseEvaluator):
         self._eval_name = eval_name.strip()
         self._transform_fn = transform_fn if transform_fn is not None else _default_context_transform
 
-        # AIDEV-NOTE: Use the registered class to avoid importing the public package back
+        # NOTE: Use the registered class to avoid importing the public package back
         # from the experiment engine, while still following LLMObs._instance replacements.
         self._llmobs_service = get_llmobs_service()
 

--- a/ddtrace/llmobs/_integration_api.py
+++ b/ddtrace/llmobs/_integration_api.py
@@ -1,8 +1,8 @@
-"""Minimal LLMObs API used by integrations during their import-time setup.
+"""Minimal LLMObs API shared by integrations and evaluators.
 
 Integrations can be imported while the full LLMObs service is initializing. Keep
-this module independent from ``_llmobs`` so integration setup does not recursively
-import the service through ``BaseLLMIntegration``.
+this module independent from _llmobs so consumers can access the registered
+service without recursively importing it through the public package.
 """
 
 from __future__ import annotations
@@ -27,6 +27,11 @@ def register_llmobs_service(service: type[LLMObs]) -> None:
     """Register the concrete LLMObs service after it has finished importing."""
     global _llmobs_service
     _llmobs_service = service
+
+
+def get_llmobs_service() -> Optional[type[LLMObs]]:
+    """Return the registered service class, or None before registration."""
+    return _llmobs_service
 
 
 def is_enabled() -> bool:

--- a/tests/llmobs/test_evaluators.py
+++ b/tests/llmobs/test_evaluators.py
@@ -1,10 +1,12 @@
 """Tests for LLMObs evaluator classes."""
 
 import asyncio
+import builtins
 from unittest import mock
 
 import pytest
 
+from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs._experiment import BaseEvaluator
 from ddtrace.llmobs._experiment import BaseSummaryEvaluator
 from ddtrace.llmobs._experiment import Dataset
@@ -305,6 +307,49 @@ class TestSummaryEvaluatorIntegration:
 
 class TestRemoteEvaluator:
     """Tests for RemoteEvaluator class."""
+
+    def test_init_does_not_import_llmobs(self):
+        original_import = builtins.__import__
+
+        def import_without_llmobs(name, *args, **kwargs):
+            if name in ("ddtrace.llmobs", "ddtrace.llmobs._llmobs"):
+                raise AssertionError("RemoteEvaluator must use the registered service")
+            return original_import(name, *args, **kwargs)
+
+        with mock.patch("builtins.__import__", side_effect=import_without_llmobs):
+            evaluator = RemoteEvaluator(eval_name="test-eval")
+
+        assert evaluator._llmobs_service is LLMObs
+
+    def test_init_uses_registered_service(self):
+        with mock.patch("ddtrace.llmobs._integration_api._llmobs_service") as service:
+            evaluator = RemoteEvaluator(eval_name="test-eval")
+
+        assert evaluator._llmobs_service is service
+
+    def test_evaluate_uses_current_service_instance(self):
+        context = EvaluatorContext(input_data="input", output_data="output")
+        with mock.patch("ddtrace.llmobs._integration_api._llmobs_service") as service:
+            previous_client = service._instance._dne_client
+            evaluator = RemoteEvaluator(eval_name="test-eval")
+            service._instance = mock.Mock()
+            current_client = service._instance._dne_client
+            current_client.evaluator_infer.return_value = {"value": True}
+
+            assert evaluator.evaluate(context) is True
+
+        previous_client.evaluator_infer.assert_not_called()
+        current_client.evaluator_infer.assert_called_once_with(
+            eval_name="test-eval", context={"span_input": "input", "span_output": "output"}
+        )
+
+    def test_evaluate_without_client(self):
+        evaluator = RemoteEvaluator(eval_name="test-eval")
+        context = EvaluatorContext(input_data="input", output_data="output")
+
+        with mock.patch.object(LLMObs._instance, "_dne_client", None):
+            with pytest.raises(ValueError, match="LLMObs experiments client is not initialized"):
+                evaluator.evaluate(context)
 
     def test_init_valid(self):
         """Test valid RemoteEvaluator initialization."""


### PR DESCRIPTION
<!-- dd-meta {"pullId":"a9c19267-a2e7-4b56-bb7d-404a686d8663","source":"chat","resourceId":"f28c4f71-907c-44af-8194-18b38d38deee","workflowId":"ea971952-4e76-4e58-9939-7b0ee1d91ae5","codeChangeId":"ea971952-4e76-4e58-9939-7b0ee1d91ae5","sourceType":"slack"} -->
## Description

Remove the runtime circular dependency ddtrace.llmobs -> ddtrace.llmobs._evaluators -> ddtrace.llmobs._evaluators.format -> ddtrace.llmobs._experiment -> ddtrace.llmobs.

- Add an accessor to the existing lightweight service registry and use it in RemoteEvaluator instead of importing the public package in its constructor.
- Preserve public imports, signatures, result handling, and current service-instance lookup.
- Add four regression tests covering construction without the reverse import, registered-service resolution, instance replacement, and missing-client errors.
- Use the requested NOTE comment prefix while preserving indentation.

## Testing

Static AST comparison confirmed the runtime cycle exists before the fix and is absent afterward (excluding TYPE_CHECKING imports). Targeted formatting and Ruff checks through scripts/lint passed previously. git diff --check passes after the comment-only follow-up.

Runtime tests were not executed: scripts/run-tests discovery and a Python 3.13 dry run completed, but the offline test environment was unavailable. Full validation remains pending due to missing betsy, pinned lint dependencies, cython-lint, and the envier.mypy plugin in the lint environment.

## Risks

Low-risk internal dependency inversion using existing service registration. Runtime regression coverage still needs CI. The latest follow-up only changes a comment prefix.

## Additional Notes

No intended public API or customer-facing behavior change. No release note needed; use changelog/no-changelog.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/f28c4f71-907c-44af-8194-18b38d38deee)

Comment @datadog to request changes