### PR TITLE
chore(llmobs): remove circular imports1

### DIFF
--- a/ddtrace/llmobs/_event_types.py
+++ b/ddtrace/llmobs/_event_types.py
@@ -1,0 +1,90 @@
+"""Shared span and experiment payload types, independent of writers and services.
+
+Keep these contracts below the consumers that construct, inspect, and send events.
+"""
+
+from typing import Any
+from typing import Mapping
+from typing import Optional
+from typing import Sequence
+from typing import TypedDict
+from typing import Union
+
+from ddtrace.llmobs.types import ExperimentConfigType
+from ddtrace.llmobs.types import _Meta
+from ddtrace.llmobs.types import _SpanLink
+
+
+# NOTE: Experiments accept general sequences/mappings, unlike the public JSONType.
+JSONType = Union[str, int, float, bool, None, Sequence["JSONType"], Mapping[str, "JSONType"]]
+
+
+class LLMObsSpanData(TypedDict, total=False):
+    """Structure of LLMObs span data attached to APM spans."""
+
+    name: str
+    parent_id: str
+    pagent_name: str
+    pagent_span_id: str
+    trace_id: str
+    ml_app: str
+    session_id: str
+    tags: dict[str, str]
+    metrics: dict[str, Any]
+    span_links: list["_SpanLink"]
+    config: "ExperimentConfigType"
+    meta: _Meta
+    _dd: dict[str, str]
+
+
+class _LLMObsSpanEventOptional(TypedDict, total=False):
+    session_id: str
+    service: str
+    status_message: str
+    collection_errors: list[str]
+    span_links: list["_SpanLink"]
+    config: "ExperimentConfigType"
+
+
+class LLMObsSpanEvent(_LLMObsSpanEventOptional):
+    span_id: str
+    trace_id: str
+    parent_id: str
+    tags: list[str]
+    name: str
+    start_ns: int
+    duration: int
+    status: str
+    meta: _Meta
+    metrics: dict[str, Any]
+    _dd: dict[str, str]
+
+
+class LLMObsExperimentEvalMetricEvent(TypedDict, total=False):
+    metric_source: str
+    span_id: str
+    trace_id: str
+    timestamp_ms: int
+    metric_type: str
+    label: str
+    categorical_value: str
+    score_value: float
+    boolean_value: bool
+    json_value: dict[str, JSONType]
+    status: str
+    error: Optional[dict[str, str]]
+    tags: list[str]
+    experiment_id: str
+    reasoning: str
+    assessment: str
+    metadata: dict[str, JSONType]
+    eval_source_type: str
+
+
+class EvaluatorInferResponse(TypedDict, total=False):
+    """Response from the evaluator_infer API endpoint."""
+
+    value: JSONType
+    assessment: Optional[str]
+    reasoning: Optional[str]
+    status: Optional[str]

--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -15,7 +15,6 @@ from typing import Awaitable
 from typing import Callable
 from typing import Iterator
 from typing import Literal
-from typing import Mapping
 from typing import Optional
 from typing import Protocol
 from typing import Sequence
@@ -57,6 +56,8 @@ from ddtrace.internal.native import rand64bits
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs._constants import DD_SITE_STAGING
 from ddtrace.llmobs._constants import DD_SITES_NEEDING_APP_SUBDOMAIN
+from ddtrace.llmobs._event_types import JSONType as JSONType
+from ddtrace.llmobs._event_types import LLMObsExperimentEvalMetricEvent
 from ddtrace.llmobs._integration_api import _LLMObsService
 from ddtrace.llmobs._integration_api import get_llmobs_service
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
@@ -72,13 +73,10 @@ if TYPE_CHECKING:
     import pandas as pd
 
     from ddtrace._trace.span import Span
-    from ddtrace.llmobs._writer import LLMObsExperimentEvalMetricEvent
-    from ddtrace.llmobs._writer import LLMObsExperimentsClient
     from ddtrace.llmobs.types import ExportedLLMObsSpan
 
 logger = get_logger(__name__)
 
-JSONType = Union[str, int, float, bool, None, Sequence["JSONType"], Mapping[str, "JSONType"]]
 ConfigType = dict[str, JSONType]
 ContextTransformFn = Callable[["EvaluatorContext"], dict[str, Any]]
 
@@ -86,11 +84,58 @@ TaskType = Callable[..., JSONType]
 AsyncTaskType = Callable[..., Awaitable[JSONType]]
 
 
+class _ExperimentsClient(Protocol):
+    """Dataset and experiment transport operations required by the engine."""
+
+    def dataset_bulk_upload(
+        self, dataset_id: str, records: list["DatasetRecord"], deduplicate: bool = True
+    ) -> None: ...
+
+    def dataset_batch_update(
+        self,
+        dataset_id: str,
+        project_id: str,
+        insert_records: list["DatasetRecord"],
+        update_records: list["DatasetRecordUpdateWithId"],
+        delete_record_ids: list[str],
+        deduplicate: bool = True,
+        create_new_version: bool = True,
+    ) -> tuple[int, list[str], list[Optional[str]]]: ...
+
+    def project_create_or_get(self, name: Optional[str] = None) -> "Project": ...
+
+    def experiment_create(
+        self,
+        name: str,
+        dataset_id: str,
+        project_id: str,
+        dataset_version: int = 0,
+        exp_config: Optional[dict[str, JSONType]] = None,
+        tags: Optional[list[str]] = None,
+        description: Optional[str] = None,
+        runs: Optional[int] = 1,
+        ensure_unique: bool = True,
+        parent_experiment_id: Optional[str] = None,
+    ) -> tuple[str, str]: ...
+
+    def experiment_update(
+        self, experiment_id: str, status: Optional[str] = None, error: Optional[str] = None
+    ) -> None: ...
+
+    def experiment_eval_post(
+        self,
+        experiment_id: str,
+        events: list[LLMObsExperimentEvalMetricEvent],
+        tags: list[str],
+        spans: Optional[list[dict]] = None,
+    ) -> None: ...
+
+
 class _ExperimentService(_LLMObsService, Protocol):
     """The experiment engine's service contract, independent of concrete LLMObs."""
 
     @property
-    def _dne_client(self) -> "LLMObsExperimentsClient": ...
+    def _dne_client(self) -> _ExperimentsClient: ...
 
     def flush(self) -> None: ...
 
@@ -1617,7 +1662,7 @@ class Dataset:
     _records_by_id: dict[str, DatasetRecord]
     _version: int
     _latest_version: int
-    _dne_client: "LLMObsExperimentsClient"
+    _dne_client: _ExperimentsClient
     _new_records_by_record_id: dict[str, DatasetRecord]
     _updated_record_ids_to_new_fields: dict[str, DatasetRecordUpdateWithId]
     _deleted_record_ids: list[str]
@@ -1634,7 +1679,7 @@ class Dataset:
         description: str,
         latest_version: int,
         version: int,
-        _dne_client: "LLMObsExperimentsClient",
+        _dne_client: _ExperimentsClient,
         filter_tags: Optional[list[str]] = None,
     ) -> None:
         self.name = name

--- a/ddtrace/llmobs/_experiment.py
+++ b/ddtrace/llmobs/_experiment.py
@@ -17,6 +17,7 @@ from typing import Iterator
 from typing import Literal
 from typing import Mapping
 from typing import Optional
+from typing import Protocol
 from typing import Sequence
 from typing import TypedDict
 from typing import Union
@@ -56,6 +57,8 @@ from ddtrace.internal.native import rand64bits
 from ddtrace.internal.utils.formats import format_trace_id
 from ddtrace.llmobs._constants import DD_SITE_STAGING
 from ddtrace.llmobs._constants import DD_SITES_NEEDING_APP_SUBDOMAIN
+from ddtrace.llmobs._integration_api import _LLMObsService
+from ddtrace.llmobs._integration_api import get_llmobs_service
 from ddtrace.llmobs._utils import _annotate_llmobs_span_data
 from ddtrace.llmobs._utils import convert_tags_dict_to_list
 from ddtrace.llmobs._utils import get_asyncio
@@ -68,7 +71,7 @@ from ddtrace.version import __version__
 if TYPE_CHECKING:
     import pandas as pd
 
-    from ddtrace.llmobs import LLMObs
+    from ddtrace._trace.span import Span
     from ddtrace.llmobs._writer import LLMObsExperimentEvalMetricEvent
     from ddtrace.llmobs._writer import LLMObsExperimentsClient
     from ddtrace.llmobs.types import ExportedLLMObsSpan
@@ -81,6 +84,31 @@ ContextTransformFn = Callable[["EvaluatorContext"], dict[str, Any]]
 
 TaskType = Callable[..., JSONType]
 AsyncTaskType = Callable[..., Awaitable[JSONType]]
+
+
+class _ExperimentService(_LLMObsService, Protocol):
+    """The experiment engine's service contract, independent of concrete LLMObs."""
+
+    @property
+    def _dne_client(self) -> "LLMObsExperimentsClient": ...
+
+    def flush(self) -> None: ...
+
+    def export_span(self, span: Optional["Span"] = None) -> Optional["ExportedLLMObsSpan"]: ...
+
+    def _experiment(
+        self,
+        *,
+        name: Optional[str] = None,
+        experiment_id: Optional[str] = None,
+        run_id: Optional[str] = None,
+        run_iteration: Optional[int] = None,
+        dataset_name: Optional[str] = None,
+        dataset_id: Optional[str] = None,
+        project_name: Optional[str] = None,
+        project_id: Optional[str] = None,
+        experiment_name: Optional[str] = None,
+    ) -> "Span": ...
 
 
 class EvaluatorResult:
@@ -489,9 +517,9 @@ class RemoteEvaluator(BaseEvaluator):
         self._eval_name = eval_name.strip()
         self._transform_fn = transform_fn if transform_fn is not None else _default_context_transform
 
-        from ddtrace.llmobs import LLMObs
-
-        self._llmobs_service = LLMObs
+        # NOTE: Keep the registered class so LLMObs._instance replacements are observed
+        # without importing the public package back from the experiment engine.
+        self._llmobs_service = get_llmobs_service()
 
     def evaluate(self, context: EvaluatorContext) -> Union[JSONType, EvaluatorResult]:
         """Evaluate using the remote LLM-as-Judge evaluator.
@@ -2032,7 +2060,7 @@ class Experiment:
         description: str = "",
         tags: Optional[dict[str, str]] = None,
         config: Optional[ConfigType] = None,
-        _llmobs_instance: Optional["LLMObs"] = None,
+        _llmobs_instance: Optional[_ExperimentService] = None,
         summary_evaluators: Optional[Sequence[Union[SummaryEvaluatorType, AsyncSummaryEvaluatorType]]] = None,
         runs: Optional[int] = None,
         is_distributed: Optional[bool] = False,
@@ -3332,7 +3360,7 @@ class SyncExperiment:
         description: str = "",
         tags: Optional[dict[str, str]] = None,
         config: Optional[ConfigType] = None,
-        _llmobs_instance: Optional["LLMObs"] = None,
+        _llmobs_instance: Optional[_ExperimentService] = None,
         summary_evaluators: Optional[Sequence[Union[SummaryEvaluatorType, AsyncSummaryEvaluatorType]]] = None,
         runs: Optional[int] = None,
         _experiment: Optional["Experiment"] = None,

--- a/ddtrace/llmobs/_integration_api.py
+++ b/ddtrace/llmobs/_integration_api.py
@@ -1,32 +1,40 @@
-"""Minimal LLMObs API used by integrations during their import-time setup.
+"""Minimal LLMObs API shared by integrations and evaluators.
 
 Integrations can be imported while the full LLMObs service is initializing. Keep
-this module independent from ``_llmobs`` so integration setup does not recursively
-import the service through ``BaseLLMIntegration``.
+this module independent from _llmobs, including for type checking, so consumers
+can access the registered service without depending on its implementation.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from typing import Any
 from typing import Optional
+from typing import Protocol
 
 
-if TYPE_CHECKING:
-    from ddtrace.llmobs._llmobs import LLMObs
+class _LLMObsService(Protocol):
+    """Service operations needed by import-time consumers."""
+
+    @property
+    def enabled(self) -> bool: ...
+
+    def annotate(self, *args: Any, **kwargs: Any) -> None: ...
 
 
-# The registered service is the ``LLMObs`` class itself, not an instance. The
-# annotation is only resolved by type checkers (via ``from __future__ import
-# annotations``), so importing ``LLMObs`` here would never run at runtime and the
-# module stays free of the ``_llmobs`` dependency it is meant to avoid.
-_llmobs_service: Optional[type[LLMObs]] = None
+# NOTE: The registered object is the LLMObs class, not an instance. Its class
+# methods satisfy the protocol without a reverse dependency on _llmobs.
+_llmobs_service: Optional[_LLMObsService] = None
 
 
-def register_llmobs_service(service: type[LLMObs]) -> None:
+def register_llmobs_service(service: _LLMObsService) -> None:
     """Register the concrete LLMObs service after it has finished importing."""
     global _llmobs_service
     _llmobs_service = service
+
+
+def get_llmobs_service() -> Optional[_LLMObsService]:
+    """Return the registered service class, or None before registration."""
+    return _llmobs_service
 
 
 def is_enabled() -> bool:

--- a/ddtrace/llmobs/_prompt_optimization.py
+++ b/ddtrace/llmobs/_prompt_optimization.py
@@ -4,10 +4,10 @@ from copy import deepcopy
 from dataclasses import dataclass
 import inspect
 import random
-from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import Optional
+from typing import Protocol
 from typing import Sequence
 from typing import TypedDict
 from typing import Union
@@ -22,10 +22,28 @@ from ddtrace.llmobs._experiment import ExperimentResult
 from ddtrace.llmobs._experiment import ExperimentRowResult
 from ddtrace.llmobs._experiment import JSONType
 from ddtrace.llmobs._experiment import SummaryEvaluatorType
+from ddtrace.llmobs._experiment import SyncExperiment
+from ddtrace.llmobs._experiment import TaskType
 
 
-if TYPE_CHECKING:
-    from ddtrace.llmobs import LLMObs
+class _PromptOptimizationService(Protocol):
+    """Experiment factory used by optimization, without importing the service."""
+
+    @property
+    def enabled(self) -> bool: ...
+
+    def experiment(
+        self,
+        *,
+        name: str,
+        task: TaskType,
+        dataset: Dataset,
+        evaluators: Sequence[EvaluatorType],
+        project_name: Optional[str] = None,
+        config: Optional[ConfigType] = None,
+        summary_evaluators: Optional[Sequence[SummaryEvaluatorType]] = None,
+        runs: Optional[int] = 1,
+    ) -> SyncExperiment: ...
 
 
 log = get_logger(__name__)
@@ -580,7 +598,7 @@ class PromptOptimization:
         summary_evaluators: Sequence[SummaryEvaluatorType],
         compute_score: Callable[[dict[str, dict[str, Any]]], float],
         labelization_function: Optional[Callable[[dict[str, Any]], str]],
-        _llmobs_instance: Optional["LLMObs"] = None,
+        _llmobs_instance: Optional[_PromptOptimizationService] = None,
         tags: Optional[dict[str, str]] = None,
         max_iterations: int = 5,
         stopping_condition: Optional[Callable[[dict[str, dict[str, Any]]], bool]] = None,

--- a/ddtrace/llmobs/_telemetry.py
+++ b/ddtrace/llmobs/_telemetry.py
@@ -8,13 +8,13 @@ from ddtrace.llmobs._constants import DROPPED_IO_COLLECTION_ERROR
 from ddtrace.llmobs._constants import ROOT_PARENT_ID
 from ddtrace.llmobs._constants import LLMObsExportMode
 from ddtrace.llmobs._constants import PromptSource
+from ddtrace.llmobs._event_types import LLMObsSpanEvent
 from ddtrace.llmobs._utils import get_llmobs_ml_app
 from ddtrace.llmobs._utils import get_llmobs_model_provider
 from ddtrace.llmobs._utils import get_llmobs_parent_id
 from ddtrace.llmobs._utils import get_llmobs_session_id
 from ddtrace.llmobs._utils import get_llmobs_span_kind
 from ddtrace.llmobs._utils import get_llmobs_tags
-from ddtrace.llmobs._writer import LLMObsSpanEvent
 from ddtrace.trace import Span
 
 

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -45,7 +45,7 @@ from ddtrace.trace import Span
 
 
 if TYPE_CHECKING:
-    from ddtrace.llmobs._writer import LLMObsSpanData
+    from ddtrace.llmobs._event_types import LLMObsSpanData
 
 
 log = get_logger(__name__)

--- a/ddtrace/llmobs/_writer.py
+++ b/ddtrace/llmobs/_writer.py
@@ -3,10 +3,8 @@ import csv
 import json
 import os
 import tempfile
-from typing import TYPE_CHECKING
 from typing import Any
 from typing import Optional
-from typing import TypedDict
 from typing import Union
 from typing import cast
 import urllib
@@ -40,6 +38,11 @@ from ddtrace.llmobs._constants import EXP_SUBDOMAIN_NAME
 from ddtrace.llmobs._constants import SPAN_ENDPOINT
 from ddtrace.llmobs._constants import SPAN_SUBDOMAIN_NAME
 from ddtrace.llmobs._eval_metric import LLMObsEvaluationMetricEvent as LLMObsEvaluationMetricEvent
+from ddtrace.llmobs._event_types import EvaluatorInferResponse as EvaluatorInferResponse
+from ddtrace.llmobs._event_types import LLMObsExperimentEvalMetricEvent as LLMObsExperimentEvalMetricEvent
+from ddtrace.llmobs._event_types import LLMObsSpanData as LLMObsSpanData
+from ddtrace.llmobs._event_types import LLMObsSpanEvent as LLMObsSpanEvent
+from ddtrace.llmobs._event_types import _LLMObsSpanEventOptional as _LLMObsSpanEventOptional
 from ddtrace.llmobs._experiment import Dataset
 from ddtrace.llmobs._experiment import DatasetRecord
 from ddtrace.llmobs._experiment import DatasetRecordUpdateWithId
@@ -51,88 +54,11 @@ from ddtrace.llmobs._experiment import RemoteEvaluatorError
 from ddtrace.llmobs._experiment import _TagOperations
 from ddtrace.llmobs._http import HTTPConnection
 from ddtrace.llmobs._utils import safe_json
-from ddtrace.llmobs.types import ExperimentConfigType
-from ddtrace.llmobs.types import _Meta
+from ddtrace.llmobs.types import ExperimentConfigType as ExperimentConfigType
 from ddtrace.version import __version__
 
 
-if TYPE_CHECKING:
-    from ddtrace.llmobs.types import ExperimentConfigType
-    from ddtrace.llmobs.types import _SpanLink
-
-
 logger = get_logger(__name__)
-
-
-class LLMObsSpanData(TypedDict, total=False):
-    """Structure of LLMObs span data attached to APM spans."""
-
-    name: str
-    parent_id: str
-    pagent_name: str
-    pagent_span_id: str
-    trace_id: str
-    ml_app: str
-    session_id: str
-    tags: dict[str, str]
-    metrics: dict[str, Any]
-    span_links: list["_SpanLink"]
-    config: "ExperimentConfigType"
-    meta: _Meta
-    _dd: dict[str, str]
-
-
-class _LLMObsSpanEventOptional(TypedDict, total=False):
-    session_id: str
-    service: str
-    status_message: str
-    collection_errors: list[str]
-    span_links: list["_SpanLink"]
-    config: "ExperimentConfigType"
-
-
-class LLMObsSpanEvent(_LLMObsSpanEventOptional):
-    span_id: str
-    trace_id: str
-    parent_id: str
-    tags: list[str]
-    name: str
-    start_ns: int
-    duration: int
-    status: str
-    meta: _Meta
-    metrics: dict[str, Any]
-    _dd: dict[str, str]
-
-
-class LLMObsExperimentEvalMetricEvent(TypedDict, total=False):
-    metric_source: str
-    span_id: str
-    trace_id: str
-    timestamp_ms: int
-    metric_type: str
-    label: str
-    categorical_value: str
-    score_value: float
-    boolean_value: bool
-    json_value: dict[str, JSONType]
-    status: str
-    error: Optional[dict[str, str]]
-    tags: list[str]
-    experiment_id: str
-    reasoning: str
-    assessment: str
-    metadata: dict[str, JSONType]
-    eval_source_type: str
-
-
-class EvaluatorInferResponse(TypedDict, total=False):
-    """Response from the evaluator_infer API endpoint."""
-
-    value: JSONType
-    assessment: Optional[str]
-    reasoning: Optional[str]
-    status: Optional[str]
 
 
 _SHOULD_USE_AGENTLESS: Optional[bool] = None

--- a/tests/llmobs/test_evaluators.py
+++ b/tests/llmobs/test_evaluators.py
@@ -9,8 +9,13 @@ from unittest import mock
 import pytest
 
 from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs import _event_types
 from ddtrace.llmobs import _experiment
 from ddtrace.llmobs import _integration_api
+from ddtrace.llmobs import _prompt_optimization
+from ddtrace.llmobs import _telemetry
+from ddtrace.llmobs import _utils
+from ddtrace.llmobs import _writer
 from ddtrace.llmobs._experiment import BaseEvaluator
 from ddtrace.llmobs._experiment import BaseSummaryEvaluator
 from ddtrace.llmobs._experiment import Dataset
@@ -22,7 +27,7 @@ from ddtrace.llmobs._experiment import SummaryEvaluatorContext
 from ddtrace.llmobs._experiment import _ExperimentRunInfo
 
 
-@pytest.mark.parametrize("module", [_experiment, _integration_api])
+@pytest.mark.parametrize("module", [_experiment, _integration_api, _prompt_optimization])
 def test_service_dependencies_do_not_import_concrete_llmobs(module):
     # NOTE: TYPE_CHECKING blocks and function bodies both contribute edges to the import graph.
     forbidden = {"ddtrace.llmobs", "ddtrace.llmobs._llmobs"}
@@ -31,6 +36,23 @@ def test_service_dependencies_do_not_import_concrete_llmobs(module):
             assert node.module not in forbidden
         elif isinstance(node, ast.Import):
             assert not forbidden.intersection(alias.name for alias in node.names)
+
+
+@pytest.mark.parametrize("module", [_experiment, _utils, _telemetry, _event_types])
+def test_event_consumers_do_not_import_writer(module):
+    for node in ast.walk(ast.parse(inspect.getsource(module))):
+        if isinstance(node, ast.ImportFrom):
+            assert node.module != "ddtrace.llmobs._writer"
+        elif isinstance(node, ast.Import):
+            assert "ddtrace.llmobs._writer" not in [alias.name for alias in node.names]
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["LLMObsSpanData", "LLMObsSpanEvent", "LLMObsExperimentEvalMetricEvent", "EvaluatorInferResponse"],
+)
+def test_writer_event_type_aliases(name):
+    assert getattr(_writer, name) is getattr(_event_types, name)
 
 
 class SimpleEvaluator(BaseEvaluator):

--- a/tests/llmobs/test_evaluators.py
+++ b/tests/llmobs/test_evaluators.py
@@ -1,10 +1,16 @@
 """Tests for LLMObs evaluator classes."""
 
+import ast
 import asyncio
+import builtins
+import inspect
 from unittest import mock
 
 import pytest
 
+from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs import _experiment
+from ddtrace.llmobs import _integration_api
 from ddtrace.llmobs._experiment import BaseEvaluator
 from ddtrace.llmobs._experiment import BaseSummaryEvaluator
 from ddtrace.llmobs._experiment import Dataset
@@ -14,6 +20,17 @@ from ddtrace.llmobs._experiment import RemoteEvaluator
 from ddtrace.llmobs._experiment import RemoteEvaluatorError
 from ddtrace.llmobs._experiment import SummaryEvaluatorContext
 from ddtrace.llmobs._experiment import _ExperimentRunInfo
+
+
+@pytest.mark.parametrize("module", [_experiment, _integration_api])
+def test_service_dependencies_do_not_import_concrete_llmobs(module):
+    # NOTE: TYPE_CHECKING blocks and function bodies both contribute edges to the import graph.
+    forbidden = {"ddtrace.llmobs", "ddtrace.llmobs._llmobs"}
+    for node in ast.walk(ast.parse(inspect.getsource(module))):
+        if isinstance(node, ast.ImportFrom):
+            assert node.module not in forbidden
+        elif isinstance(node, ast.Import):
+            assert not forbidden.intersection(alias.name for alias in node.names)
 
 
 class SimpleEvaluator(BaseEvaluator):
@@ -305,6 +322,43 @@ class TestSummaryEvaluatorIntegration:
 
 class TestRemoteEvaluator:
     """Tests for RemoteEvaluator class."""
+
+    def test_init_does_not_import_llmobs(self):
+        original_import = builtins.__import__
+
+        def import_without_llmobs(name, *args, **kwargs):
+            if name in ("ddtrace.llmobs", "ddtrace.llmobs._llmobs"):
+                raise AssertionError("RemoteEvaluator must use the registered service")
+            return original_import(name, *args, **kwargs)
+
+        with mock.patch("builtins.__import__", side_effect=import_without_llmobs):
+            evaluator = RemoteEvaluator(eval_name="test-eval")
+
+        assert evaluator._llmobs_service is LLMObs
+
+    def test_evaluate_uses_current_service_instance(self):
+        context = EvaluatorContext(input_data="input", output_data="output")
+        with mock.patch.object(_integration_api, "_llmobs_service") as service:
+            previous_client = service._instance._dne_client
+            evaluator = RemoteEvaluator(eval_name="test-eval")
+            assert evaluator._llmobs_service is service
+            service._instance = mock.Mock()
+            current_client = service._instance._dne_client
+            current_client.evaluator_infer.return_value = {"value": True}
+
+            assert evaluator.evaluate(context) is True
+
+        previous_client.evaluator_infer.assert_not_called()
+        current_client.evaluator_infer.assert_called_once_with(
+            eval_name="test-eval", context={"span_input": "input", "span_output": "output"}
+        )
+
+    def test_evaluate_without_client(self):
+        evaluator = RemoteEvaluator(eval_name="test-eval")
+        context = EvaluatorContext(input_data="input", output_data="output")
+        with mock.patch.object(LLMObs._instance, "_dne_client", None):
+            with pytest.raises(ValueError, match="LLMObs experiments client is not initialized"):
+                evaluator.evaluate(context)
 
     def test_init_valid(self):
         """Test valid RemoteEvaluator initialization."""


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3a0ae5ac-164a-47ed-b867-f1732d5b5d5c","source":"chat","resourceId":"f28c4f71-907c-44af-8194-18b38d38deee","workflowId":"2db62d80-5d0a-4ffa-8afc-14b84ef47cff","codeChangeId":"2db62d80-5d0a-4ffa-8afc-14b84ef47cff","sourceType":"slack"} -->
## Description

Remove the LLMObs circular import components through shared contracts and dependency inversion, including imports inside TYPE_CHECKING blocks.

- Retain the earlier registry-based RemoteEvaluator lookup and service protocols, removing the evaluator-to-public-service cycle without deferred imports.
- Extract span/event payload types and the existing sequence/mapping-compatible experiment JSONType into ddtrace/llmobs/_event_types.py. Preserve the writer's event-type import paths as aliases and preserve the experiment JSONType alias.
- Have utilities, telemetry, and the experiment engine import event types independently of the writer.
- Define a consumer-owned experiments-client protocol instead of importing the concrete writer client into the experiment engine.
- Define a prompt-optimization service protocol instead of importing the public LLMObs class.
- Extend structural regression coverage across TYPE_CHECKING blocks and function bodies, and add checks that writer aliases refer to the extracted types. Retain the runtime tests for RemoteEvaluator lookup, instance replacement, and missing clients.
- Document the dependency boundaries in internal docstrings and preserve NOTE comment style. Public entry points and runtime arguments remain unchanged.

## Testing

- Official cycles.py analyze succeeds. Compared with the latest iteration baseline, detected components decrease from 4 to 2. Neither remaining component includes LLMObs.
- Official cycles.py compare reports two LLMObs components removed, no new components, and the unchanged AppSec/error-tracking components.
- Targeted and repository-wide Python formatting and Ruff checks pass through scripts/lint, using locally installed tools with dependency synchronization disabled.
- Full scripts/lint checks stops at the missing cython-lint executable after Python formatting/lint pass.
- Focused typing with --follow-imports=silent passes for the six consumer/service files. Including the writer reports its existing unreachable-code diagnostic; the seven-file check passes with that diagnostic category disabled. This is not a clean unsuppressed repository-wide type check.
- scripts/run-tests discovered the LLMObs suite and attempted Python 3.13 environment 7667b27, selecting evaluator, experiment, experiment-writer, and utility tests. Attempts with 180-second and 300-second limits timed out during image/environment setup and native compilation, before tests ran. Test containers were stopped afterward; runtime regression validation remains pending.
- git diff --check passes.

## Risks

Internal type ownership and dependency changes with no intended runtime behavior change. Event field definitions and existing writer aliases are preserved. Runtime tests still require validation in a fully built environment. AppSec and error-tracking cycles are explicitly outside this change's scope.

## Additional Notes

Internal-only refactor; no release note needed. Use changelog/no-changelog.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/f28c4f71-907c-44af-8194-18b38d38deee)

Comment @datadog to request changes