### PR TITLE
ci: retry riot wait step on transient pip network failures

### DIFF
--- a/scripts/ddtest_jobs.py
+++ b/scripts/ddtest_jobs.py
@@ -153,7 +153,9 @@ def emit_ddtest_jobs(
         # Plan only collects; it sends no traces, so it never waits for the
         # testagent even for snapshot suites.
         if wait_for and not plan:
-            print(f"    - riot -v run -s --pass-env wait -- {' '.join(wait_for)}", file=f)
+            # Retry up to twice on transient pip network failures; service-check
+            # failures are NOT retried.  See scripts/riot-wait-pip-retry.sh.
+            print(f"    - scripts/riot-wait-pip-retry.sh {' '.join(wait_for)}", file=f)
 
     def emit_variables(extra: t.Optional[dict[str, str]] = None) -> None:
         print("  variables:", file=f)

--- a/scripts/gen_gitlab_config.py
+++ b/scripts/gen_gitlab_config.py
@@ -141,9 +141,9 @@ class JobSpec:
             lines.append("    - pip cache info")
         lines.append(f'    - export NIGHTLY_BUILD="{_nightly_build}"')
         if wait_for:
-            _wait_cmd = f"riot -v run -s --pass-env wait -- {' '.join(wait_for)}"
-            # Retry twice on transient pip network failures (connection reset mid-download).
-            lines.append(f"    - {_wait_cmd} || {_wait_cmd} || {_wait_cmd}")
+            # Retry up to twice on transient pip network failures; service-check
+            # failures are NOT retried.  See scripts/riot-wait-pip-retry.sh.
+            lines.append(f"    - scripts/riot-wait-pip-retry.sh {' '.join(wait_for)}")
 
         env = dict(self.env or {})
         if not env or "SUITE_NAME" not in env:

--- a/scripts/gen_gitlab_config.py
+++ b/scripts/gen_gitlab_config.py
@@ -141,7 +141,9 @@ class JobSpec:
             lines.append("    - pip cache info")
         lines.append(f'    - export NIGHTLY_BUILD="{_nightly_build}"')
         if wait_for:
-            lines.append(f"    - riot -v run -s --pass-env wait -- {' '.join(wait_for)}")
+            _wait_cmd = f"riot -v run -s --pass-env wait -- {' '.join(wait_for)}"
+            # Retry twice on transient pip network failures (connection reset mid-download).
+            lines.append(f"    - {_wait_cmd} || {_wait_cmd} || {_wait_cmd}")
 
         env = dict(self.env or {})
         if not env or "SUITE_NAME" not in env:

--- a/scripts/riot-wait-pip-retry.sh
+++ b/scripts/riot-wait-pip-retry.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Runs "riot -v run -s --pass-env wait -- $@" and retries up to twice,
+# but ONLY if the failure was caused by a transient pip network error.
+# Failures from the wait scripts themselves (e.g. service unavailable) are
+# not retried, so a long-running readiness check like check_opensearch does
+# not consume the full job timeout multiple times.
+
+set -euo pipefail
+
+# Patterns that indicate a pip install failure rather than a service failure.
+_PIP_ERR_PATTERN='pip|ConnectionReset|HTTPError|ChunkedEncoding|ProtocolError|Could not install'
+
+_try_wait() {
+    local _tmpfile _rc=0
+    _tmpfile=$(mktemp)
+    riot -v run -s --pass-env wait -- "$@" >"$_tmpfile" 2>&1 || _rc=$?
+    cat "$_tmpfile"
+    if [ "$_rc" -ne 0 ] && grep -qE "$_PIP_ERR_PATTERN" "$_tmpfile"; then
+        rm -f "$_tmpfile"
+        return 2  # pip error -- caller should retry
+    fi
+    rm -f "$_tmpfile"
+    return "$_rc"
+}
+
+_try_wait "$@" && exit 0
+_rc=$?
+[ "$_rc" -eq 2 ] || exit "$_rc"
+
+# First retry
+_try_wait "$@" && exit 0
+_rc=$?
+[ "$_rc" -eq 2 ] || exit "$_rc"
+
+# Second (final) retry -- let it fail naturally
+exec riot -v run -s --pass-env wait -- "$@"


### PR DESCRIPTION
## Description

We currently are getting job failures whenever a package install fails due to a random network blip. This retries up to two times (so it's three times total at most). 