### PR TITLE
ci: retry riot wait on network failures

### DIFF
--- a/scripts/gen_gitlab_config.py
+++ b/scripts/gen_gitlab_config.py
@@ -141,7 +141,9 @@ class JobSpec:
             lines.append("    - pip cache info")
         lines.append(f'    - export NIGHTLY_BUILD="{_nightly_build}"')
         if wait_for:
-            lines.append(f"    - riot -v run -s --pass-env wait -- {' '.join(wait_for)}")
+            _wait_cmd = f"riot -v run -s --pass-env wait -- {' '.join(wait_for)}"
+            # Retry twice on transient pip network failures (connection reset mid-download).
+            lines.append(f"    - {_wait_cmd} || {_wait_cmd} || {_wait_cmd}")
 
         env = dict(self.env or {})
         if not env or "SUITE_NAME" not in env:


### PR DESCRIPTION
<!-- dd-meta {"pullId":"5ffa7dc5-259a-4b5e-b777-03d16a74039e","source":"chat","resourceId":"7ad9a631-5135-4bfd-90b3-46cf8df583ca","workflowId":"ddcef19f-57bd-4efb-8f39-28794ba5f12c","codeChangeId":"ddcef19f-57bd-4efb-8f39-28794ba5f12c","sourceType":"chat"} -->
## Description

The `riot -v run -s --pass-env wait -- <services>` step occasionally fails with a mid-download `ConnectionResetError` while pip is installing the `wait` venv dependencies (azure-storage-blob, cassandra-driver, etc.). This is a transient infrastructure flake — the SSL connection is reset by the peer mid-stream, which `PIP_RETRIES` does not cover because it only retries at the HTTP connection level, not for incomplete response body reads.

The fix wraps the command with `|| cmd || cmd` so it retries up to two additional times before failing the job.

## Testing

This is a CI config generator change. The generated YAML now emits:
```
- riot -v run -s --pass-env wait -- testagent || riot -v run -s --pass-env wait -- testagent || riot -v run -s --pass-env wait -- testagent
```
In bash, `||` short-circuits: the second and third invocations only run if the previous one failed, so healthy runs are unaffected.

## Risks

Low. If the wait step fails 3 times in a row the job still fails, so the retry does not mask persistent failures. Healthy runs pay no extra cost (short-circuit evaluation).

## Additional Notes

The root failure was observed in the merge queue for dd/kowalski/unflake-gc-monitor-in-flight-start — pip lost its connection downloading `azure-storage-blob` mid-response for the `wait` venv (Python 3.9).

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/7ad9a631-5135-4bfd-90b3-46cf8df583ca)

Comment @datadog to request changes