### PR TITLE
refactor(errortracking): remove handled exceptions import cycle

### DIFF
--- a/ddtrace/errortracking/_handled_exceptions/callbacks.py
+++ b/ddtrace/errortracking/_handled_exceptions/callbacks.py
@@ -7,8 +7,8 @@ import traceback
 from ddtrace import config
 from ddtrace import tracer
 from ddtrace._trace.span import Span
-from ddtrace.errortracking._handled_exceptions.collector import HandledExceptionCollector
-from ddtrace.errortracking._handled_exceptions.collector import SpanEventData
+from ddtrace.errortracking._handled_exceptions.events import SpanEventData
+from ddtrace.errortracking._handled_exceptions.events import capture_exception_event
 from ddtrace.internal.utils.time import Time
 
 
@@ -72,4 +72,4 @@ def _default_errortracking_exc_callback(*args, span: Span, exc=None):
     generated = _generate_span_event(span, exc)
     if generated is not None:
         exc, span, span_event = generated
-        HandledExceptionCollector.capture_exception_event(span, exc, span_event)
+        capture_exception_event(span, exc, span_event)

--- a/ddtrace/errortracking/_handled_exceptions/collector.py
+++ b/ddtrace/errortracking/_handled_exceptions/collector.py
@@ -1,51 +1,23 @@
 import sys
 import typing as t
-from typing import NamedTuple
 
 from ddtrace._trace.span import Span
+from ddtrace.errortracking._handled_exceptions.events import SpanEventData
+from ddtrace.errortracking._handled_exceptions.events import capture_exception_event
+from ddtrace.errortracking._handled_exceptions.events import clear_exception_events
+from ddtrace.errortracking._handled_exceptions.events import get_exception_events
+from ddtrace.errortracking._handled_exceptions.events import on_span_exception
 from ddtrace.internal import core
-from ddtrace.internal.constants import COLLECTOR_MAX_SIZE_PER_SPAN
-from ddtrace.internal.constants import SPAN_EVENTS_HAS_EXCEPTION
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.service import Service
 from ddtrace.internal.settings.errortracking import config
 
 
-class SpanEventData(NamedTuple):
-    name: str
-    attributes: dict
-    time_unix_nano: t.Optional[int] = None
-
-
 log = get_logger(__name__)
-
-
-def _add_span_events(span: Span) -> None:
-    """
-    If the same error is handled/rethrown multiple times, we want
-    to report only one span events. Therefore, we do not add directly
-    a span event for every handled exceptions, we store them in the span
-    and add them when the span finishes.
-    """
-    exception_data = HandledExceptionCollector.get_exception_events(span.span_id).values()
-    events = [event for _exc, event in exception_data]
-    if events:
-        span._set_attribute(SPAN_EVENTS_HAS_EXCEPTION, "true")
-        for event in events:
-            span._add_event(event.name, event.attributes, event.time_unix_nano)
-    HandledExceptionCollector.clear_exception_events(span.span_id)
-
-
-def _on_span_exception(span, _exc_msg, exc_val, _exc_tb):
-    exception_events = HandledExceptionCollector.get_exception_events(span.span_id)
-    exc_id = id(exc_val)
-    if exception_events and exc_id in exception_events:
-        del exception_events[exc_id]
 
 
 class HandledExceptionCollector(Service):
     _instance: t.Optional["HandledExceptionCollector"] = None
-    _span_exception_events: dict[int, dict[int, tuple[Exception, SpanEventData]]] = {}
 
     def __init__(self) -> None:
         super(HandledExceptionCollector, self).__init__()
@@ -60,7 +32,7 @@ class HandledExceptionCollector(Service):
         log.debug("Enabling %s", cls.__name__)
         cls._instance = cls()
         cls._instance.start()
-        core.on("span.exception", _on_span_exception)
+        core.on("span.exception", on_span_exception)
 
         log.debug("%s enabled", cls.__name__)
 
@@ -116,20 +88,12 @@ class HandledExceptionCollector(Service):
 
     @classmethod
     def capture_exception_event(cls, span: Span, exc: Exception, event: SpanEventData):
-        span_id = span.span_id
-        events_dict = cls._span_exception_events.setdefault(span_id, {})
-        if not events_dict:
-            span._add_on_finish_exception_callback(_add_span_events)
-        exc_id = id(exc)
-        if exc_id in events_dict or len(events_dict) < COLLECTOR_MAX_SIZE_PER_SPAN:
-            # Store both exception and event to keep exception alive and prevent ID reuse
-            events_dict[exc_id] = (exc, event)
+        capture_exception_event(span, exc, event)
 
     @classmethod
     def get_exception_events(cls, span_id: int):
-        return cls._span_exception_events.get(span_id, {})
+        return get_exception_events(span_id)
 
     @classmethod
     def clear_exception_events(cls, span_id: int):
-        if span_id in cls._span_exception_events:
-            del cls._span_exception_events[span_id]
+        clear_exception_events(span_id)

--- a/ddtrace/errortracking/_handled_exceptions/events.py
+++ b/ddtrace/errortracking/_handled_exceptions/events.py
@@ -1,0 +1,55 @@
+import typing as t
+from typing import NamedTuple
+
+from ddtrace._trace.span import Span
+from ddtrace.internal.constants import COLLECTOR_MAX_SIZE_PER_SPAN
+from ddtrace.internal.constants import SPAN_EVENTS_HAS_EXCEPTION
+
+
+class SpanEventData(NamedTuple):
+    name: str
+    attributes: dict[str, t.Any]
+    time_unix_nano: t.Optional[int] = None
+
+
+_span_exception_events: dict[int, dict[int, tuple[Exception, SpanEventData]]] = {}
+
+
+def add_span_events(span: Span) -> None:
+    """
+    If the same error is handled/rethrown multiple times, report only one span event.
+    Store handled exceptions until the span finishes so they can be deduplicated.
+    """
+    exception_data = get_exception_events(span.span_id).values()
+    events = [event for _exc, event in exception_data]
+    if events:
+        span._set_attribute(SPAN_EVENTS_HAS_EXCEPTION, "true")
+        for event in events:
+            span._add_event(event.name, event.attributes, event.time_unix_nano)
+    clear_exception_events(span.span_id)
+
+
+def on_span_exception(span: Span, _exc_msg: object, exc_val: BaseException, _exc_tb: object) -> None:
+    exception_events = get_exception_events(span.span_id)
+    exc_id = id(exc_val)
+    if exception_events and exc_id in exception_events:
+        del exception_events[exc_id]
+
+
+def capture_exception_event(span: Span, exc: Exception, event: SpanEventData) -> None:
+    span_id = span.span_id
+    events_dict = _span_exception_events.setdefault(span_id, {})
+    if not events_dict:
+        span._add_on_finish_exception_callback(add_span_events)
+    exc_id = id(exc)
+    if exc_id in events_dict or len(events_dict) < COLLECTOR_MAX_SIZE_PER_SPAN:
+        # Store both exception and event to keep exception alive and prevent ID reuse.
+        events_dict[exc_id] = (exc, event)
+
+
+def get_exception_events(span_id: int) -> dict[int, tuple[Exception, SpanEventData]]:
+    return _span_exception_events.get(span_id, {})
+
+
+def clear_exception_events(span_id: int) -> None:
+    _span_exception_events.pop(span_id, None)


### PR DESCRIPTION
## Description
Extract handled-exception event storage and deduplication into a dependency-neutral module. This removes the import cycle between the bytecode injector, callbacks, collector, and bytecode reporting while preserving compatibility.
## Testing
- Python 3.11 and 3.12 error-tracking suites
- Full lint checks
## Risks
Low. This is an internal refactor with unchanged behavior.
## Additional Notes
No release note is needed because this is an internal-only refactor.