### PR TITLE
ci: support for dogfooding build in nightly pipeline

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -220,6 +220,12 @@ variables:
   script:
     - |
       set -euo pipefail
+      # On nightly runs NIGHTLY_LOCAL_SEGMENT is set but PACKAGE_VERSION has no local
+      # segment (kept clean for validation).  Inject it locally for this job only.
+      if [ -n "${NIGHTLY_LOCAL_SEGMENT:-}" ] && [[ "${PACKAGE_VERSION:-}" != *+* ]]; then
+        echo "Nightly build -- injecting local segment: ${PACKAGE_VERSION}+${NIGHTLY_LOCAL_SEGMENT}"
+        export PACKAGE_VERSION="${PACKAGE_VERSION}+${NIGHTLY_LOCAL_SEGMENT}"
+      fi
       # Only run when the version has a local segment (e.g. 4.1.3rc3+memory-leak-fix).
       # A plain semver or pre-release (4.1.3, 4.1.3rc3) skips this job.
       if [[ "${PACKAGE_VERSION:-}" != *+* ]]; then
@@ -457,7 +463,15 @@ download_dependency_wheels:
   script:
     - .gitlab/scripts/upload-debug-symbols-to-backend.sh
 
-# Extract package version from pyproject.toml and save to dotenv artifact
+# Extract package version from pyproject.toml and save to dotenv artifact.
+#
+# PACKAGE_VERSION always holds the raw version from pyproject.toml so that
+# validate-ddtrace-package.py (which reads PACKAGE_VERSION) keeps working.
+#
+# On nightly pipelines (scheduled or API-triggered with NIGHTLY_BUILD=true),
+# NIGHTLY_LOCAL_SEGMENT=internal-dogfooding is also exported.  The
+# patch-wheel-versions jobs pick it up and inject it locally (without touching
+# PACKAGE_VERSION) so the dogfooding wheel gets published.
 "package version":
   image: registry.ddbuild.io/images/mirror/python:3.14.0
   tags: [ "arch:amd64" ]
@@ -465,6 +479,12 @@ download_dependency_wheels:
   script:
     - PACKAGE_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
     - echo "PACKAGE_VERSION=${PACKAGE_VERSION}" | tee -a package_version.env
+    - |
+      if { [ "${CI_PIPELINE_SOURCE:-}" = "schedule" ] || [ "${NIGHTLY_BUILD:-}" = "true" ]; } \
+          && [[ "${PACKAGE_VERSION}" != *+* ]]; then
+        echo "Nightly pipeline -- exporting NIGHTLY_LOCAL_SEGMENT=internal-dogfooding"
+        echo "NIGHTLY_LOCAL_SEGMENT=internal-dogfooding" | tee -a package_version.env
+      fi
     # Validate commit tag matches version if tag is set
     - |
       if [ -n "${CI_COMMIT_TAG:-}" ]; then


### PR DESCRIPTION
## Description

This will make it possible to publish the dogfooding build automatically every night as part of the nightly pipeline (so that every time we want to upgrade internally, we have a recent version ready to use). 