### PR TITLE
fix(mcp): skip patching when `mcp` is not the MCP SDK

### DIFF
--- a/ddtrace/contrib/internal/mcp/patch.py
+++ b/ddtrace/contrib/internal/mcp/patch.py
@@ -13,6 +13,7 @@ from ddtrace import config
 from ddtrace._trace.span import Span
 from ddtrace.constants import ERROR_MSG
 from ddtrace.contrib.internal.trace_utils import activate_distributed_headers
+from ddtrace.contrib.trace_utils import iswrapped
 from ddtrace.contrib.trace_utils import unwrap
 from ddtrace.contrib.trace_utils import wrap
 from ddtrace.internal.logger import get_logger
@@ -41,7 +42,10 @@ config._add(
 def get_version() -> str:
     from importlib.metadata import version
 
-    return version("mcp")
+    try:
+        return version("mcp")
+    except Exception:
+        return ""
 
 
 def _supported_versions() -> dict[str, str]:
@@ -281,12 +285,16 @@ def patch():
     if getattr(mcp, "__datadog_patch", False):
         return
 
+    try:
+        from mcp.client.session import ClientSession
+        from mcp.shared.session import BaseSession
+        from mcp.shared.session import RequestResponder
+    except ImportError:
+        log.debug("mcp is importable but is not the MCP SDK, skipping instrumentation")
+        return
+
     mcp.__datadog_patch = True
     mcp._datadog_integration = MCPIntegration(integration_config=config.mcp)
-
-    from mcp.client.session import ClientSession
-    from mcp.shared.session import BaseSession
-    from mcp.shared.session import RequestResponder
 
     wrap(ClientSession, "__aenter__", traced_client_session_aenter)
     wrap(ClientSession, "__aexit__", traced_client_session_aexit)
@@ -294,9 +302,12 @@ def patch():
     wrap(ClientSession, "call_tool", traced_call_tool)
     wrap(ClientSession, "list_tools", traced_client_session_list_tools)
     wrap(ClientSession, "initialize", traced_client_session_initialize)
-    wrap(RequestResponder, "__enter__", traced_request_responder_enter)
-    wrap(RequestResponder, "__exit__", traced_request_responder_exit)
     wrap(RequestResponder, "respond", traced_request_responder_respond)
+
+    # ``RequestResponder`` gained the context manager protocol in mcp 1.3.0.
+    if hasattr(RequestResponder, "__enter__") and hasattr(RequestResponder, "__exit__"):
+        wrap(RequestResponder, "__enter__", traced_request_responder_enter)
+        wrap(RequestResponder, "__exit__", traced_request_responder_exit)
 
 
 def unpatch():
@@ -305,6 +316,8 @@ def unpatch():
 
     mcp.__datadog_patch = False
 
+    # ``patch()`` sets ``__datadog_patch`` only once these imports have
+    # succeeded, so they cannot fail here.
     from mcp.client.session import ClientSession
     from mcp.shared.session import BaseSession
     from mcp.shared.session import RequestResponder
@@ -315,8 +328,11 @@ def unpatch():
     unwrap(ClientSession, "call_tool")
     unwrap(ClientSession, "list_tools")
     unwrap(ClientSession, "initialize")
-    unwrap(RequestResponder, "__enter__")
-    unwrap(RequestResponder, "__exit__")
     unwrap(RequestResponder, "respond")
+
+    # Only wrapped on mcp >= 1.3.0, see patch().
+    if iswrapped(RequestResponder, "__enter__"):
+        unwrap(RequestResponder, "__enter__")
+        unwrap(RequestResponder, "__exit__")
 
     delattr(mcp, "_datadog_integration")

--- a/ddtrace/contrib/internal/mcp/patch.py
+++ b/ddtrace/contrib/internal/mcp/patch.py
@@ -285,15 +285,19 @@ def patch():
     if getattr(mcp, "__datadog_patch", False):
         return
 
+    # Claimed before the imports below so a concurrent patch() cannot clear the
+    # guard above and wrap everything a second time.
+    mcp.__datadog_patch = True
+
     try:
         from mcp.client.session import ClientSession
         from mcp.shared.session import BaseSession
         from mcp.shared.session import RequestResponder
     except ImportError:
+        mcp.__datadog_patch = False
         log.debug("mcp is importable but is not the MCP SDK, skipping instrumentation")
         return
 
-    mcp.__datadog_patch = True
     mcp._datadog_integration = MCPIntegration(integration_config=config.mcp)
 
     wrap(ClientSession, "__aenter__", traced_client_session_aenter)
@@ -304,7 +308,7 @@ def patch():
     wrap(ClientSession, "initialize", traced_client_session_initialize)
     wrap(RequestResponder, "respond", traced_request_responder_respond)
 
-    # ``RequestResponder`` gained the context manager protocol in mcp 1.3.0.
+    # RequestResponder gained the context manager protocol in mcp 1.3.0.
     if hasattr(RequestResponder, "__enter__") and hasattr(RequestResponder, "__exit__"):
         wrap(RequestResponder, "__enter__", traced_request_responder_enter)
         wrap(RequestResponder, "__exit__", traced_request_responder_exit)
@@ -316,8 +320,8 @@ def unpatch():
 
     mcp.__datadog_patch = False
 
-    # ``patch()`` sets ``__datadog_patch`` only once these imports have
-    # succeeded, so they cannot fail here.
+    # Only reachable with __datadog_patch set, which patch() leaves set only
+    # when these imports succeeded, so they cannot fail here.
     from mcp.client.session import ClientSession
     from mcp.shared.session import BaseSession
     from mcp.shared.session import RequestResponder

--- a/releasenotes/notes/mcp-defer-submodule-imports-042f381fe4b9347a.yaml
+++ b/releasenotes/notes/mcp-defer-submodule-imports-042f381fe4b9347a.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    mcp: Resolves an error logged when a module named ``mcp`` is importable but
+    is not the MCP SDK. Patching is now skipped instead of raising.


### PR DESCRIPTION
`patch()` force-imports `mcp.client.session` and `mcp.shared.session`, so any environment where a module named `mcp` is importable but isn't the MCP SDK raises `ModuleNotFoundError`, which `_monkey` logs and reports as an integration error.

- Guard the imports with `except ImportError` and skip patching — there's nothing to instrument. `__datadog_patch` is set only after they succeed, so `unpatch()` needs no guard.
- Gate the `RequestResponder.__enter__`/`__exit__` wraps behind `hasattr`. They arrived in mcp 1.3.0 and are the only wrap targets with a version seam (checked 1.0.0 → 1.28.1); older versions previously raised `AttributeError` and lost the integration entirely. Wrapped as a pair, since `__enter__` starts the span and `__exit__` finishes it.
- Guard `get_version()`. It's called outside `_monkey`'s try/except, so now that `patch()` no longer raises, an unguarded `version("mcp")` would break the user's `import mcp`.

Claude session: `9d18f8a0-0c33-438b-8653-9d02d74aead3`
Resume: `claude --resume 9d18f8a0-0c33-438b-8653-9d02d74aead3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
