### PR TITLE
wip(ci_visibility): preserve pytest log delivery

### DIFF
--- a/ddtrace/testing/internal/logging.py
+++ b/ddtrace/testing/internal/logging.py
@@ -2,6 +2,7 @@ from functools import wraps
 import logging
 import sys
 import typing as t
+import weakref
 
 from ddtrace.internal.settings import env
 from ddtrace.testing.internal.utils import asbool
@@ -10,6 +11,44 @@ from ddtrace.testing.internal.utils import asbool
 testing_logger = logging.getLogger("ddtrace.testing")
 
 F = t.TypeVar("F", bound=t.Callable[..., t.Any])
+
+
+class _DDTraceClosedStreamFilter(logging.Filter):
+    """Skip tracer records only at a stream destination that can no longer accept them."""
+
+    def __init__(self, handler: logging.StreamHandler) -> None:
+        super().__init__()
+        self._handler = weakref.ref(handler)
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.name != "ddtrace" and not record.name.startswith("ddtrace."):
+            return True
+        handler = self._handler()
+        return handler is None or getattr(handler.stream, "closed", False) is not True
+
+
+def protect_ddtrace_stream_handlers() -> None:
+    """Protect existing plain stream handlers at pytest teardown without changing log routing.
+
+    Filters remain attached for interpreter shutdown and check the current stream on
+    every record, so reusing a handler with an open stream restores normal delivery.
+    Scan again at final cleanup to include handlers installed by other teardown hooks.
+    Handlers created after pytest returns remain the caller's responsibility.
+    """
+    loggers = [logging.getLogger()]
+    loggers.extend(
+        logger
+        for name, logger in logging.Logger.manager.loggerDict.copy().items()
+        if (name == "ddtrace" or name.startswith("ddtrace.")) and isinstance(logger, logging.Logger)
+    )
+    for logger in loggers:
+        for handler in list(logger.handlers):
+            # AIDEV-NOTE: File handlers can reopen their streams, and custom handlers
+            # own their error handling. Only protect the standard StreamHandler.
+            if type(handler) is logging.StreamHandler and not any(
+                isinstance(f, _DDTraceClosedStreamFilter) for f in handler.filters
+            ):
+                handler.addFilter(_DDTraceClosedStreamFilter(handler))
 
 
 class _SafeStreamHandler(logging.StreamHandler):

--- a/ddtrace/testing/internal/pytest/plugin.py
+++ b/ddtrace/testing/internal/pytest/plugin.py
@@ -32,6 +32,7 @@ from ddtrace.testing.internal.constants import ITRSkippingLevel
 from ddtrace.testing.internal.errors import SetupError
 from ddtrace.testing.internal.git import get_workspace_path
 from ddtrace.testing.internal.logging import catch_and_log_exceptions
+from ddtrace.testing.internal.logging import protect_ddtrace_stream_handlers
 from ddtrace.testing.internal.logging import setup_logging
 from ddtrace.testing.internal.offline_mode import get_offline_mode
 from ddtrace.testing.internal.pytest._discovery import is_discovery_mode_enabled
@@ -1566,12 +1567,12 @@ def _is_option_true(option: str, early_config: pytest.Config, args: list[str]) -
 def pytest_load_initial_conftests(
     early_config: pytest.Config, parser: pytest.Parser, args: list[str]
 ) -> t.Generator[None, None, None]:
-    # NOTE: This must run before the _is_enabled_early guard. The tracer initialises
-    # on import (before CLI parsing), so its _atexit handler fires regardless of
-    # whether --ddtrace is passed. If this line moves below the guard, ddtrace logs
-    # will propagate to user-configured root handlers whose streams pytest closes
-    # during teardown, reintroducing the "I/O operation on closed file" error (#16712).
-    logging.getLogger("ddtrace").propagate = False
+    # AIDEV-NOTE: Register before the enablement guard: importing the tracer also
+    # registers its exit hook without --ddtrace (#16712). Cleanup runs in LIFO order,
+    # so registering before capture starts lets this rescan run after capture cleanup
+    # and include handlers installed by later hooks. Never disable propagation: healthy
+    # root handlers must still receive tracer diagnostics, including at shutdown.
+    early_config.add_cleanup(protect_ddtrace_stream_handlers)
 
     if not _is_enabled_early(early_config, args):
         yield
@@ -1611,6 +1612,20 @@ def pytest_load_initial_conftests(
     if session_manager.settings.coverage_enabled:
         setup_coverage_collection()
 
+    yield
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_sessionfinish() -> t.Generator[None, None, None]:
+    # Fixture capture streams can already be closed when session teardown starts.
+    protect_ddtrace_stream_handlers()
+    yield
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_unconfigure() -> t.Generator[None, None, None]:
+    # This also runs after collection errors and includes sessionfinish reconfiguration.
+    protect_ddtrace_stream_handlers()
     yield
 
 

--- a/releasenotes/notes/fix-pytest-log-propagation-closed-file-3dcb4cc3c51c967f.yaml
+++ b/releasenotes/notes/fix-pytest-log-propagation-closed-file-3dcb4cc3c51c967f.yaml
@@ -1,11 +1,7 @@
 ---
 fixes:
   - |
-    CI Visibility: Fixes a regression where the ddtrace pytest plugin could emit
-    ``--- Logging error ---`` tracebacks with ``ValueError: I/O operation on closed
-    file`` at the end of a test session when a custom logging configuration
-    installed via ``logging.config.dictConfig`` (or similar) replaces the root
-    logger handlers with a stream that pytest closes during teardown. This issue
-    was introduced when the new pytest plugin became the default in v4.5.0; the
-    previous plugin already prevented ddtrace logs from propagating to the root
-    logger.
+    CI visibility: Fixes ``ValueError: I/O operation on closed file`` logging
+    tracebacks at the end of pytest sessions when standard stream handlers point
+    to streams closed by pytest. Tracer logs continue to reach healthy root
+    handlers, including file output and log forwarding.

--- a/tests/testing/internal/pytest/test_pytest_log_propagation.py
+++ b/tests/testing/internal/pytest/test_pytest_log_propagation.py
@@ -6,9 +6,8 @@ ddtrace log records emitted at interpreter shutdown (via Tracer._atexit) propaga
 the root logger's handler.  By that point pytest has already closed its captured
 sys.stdout, so the handler raises ValueError: I/O operation on closed file.
 
-The fix sets logging.getLogger("ddtrace").propagate = False in
-pytest_load_initial_conftests (before the --ddtrace early-enable guard), mirroring
-the old plugin's unconditional take_over_logger_stream_handler() call.
+Teardown protects closed stream destinations while preserving delivery to healthy
+handlers and leaving user-configured propagation unchanged.
 
 These tests use runpytest_subprocess because the bug only manifests at interpreter
 shutdown (atexit), which does not fire in inline_run.
@@ -75,22 +74,6 @@ _TEST_FAIL = textwrap.dedent(
     """
 )
 
-# A passing test that verifies the ddtrace logger's propagate attribute is False
-# at test-run time (i.e. after pytest_load_initial_conftests has run).
-_TEST_PROPAGATE_IS_FALSE = textwrap.dedent(
-    """\
-    import logging
-
-
-    def test_ddtrace_logger_propagate_is_false():
-        ddtrace_logger = logging.getLogger("ddtrace")
-        assert ddtrace_logger.propagate is False, (
-            f"ddtrace logger propagate should be False, got {ddtrace_logger.propagate}"
-        )
-    """
-)
-
-
 # Infrastructure mock plugin — loaded via -p dd_log_prop_infra.
 # Sets up mocks in the subprocess so the plugin can initialise without a real agent.
 # Mirrors the approach in test_pytest_log_correlation.py.
@@ -144,7 +127,7 @@ def subprocess_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestDdtraceLoggerPropagation:
-    """Verify that the ddtrace logger does not propagate to user-configured root handlers."""
+    """Verify shutdown safety without overriding the user's logging configuration."""
 
     def test_no_logging_error_without_ddtrace_flag(self, pytester: Pytester) -> None:
         """Without --ddtrace, the plugin still loads and must prevent the logging error.
@@ -181,15 +164,20 @@ class TestDdtraceLoggerPropagation:
         result.assert_outcomes(failed=1)
         _assert_no_logging_error(result)
 
-    def test_ddtrace_logger_propagate_is_false(self, pytester: Pytester) -> None:
-        """The ddtrace logger must have propagate = False during the test session.
+    @pytest.mark.parametrize("propagate", [False, True])
+    def test_ddtrace_logger_propagation_is_preserved(
+        self, pytester: Pytester, logging_probe_env: None, propagate: bool
+    ) -> None:
+        pytester.makepyfile(early_logging=f"import logging\nlogging.getLogger('ddtrace').propagate = {propagate!r}")
+        pytester.makepyfile(
+            test_file=f"""\
+            import logging
 
-        This holds even without --ddtrace because the fix runs unconditionally
-        in pytest_load_initial_conftests.
-        """
-        pytester.makepyfile(test_file=_TEST_PROPAGATE_IS_FALSE)
-
-        result = pytester.runpytest_subprocess("-v")
+            def test_propagation():
+                assert logging.getLogger("ddtrace").propagate is {propagate!r}
+            """
+        )
+        result = _run_logging_probe(pytester, "-p", "early_logging")
         result.assert_outcomes(passed=1)
 
     def test_no_logging_error_without_custom_logger(self, pytester: Pytester) -> None:
@@ -327,10 +315,10 @@ def test_direct_handler(logger):
 
 @pytest.mark.usefixtures("logging_probe_env")
 class TestLoggingDeliveryCompatibility:
-    """Preservation probes: tracer-to-root cases should fail with PR #20101's blanket cutoff.
+    """Preservation probes that catch a blanket propagation cutoff.
 
     These intentionally assert delivery, not the implementation's propagate value.
-    Application and direct-handler cases are unaffected controls, not expected failures.
+    Application and direct-handler cases are unaffected controls.
     """
 
     @pytest.mark.parametrize("logger_name", ["ddtrace._trace.tracer", "application"])
@@ -446,6 +434,116 @@ class TestLoggingDeliveryCompatibility:
 
 @pytest.mark.usefixtures("logging_probe_env")
 class TestLoggingDeliveryControls:
+    @pytest.mark.parametrize("capture", ["fd", "sys", "no"])
+    @pytest.mark.parametrize("destination", ["root", "ddtrace", "ddtrace._trace.tracer"])
+    def test_shutdown_preserves_healthy_root_handler(self, pytester: Pytester, capture: str, destination: str) -> None:
+        """A dead destination must not suppress a record at a healthy root handler."""
+        pytester.makepyfile(
+            test_shutdown=f"""\
+            import atexit
+            import logging
+            import sys
+
+            def test_shutdown():
+                root = logging.getLogger()
+                root.setLevel(logging.DEBUG)
+                root.addHandler(logging.FileHandler("root.log"))
+                destination = root if {destination!r} == "root" else logging.getLogger({destination!r})
+                destination.addHandler(logging.StreamHandler(sys.stdout))
+                logger = logging.getLogger("ddtrace._trace.tracer")
+                logger.error("during test delivery")
+                atexit.register(logger.error, "shutdown delivery")
+            """
+        )
+        result = _run_logging_probe(pytester, f"--capture={capture}")
+        result.assert_outcomes(passed=1)
+        output = (pytester.path / "root.log").read_text()
+        assert "during test delivery" in output
+        assert "shutdown delivery" in output
+        _assert_no_logging_error(result)
+
+    def test_handler_installed_during_unconfigure(self, pytester: Pytester) -> None:
+        pytester.makeconftest(
+            """\
+            import atexit
+            import io
+            import logging
+
+            def pytest_unconfigure(config):
+                stream = io.StringIO()
+                root = logging.getLogger()
+                root.addHandler(logging.StreamHandler(stream))
+                root.addHandler(logging.FileHandler("late.log"))
+                config.add_cleanup(stream.close)
+                atexit.register(logging.getLogger("ddtrace._trace.tracer").error, "late shutdown delivery")
+            """
+        )
+        pytester.makepyfile("def test_pass(): pass")
+        result = _run_logging_probe(pytester)
+        result.assert_outcomes(passed=1)
+        assert "late shutdown delivery" in (pytester.path / "late.log").read_text()
+        _assert_no_logging_error(result)
+
+    def test_collection_error_still_protects_shutdown(self, pytester: Pytester) -> None:
+        pytester.makeconftest(
+            """\
+            import atexit
+            import logging
+            import sys
+
+            root = logging.getLogger()
+            root.addHandler(logging.StreamHandler(sys.stdout))
+            root.addHandler(logging.FileHandler("collection.log"))
+            atexit.register(logging.getLogger("ddtrace._trace.tracer").error, "collection shutdown delivery")
+            """
+        )
+        pytester.makepyfile("raise RuntimeError('collection failure')")
+        result = _run_logging_probe(pytester)
+        result.assert_outcomes(errors=1)
+        assert "collection shutdown delivery" in (pytester.path / "collection.log").read_text()
+        _assert_no_logging_error(result)
+
+    def test_repeated_pytest_main_preserves_logging_and_tracer(self, pytester: Pytester) -> None:
+        pytester.makepyfile(
+            test_session="""\
+            import logging
+            import sys
+
+            def test_session():
+                logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))
+                logging.getLogger("ddtrace._trace.tracer").error("during session")
+            """
+        )
+        script = pytester.makepyfile(
+            run_sessions="""\
+            import logging
+            import pytest
+            import ddtrace
+            from ddtrace.testing.internal.logging import _DDTraceClosedStreamFilter
+
+            root = logging.getLogger()
+            root.setLevel(logging.DEBUG)
+            root.addHandler(logging.FileHandler("sessions.log"))
+            for _ in range(2):
+                assert pytest.main([
+                    "-p", "ddtrace.testing.internal.pytest.entry_point",
+                    "--confcutdir=.", "-q", "test_session.py",
+                ]) == 0
+                assert ddtrace.tracer.enabled
+                assert logging.getLogger("ddtrace").propagate is True
+                for handler in root.handlers:
+                    if type(handler) is logging.StreamHandler:
+                        assert sum(isinstance(f, _DDTraceClosedStreamFilter) for f in handler.filters) == 1
+                logging.getLogger("ddtrace._trace.tracer").error("after session")
+            """
+        )
+        result = pytester.runpython(script)
+        assert result.ret == 0
+        output = (pytester.path / "sessions.log").read_text()
+        assert output.count("during session") == 2
+        assert output.count("after session") == 2
+        _assert_no_logging_error(result)
+
     @pytest.mark.parametrize("debug", [False, True])
     def test_tracer_file_logging(self, pytester: Pytester, monkeypatch: pytest.MonkeyPatch, debug: bool) -> None:
         log_file = pytester.path / "tracer.log"

--- a/tests/testing/internal/pytest/test_pytest_log_propagation.py
+++ b/tests/testing/internal/pytest/test_pytest_log_propagation.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import textwrap
 
 from _pytest.pytester import Pytester
+from _pytest.pytester import RunResult
 import pytest
 
 
@@ -201,4 +202,284 @@ class TestDdtraceLoggerPropagation:
 
         result = pytester.runpytest_subprocess("-v")
         result.assert_outcomes(passed=1)
+        _assert_no_logging_error(result)
+
+
+@pytest.fixture()
+def logging_probe_env(pytester: Pytester, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the nested session independent of the repository's logging configuration."""
+    for name in (
+        "PYTEST_ADDOPTS",
+        "PYTEST_PLUGINS",
+        "PYTEST_XDIST_WORKER",
+        "PYTEST_XDIST_WORKER_COUNT",
+        "DD_TRACE_DEBUG",
+        "DD_TRACE_LOG_LEVEL",
+        "DD_TRACE_LOG_FILE",
+        "DD_TRACE_LOG_FILE_LEVEL",
+        "DD_TRACE_LOG_FILE_SIZE_BYTES",
+        "DD_CIVISIBILITY_LOG_LEVEL",
+        "DD_LOGS_INJECTION",
+        "DD_AGENTLESS_LOG_SUBMISSION_ENABLED",
+        "_DD_CIVISIBILITY_USE_CI_CONTEXT_PROVIDER",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
+    monkeypatch.setenv("DD_PYTEST_USE_NEW_PLUGIN", "true")
+    monkeypatch.setenv("DD_CIVISIBILITY_ENABLED", "true")
+    monkeypatch.setenv("DD_TRACE_ENABLED", "true")
+    monkeypatch.setenv("DD_TRACE_LOG_STREAM_HANDLER", "true")
+    monkeypatch.setenv("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "false")
+    monkeypatch.setenv("DD_REMOTE_CONFIGURATION_ENABLED", "false")
+    pytester.makeini("[pytest]")
+
+
+def _run_logging_probe(pytester: Pytester, *args: str) -> RunResult:
+    # AIDEV-NOTE: Use stock pytest in a subprocess. tests/conftest.py overrides caplog
+    # to restore ddtrace propagation, which would hide the compatibility regression.
+    return pytester.runpytest_subprocess(
+        "-p",
+        "ddtrace.testing.internal.pytest.entry_point",
+        "--confcutdir",
+        str(pytester.path),
+        "-v",
+        *args,
+    )
+
+
+_DELIVERY_PROBE = """\
+import logging
+from unittest.mock import Mock
+
+import pytest
+
+import ddtrace
+from ddtrace.contrib.internal.logging.patch import patch
+from ddtrace.internal.utils.formats import format_trace_id
+from ddtrace.testing.internal.logs import LogsHandler
+from ddtrace.trace import Span
+
+
+@pytest.fixture
+def logger():
+    logger = logging.getLogger(LOGGER_NAME)
+    logger.setLevel(logging.DEBUG)
+    return logger
+
+
+def test_caplog(logger, caplog):
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        for level in (logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR):
+            logger.log(level, "delivery probe %s", level)
+    records = [record for record in caplog.records if record.name == LOGGER_NAME]
+    assert [record.levelno for record in records] == [10, 20, 30, 40]
+
+
+def test_root_handler(logger):
+    handler = logging.Handler()
+    handler.emit = Mock()
+    root = logging.getLogger()
+    root.addHandler(handler)
+    try:
+        logger.error("root delivery probe")
+        handler.emit.assert_called_once()
+        assert handler.emit.call_args.args[0].getMessage() == "root delivery probe"
+    finally:
+        root.removeHandler(handler)
+
+
+def test_submission_handler(logger):
+    # Exercise the real handler's routing and encoding without sending any data.
+    writer = Mock(hostname="test-host", service="test-service")
+    handler = LogsHandler(writer)
+    root = logging.getLogger()
+    root.setLevel(logging.WARNING)
+    root.addHandler(handler)
+    try:
+        logger.error("submission delivery probe")
+        writer.put_event.assert_called_once()
+        event = writer.put_event.call_args.args[0]
+        assert event["message"] == "submission delivery probe"
+        assert event["status"] == "error"
+    finally:
+        root.removeHandler(handler)
+
+
+def test_direct_handler(logger):
+    patch()
+    handler = logging.Handler()
+    handler.emit = Mock()
+    logger.addHandler(handler)
+    previous = ddtrace.tracer.context_provider.active()
+    span = Span("correlation-probe")
+    ddtrace.tracer.context_provider.activate(span)
+    try:
+        logger.error("direct delivery probe")
+        handler.emit.assert_called_once()
+        record = handler.emit.call_args.args[0]
+        assert getattr(record, "dd.trace_id") == format_trace_id(span.trace_id)
+        assert getattr(record, "dd.span_id") == str(span.span_id)
+    finally:
+        ddtrace.tracer.context_provider.activate(previous)
+        logger.removeHandler(handler)
+"""
+
+
+@pytest.mark.usefixtures("logging_probe_env")
+class TestLoggingDeliveryCompatibility:
+    """Preservation probes: tracer-to-root cases should fail with PR #20101's blanket cutoff.
+
+    These intentionally assert delivery, not the implementation's propagate value.
+    Application and direct-handler cases are unaffected controls, not expected failures.
+    """
+
+    @pytest.mark.parametrize("logger_name", ["ddtrace._trace.tracer", "application"])
+    @pytest.mark.parametrize("destination", ["caplog", "root_handler", "submission_handler", "direct_handler"])
+    def test_record_delivery(
+        self, pytester: Pytester, monkeypatch: pytest.MonkeyPatch, logger_name: str, destination: str
+    ) -> None:
+        if destination == "direct_handler":
+            monkeypatch.setenv("DD_LOGS_INJECTION", "true")
+        pytester.makepyfile(test_delivery=f"LOGGER_NAME = {logger_name!r}\n" + _DELIVERY_PROBE)
+        result = _run_logging_probe(pytester, "-k", f"test_{destination}")
+        result.assert_outcomes(passed=1)
+
+    @pytest.mark.parametrize("logger_name", ["ddtrace._trace.tracer", "application"])
+    @pytest.mark.parametrize("destination", ["live", "file", "failure_report"])
+    def test_pytest_log_output(self, pytester: Pytester, logger_name: str, destination: str) -> None:
+        pytester.makepyfile(
+            test_output=f"""\
+            import logging
+
+            def test_output():
+                logging.getLogger({logger_name!r}).error("output delivery probe")
+                assert {destination != "failure_report"!r}
+            """
+        )
+        log_format = "LOG-PROBE:%(name)s:%(message)s"
+        log_file = pytester.path / "pytest.log"
+        options = {
+            "live": ["--log-cli-level=DEBUG", f"--log-cli-format={log_format}"],
+            "file": [f"--log-file={log_file}", "--log-file-level=DEBUG", f"--log-file-format={log_format}"],
+            "failure_report": ["--log-level=DEBUG", f"--log-format={log_format}"],
+        }
+        result = _run_logging_probe(pytester, *options[destination])
+        if destination == "failure_report":
+            result.assert_outcomes(failed=1)
+            result.stdout.fnmatch_lines(["*Captured log call*"])
+        else:
+            result.assert_outcomes(passed=1)
+        # The prefix proves delivery via pytest's handler, not the tracer's stderr handler
+        # or a source-code excerpt in an assertion failure.
+        expected = f"LOG-PROBE:{logger_name}:output delivery probe"
+        output = log_file.read_text() if destination == "file" else result.stdout.str()
+        assert expected in output
+
+    @pytest.mark.parametrize("mode", ["no_flag", "no_ddtrace", "kill_switch", "debug", "ci_none", "no_stream"])
+    @pytest.mark.parametrize("when", ["before_plugin", "after_plugin"])
+    def test_root_only_configuration(
+        self, pytester: Pytester, monkeypatch: pytest.MonkeyPatch, mode: str, when: str
+    ) -> None:
+        """Root-only logging is the documented workaround for duplicate tracer logs."""
+        options = []
+        if mode == "no_ddtrace":
+            options.append("--no-ddtrace")
+        elif mode == "kill_switch":
+            monkeypatch.setenv("DD_CIVISIBILITY_ENABLED", "false")
+            options.append("--ddtrace")
+        elif mode == "debug":
+            monkeypatch.setenv("DD_TRACE_DEBUG", "true")
+        elif mode == "ci_none":
+            monkeypatch.setenv("DD_CIVISIBILITY_LOG_LEVEL", "NONE")
+        elif mode == "no_stream":
+            monkeypatch.setenv("DD_TRACE_LOG_STREAM_HANDLER", "false")
+
+        pytester.makepyfile(
+            root_logging_config="""\
+            import io
+            import logging
+            from logging.config import dictConfig
+
+            output = io.StringIO()
+
+            def configure():
+                dictConfig({
+                    "version": 1,
+                    "disable_existing_loggers": False,
+                    "handlers": {"probe": {"class": "logging.StreamHandler", "stream": output}},
+                    "root": {"level": "DEBUG", "handlers": ["probe"]},
+                })
+                logger = logging.getLogger("ddtrace")
+                for handler in list(logger.handlers):
+                    logger.removeHandler(handler)
+            """
+        )
+        if when == "before_plugin":
+            pytester.makepyfile(
+                early_logging="""\
+                import logging
+                from root_logging_config import configure
+
+                configure()
+                logging.getLogger("ddtrace").propagate = True
+                """
+            )
+            # Explicit -p plugins are imported before pytest_load_initial_conftests runs.
+            options.extend(["-p", "early_logging"])
+        pytester.makepyfile(
+            test_root_config=f"""\
+            import logging
+            from root_logging_config import configure, output
+
+            def test_root_config():
+                if {when == "after_plugin"!r}:
+                    configure()
+                logging.getLogger("application").error("application root probe")
+                logging.getLogger("ddtrace._trace.tracer").error("tracer root probe")
+                assert "application root probe" in output.getvalue()
+                assert "tracer root probe" in output.getvalue()
+            """
+        )
+        result = _run_logging_probe(pytester, *options)
+        result.assert_outcomes(passed=1)
+
+
+@pytest.mark.usefixtures("logging_probe_env")
+class TestLoggingDeliveryControls:
+    @pytest.mark.parametrize("debug", [False, True])
+    def test_tracer_file_logging(self, pytester: Pytester, monkeypatch: pytest.MonkeyPatch, debug: bool) -> None:
+        log_file = pytester.path / "tracer.log"
+        monkeypatch.setenv("DD_TRACE_LOG_FILE", str(log_file))
+        monkeypatch.setenv("DD_TRACE_LOG_FILE_LEVEL", "DEBUG")
+        monkeypatch.setenv("DD_TRACE_DEBUG", str(debug).lower())
+        pytester.makepyfile(
+            test_file="""\
+            import logging
+
+            def test_file():
+                logging.getLogger("ddtrace._trace.tracer").error("tracer file probe")
+            """
+        )
+        result = _run_logging_probe(pytester)
+        result.assert_outcomes(passed=1)
+        assert "tracer file probe" in log_file.read_text()
+        _assert_no_logging_error(result)
+
+    def test_shutdown_emission_reaches_direct_handler(self, pytester: Pytester) -> None:
+        """Absence of a shutdown traceback must not mean no shutdown record was emitted."""
+        pytester.makeconftest(_CONFTEST_WITH_ROOT_STREAM_HANDLER)
+        pytester.makepyfile(
+            test_shutdown="""\
+            import atexit
+            import logging
+
+            def test_shutdown(configure_root_logger):
+                logger = logging.getLogger("ddtrace._trace.tracer")
+                logger.addHandler(logging.FileHandler("shutdown.log"))
+                atexit.register(logger.error, "shutdown delivery probe")
+            """
+        )
+        result = _run_logging_probe(pytester)
+        result.assert_outcomes(passed=1)
+        assert "shutdown delivery probe" in (pytester.path / "shutdown.log").read_text()
         _assert_no_logging_error(result)

--- a/tests/testing/internal/test_logging.py
+++ b/tests/testing/internal/test_logging.py
@@ -7,8 +7,12 @@ from typing import Optional
 from unittest.mock import Mock
 from unittest.mock import patch
 
+import pytest
+
+from ddtrace.testing.internal.logging import _DDTraceClosedStreamFilter
 from ddtrace.testing.internal.logging import _SafeStreamHandler
 from ddtrace.testing.internal.logging import catch_and_log_exceptions
+from ddtrace.testing.internal.logging import protect_ddtrace_stream_handlers
 from ddtrace.testing.internal.logging import setup_logging
 from ddtrace.testing.internal.logging import testing_logger
 
@@ -236,3 +240,71 @@ class TestSafeStreamHandler:
 
         # The default handleError should have printed the traceback for the TypeError.
         assert "Logging error" in real_stderr.getvalue()
+
+
+class TestDDTraceClosedStreamFilter:
+    @pytest.mark.parametrize("name", ["ddtrace", "ddtrace._trace.tracer", "application", "ddtrace_other"])
+    def test_only_closed_tracer_destination_is_filtered(self, name: str) -> None:
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.addFilter(_DDTraceClosedStreamFilter(handler))
+        record = logging.makeLogRecord({"name": name, "msg": "delivery probe"})
+        handler.handle(record)
+        assert stream.getvalue() == "delivery probe\n"
+        stream.close()
+
+        with patch.object(handler, "handleError") as error:
+            handler.handle(record)
+        assert error.call_count == (0 if name == "ddtrace" or name.startswith("ddtrace.") else 1)
+
+        # A reused handler must not stay muted after replacing its closed stream.
+        handler.stream = io.StringIO()
+        handler.handle(record)
+        assert handler.stream.getvalue() == "delivery probe\n"
+
+    @pytest.mark.parametrize("exception", [ValueError("invalid format"), TypeError("invalid format")])
+    def test_formatter_errors_remain_visible(self, exception: Exception) -> None:
+        handler = logging.StreamHandler(io.StringIO())
+        handler.addFilter(_DDTraceClosedStreamFilter(handler))
+        handler.setFormatter(Mock(format=Mock(side_effect=exception)))
+        record = logging.makeLogRecord({"name": "ddtrace", "msg": "delivery probe"})
+        with patch.object(handler, "handleError") as error:
+            handler.handle(record)
+        error.assert_called_once_with(record)
+
+    def test_scanning_preserves_handlers_and_is_idempotent(self, tmp_path) -> None:
+        root = logging.RootLogger(logging.WARNING)
+        tracer = logging.Logger("ddtrace")
+        child = logging.Logger("ddtrace.child")
+        application = logging.Logger("application")
+        handlers: list[logging.Handler] = [logging.StreamHandler(io.StringIO()) for _ in range(4)]
+        for logger, handler in zip((root, tracer, child, application), handlers):
+            logger.addHandler(handler)
+        existing_filter = logging.Filter()
+        handlers[0].addFilter(existing_filter)
+        file_handler = logging.FileHandler(tmp_path / "reopen.log", delay=True)
+        custom_handler = _SafeStreamHandler(io.StringIO())
+        root.addHandler(file_handler)
+        root.addHandler(custom_handler)
+        before = list(root.handlers)
+        try:
+            with (
+                patch("logging.getLogger", return_value=root),
+                patch.dict(
+                    logging.Logger.manager.loggerDict,
+                    {"ddtrace": tracer, "ddtrace.child": child, "application": application},
+                    clear=True,
+                ),
+            ):
+                protect_ddtrace_stream_handlers()
+                protect_ddtrace_stream_handlers()
+            assert root.handlers == before
+            assert handlers[0].filters[0] is existing_filter
+            for handler in handlers[:3]:
+                assert sum(isinstance(f, _DDTraceClosedStreamFilter) for f in handler.filters) == 1
+            assert handlers[3].filters == []
+            assert file_handler.filters == []
+            assert custom_handler.filters == []
+        finally:
+            for handler in [*handlers, file_handler, custom_handler]:
+                handler.close()


### PR DESCRIPTION
<!-- dd-meta {"pullId":"cea9b0fd-5851-4c4f-b4b0-18a30ddd7584","source":"chat","resourceId":"c0096dbc-5d7d-4dc0-9dac-95643f43b151","workflowId":"f964c044-b498-4df8-a367-1861336af4f1","codeChangeId":"f964c044-b498-4df8-a367-1861336af4f1","sourceType":"slack"} -->
## Description

Fix the closed-stream shutdown error in #16712 without the whole-process loss of tracer log delivery exposed by the compatibility probes for #20101.

- Replace the unconditional ddtrace propagation cutoff with per-handler filters installed during pytest teardown. Only ddtrace records destined for already-closed ordinary StreamHandlers are skipped; healthy root and direct handlers continue receiving records.
- Rescan at session finish, unconfigure, and final cleanup, including when instrumentation is disabled. Preserve propagation settings, handler ownership, formatting, application records, and the global tracer's lifetime.
- Exclude FileHandler and custom handler subclasses, preserve existing filters, avoid duplicate filters across repeated pytest sessions, and allow delivery again if a handler's stream is replaced.
- Retain the 29 subprocess compatibility/control cases added earlier, replace the implementation-specific propagation assertion with preservation tests, and add shutdown/root-file delivery, late configuration, collection-error, repeated pytest.main(), and filter unit tests.
- Update the existing customer-facing release note to describe preserved diagnostic delivery.

## Testing

Python 3.13.13:

- scripts/run-tests --venv 3dc4202 -- -n 0 -k 'test_pytest_log_propagation or test_logging or test_pytest_log_correlation or test_plugin': 181 passed on pytest 7.4.4.
- scripts/run-tests -s --venv 1b6f43f -- -n 0 -k 'test_pytest_log_propagation or test_logging or test_pytest_log_correlation or test_plugin': 181 passed on pytest 8.4.2 in the final restored state.
- All 18 previously failing delivery probes now pass, alongside the original shutdown regressions and application/correlation/submission-handler controls.
- Negative control: temporarily disabled the closed-stream filter; all three targeted fd-capture shutdown tests failed with ValueError: I/O operation on closed file. Restored the filter before the final passing run.
- Python formatting and Ruff checks passed through scripts/lint for all four edited Python files; git diff --check passed.
- Scoped type checking passed for the logging helper and subprocess test module. Wider typing reports existing diagnostics in the plugin, imported dependencies, and an unchanged unreachable statement in test_logging.py. Full lint remains limited by unavailable auxiliary tools, including cython-lint.

## Risks

The protection is deliberately limited to existing standard stream handlers at pytest teardown; custom/file handler behavior is unchanged. Handlers installed after pytest returns remain the caller's responsibility. The filter checks whether a stream is already closed at dispatch, not arbitrary concurrent closure between filtering and writing. The submission probe uses the real handler with a mock writer; it does not validate remote intake delivery.

## Additional Notes

No global logging monkeypatch, no global exception suppression, and no early shutdown of the global tracer. No commit, push, or remote PR update performed.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/c0096dbc-5d7d-4dc0-9dac-95643f43b151)

Comment @datadog to request changes