### PR TITLE
chore(deps): bump libdatadog to latest main

### DIFF
--- a/src/native/Cargo.lock
+++ b/src/native/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
 [[package]]
 name = "build_common"
 version = "43.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "cbindgen",
  "serde",
@@ -545,32 +545,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
-name = "datadog-live-debugger"
-version = "0.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
-dependencies = [
- "anyhow",
- "bytes",
- "constcat",
- "futures",
- "http 1.4.2",
- "libdd-capabilities",
- "libdd-capabilities-impl",
- "libdd-common",
- "libdd-data-pipeline",
- "libdd-remote-config",
- "percent-encoding",
- "serde",
- "serde_json",
- "smallvec",
- "strum",
- "strum_macros",
- "sys-info",
- "tokio",
- "uuid",
-]
-
-[[package]]
 name = "ddtrace-native"
 version = "0.1.0"
 dependencies = [
@@ -578,7 +552,6 @@ dependencies = [
  "base64",
  "build_common",
  "bytes",
- "datadog-live-debugger",
  "libc",
  "libdd-capabilities-impl",
  "libdd-common",
@@ -589,6 +562,7 @@ dependencies = [
  "libdd-http-client",
  "libdd-ipc",
  "libdd-library-config",
+ "libdd-live-debugger",
  "libdd-log",
  "libdd-otel-thread-ctx",
  "libdd-profiling-ffi",
@@ -1001,6 +975,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.2",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,6 +1175,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http 1.4.2",
  "http-body",
  "httparse",
@@ -1571,7 +1565,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libdd-alloc"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "allocator-api2",
  "libc",
@@ -1581,7 +1575,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1594,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1608,7 +1602,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "5.2.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1648,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "libdd-common-ffi"
 version = "43.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1662,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "libdd-crashtracker"
 version = "2.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "anyhow",
  "blazesym",
@@ -1698,7 +1692,7 @@ dependencies = [
 [[package]]
 name = "libdd-data-pipeline"
 version = "9.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1709,6 +1703,8 @@ dependencies = [
  "getrandom 0.2.17",
  "http 1.4.2",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common",
@@ -1723,12 +1719,14 @@ dependencies = [
  "libdd-trace-protobuf",
  "libdd-trace-stats",
  "libdd-trace-utils",
+ "prost",
  "rmp-serde",
  "serde",
  "serde_json",
  "sha2",
  "tokio",
  "tokio-util",
+ "tonic",
  "tracing",
  "uuid",
  "web-time",
@@ -1736,8 +1734,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline-core"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+version = "0.1.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "http 1.4.2",
  "libdd-capabilities",
@@ -1751,7 +1749,7 @@ dependencies = [
 [[package]]
 name = "libdd-data-pipeline-ffi"
 version = "43.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "build_common",
  "libdd-capabilities-impl",
@@ -1770,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.1.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "prost",
 ]
@@ -1778,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "libdd-dogstatsd-client"
 version = "5.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1794,7 +1792,7 @@ dependencies = [
 [[package]]
 name = "libdd-ffe"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "chrono",
  "derive_more",
@@ -1816,7 +1814,7 @@ dependencies = [
 [[package]]
 name = "libdd-gotter"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "libc",
 ]
@@ -1824,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "libdd-http-client"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "bytes",
  "fastrand",
@@ -1840,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "libdd-ipc"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1868,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "libdd-ipc-macros"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1879,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "anyhow",
  "libc",
@@ -1896,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "libdd-library-config-ffi"
 version = "0.0.2"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1918,9 +1916,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdd-live-debugger"
+version = "0.1.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "constcat",
+ "futures",
+ "http 1.4.2",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common",
+ "libdd-data-pipeline",
+ "libdd-remote-config",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "strum",
+ "strum_macros",
+ "sys-info",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "libdd-log"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "chrono",
  "tracing",
@@ -1931,12 +1955,12 @@ dependencies = [
 [[package]]
 name = "libdd-otel-thread-ctx"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 
 [[package]]
 name = "libdd-otel-thread-ctx-ffi"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "build_common",
  "libdd-common-ffi",
@@ -1946,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1986,7 +2010,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling-ffi"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -2011,7 +2035,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling-protobuf"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "prost",
 ]
@@ -2019,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "libdd-remote-config"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "anyhow",
  "base64",
@@ -2057,7 +2081,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "async-trait",
  "futures",
@@ -2074,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime-ffi"
 version = "43.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "build_common",
  "libdd-shared-runtime",
@@ -2084,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "libdd-telemetry"
 version = "7.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2115,7 +2139,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.2"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "serde",
 ]
@@ -2123,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf",
@@ -2132,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-obfuscation"
 version = "7.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "anyhow",
  "fluent-uri",
@@ -2148,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "5.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "prost",
  "serde",
@@ -2158,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-stats"
 version = "8.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2187,7 +2211,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-utils"
 version = "11.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "anyhow",
  "base64",
@@ -2224,7 +2248,7 @@ dependencies = [
 [[package]]
 name = "libdd-tracer-flare"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=7d0d04f15b0f93aa7b66df44d24fbd19ca925a82#7d0d04f15b0f93aa7b66df44d24fbd19ca925a82"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4021,6 +4045,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4071,6 +4106,26 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "base64",
+ "bytes",
+ "http 1.4.2",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "tower"
@@ -4124,6 +4179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
@@ -4138,6 +4194,17 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/src/native/Cargo.toml
+++ b/src/native/Cargo.toml
@@ -32,20 +32,20 @@ serde = "1.0"
 serde_json = "1.0"
 smallvec = "1"
 tokio = "1"
-libdd-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", optional = true, features = ["pyo3"] }
-libdd-ipc = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", features = ["one_way_shm_futex"] }
-datadog-live-debugger = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
-libdd-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", features = [
+libdd-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82", optional = true, features = ["pyo3"] }
+libdd-ipc = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82", features = ["one_way_shm_futex"] }
+libdd-live-debugger = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82" }
+libdd-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82", features = [
   "agentless",
 ] }
-libdd-telemetry = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
-libdd-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
-libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", optional = true }
-libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", optional = true }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
-libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
-libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", features = [
+libdd-telemetry = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82" }
+libdd-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82" }
+libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82", optional = true }
+libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82", optional = true }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82" }
+libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82" }
+libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82", features = [
   "stats-obfuscation",
   "compression"
 ] }
@@ -54,17 +54,17 @@ libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "v4
 # hostnames resolved through custom search/ndots resolv.conf setups (e.g.
 # Docker Compose/Kubernetes service names via embedded DNS) — it uses the
 # system resolver instead, like the stdlib http.client this replaces did.
-libdd-http-client = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", default-features = false, features = [
+libdd-http-client = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82", default-features = false, features = [
   "https",
   "hyper-backend",
   "hyper-proxy",
 ] }
-libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
-libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", optional = true, features = [
+libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82" }
+libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82", optional = true, features = [
     "cbindgen",
 ] }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82" }
 native-proc-macro = { path = "native_proc_macro" }
 strum = { version = "0.26", default-features = false }
 percent-encoding = "2.3"
@@ -73,8 +73,8 @@ tracing = { version = "0.1", default-features = false }
 pyo3-ffi = { version = "0.28", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", features = ["otel-thread-ctx"]}
-libdd-otel-thread-ctx = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82", features = ["otel-thread-ctx"]}
+libdd-otel-thread-ctx = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82" }
 libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -82,7 +82,7 @@ libc = "0.2"
 
 [build-dependencies]
 pyo3-build-config = "0.28"
-build_common = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", features = [
+build_common = { git = "https://github.com/DataDog/libdatadog", rev = "7d0d04f15b0f93aa7b66df44d24fbd19ca925a82", features = [
     "cbindgen",
 ] }
 

--- a/src/native/debugger.rs
+++ b/src/native/debugger.rs
@@ -1,6 +1,6 @@
 //! Sender for Dynamic Instrumentation logs, snapshots and probe diagnostics.
 //!
-//! A thin PyO3 wrapper around `datadog_live_debugger::sender`.
+//! A thin PyO3 wrapper around `libdd_live_debugger::sender`.
 //!
 //! Each send runs `runtime.block_on(...)` inside `py.detach`, releasing the GIL
 //! for the duration of the I/O. The uploader already runs on its own periodic thread,
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use datadog_live_debugger::sender::{
+use libdd_live_debugger::sender::{
     self, debugger_intake_endpoint, Config as SenderConfig, DebuggerType, PayloadRejected,
 };
 use libdd_common::{parse_uri, Endpoint};

--- a/src/native/debugger.rs
+++ b/src/native/debugger.rs
@@ -10,10 +10,10 @@ use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use libdd_common::{parse_uri, Endpoint};
 use libdd_live_debugger::sender::{
     self, debugger_intake_endpoint, Config as SenderConfig, DebuggerType, PayloadRejected,
 };
-use libdd_common::{parse_uri, Endpoint};
 use libdd_shared_runtime::{BlockingRuntime, ForkSafeRuntime};
 use native_proc_macro::ConvertToPyO3Enum;
 use percent_encoding::{percent_encode, AsciiSet, NON_ALPHANUMERIC};

--- a/src/native/symdb.rs
+++ b/src/native/symdb.rs
@@ -6,8 +6,8 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use libdd_live_debugger::sender::{self, Config as SenderConfig};
 use libdd_common::Endpoint;
+use libdd_live_debugger::sender::{self, Config as SenderConfig};
 use libdd_shared_runtime::ForkSafeRuntime;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;

--- a/src/native/symdb.rs
+++ b/src/native/symdb.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use datadog_live_debugger::sender::{self, Config as SenderConfig};
+use libdd_live_debugger::sender::{self, Config as SenderConfig};
 use libdd_common::Endpoint;
 use libdd_shared_runtime::ForkSafeRuntime;
 use pyo3::exceptions::PyValueError;


### PR DESCRIPTION
<!-- dd-meta {"pullId":"00000000-0000-0000-0000-000000000000","source":"chat","resourceId":"47af8f8d-0e9c-4d93-9936-fe0b153df2e2","workflowId":"bea6ed67-8495-40c2-9311-d82234d1299a","codeChangeId":"bea6ed67-8495-40c2-9311-d82234d1299a","sourceType":"chat"} -->
## Description

Bumps every `libdatadog` crate in `src/native` from the `v43.0.0` tag to the latest commit on
`libdatadog` `main` (`7d0d04f15b0f93aa7b66df44d24fbd19ca925a82`, "fix(trace-obfuscation): scan all
span meta for credit-card obfuscation"), so the native extension picks up the 24 commits landed
since v43.0.0.

One breaking change had to be handled, and it was mechanical:

- `datadog-live-debugger` was renamed to `libdd-live-debugger` upstream
  (libdatadog #2450, "prepare crate for publishing"). The dependency name in
  `src/native/Cargo.toml` and the `datadog_live_debugger::` paths in `src/native/debugger.rs` and
  `src/native/symdb.rs` were updated accordingly. The crate's module layout, `sender` API, and
  default features are unchanged, so no call-site logic changed.

No other breaking changes were found: the remaining upstream changes touching crates we depend on
are additive (`WorkerHandle::set_fork_restart` in `libdd-shared-runtime`, `update-and-attach` in
`libdd-otel-thread-ctx`, OTLP gRPC transport and native export telemetry in `libdd-data-pipeline`,
new v1-native JSON encoders in `libdd-trace-utils`) or internal fixes (remote-config fetcher
identity refresh, OTel HTTP names in trace stats, obfuscation config for OTLP stats,
credit-card obfuscation across all span meta).

`src/native/Cargo.lock` is regenerated: besides the rev/name changes, it pulls in `h2`,
`tonic`, `tokio-stream`, and `tracing-attributes` as transitive dependencies of the new
`libdd-data-pipeline` OTLP gRPC transport.

## Testing

- `cargo check --all-features` in `src/native` against the new revision succeeds with no warnings
  or errors, covering the `crashtracker`, `profiling`, `ffe`, and `stats` features in addition to
  the default set. Because the sandbox cannot reach `github.com`, the check was run against a local
  clone of the same libdatadog commit; the committed `Cargo.toml`/`Cargo.lock` point at the real
  upstream revision.
- No Python-level changes, so CI's existing native build and tracer suites are the relevant
  validation.

## Risks

Medium: this is a native dependency bump, so any regression lands in the tracer's hot paths
(trace/stats export, telemetry, remote config, crashtracker). The Python-facing API is unchanged
and the only source edit is a crate rename, so the risk comes from upstream changes rather than
from this diff. Draft PR — full CI (including native builds on all platforms and system tests)
should be green before merging.

## Additional Notes

Opened as a draft. Following the convention of previous libdatadog bumps
(for example "chore(deps): bump to libdatadog v42.0.0"), no release note is included; the
`changelog/no-changelog` label should be applied.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/47af8f8d-0e9c-4d93-9936-fe0b153df2e2)

Comment @datadog to request changes