### PR TITLE
ci: copy missing pytorch test helper

### DIFF
--- a/.github/workflows/pytorch_gpu_tests.yml
+++ b/.github/workflows/pytorch_gpu_tests.yml
@@ -73,6 +73,7 @@ jobs:
           mkdir -p "$TEST_ROOT/profiling"
           cp "$REPO_ROOT/tests/__init__.py" "$TEST_ROOT/"
           cp "$REPO_ROOT/tests/utils.py" "$TEST_ROOT/"
+          cp "$REPO_ROOT/tests/_ddtest_env_helpers.py" "$TEST_ROOT/"
           cp "$REPO_ROOT/tests/subprocesstest.py" "$TEST_ROOT/"
           cp "$REPO_ROOT/tests/profiling/__init__.py" "$TEST_ROOT/profiling/"
           cp "$REPO_ROOT/tests/profiling/test_pytorch.py" "$TEST_ROOT/profiling/"


### PR DESCRIPTION
## Description

This fixes collection failures in the PyTorch GPU workflow. `tests/utils.py` imports `tests._ddtest_env_helpers`, but the workflow omitted that dependency when copying tests.

