### PR TITLE
ci: block new AIDEV-* comment anchors

### DIFF
--- a/.cursor/rules/ai-guard.mdc
+++ b/.cursor/rules/ai-guard.mdc
@@ -202,7 +202,7 @@ except AIGuardAbortError as e:
 
 Framework plugins (`AIGuardStrandsPlugin`, `AIGuardStrandsHookProvider`) are
 re-exported lazily from `ai_guard/__init__.py` via a module-level
-`__getattr__`; see the `AIDEV-NOTE` there before changing import timing.
+`__getattr__`; read the inline comment there before changing import timing.
 
 ## Development guidelines
 
@@ -221,7 +221,8 @@ re-exported lazily from `ai_guard/__init__.py` via a module-level
 - **Respect the context counter.** When adding a framework integration that
   may nest over a provider integration, wrap with `aiguard_context()` and have
   the provider listener honor `is_aiguard_context_active()`.
-- **Preserve `AIDEV-NOTE` anchors** (lazy import timing, stream counter
-  lifecycle, legacy message translation) — they encode non-obvious invariants.
+- **Preserve inline invariant comments** (lazy import timing, stream counter
+  lifecycle, legacy message translation) when editing nearby code; do not add
+  new `AIDEV-*` anchor labels (deprecated — see AGENTS.md).
 - **Tests** live under `tests/aiguard/`. Use the `run-tests` skill;
   never run `pytest` directly.

--- a/.cursor/rules/dd-trace-py.mdc
+++ b/.cursor/rules/dd-trace-py.mdc
@@ -14,7 +14,7 @@ When unsure about implementation details, ALWAYS ask the developer.
 Read and follow `AGENTS.md` for:
 - Project rules (testing, linting, formatting)
 - Key architecture
-- AIDEV anchor comments
+- Inline knowledge comments (AIDEV anchors deprecated)
 - PR guidelines
 - Skills reference
 - Domain guides

--- a/.github/actions/generated-change-patch/action.yml
+++ b/.github/actions/generated-change-patch/action.yml
@@ -20,7 +20,7 @@ outputs:
 runs:
   using: composite
   steps:
-    # AIDEV-NOTE: Keep patch application and validation in this single shell step,
+    # Keep patch application and validation in this single shell step,
     # and do not add repository-mutating steps between this action and PR creation.
     # The patch is untrusted data and must not replace code that is executed later.
     - id: patch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -515,6 +515,39 @@ check_added_file_size:
       git fetch origin "${BASE_BRANCH}"
     - python3 scripts/check_added_file_size.py --base-ref FETCH_HEAD
 
+check_no_new_aidev_anchors:
+  stage: tests
+  needs: []
+  extends: .testrunner
+  variables:
+    # Needs full history to reliably compute a merge-base against the fetched
+    # base branch; a shallow clone can leave HEAD and FETCH_HEAD without a
+    # common ancestor.
+    GIT_DEPTH: "0"
+  rules:
+    - if: !reference [.is_main]
+      when: never
+    - if: !reference [.is_release]
+      when: never
+    - if: !reference [.is_release_branch]
+      when: never
+    - if: !reference [.is_gh_merge_queue]
+      when: never
+    - if: !reference [.is_devflow_merge_queue]
+      when: never
+    - when: on_success
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
+  script:
+    - |
+      if [ -z "${GH_TOKEN:-}" ]; then
+        export GH_TOKEN=$(dd-octo-sts token --scope DataDog/dd-trace-py --policy gitlab.github-access.read)
+      fi
+      BASE_BRANCH=$(.gitlab/scripts/resolve-base-branch.sh)
+      git fetch origin "${BASE_BRANCH}"
+    - python3 scripts/check_no_new_aidev_anchors.py --base-ref FETCH_HEAD
+
 
 "summarize failures":
   stage: .post

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -127,7 +127,7 @@ include:
     - ln -s "${CI_PROJECT_DIR}" "/home/bits/project"
 
 # ---------------------------------------------------------------------------
-# AIDEV-NOTE: DDTest must receive the complete suitespec command. Falling back
+# DDTest must receive the complete suitespec command. Falling back
 # to bare pytest bypasses per-suite exclusions and can select unavailable tools.
 # DDTest's uv backend is intentionally self-contained: it creates an ephemeral
 # environment from the suite lock and runs the exact suite command emitted by

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,15 +62,6 @@ Do not add a comment if the comment simply states what the code does, and not wh
 - **Configuration is via environment variables** — follow existing patterns in `ddtrace/internal/settings/`.
 - **Integrations are modular** — each lives under `ddtrace/contrib/` and follows the `Pin`/`patch`/`unpatch` pattern.
 
-## AIDEV Anchor Comments
-
-Add `AIDEV-NOTE:`, `AIDEV-TODO:`, or `AIDEV-QUESTION:` comments as inline knowledge for AI and developers.
-
-- Before scanning files, **grep for existing `AIDEV-*` anchors** in relevant subdirectories first.
-- **Update relevant anchors** when modifying associated code.
-- **Never remove** `AIDEV-NOTE`s without explicit human instruction.
-- Add anchors when code is complex, important, confusing, or potentially buggy.
-
 ## PR Guidelines
 
 Follow **`docs/contributing.rst`** ("Pull Request Requirements" and "Branches and Pull Requests" sections).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,14 +11,15 @@ Single source of truth for all AI coding assistants. Tool-specific entry points
 4. **No public API breakage** — Never change public API contracts; real applications depend on them.
 5. **No secrets** — Never commit secrets; use environment variables.
 6. **Don't assume business logic** — Ask when unsure about implementation details.
-7. **TODO/NOTE comments are protected** — Never remove `TODO` or `NOTE` comments without explicit human instruction. Update them when modifying related code.
-8. **Test before committing** — Run relevant tests to validate changes before committing.
-9. **Performance matters** — This library runs in production hot paths. Benchmark changes to C/C++/Cython/Rust code.
-10. **Update docs** — Add/update documentation when changing internal or public APIs.
-11. **No stray prints** — Check for and remove unexpected `print()` calls.
-12. **Keep integration skills current** — When modifying integration code in `ddtrace/contrib/internal/` or `ddtrace/llmobs/_integrations/`, review `.claude/skills/apm-integrations/` and `.claude/skills/llmobs-integrations/` and update any reference files that describe the changed patterns.
-13. **Docstrings and comments** — Docstrings Sphinx renders use reStructuredText; everything else is plain prose. See "Docstrings and Comments" below.
-14. **No deferred imports to paper over circular imports** — Never fix (or leave in place) a circular import by moving an `import` inside a function/method body. This hides the structural problem instead of fixing it, and is explicitly banned by the `circular-import-analysis` skill. Use that skill to find the real architectural fix (extract shared types, invert the dependency, or move the code to the module that owns it) any time you add/move a module or see a new cycle reported.
+7. **No new `AIDEV-*` anchor comments** — The guild deprecated `AIDEV-NOTE:`, `AIDEV-TODO:`, and `AIDEV-QUESTION:` labels. Use plain inline comments (see "Docstrings and Comments"). When editing code that still has an old anchor, convert it to a plain comment; do not add new anchors. CI blocks new anchors on changed lines.
+8. **TODO/NOTE comments are protected** — Never remove `TODO` or `NOTE` comments without explicit human instruction. Update them when modifying related code.
+9. **Test before committing** — Run relevant tests to validate changes before committing.
+10. **Performance matters** — This library runs in production hot paths. Benchmark changes to C/C++/Cython/Rust code.
+11. **Update docs** — Add/update documentation when changing internal or public APIs.
+12. **No stray prints** — Check for and remove unexpected `print()` calls.
+13. **Keep integration skills current** — When modifying integration code in `ddtrace/contrib/internal/` or `ddtrace/llmobs/_integrations/`, review `.claude/skills/apm-integrations/` and `.claude/skills/llmobs-integrations/` and update any reference files that describe the changed patterns.
+14. **Docstrings and comments** — Docstrings Sphinx renders use reStructuredText; everything else is plain prose. See "Docstrings and Comments" below.
+15. **No deferred imports to paper over circular imports** — Never fix (or leave in place) a circular import by moving an `import` inside a function/method body. This hides the structural problem instead of fixing it, and is explicitly banned by the `circular-import-analysis` skill. Use that skill to find the real architectural fix (extract shared types, invert the dependency, or move the code to the module that owns it) any time you add/move a module or see a new cycle reported.
 
 ## Docstrings and Comments
 

--- a/ddtrace/_trace/span.py
+++ b/ddtrace/_trace/span.py
@@ -180,7 +180,7 @@ class Span(SpanData):
     def _update_tags_from_context(self) -> None:
         ctx = self.context
         with ctx:
-            # AIDEV-NOTE: traceparent and tracestate are propagation state, not DD-native
+            # traceparent and tracestate are propagation state, not DD-native
             # span metadata. Copy both context dictionaries while filtering them.
             self._set_default_context_attributes(ctx._meta, ctx._metrics)
 

--- a/ddtrace/_trace/subscribers/http_client.py
+++ b/ddtrace/_trace/subscribers/http_client.py
@@ -16,7 +16,7 @@ from ddtrace.propagation.http import HTTPPropagator
 
 log = get_logger(__name__)
 
-# AIDEV-NOTE: set True by a higher-level integration to skip its own injection
+# set True by a higher-level integration to skip its own injection
 # (e.g. botocore SigV4, requests suppressing the nested urllib3 span). Only
 # `patched_api_call`, `_wrapped_api_call`, and `_wrap_adapter_send` may set this,
 # and must reset() in try/finally — see PR #18152 for the leak that caused.

--- a/ddtrace/aiguard/__init__.py
+++ b/ddtrace/aiguard/__init__.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from typing import Any
 
 
-# AIDEV-NOTE: Lazy re-exports (PEP 562). Importing an internal submodule (e.g.
+# Lazy re-exports (PEP 562). Importing an internal submodule (e.g.
 # ddtrace.aiguard._constants from ddtrace.internal.settings.aiguard, which is
 # loaded during product discovery on every ddtrace-run) must NOT drag in the
 # client stack. Eager imports here would load ddtrace.aiguard._api_client (and

--- a/ddtrace/aiguard/_listener.py
+++ b/ddtrace/aiguard/_listener.py
@@ -76,7 +76,7 @@ def _langchain_listen(client: AIGuardClient) -> None:
     core.on("langchain.llm.agenerate.before", partial(_langchain_llm_generate_before, client))
     core.on("langchain.llm.stream.before", partial(_langchain_llm_stream_before, client))
 
-    # AIDEV-NOTE: ``.stream.started`` is dispatched lazily from
+    # ``.stream.started`` is dispatched lazily from
     # ``BaseLangchainStreamHandler.start_stream`` (called by
     # ``TracedStream.__iter__`` / ``__aiter__`` on iteration entry), so a
     # stream created but never consumed cannot leak the counter into the
@@ -85,7 +85,7 @@ def _langchain_listen(client: AIGuardClient) -> None:
     core.on("langchain.chatmodel.stream.started", _langchain_stream_started)
     core.on("langchain.llm.stream.started", _langchain_stream_started)
 
-    # AIDEV-NOTE: ``.finally`` listeners release the AI Guard active-context
+    # ``.finally`` listeners release the AI Guard active-context
     # counter. For non-streaming ``*.generate.*`` paths the counter is bumped
     # by the matching ``.before`` listener (``func(...)`` runs synchronously
     # so set + reset wrap the SDK call). For streaming the counter is bumped
@@ -169,7 +169,7 @@ def _install_openai_wrappers(client: AIGuardClient) -> None:
         client, reconstruct_openai_responses, _openai_response_create_after
     )
 
-    # AIDEV-NOTE: this wrap-target list MUST stay in sync with the contrib's own
+    # this wrap-target list MUST stay in sync with the contrib's own
     # wrap() calls in ddtrace/contrib/internal/openai/patch.py::patch() (the
     # ``_RESOURCES`` loop). ``parse`` is intentionally skipped: it is non-streaming
     # in the inspected SDKs. If the contrib adds/renames a streaming target, that
@@ -383,7 +383,7 @@ def _install_anthropic_wrappers(client: AIGuardClient) -> None:
 
         return BufferedAIGuardAsyncStream(result, reconstruct=reconstruct_anthropic, evaluate=evaluate)
 
-    # AIDEV-NOTE: this wrap-target list MUST stay in sync with the contrib's own
+    # this wrap-target list MUST stay in sync with the contrib's own
     # wrap() calls in ddtrace/contrib/internal/anthropic/patch.py::patch(). If the
     # contrib adds/renames a streaming target or changes the >= (0, 37) beta gate,
     # that surface silently goes unbuffered here -- a security gap with no failing

--- a/ddtrace/aiguard/_streaming.py
+++ b/ddtrace/aiguard/_streaming.py
@@ -75,7 +75,7 @@ def _text_delta_from_chunk(chunk: Any) -> Optional[str]:
 def _reconstruct_and_evaluate(reconstruct: ReconstructFn, evaluate: EvaluateFn, chunks: list[Any]) -> None:
     """Reconstruct a provider response from buffered *chunks* and run the AI Guard verdict.
 
-    AIDEV-NOTE: reconstruction must fail OPEN -- a converter bug must not break
+    reconstruction must fail OPEN -- a converter bug must not break
     the user's legitimate stream. Only ``evaluate`` (a block decision) is allowed
     to raise; reconstruction errors are swallowed and the buffer is replayed
     unevaluated. ``evaluate`` itself (``_anthropic_messages_create_after``) already

--- a/ddtrace/aiguard/_streaming.py
+++ b/ddtrace/aiguard/_streaming.py
@@ -75,7 +75,7 @@ def _text_delta_from_chunk(chunk: Any) -> Optional[str]:
 def _reconstruct_and_evaluate(reconstruct: ReconstructFn, evaluate: EvaluateFn, chunks: list[Any]) -> None:
     """Reconstruct a provider response from buffered *chunks* and run the AI Guard verdict.
 
-    reconstruction must fail OPEN -- a converter bug must not break
+    Reconstruction must fail OPEN -- a converter bug must not break
     the user's legitimate stream. Only ``evaluate`` (a block decision) is allowed
     to raise; reconstruction errors are swallowed and the buffer is replayed
     unevaluated. ``evaluate`` itself (``_anthropic_messages_create_after``) already

--- a/ddtrace/aiguard/integrations/_anthropic.py
+++ b/ddtrace/aiguard/integrations/_anthropic.py
@@ -72,7 +72,7 @@ def _wrap_abort_error(cause: AIGuardAbortError) -> AIGuardAbortError:
     """
     exception_class: type[AIGuardAbortError] = AIGuardAbortError
     try:
-        # AIDEV-NOTE: import lazily -- ``_anthropic_errors`` pulls in the optional
+        # import lazily -- ``_anthropic_errors`` pulls in the optional
         # Anthropic SDK at import time. Python's import lock guarantees all
         # concurrent cold imports observe the same class object.
         from ddtrace.aiguard.integrations._anthropic_errors import AnthropicAIGuardAbortError
@@ -264,7 +264,7 @@ def _format_server_tool_result_block(block: Any) -> Message:
     return msg
 
 
-# AIDEV-NOTE: Anthropic block types intentionally NOT mapped to AI Guard
+# Anthropic block types intentionally NOT mapped to AI Guard
 # content; unknown types are logged at debug-level. ``document`` is NOT
 # dropped (APMSP-3286): it carries model-visible content, see
 # _format_document_block.
@@ -621,7 +621,7 @@ def _anthropic_messages_create_before(client: AIGuardClient, kwargs: dict[str, A
         return None
 
     system = kwargs.get("system")
-    # AIDEV-NOTE: Top-level ``system`` may be an Iterable[TextBlockParam].
+    # Top-level ``system`` may be an Iterable[TextBlockParam].
     # Materialise generators before conversion and write them back, otherwise
     # AI Guard consumes the iterator and the SDK later serializes an exhausted
     # prompt.
@@ -637,7 +637,7 @@ def _anthropic_messages_create_before(client: AIGuardClient, kwargs: dict[str, A
         logger.debug("AI Guard anthropic before-hook skipped: no convertible messages")
         return None
 
-    # AIDEV-NOTE: Anthropic supports final assistant turns as response prefill
+    # Anthropic supports final assistant turns as response prefill
     # input; unlike OpenAI, those are still pre-model request content and must
     # be evaluated before calling the SDK.
     last_role = ai_guard_messages[-1].get("role")

--- a/ddtrace/aiguard/integrations/_anthropic_errors.py
+++ b/ddtrace/aiguard/integrations/_anthropic_errors.py
@@ -25,7 +25,7 @@ from ddtrace.aiguard._api_client import AIGuardAbortError
 class AnthropicAIGuardAbortError(anthropic.UnprocessableEntityError, AIGuardAbortError):  # type: ignore[misc]
     """AI Guard block error that also satisfies the Anthropic SDK hierarchy.
 
-    AIDEV-NOTE: catchability asymmetry vs plain ``AIGuardAbortError``.
+    catchability asymmetry vs plain ``AIGuardAbortError``.
     ``AIGuardAbortError`` derives from ``DDBlockException(BaseException)`` so a
     generic ``except Exception:`` does NOT catch it. This subclass also inherits
     from Anthropic's ``UnprocessableEntityError``, which is ``Exception``-derived,
@@ -50,7 +50,7 @@ class AnthropicAIGuardAbortError(anthropic.UnprocessableEntityError, AIGuardAbor
         self.tag_probs = tag_probs
 
         message = f"AIGuardAbortError(action='{action}', reason='{reason}', tags='{tags}')"
-        # AIDEV-NOTE: We can't call the SDK ``UnprocessableEntityError.__init__``
+        # We can't call the SDK ``UnprocessableEntityError.__init__``
         # here. Its MRO super() chain ends up at ``AIGuardAbortError.__init__``
         # (which requires ``(action, reason)``), not ``Exception.__init__``, so
         # the SDK's ``APIError`` initializer raises ``TypeError: missing

--- a/ddtrace/aiguard/integrations/_langchain.py
+++ b/ddtrace/aiguard/integrations/_langchain.py
@@ -256,7 +256,7 @@ def _get_tool_runtime_messages(tool_runtime: Any) -> list[Any]:
     under evaluation is re-appended by the caller as a single-tool-call
     assistant message (mirroring the legacy agent-action conversion).
 
-    AIDEV-NOTE: langchain >= 1.0 only. ``ToolRuntime`` and the langgraph
+    langchain >= 1.0 only. ``ToolRuntime`` and the langgraph
     ``ToolNode`` execution path this serves do not exist on earlier
     langchain releases; the legacy (< 1.0) agent path uses
     :func:`_handle_agent_action_result` instead.

--- a/ddtrace/aiguard/integrations/_langchain.py
+++ b/ddtrace/aiguard/integrations/_langchain.py
@@ -256,7 +256,7 @@ def _get_tool_runtime_messages(tool_runtime: Any) -> list[Any]:
     under evaluation is re-appended by the caller as a single-tool-call
     assistant message (mirroring the legacy agent-action conversion).
 
-    langchain >= 1.0 only. ``ToolRuntime`` and the langgraph
+    LangChain >= 1.0 only. ``ToolRuntime`` and the langgraph
     ``ToolNode`` execution path this serves do not exist on earlier
     langchain releases; the legacy (< 1.0) agent path uses
     :func:`_handle_agent_action_result` instead.

--- a/ddtrace/aiguard/integrations/_openai.py
+++ b/ddtrace/aiguard/integrations/_openai.py
@@ -28,7 +28,7 @@ def _wrap_abort_error(cause: AIGuardAbortError) -> AIGuardAbortError:
     """
     exception_class: type[AIGuardAbortError] = AIGuardAbortError
     try:
-        # AIDEV-NOTE: import lazily -- ``_openai_errors`` pulls in the optional
+        # import lazily -- ``_openai_errors`` pulls in the optional
         # OpenAI SDK at import time. Python's import lock guarantees all
         # concurrent cold imports observe the same class object.
         from ddtrace.aiguard.integrations._openai_errors import OpenAIAIGuardAbortError

--- a/ddtrace/aiguard/integrations/_openai_errors.py
+++ b/ddtrace/aiguard/integrations/_openai_errors.py
@@ -25,7 +25,7 @@ from ddtrace.aiguard._api_client import AIGuardAbortError
 class OpenAIAIGuardAbortError(openai.UnprocessableEntityError, AIGuardAbortError):  # type: ignore[misc]
     """AI Guard block error that also satisfies the OpenAI SDK hierarchy.
 
-    AIDEV-NOTE: catchability asymmetry vs plain ``AIGuardAbortError``.
+    catchability asymmetry vs plain ``AIGuardAbortError``.
     ``AIGuardAbortError`` derives from ``DDBlockException(BaseException)`` so a
     generic ``except Exception:`` does NOT catch it. This subclass also inherits
     from OpenAI's ``UnprocessableEntityError``, which is ``Exception``-derived,
@@ -50,7 +50,7 @@ class OpenAIAIGuardAbortError(openai.UnprocessableEntityError, AIGuardAbortError
         self.tag_probs = tag_probs
 
         message = f"AIGuardAbortError(action='{action}', reason='{reason}', tags='{tags}')"
-        # AIDEV-NOTE: We can't call the SDK ``UnprocessableEntityError.__init__``
+        # We can't call the SDK ``UnprocessableEntityError.__init__``
         # here. Its MRO super() chain ends up at ``AIGuardAbortError.__init__``
         # (which requires ``(action, reason)``), not ``Exception.__init__``, so
         # the SDK's ``APIError`` initializer raises ``TypeError: missing

--- a/ddtrace/aiguard/integrations/_openai_responses.py
+++ b/ddtrace/aiguard/integrations/_openai_responses.py
@@ -51,7 +51,7 @@ logger = ddlogger.get_logger(__name__)
 _RESPONSE_TEXT_BLOCK_TYPES = ("input_text", "output_text")
 # Refusal-style blocks carry their content under a ``refusal`` key.
 _RESPONSE_REFUSAL_BLOCK_TYPES = ("refusal", "output_refusal")
-# AIDEV-NOTE: Item types that must never reach the AI Guard evaluator.
+# Item types that must never reach the AI Guard evaluator.
 # - ``reasoning``: internal chain-of-thought emitted by reasoning-capable
 #   models; evaluating it would gate on the model's private deliberation
 #   rather than the user-visible conversation, and could leak CoT into AI
@@ -160,7 +160,7 @@ def _render_prompt_variable_value(value: Any) -> Optional[str]:
         if text is not None:
             return text
 
-        # AIDEV-NOTE: Prompt-template variables are user-controlled input.
+        # Prompt-template variables are user-controlled input.
         # Render unknown mappings recursively so object-valued text cannot
         # bypass AI Guard, but redact OpenAI file/image locator fields instead
         # of raw ``str(mapping)`` to avoid leaking signed URLs or opaque ids.
@@ -301,7 +301,7 @@ def _convert_openai_response_input(instructions: Any, input_: Any, prompt: Any =
       - Unknown / forward-incompatible types are silently dropped (the
         converter fails open so SDK calls don't break on new payload shapes).
 
-    AIDEV-NOTE: fail-open security tradeoff. Per-item exceptions are
+    fail-open security tradeoff. Per-item exceptions are
     swallowed (``logger.debug`` only) and items with unrecognised shape are
     dropped. If the entire ``input`` list is unconvertible — or yields only
     a ``system`` message from ``instructions`` — the before-hook returns

--- a/ddtrace/aiguard/integrations/_openai_responses.py
+++ b/ddtrace/aiguard/integrations/_openai_responses.py
@@ -301,7 +301,7 @@ def _convert_openai_response_input(instructions: Any, input_: Any, prompt: Any =
       - Unknown / forward-incompatible types are silently dropped (the
         converter fails open so SDK calls don't break on new payload shapes).
 
-    fail-open security tradeoff. Per-item exceptions are
+    Fail-open security tradeoff. Per-item exceptions are
     swallowed (``logger.debug`` only) and items with unrecognised shape are
     dropped. If the entire ``input`` list is unconvertible — or yields only
     a ``system`` message from ``instructions`` — the before-hook returns

--- a/ddtrace/aiguard/integrations/litellm.py
+++ b/ddtrace/aiguard/integrations/litellm.py
@@ -193,7 +193,7 @@ class DatadogAIGuardGuardrail(CustomGuardrail):  # type: ignore[misc]
         raw = dynamic_params.get("block")
         if raw is None:
             return server_block
-        # AIDEV-NOTE: intentionally fail-secure — only the literal "false" is treated as
+        # intentionally fail-secure — only the literal "false" is treated as
         # "don't add block"; any other value errs toward blocking. The `or server_block`
         # below means dynamic params can never weaken server policy regardless.
         dynamic_block = raw if isinstance(raw, bool) else str(raw).lower() != "false"

--- a/ddtrace/aiguard/integrations/strands.py
+++ b/ddtrace/aiguard/integrations/strands.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 from typing import Any
 
 
-# AIDEV-NOTE: strands-agents is optional. Guard its imports so this module
+# strands-agents is optional. Guard its imports so this module
 # always imports cleanly — ``ddtrace.aiguard.__getattr__`` imports it directly
 # and relies on both classes being defined (real when strands is present, stub
 # otherwise). ``_HAS_STRANDS`` covers the hooks API (HookProvider); the separate
@@ -94,7 +94,7 @@ _INVOCATION_CTX_KEY = "_dd_ai_guard_ctx"
 _HANDLED_CONTENT_KEYS = frozenset({"text", "toolUse", "toolResult", "json"})
 _CONTROL_CONTENT_KEYS = frozenset({"cachePoint", "reasoningContent"})
 
-# AIDEV-NOTE: APMSP-3089 — non-text content must NOT be silently dropped.
+# APMSP-3089 — non-text content must NOT be silently dropped.
 # Dropping every non-text block made a document/image-only prompt produce zero
 # AI Guard messages, so evaluation was skipped while the model saw uninspected
 # content (a bypass). We emit a placeholder marker for each model-visible

--- a/ddtrace/appsec/_constants.py
+++ b/ddtrace/appsec/_constants.py
@@ -415,7 +415,7 @@ class STACK_TRACE(metaclass=Constant_Class):
     TAG: Literal["_dd.stack"] = "_dd.stack"
 
 
-# AIDEV-NOTE: AI_GUARD constants moved to ddtrace/aiguard/_constants.py to align with the
+# AI_GUARD constants moved to ddtrace/aiguard/_constants.py to align with the
 # top-level aiguard package. Import from there: `from ddtrace.aiguard._constants import AI_GUARD`.
 
 

--- a/ddtrace/appsec/_iast/_taint_tracking/__init__.py
+++ b/ddtrace/appsec/_iast/_taint_tracking/__init__.py
@@ -48,7 +48,7 @@ from ddtrace.internal.logger import get_logger
 
 log = get_logger(__name__)
 
-# AIDEV-NOTE: _get_iast_context_id is imported lazily — a top-level import here
+# _get_iast_context_id is imported lazily — a top-level import here
 # circularly bootstraps via _iast_request_context_base -> _taint_tracking._context
 # -> _taint_tracking/__init__.py. The cached module-global avoids the per-call
 # import dance on this hot path.
@@ -78,7 +78,7 @@ def get_ranges(string_input: Any, context_id: Optional[int] = None) -> Any:
 
 
 def copy_ranges_from_strings(str_1: Any, str_2: Any, context_id: Optional[int] = None) -> None:
-    # AIDEV-NOTE: scope the copy to the active request slot to match the scoped
+    # scope the copy to the active request slot to match the scoped
     # get_ranges() read path; otherwise the native multi-slot resolver may write
     # the derived taint into a concurrent request's map and the scoped read misses it.
     if context_id is None:

--- a/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.h
+++ b/ddtrace/appsec/_iast/_taint_tracking/context/taint_engine_context.h
@@ -92,7 +92,7 @@ class TaintEngineContext
     // request context maps and return the first map that contains at least
     // one of these ranges in any of its stored TaintedObjects. Returns nullptr
     // if none of the ranges are found in any active map.
-    // AIDEV-QUESTION: Should this require all ranges to be found in the same
+    // TODO: Should this require all ranges to be found in the same
     // map/object, or is finding any one sufficient? Implemented as "any"
     // for now for performance and broader matching.
     TaintedObjectMapTypePtr get_tainted_object_map_from_ranges(const TaintRangeRefs& ranges);

--- a/ddtrace/appsec/_iast/_taint_tracking/tests/test_taint_engine_context.cpp
+++ b/ddtrace/appsec/_iast/_taint_tracking/tests/test_taint_engine_context.cpp
@@ -35,7 +35,7 @@ class ApplicationContextTest : public ::testing::Test
   protected:
     void SetUp() override
     {
-        // AIDEV-NOTE: Global interpreter is managed by tests/pyenv_env.cpp
+        // Global interpreter is managed by tests/pyenv_env.cpp
         taint_engine_context = std::make_unique<TaintEngineContext>();
         taint_engine_context->clear_all_request_context_slots();
     }

--- a/ddtrace/appsec/ai_guard/__init__.py
+++ b/ddtrace/appsec/ai_guard/__init__.py
@@ -11,7 +11,7 @@ from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.internal.utils.deprecations import deprecate
 
 
-# AIDEV-NOTE: lazy re-export shim. Accessing any public symbol here warns once
+# lazy re-export shim. Accessing any public symbol here warns once
 # (cached back into globals()) and forwards to its new home. Most symbols moved
 # to ddtrace.aiguard; the Strands classes moved to
 # ddtrace.aiguard.integrations.strands (they are deliberately not re-exported

--- a/ddtrace/contrib/internal/aiobotocore/patch.py
+++ b/ddtrace/contrib/internal/aiobotocore/patch.py
@@ -4,7 +4,7 @@ import wrapt
 from ddtrace import config
 from ddtrace._trace.pin import Pin
 
-# AIDEV-NOTE: _http_propagation_suppressed is the shared seam telling the
+# _http_propagation_suppressed is the shared seam telling the
 # aiohttp-layer subscriber to skip its own injection during AWS calls; _wrapped_api_call
 # is one of its two permitted setters. See the ownership contract on its
 # definition in ddtrace/_trace/subscribers/http_client.py.
@@ -13,7 +13,7 @@ from ddtrace._trace.utils_botocore.span_tags import _derive_peer_hostname
 from ddtrace.constants import _SPAN_MEASURED_KEY
 from ddtrace.constants import SPAN_KIND
 
-# AIDEV-NOTE: Shared with botocore; this integration registers its own owner-gated
+# Shared with botocore; this integration registers its own owner-gated
 # wrapper via _ensure_before_sign_handler. See botocore/patch.py for the contract.
 from ddtrace.contrib.internal.botocore.patch import _ensure_before_sign_handler
 from ddtrace.contrib.internal.botocore.patch import _inject_trace_headers_handler

--- a/ddtrace/contrib/internal/anthropic/patch.py
+++ b/ddtrace/contrib/internal/anthropic/patch.py
@@ -50,7 +50,7 @@ def traced_chat_model_generate(func: Callable[..., Any], instance: Any, args: An
         instance=instance,
     )
 
-    # AIDEV-NOTE: For streaming, dispatch_end_event=False defers the ended event
+    # For streaming, dispatch_end_event=False defers the ended event
     # until the stream handler calls ctx.dispatch_ended_event() in finalize_stream().
     # For errors, we must manually dispatch so the span finishes with error info.
     with core.context_with_event(event, dispatch_end_event=False) as ctx:
@@ -121,7 +121,7 @@ def patch() -> None:
     integration = AnthropicIntegration(integration_config=config.anthropic)
     anthropic._datadog_integration = integration
 
-    # AIDEV-NOTE: AI Guard mirrors this wrap-target list in
+    # AI Guard mirrors this wrap-target list in
     # ddtrace/appsec/_ai_guard/_listener.py::_install_anthropic_wrappers to
     # install its outermost streaming buffer. If you add/rename a target or
     # change the >= (0, 37) beta gate below, update that list too or the new

--- a/ddtrace/contrib/internal/aws_durable_execution_sdk_python/patch.py
+++ b/ddtrace/contrib/internal/aws_durable_execution_sdk_python/patch.py
@@ -126,7 +126,7 @@ def _traced_durable_execution(wrapped: Callable, instance: Any, args: tuple, kwa
 
         # Mark our _datadog_* checkpoints visited so the SDK's replay tracker
         # transitions REPLAY → NEW; without this it stays stuck in REPLAY.
-        # AIDEV-NOTE: always-on even when cross_invocation_tracing is off — if
+        # always-on even when cross_invocation_tracing is off — if
         # the writer was previously enabled, those ops still exist on resume and
         # must be marked or the SDK pins to REPLAY forever.
         mark_trace_context_checkpoints_visited(state)
@@ -183,7 +183,7 @@ def _traced_process(wrapped: Callable, instance: Any, args: tuple, kwargs: dict)
             is_replayed = checkpoint.is_succeeded() or checkpoint.is_failed()
             event.replayed = is_replayed
             event.id = operation_id
-            # AIDEV-NOTE: report operation_attempt 0-indexed (0 = original, 1 =
+            # report operation_attempt 0-indexed (0 = original, 1 =
             # first retry) so a fresh execution and its replay agree. The
             # server-maintained step_details.attempt is read at two points: a
             # pending checkpoint holds the prior-failure count (already the
@@ -194,7 +194,7 @@ def _traced_process(wrapped: Callable, instance: Any, args: tuple, kwargs: dict)
                 operation = checkpoint.operation
                 if operation is not None and operation.step_details is not None:
                     attempt = operation.step_details.attempt
-                    # AIDEV-NOTE: the `attempt > 0` guard is purely defensive;
+                    # the `attempt > 0` guard is purely defensive;
                     # we have NOT observed attempt == 0 on a terminal checkpoint. It
                     # avoids emitting operation_attempt = -1 if a terminal StepDetails
                     # ever lacks "Attempt" (from_dict defaults it to 0).
@@ -274,7 +274,7 @@ def patch():
 
     aws_durable_execution_sdk_python._datadog_patch = True
 
-    # AIDEV-NOTE: durable_execution is re-exported from the top-level __init__
+    # durable_execution is re-exported from the top-level __init__
     # via ``from .execution import durable_execution``. That creates a separate
     # name binding, so we must wrap in BOTH modules.
     wrap("aws_durable_execution_sdk_python.execution", "durable_execution", _traced_durable_execution)

--- a/ddtrace/contrib/internal/aws_durable_execution_sdk_python/trace_checkpoint.py
+++ b/ddtrace/contrib/internal/aws_durable_execution_sdk_python/trace_checkpoint.py
@@ -7,11 +7,11 @@ reads the highest N from ``InitialExecutionState.Operations`` to re-activate the
 Only runs on the suspend path; no-op when stable headers (``HTTP_HEADER_PARENT_ID``
 excluded) match the most recent prior checkpoint.
 
-AIDEV-NOTE: only Datadog-style headers are written — both writer and reader are
+only Datadog-style headers are written — both writer and reader are
 Datadog code (this integration and ``datadog-lambda-python``), so W3C/B3 headers
 would just bloat the payload.
 
-AIDEV-NOTE: ``_datadog_*`` is a reserved step name; the SDK does not enforce this.
+``_datadog_*`` is a reserved step name; the SDK does not enforce this.
 """
 
 from __future__ import annotations

--- a/ddtrace/contrib/internal/aws_durable_execution_sdk_python/trace_checkpoint.py
+++ b/ddtrace/contrib/internal/aws_durable_execution_sdk_python/trace_checkpoint.py
@@ -7,7 +7,7 @@ reads the highest N from ``InitialExecutionState.Operations`` to re-activate the
 Only runs on the suspend path; no-op when stable headers (``HTTP_HEADER_PARENT_ID``
 excluded) match the most recent prior checkpoint.
 
-only Datadog-style headers are written — both writer and reader are
+Only Datadog-style headers are written — both writer and reader are
 Datadog code (this integration and ``datadog-lambda-python``), so W3C/B3 headers
 would just bloat the payload.
 

--- a/ddtrace/contrib/internal/botocore/patch.py
+++ b/ddtrace/contrib/internal/botocore/patch.py
@@ -16,7 +16,7 @@ import ddtrace
 from ddtrace import config
 from ddtrace._trace.pin import Pin
 
-# AIDEV-NOTE: _http_propagation_suppressed is the shared seam telling the
+# _http_propagation_suppressed is the shared seam telling the
 # urllib3-layer subscriber to skip its own injection during AWS calls. See the
 # ownership contract on its definition in ddtrace/_trace/subscribers/http_client.py.
 from ddtrace._trace.subscribers.http_client import _http_propagation_suppressed
@@ -136,7 +136,7 @@ def _inject_trace_headers_handler(request, **kwargs):
     ):
         return
 
-    # AIDEV-NOTE: Uses the global tracer's current_span() because the before-sign
+    # Uses the global tracer's current_span() because the before-sign
     # event hands us the AWSRequest, not the client, so there's no Pin to read here.
     span = ddtrace.tracer.current_span()
     if span is None:
@@ -167,7 +167,7 @@ def _botocore_before_sign_handler(request, **kwargs):
     _inject_trace_headers_handler(request, **kwargs)
 
 
-# AIDEV-NOTE: Also imported by ddtrace.contrib.internal.aiobotocore.patch;
+# Also imported by ddtrace.contrib.internal.aiobotocore.patch;
 # rename in lockstep. Each integration passes its own owner-gated handler.
 def _ensure_before_sign_handler(client, handler) -> bool:
     """Register ``handler`` for ``before-sign`` on this client's emitter, once.

--- a/ddtrace/contrib/internal/botocore/services/kinesis.py
+++ b/ddtrace/contrib/internal/botocore/services/kinesis.py
@@ -56,7 +56,7 @@ def update_record(ctx, record: dict[str, Any], stream: str, inject_trace_context
 def select_records_for_injection(params: list[Any], inject_trace_context: bool) -> list[tuple[Any, bool]]:
     records_to_inject_into = []
     if "Records" in params and params["Records"]:
-        # AIDEV-NOTE: Kinesis PutRecords originally injected trace context into only the
+        # Kinesis PutRecords originally injected trace context into only the
         # first record in the batch (see PR #3178 for the original discussion). We now
         # inject every record because downstream consumers can receive records
         # individually rather than as the original producer batch.

--- a/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
+++ b/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py
@@ -419,7 +419,7 @@ class ClaudeAgentSdkAsyncStreamHandler(AsyncStreamHandler):
     def _handle_assistant_message(self, chunk: Any, content: Any) -> None:
         """Buffer the chunk, deduping by message_id so one model turn maps to one llm span.
 
-        AIDEV-NOTE: The SDK may split one model turn (e.g. a text block plus a tool_use
+        The SDK may split one model turn (e.g. a text block plus a tool_use
         block) into several AssistantMessage chunks that each repeat the same message-level
         usage. Buffering and merging chunks of one message into a single llm span (flushed on
         turn change / UserMessage / ResultMessage) keeps token counts from being

--- a/ddtrace/contrib/internal/coverage/patch.py
+++ b/ddtrace/contrib/internal/coverage/patch.py
@@ -25,7 +25,7 @@ _coverage_instance: Optional[Any] = None
 _owns_coverage_instance = False
 _cached_coverage_percentage: Optional[float] = None
 
-# AIDEV-NOTE: External tools such as pytest-cov can own Coverage.current(). We may cache
+# External tools such as pytest-cov can own Coverage.current(). We may cache
 # their instance to generate reports, but must never stop, save, or erase it.
 
 

--- a/ddtrace/contrib/internal/grpc/aio_client_interceptor.py
+++ b/ddtrace/contrib/internal/grpc/aio_client_interceptor.py
@@ -71,7 +71,7 @@ _GRPC_AIO_ERROR_HANDLED = "_dd.grpc_aio.error_handled"
 
 def _done_callback_stream(span: Span) -> Callable[[aio.Call], None]:
     def func(call: aio.Call) -> None:
-        # AIDEV-NOTE: gRPC can mark the call done and invoke this callback while
+        # gRPC can mark the call done and invoke this callback while
         # the stream iterator's `_raise_for_status()` is still building the
         # `AioRpcError` — i.e. before control reaches our `except aio.AioRpcError`
         # handler and `_handle_stream_rpc_error` has had a chance to set the ctx
@@ -148,7 +148,7 @@ async def _handle_cancelled_error(call: aio.Call, span: Span) -> None:
 
 
 async def _handle_stream_rpc_error(span: Span, call: aio.Call, rpc_error: aio.AioRpcError) -> None:
-    # AIDEV-NOTE: rpc_error.details() can return the transport placeholder
+    # rpc_error.details() can return the transport placeholder
     # "Internal error from Core" if trailers haven't been processed yet; awaiting
     # call.code()/details() blocks until the call is fully terminated and returns
     # the authoritative final state. Set the ctx flag synchronously before

--- a/ddtrace/contrib/internal/langchain/utils.py
+++ b/ddtrace/contrib/internal/langchain/utils.py
@@ -16,7 +16,7 @@ class BaseLangchainStreamHandler:
             chunk_callback(chunk)
 
     def start_stream(self):
-        # AIDEV-NOTE: dispatched lazily from ``TracedStream.__iter__`` /
+        # dispatched lazily from ``TracedStream.__iter__`` /
         # ``TracedAsyncStream.__aiter__`` (via ``BaseStreamHandler.start_stream``),
         # so it only runs when the caller actually starts iterating. Bumping
         # the AI Guard depth counter here — instead of in the ``.before``
@@ -31,7 +31,7 @@ class BaseLangchainStreamHandler:
         on_span_finish = self.options.get("on_span_finish", None)
         if on_span_finish:
             on_span_finish(self.primary_span, self.chunks)
-        # AIDEV-NOTE: dispatch the AI Guard ``.finally`` event before finishing
+        # dispatch the AI Guard ``.finally`` event before finishing
         # the span so the active-context counter set by ``start_stream`` is
         # released on every iteration-exit path — success, exception, early
         # ``break``, or ``aclose()`` — since ``finalize_stream`` is called
@@ -103,7 +103,7 @@ def shared_stream(
             LangchainStreamHandler(integration, span, args, kwargs, **handler_kwargs),
         )
     except (DDBlockException, Exception):
-        # AIDEV-NOTE: catch ``DDBlockException`` explicitly (parent of
+        # catch ``DDBlockException`` explicitly (parent of
         # ``AIGuardAbortError``) since it inherits from ``BaseException`` —
         # otherwise the AI Guard abort would slip past ``except Exception:``
         # and the LLM span would never get ``set_exc_info`` / ``finish``,

--- a/ddtrace/contrib/internal/langgraph/patch.py
+++ b/ddtrace/contrib/internal/langgraph/patch.py
@@ -203,7 +203,7 @@ def traced_runnable_seq_astream(func, instance, args, kwargs):
                     yield item
                 except StopAsyncIteration:
                     break
-                # AIDEV-NOTE: do not widen to bare ``BaseException`` here - this wraps a ``yield``, so
+                # do not widen to bare ``BaseException`` here - this wraps a ``yield``, so
                 # ``GeneratorExit`` / ``CancelledError`` from normal stream teardown must not be caught
                 # (they'd be mis-reported as span errors). The ``finally`` below still closes the span.
                 except (DDBlockException, Exception) as e:
@@ -290,7 +290,7 @@ def traced_pregel_stream(func, instance, args, kwargs):
                         span.set_exc_info(*sys.exc_info())
                     raise
         finally:
-            # AIDEV-NOTE: finish in ``finally`` so the span closes on every exit, including early
+            # finish in ``finally`` so the span closes on every exit, including early
             # abandonment - a consumer ``break`` tears the generator down via ``GeneratorExit``, which is
             # intentionally not caught above, so teardown is not flagged as an error. ``response`` stays
             # ``None`` unless the stream ran to completion, so abandonment reports no misleading output.
@@ -338,7 +338,7 @@ def traced_pregel_astream(func, instance, args, kwargs):
                         span.set_exc_info(*sys.exc_info())
                     raise
         finally:
-            # AIDEV-NOTE: finish in ``finally`` so the span closes on every exit, including early
+            # finish in ``finally`` so the span closes on every exit, including early
             # abandonment - a consumer ``break`` on ``__interrupt__`` (human-in-the-loop) tears the generator
             # down via ``GeneratorExit``, which is intentionally not caught above, so teardown is not
             # flagged as an error. ``response`` stays ``None`` unless the stream ran to completion.

--- a/ddtrace/contrib/internal/openai_agents/patch.py
+++ b/ddtrace/contrib/internal/openai_agents/patch.py
@@ -36,7 +36,7 @@ async def _patched_run_single_turn(func, instance, args, kwargs):
         log.debug("No current span available, skipping tag_agent_manifest")
         return result
 
-    # AIDEV-NOTE: MLOB-7584 — the SDK doesn't guard this wrap site, so an unguarded raise here
+    # MLOB-7584 — the SDK doesn't guard this wrap site, so an unguarded raise here
     # would surface in the user's Runner.run.
     try:
         integration = agents._datadog_integration
@@ -56,7 +56,7 @@ def _has_module_level_run_loop() -> bool:
         return False
 
 
-# AIDEV-NOTE: MLOB-7584 — agents >= 0.8.0 moved the per-turn fn to agents.run_internal.run_loop. Wrap the
+# MLOB-7584 — agents >= 0.8.0 moved the per-turn fn to agents.run_internal.run_loop. Wrap the
 # agents.run re-export (run.py binds the name at import, so the definition is too late); streamed lives in run_loop.
 # Both variants share one wrapper — the unified scanner resolves the agent for every shape.
 _MODULE_RUN_LOOP_WRAP_TARGETS = [

--- a/ddtrace/contrib/internal/pytest/_plugin_v2.py
+++ b/ddtrace/contrib/internal/pytest/_plugin_v2.py
@@ -431,7 +431,7 @@ def _handle_coverage_patch_early(config):
 def pytest_configure(config: pytest_Config) -> None:
     global skip_pytest_runtest_protocol, skipped_suites
 
-    # AIDEV-NOTE: Reset per-session module-level state for every new main-process
+    # Reset per-session module-level state for every new main-process
     # session. This is necessary when inline_run() calls pytest.main() inside an
     # outer xdist worker: the module is already imported, so module-level
     # initialisations don't re-run. Without this reset, skipped_suites accumulates
@@ -498,7 +498,7 @@ def pytest_configure(config: pytest_Config) -> None:
 
                 if not hasattr(config, "workerinput"):
                     # Main process: reset per-session xdist ITR skip counter.
-                    # AIDEV-NOTE: Do NOT guard with PYTEST_XDIST_WORKER_VALUE is None here.
+                    # Do NOT guard with PYTEST_XDIST_WORKER_VALUE is None here.
                     # PYTEST_XDIST_WORKER_VALUE is a module-level constant frozen at import time.
                     # When inline_run() is called inside an outer xdist worker, the constant is
                     # "gw0" for the entire process lifetime, so the reset would never fire and

--- a/ddtrace/contrib/internal/pytorch/_distributed.py
+++ b/ddtrace/contrib/internal/pytorch/_distributed.py
@@ -33,7 +33,7 @@ _deepspeed_hook_registered: bool = False
 
 # Tracks the active ExecutionContext for the current distributed training session.
 # Presence (non-None) doubles as the "bootstrapped" flag.
-# AIDEV-NOTE: ContextVar is per-thread — safe because init/destroy_process_group always run on the same thread in DDP.
+# ContextVar is per-thread — safe because init/destroy_process_group always run on the same thread in DDP.
 _rank_ctx: contextvars.ContextVar[Optional[core.ExecutionContext[Any]]] = contextvars.ContextVar(
     "pytorch_rank_ctx", default=None
 )
@@ -44,7 +44,7 @@ def _step_profiling_enabled() -> bool:
 
 
 # Wire-format env var names set by the Ray contrib on worker processes.
-# AIDEV-NOTE: duplicated from ddtrace.contrib.internal.ray intentionally —
+# duplicated from ddtrace.contrib.internal.ray intentionally —
 # contrib-to-contrib imports break isolation (ray contrib may not be installed).
 # If these names ever change, update both sides.
 _RAY_SUBMISSION_ID_ENV = "_RAY_SUBMISSION_ID"
@@ -57,7 +57,7 @@ def _reset_child_state() -> None:
     ctx = _rank_ctx.get()
     if ctx is not None:
         _rank_ctx.set(None)
-        # AIDEV-NOTE: Deferred imports + manual reset — import system may be unsafe post-fork.
+        # Deferred imports + manual reset — import system may be unsafe post-fork.
         try:
             from ddtrace.internal.core import _CURRENT_CONTEXT  # noqa: PLC0415
             from ddtrace.internal.core import ROOT_CONTEXT_ID  # noqa: PLC0415
@@ -169,7 +169,7 @@ def _wrapped_init_process_group(wrapped: Any, instance: Any, args: Any, kwargs: 
 
     if not already:
         ctx = core.context_with_data("pytorch.rank", dispatch_end_event=False)  # type: ignore[no-untyped-call]
-        # AIDEV-NOTE: __enter__() updates _CURRENT_CONTEXT so child spans are parented here; dispatch_end_event=False
+        # __enter__() updates _CURRENT_CONTEXT so child spans are parented here; dispatch_end_event=False
         # defers the ended event — dispatch_ended_event() + __exit__() are called in _wrapped_destroy_process_group.
         ctx.__enter__()
         _rank_ctx.set(ctx)
@@ -279,7 +279,7 @@ def _wrapped_fsdp_init(wrapped: Any, instance: Any, args: Any, kwargs: Any) -> A
 
 
 def _install_fsdp() -> None:
-    # AIDEV-NOTE: defer the import of torch.distributed.fsdp until the user
+    # defer the import of torch.distributed.fsdp until the user
     # actually imports it. Eagerly importing it pulls _dynamo + sympy (~1.3s
     # startup cost) for every DDP workload that never uses FSDP.
     global _fsdp_hook_registered

--- a/ddtrace/contrib/internal/trace_utils.py
+++ b/ddtrace/contrib/internal/trace_utils.py
@@ -626,7 +626,7 @@ def _copy_trace_level_tags(target_span: Span, parent: Span):
     raw_tracestate = parent.context._meta.get(W3C_TRACESTATE_KEY, "")
     ot_value = w3c_get_tracestate_list_member(raw_tracestate, "ot")
     if ot_value is not None:
-        # AIDEV-NOTE: WebSocket message spans start independent traces. Copy only canonical ot=
+        # WebSocket message spans start independent traces. Copy only canonical ot=
         # sampling data; other vendor members describe the parent trace.
         target_span.context._meta[W3C_TRACESTATE_KEY] = "ot=" + ot_value
 

--- a/ddtrace/internal/_threads.cpp
+++ b/ddtrace/internal/_threads.cpp
@@ -479,7 +479,7 @@ typedef struct periodic_thread
     std::chrono::time_point<std::chrono::steady_clock> _next_call_time;
 
     std::unique_ptr<Event> _started;
-    // AIDEV-NOTE: _stopped uses shared_ptr so the lambda can capture a copy.
+    // _stopped uses shared_ptr so the lambda can capture a copy.
     // When PyRef's Py_DECREF drops the Python refcount to zero during thread
     // teardown, dealloc resets self->_stopped (decrementing the shared_ptr
     // refcount), but the lambda's captured copy keeps the Event alive until
@@ -631,7 +631,7 @@ PeriodicThread__on_shutdown(PeriodicThread* self)
 static PyObject*
 _PeriodicThread_do_start(PeriodicThread* self, bool reset_next_call_time = false)
 {
-    // AIDEV-NOTE: PyRef is constructed before the lock — it only requires the
+    // PyRef is constructed before the lock — it only requires the
     // GIL (held here), not _thread_mutex. This keeps self alive across the
     // entire window between std::thread creation and the moment the lambda
     // acquires the GIL, during which the OS thread holds only a raw C pointer.

--- a/ddtrace/internal/ci_visibility/recorder.py
+++ b/ddtrace/internal/ci_visibility/recorder.py
@@ -666,7 +666,7 @@ class CIVisibility(Service, CIVisibilityProtocol):
             cls._instance.is_known_tests_enabled(),
         )
 
-    # AIDEV-NOTE: _suspend()/_resume() allow a nested pytest session (e.g. inline_run())
+    # _suspend()/_resume() allow a nested pytest session (e.g. inline_run())
     # or a test fixture to get a clean-slate view of CIVisibility without stopping the
     # outer session's instance.  Unlike calling disable(), _suspend() never calls stop()
     # on the instance, so the outer tracer and telemetry keep running.  Pair them in a

--- a/ddtrace/internal/coverage/code.py
+++ b/ddtrace/internal/coverage/code.py
@@ -115,7 +115,7 @@ class ModuleCodeCollector(ModuleWatchdog):
         self._import_time_contexts: dict[str, "ModuleCodeCollector.CollectInContext"] = {}
         self._import_time_name_to_path: dict[str, str] = {}
         self._import_names_by_path: dict[str, set[tuple[str, tuple[str, ...]]]] = defaultdict(set)
-        # AIDEV-NOTE: Import metadata can grow during late/dynamic imports. Clear this cache whenever import coverage
+        # Import metadata can grow during late/dynamic imports. Clear this cache whenever import coverage
         # metadata changes so per-test import-time augmentation does not miss newly discovered dependencies.
         self._direct_import_time_dependency_paths_cache: dict[str, frozenset[str]] = {}
         self._import_time_dependency_paths_cache: dict[str, frozenset[str]] = {}

--- a/ddtrace/internal/coverage/instrumentation_py3_12.py
+++ b/ddtrace/internal/coverage/instrumentation_py3_12.py
@@ -413,7 +413,7 @@ def _extract_lines_and_imports(
     injection needs richer bytecode objects, but conservative import metadata and line extraction can be decoded from
     CPython wordcode directly with much lower overhead.
 
-    AIDEV-NOTE: This raw scanner handles CPython 3.12+ bytecode details that are easy to lose when editing:
+    This raw scanner handles CPython 3.12+ bytecode details that are easy to lose when editing:
     CACHE entries must not enter the argument history; 3.14+ LOAD_SMALL_INT stores the integer directly instead of
     indexing co_consts; dis.findlinestarts() owns the version-specific line table decoding; and 3.15+ PEP 810
     bit-packs IMPORT_NAME's co_names index behind lazy-import flag bits.
@@ -501,7 +501,7 @@ def _extract_lines_and_imports(
                 else:
                     import_names[line] = (current_import_package or package, (import_from_name,))
 
-            # AIDEV-NOTE: Decode argument value and shift history after opcode handling. IMPORT_NAME reads
+            # Decode argument value and shift history after opcode handling. IMPORT_NAME reads
             # prev_prev_value before this block because the import sequence is level, fromlist, IMPORT_NAME.
             if opcode == LOAD_CONST:
                 decoded = code.co_consts[current_arg]

--- a/ddtrace/internal/datastreams/google_cloud_pubsub.py
+++ b/ddtrace/internal/datastreams/google_cloud_pubsub.py
@@ -53,7 +53,7 @@ def dsm_pubsub_receive(subscription: str, message: Any, span: Optional[Any]) -> 
     payload_size += _calculate_byte_size(attributes)
 
     ctx = DsmPathwayCodec.decode(attributes, processor())
-    # AIDEV-NOTE: dd-trace-py uses the `topic:` tag key as the generic destination
+    # dd-trace-py uses the `topic:` tag key as the generic destination
     # identifier for every messaging integration (Kafka, Kinesis, SQS, SNS, RabbitMQ).
     # The *value* on the consumer side is the Pub/Sub subscription path, which
     # preserves fan-out distinction (multiple subscriptions on the same topic each

--- a/ddtrace/internal/forksafe.py
+++ b/ddtrace/internal/forksafe.py
@@ -39,7 +39,7 @@ _forked = False
 # many generations of forks have occurred since the original process.
 _fork_generation = 0
 
-# AIDEV-NOTE: Process managers such as Celery can close inherited file descriptors after
+# Process managers such as Celery can close inherited file descriptors after
 # Python's after-in-child callbacks return. Native workers must not be rebuilt while this
 # flag is set because their newly opened descriptors would be swept up by that later cleanup.
 _in_child_hook = False

--- a/ddtrace/internal/openfeature/_provider.py
+++ b/ddtrace/internal/openfeature/_provider.py
@@ -179,7 +179,7 @@ class DataDogProvider(AbstractProvider):
         # EVP flagevaluation writer + hook — gated by DD_FLAGGING_EVALUATION_COUNTS_ENABLED
         # (default on). Gates ONLY the EVP path; the OTel path above is always registered
         # when the provider is enabled (preserves the existing OTel non-regression).
-        # AIDEV-NOTE: the killswitch is read through the ddtrace config system
+        # the killswitch is read through the ddtrace config system
         # (OpenFeatureConfig.flagging_evaluation_counts_enabled, registered in
         # supported-configurations.json) rather than raw os.environ. It comes from the
         # fresh instance_config built at the top of __init__, so the value reflects the
@@ -298,7 +298,7 @@ class DataDogProvider(AbstractProvider):
             self._status = ProviderStatus.READY
             return  # SDK will dispatch PROVIDER_READY
 
-        # AIDEV-NOTE: the wait above must stay bounded. A blocked initialize() blocks
+        # the wait above must stay bounded. A blocked initialize() blocks
         # set_provider() in openfeature-sdk 0.8.x and set_provider_and_wait() in 0.10+.
         # The 10s default stays inside gunicorn's 30s worker timeout. Raising the
         # OpenFeature error is also required: the SDK converts it to PROVIDER_ERROR for
@@ -448,7 +448,7 @@ class DataDogProvider(AbstractProvider):
           flag is not found in the configuration
         - Returns error with error_code and error_message on other errors
         """
-        # AIDEV-NOTE: Stamp eval-time at provider entry so every OpenFeature exit path
+        # Stamp eval-time at provider entry so every OpenFeature exit path
         # can feed the EVP flagevaluation hook first_evaluation/last_evaluation from
         # evaluation time, not the later hook/flush time.
         flag_metadata: dict[str, typing.Any] = {EVAL_TIMESTAMP_METADATA_KEY: int(time.time() * 1000)}

--- a/ddtrace/internal/openfeature/_remoteconfiguration.py
+++ b/ddtrace/internal/openfeature/_remoteconfiguration.py
@@ -27,7 +27,7 @@ class FeatureFlagCallback(RCCallback):
     """Remote Configuration callback for Feature Flagging and Experimentation (FFE)."""
 
     def __init__(self) -> None:
-        # AIDEV-NOTE: Path of the configuration currently loaded, so a removal only
+        # Path of the configuration currently loaded, so a removal only
         # clears it when it names that same path. Replacing a config is remove(old) +
         # add(new), and a forked child can see the two in either order because the
         # shared-memory distribution publishes a manifest per file operation (see

--- a/ddtrace/internal/opentelemetry/sampling.py
+++ b/ddtrace/internal/opentelemetry/sampling.py
@@ -140,7 +140,7 @@ def resolve_otel_sampling_decision(
     the upstream sampled bit. Explicit non-probabilistic decisions erase th while
     preserving a valid inherited rv and unknown fields.
     """
-    # AIDEV-NOTE: Valid inherited sampling fields remain authoritative because the
+    # Valid inherited sampling fields remain authoritative because the
     # tracer follows the upstream sampled bit. Only a non-probabilistic decision
     # invalidates an inherited threshold.
     if ot_value is None:

--- a/ddtrace/internal/opentelemetry/span.py
+++ b/ddtrace/internal/opentelemetry/span.py
@@ -156,7 +156,7 @@ class Span(OtelSpan):
 
         context = self._ddspan.context
         tf = TraceFlags(context._trace_flags)
-        # AIDEV-NOTE: Consume canonical tracestate entries directly. Formatting an HTTP
+        # Consume canonical tracestate entries directly. Formatting an HTTP
         # header only for TraceState.from_header() to split it again is measurable here.
         ts = TraceState(context._tracestate_entries(self._ddspan.span_id))
 

--- a/ddtrace/internal/packages.py
+++ b/ddtrace/internal/packages.py
@@ -21,7 +21,7 @@ Distribution = t.NamedTuple("Distribution", [("name", str), ("version", str)])
 
 _PACKAGE_DISTRIBUTIONS: t.Optional[t.Mapping[str, t.List[str]]] = None  # noqa: UP006
 
-# AIDEV-NOTE: dist.metadata access is per-dist defensive — malformed METADATA
+# dist.metadata access is per-dist defensive — malformed METADATA
 # (rare but real on system-Python / CI images) must not poison the @callonce cache.
 _BAD_DISTS_WARNED: set[str] = set()
 
@@ -359,7 +359,7 @@ def _package_for_root_module_mapping() -> t.Optional[dict[str, Distribution]]:
         )
         return None
 
-    # AIDEV-NOTE: per-dist try/except — one bad dist used to collapse the whole
+    # per-dist try/except — one bad dist used to collapse the whole
     # mapping to None (silently breaking is_third_party for the rest of the process).
     mapping: dict[str, Distribution] = {}
     for dist in dists:

--- a/ddtrace/internal/sampling.py
+++ b/ddtrace/internal/sampling.py
@@ -42,7 +42,7 @@ class PriorityCategory(object):
     RULE_DYNAMIC = "rule_dynamic"
 
 
-# AIDEV-NOTE: sampling mechanism is an opaque integer; validate syntax/range only, not enum
+# sampling mechanism is an opaque integer; validate syntax/range only, not enum
 # membership, or unenumerated-but-valid ids get silently dropped (#13516, #19335). Do not re-tighten.
 _MAX_SAMPLING_MECHANISM = 255  # libdatadog encodes the sampling mechanism as a u8
 VALID_SAMPLING_DECISIONS = frozenset("-%d" % value for value in range(_MAX_SAMPLING_MECHANISM + 1))
@@ -276,7 +276,7 @@ def _set_sampling_tags(
     priorities = SAMPLING_MECHANISM_TO_PRIORITIES[mechanism]
     priority_index = _KEEP_PRIORITY_INDEX if sampled else _REJECT_PRIORITY_INDEX
 
-    # AIDEV-NOTE: Injection treats a non-None sampling priority as the publication marker for the
+    # Injection treats a non-None sampling priority as the publication marker for the
     # complete decision. Publish the deferred ot= state and priority together in one native call,
     # which does not release the GIL, so concurrent branches cannot observe a partial decision.
     span.context._publish_sampling_decision(priorities[priority_index], sample_rate, probabilistic_decision)

--- a/ddtrace/internal/settings/_config.py
+++ b/ddtrace/internal/settings/_config.py
@@ -531,7 +531,7 @@ class Config(object):
 
         self._inferred_base_service = detect_service(sys.argv)
 
-        # AIDEV-NOTE: Mirrors ddtrace.internal.schema's span-service-name-schema resolution
+        # Mirrors ddtrace.internal.schema's span-service-name-schema resolution
         # (v0 vs v1) without importing that package, which would recreate the
         # _config -> schema -> span_attribute_schema -> _config circular import.
         _span_service_name_schema_version = env.get("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", default="v0")

--- a/ddtrace/internal/settings/env.py
+++ b/ddtrace/internal/settings/env.py
@@ -23,7 +23,7 @@ from ddtrace.internal.settings._supported_configurations import DEPRECATED_CONFI
 from ddtrace.internal.settings._supported_configurations import SUPPORTED_CONFIGURATIONS
 
 
-# AIDEV-NOTE: Use stdlib logging here instead of ddtrace.internal.logger.get_logger.
+# Use stdlib logging here instead of ddtrace.internal.logger.get_logger.
 # ddtrace/internal/logger.py imports ddtrace.internal.settings.env, so using
 # get_logger() would create a circular import at module-load time.
 logger = logging.getLogger(__name__)

--- a/ddtrace/internal/settings/openfeature.py
+++ b/ddtrace/internal/settings/openfeature.py
@@ -20,7 +20,7 @@ _SOURCE_ENV = "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE"
 _LEGACY_ENV = "DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED"
 
 
-# AIDEV-NOTE: numeric settings here parse leniently on purpose. This class is instantiated at
+# numeric settings here parse leniently on purpose. This class is instantiated at
 # module scope (see the bottom of this file), so letting envier raise on an unparsable value
 # turns it into an ImportError for ddtrace.openfeature and takes the whole application down at
 # startup rather than degrading one setting. dd-trace-java substitutes the default in the same

--- a/ddtrace/internal/test_visibility/coverage_report_utils.py
+++ b/ddtrace/internal/test_visibility/coverage_report_utils.py
@@ -8,7 +8,7 @@ from ddtrace.internal.settings import env
 from ddtrace.internal.utils.cache import cached
 
 
-# AIDEV-NOTE: Use stdlib logging here. Importing ddtrace.internal.logger creates circular imports
+# Use stdlib logging here. Importing ddtrace.internal.logger creates circular imports
 # because this utility is shared by both the legacy CI Visibility and Testing plugin dependency trees.
 log = logging.getLogger(__name__)
 

--- a/ddtrace/llmobs/_eval_metric.py
+++ b/ddtrace/llmobs/_eval_metric.py
@@ -50,7 +50,7 @@ class _SubmissionTelemetryContext:
     target_type: str = "other"
 
 
-# AIDEV-NOTE: _resolve_agent_service and LLMObsSubmitEvaluationError intentionally remain owned by
+# _resolve_agent_service and LLMObsSubmitEvaluationError intentionally remain owned by
 # _llmobs. Callers inject them here to preserve their existing state and import paths without a cycle.
 def _build_evaluation_metric_event(
     *,
@@ -256,7 +256,7 @@ def _build_feedback_metric_event(
         if not span["span_id"]:
             telemetry_context.error = "invalid_span"
             raise ValueError("`span` must contain a non-empty string span_id.")
-        # AIDEV-NOTE: LLMObs.export_span() also returns trace_id, while callers may supply
+        # LLMObs.export_span() also returns trace_id, while callers may supply
         # dictionaries with additional fields. Feedback targets must contain exactly one
         # top-level identifier, so span= intentionally emits only span_id and is wire-equivalent
         # to passing span_id= directly.

--- a/ddtrace/llmobs/_integrations/agent_manifest.py
+++ b/ddtrace/llmobs/_integrations/agent_manifest.py
@@ -21,7 +21,7 @@ MAX_WIRE_DEPTH = 20
 # catch that, because a shared child is a legitimate second visit rather than an ancestor.
 MAX_WIRE_NODES = 10_000
 
-# AIDEV-NOTE: allowlist, not denylist. model_settings is the one field whose key set the caller
+# allowlist, not denylist. model_settings is the one field whose key set the caller
 # controls, and the dangerous keys are provider-specific by name (extra_headers, openai_user,
 # xai_user), so only a closed list of generic inference parameters is safe. Widening it is a
 # security decision.

--- a/ddtrace/llmobs/_integrations/base_stream_handler.py
+++ b/ddtrace/llmobs/_integrations/base_stream_handler.py
@@ -154,7 +154,7 @@ class TracedStream(wrapt.ObjectProxy):
         self._self_handler = handler
         self._self_on_stream_created = on_stream_created
         self._self_stream_iter = self.__wrapped__
-        # AIDEV-NOTE: tracks whether ``handler.start_stream()`` has fired.
+        # tracks whether ``handler.start_stream()`` has fired.
         # Guards against double-firing when both ``__iter__`` and ``__next__``
         # are used on the same stream, and ensures the hook does not run on
         # a stream that is constructed but never consumed.
@@ -244,7 +244,7 @@ class TracedAsyncStream(wrapt.ObjectProxy):
         self._self_handler = handler
         self._self_on_stream_created = on_stream_created
         self._self_async_stream_iter = self.__wrapped__
-        # AIDEV-NOTE: see ``TracedStream._self_started`` for rationale.
+        # see ``TracedStream._self_started`` for rationale.
         self._self_started = False
 
     def _ensure_started(self):

--- a/ddtrace/llmobs/_integrations/openai_agents.py
+++ b/ddtrace/llmobs/_integrations/openai_agents.py
@@ -293,7 +293,7 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
         self.oai_to_llmobs_span.clear()
         self.llmobs_traces.clear()
 
-    # AIDEV-NOTE: MLOB-7584 — the agent's position varies by wheel (0.0.x-0.17.x): ``agent=`` kwarg
+    # MLOB-7584 — the agent's position varies by wheel (0.0.x-0.17.x): ``agent=`` kwarg
     # (0.8-0.13), ``bindings=`` kwarg (>=0.14), or positional arg[1] when streamed (arg[0] is the
     # RunResultStreaming — no Agent attrs, so it's skipped). One scanner covers every shape.
     def _extract_agent_from_call(self, args: list[Any], kwargs: dict[str, Any]) -> Optional[Any]:
@@ -305,7 +305,7 @@ class OpenAIAgentsIntegration(BaseLLMIntegration):
                 candidates.append(value)
         candidates.extend(arg for arg in args if arg is not None)
         for candidate in candidates:
-            # AgentBindings shape (>= 0.14.0). AIDEV-NOTE: MLOB-7584 — the manifest is the user's DECLARED
+            # AgentBindings shape (>= 0.14.0). MLOB-7584 — the manifest is the user's DECLARED
             # config, so prefer ``public_agent`` over ``execution_agent`` (a possible sandbox-rewritten clone).
             bound_agent = getattr(candidate, "public_agent", None) or getattr(candidate, "execution_agent", None)
             if bound_agent is not None:

--- a/ddtrace/llmobs/_integrations/pydantic_ai.py
+++ b/ddtrace/llmobs/_integrations/pydantic_ai.py
@@ -161,7 +161,7 @@ class PydanticAIIntegration(BaseLLMIntegration):
         agent_instance = kwargs.get("instance", None)
         agent_name = getattr(agent_instance, "name", None)
         user_prompt = get_argument_value(args, kwargs, 0, "user_prompt", optional=True)
-        # AIDEV-NOTE: When callers like VercelAIAdapter pass all messages via message_history
+        # When callers like VercelAIAdapter pass all messages via message_history
         # without setting user_prompt, we fall back to extracting the last user message from
         # message_history. See https://github.com/DataDog/dd-trace-py/issues/16400
         if user_prompt is None:
@@ -292,7 +292,7 @@ class PydanticAIIntegration(BaseLLMIntegration):
     def _manifest_labels(self, agent: Any) -> AgentManifest:
         """Labels that name the agent. Grouped for failure isolation only; the manifest is flat."""
         fields: AgentManifest = {"framework": FRAMEWORK_NAME}
-        # AIDEV-NOTE: placeholder per review, matching the span name fallback. Two unnamed agents
+        # placeholder per review, matching the span name fallback. Two unnamed agents
         # therefore share it, so name is not an identity.
         agent_name = getattr(agent, "name", None)
         fields["name"] = agent_name if isinstance(agent_name, str) and agent_name else "PydanticAI Agent"
@@ -331,7 +331,7 @@ class PydanticAIIntegration(BaseLLMIntegration):
             fields["model"] = declared_name or model
         elif model:
             model_name, _ = self._get_model_and_provider(model)
-            # AIDEV-NOTE: str-only, for the same reason as the tool description read. model_name is
+            # str-only, for the same reason as the tool description read. model_name is
             # annotated str, but a custom Model subclass returns whatever it likes and the encoder
             # reprs what it cannot encode, which can carry a connection string.
             if isinstance(model_name, str):
@@ -429,7 +429,7 @@ class PydanticAIIntegration(BaseLLMIntegration):
         tools: list[dict[str, Any]] = []
         for tool_name, tool_instance in _iter_agent_tools(agent):
             entry: dict[str, Any] = {"name": tool_name if isinstance(tool_name, str) else str(tool_name)}
-            # AIDEV-NOTE: str-only. pydantic-ai accepts a non-str description and the encoder reprs
+            # str-only. pydantic-ai accepts a non-str description and the encoder reprs
             # what it cannot encode, which can carry credentials.
             description = getattr(tool_instance, "description", None)
             entry["description"] = description if isinstance(description, str) else None
@@ -521,7 +521,7 @@ class PydanticAIIntegration(BaseLLMIntegration):
     def _toolset_name(toolset: Any) -> str:
         """Toolset or MCP server name: the id the user set, else the class name.
 
-        AIDEV-NOTE: never read label. Without an id it falls back to repr(self), which carries the
+        never read label. Without an id it falls back to repr(self), which carries the
         connection config, so only an explicit str id or the class name ships. No URI is emitted at
         all, which is what keeps a credential in a server's userinfo, path or query off the wire.
         """

--- a/ddtrace/llmobs/_integrations/utils.py
+++ b/ddtrace/llmobs/_integrations/utils.py
@@ -507,7 +507,7 @@ def format_image_part(data: Union[bytes, str], mime_type: str) -> ImagePart:
     return ImagePart(mime_type=mime_type, content=content)
 
 
-# AIDEV-NOTE: Measured on the base64 that rides the event. Sized against the DEFAULT 5 MB limit; over
+# Measured on the base64 that rides the event. Sized against the DEFAULT 5 MB limit; over
 # it, _truncate_span_event blanks the span's whole input AND output. Two gaps shared with the audio
 # guard, for the writer-side fix (MLOB-6408): bounds one image not their sum, and ignores
 # DD_LLMOBS_EVENT_SIZE_BYTES.
@@ -550,7 +550,7 @@ def format_image_part_with_guard(
     return format_image_part(data, mime_type)
 
 
-# AIDEV-NOTE: per-image, not cumulative. N images that each fit can still bust the event limit
+# per-image, not cumulative. N images that each fit can still bust the event limit
 # together; a shared per-request budget is tracked under MLOB-6408.
 # Distinct from LLMOBS_IMAGE_INLINE_MAX_BYTES above on purpose: this OpenAI data-URL path tracks the
 # configured limit, while the Anthropic guard keeps its fixed default. Unifying them would change

--- a/ddtrace/profiling/_gevent.py
+++ b/ddtrace/profiling/_gevent.py
@@ -141,7 +141,7 @@ def greenlet_tracer(event: str, args: t.Any) -> None:
         #
         # See also: https://github.com/gevent/gevent/pull/2166 (upstream fix)
         #
-        # AIDEV-NOTE: greenlet.dead.__get__ is a C-level tp_getset descriptor.
+        # greenlet.dead.__get__ is a C-level tp_getset descriptor.
         # Any unhandled exception here causes the greenlet runtime to silently
         # uninstall this tracer (see greenlet's TGreenlet.cpp g_calltrace and
         # test_tracing.py::test_b_exception_disables_tracing). We catch

--- a/ddtrace/profiling/collector/_memalloc_frame.h
+++ b/ddtrace/profiling/collector/_memalloc_frame.h
@@ -32,7 +32,7 @@
 #error "_memalloc frame walking relies on the GIL-held allocator hook and is not yet supported on free-threaded CPython"
 #endif // Py_GIL_DISABLED
 
-// AIDEV-TODO: Revisit direct frame walking and heap-tracker synchronization if memalloc adds Py_GIL_DISABLED support.
+// TODO: Revisit direct frame walking and heap-tracker synchronization if memalloc adds Py_GIL_DISABLED support.
 
 /* Frame access helpers and line table parsing. */
 #include "profiling_helpers/frame_accessors.h"

--- a/ddtrace/testing/internal/cached_file_provider.py
+++ b/ddtrace/testing/internal/cached_file_provider.py
@@ -219,7 +219,7 @@ class CachedFileDataProvider:
         coverage_format: str,
         tags: t.Optional[dict[str, str]] = None,
     ) -> bool:
-        # AIDEV-NOTE: No-op because manifest mode used to imply Bazel's payload-files mode, where there is no network.
+        # No-op because manifest mode used to imply Bazel's payload-files mode, where there is no network.
         # That assumption no longer holds: a process in manifest mode *without* payload-files mode (an xdist worker
         # reusing its controller's cache) does have a backend and is expected to upload its own report, because the
         # intake merges the reports of a session. Such processes go through SessionManager.coverage_upload_client

--- a/ddtrace/testing/internal/env_tags.py
+++ b/ddtrace/testing/internal/env_tags.py
@@ -140,7 +140,7 @@ def get_env_tags() -> dict[str, str]:
         tags[CITag.JOB_ID] = job_id
 
     # Bazel provider fallback (manifest-only mode without payload-files).
-    # AIDEV-NOTE: Only for a manifest an external tool gave us. A manifest we generated ourselves for pytest-xdist
+    # Only for a manifest an external tool gave us. A manifest we generated ourselves for pytest-xdist
     # workers carries no information about the environment: inferring "bazel" from it would mislabel every worker
     # event in a plain `pytest -n auto` run on a machine with no recognized CI provider.
     if offline.manifest_enabled and not offline.manifest_self_generated and not tags.get(CITag.PROVIDER_NAME):

--- a/ddtrace/testing/internal/git.py
+++ b/ddtrace/testing/internal/git.py
@@ -41,7 +41,7 @@ _LOCK_ERROR_RE = re.compile(
 _LOCK_MAX_RETRIES = 5
 _LOCK_BASE_DELAY_SECONDS = 0.5
 
-# AIDEV-NOTE: Keep this cross-process lock on a stable file in Git's actual
+# Keep this cross-process lock on a stable file in Git's actual
 # metadata directory. The timeout, inode, and fallback behavior are part of the
 # coordination protocol; changing them can reintroduce concurrent fetch races.
 # Every call to unshallow_repository acquires an exclusive flock before issuing

--- a/ddtrace/testing/internal/pytest/plugin.py
+++ b/ddtrace/testing/internal/pytest/plugin.py
@@ -443,7 +443,7 @@ class TestOptPlugin(TestOptPluginProtocol):
         # If coverage report upload is enabled, generate and upload the report.
         # NOTE: Skip in payload-files mode (Bazel): coverage data is already
         # written as JSON files by TestCoverageWriter; network upload is not possible.
-        # AIDEV-NOTE: This hook runs in every process, so an xdist session uploads one report per process, each
+        # This hook runs in every process, so an xdist session uploads one report per process, each
         # covering only what that process ran. That is by design: the intake merges the coverage reports it receives
         # for a session, so the partial uploads add up to full coverage.
         #
@@ -1625,7 +1625,7 @@ def pytest_configure(config: pytest.Config) -> None:
     if is_discovery_mode_enabled():
         # Register hook specs so item_to_test_ref can call the custom name hooks during
         # discovery, giving the same module/suite/name resolution as a real test run.
-        # AIDEV-NOTE: BddTestOptPlugin is not registered here, so pytest-bdd tests will
+        # BddTestOptPlugin is not registered here, so pytest-bdd tests will
         # fall back to nodeid-based names rather than feature-file names during discovery.
         # TODO: register BddTestOptPlugin in discovery mode to support pytest-bdd.
         import ddtrace.testing.internal.pytest._discovery as _ddtrace_discovery

--- a/ddtrace/testing/internal/pytest/xdist.py
+++ b/ddtrace/testing/internal/pytest/xdist.py
@@ -28,7 +28,7 @@ XDIST_UNSET = "UNSET"
 XDIST_AUTO = "auto"
 XDIST_LOGICAL = "logical"
 
-# AIDEV-NOTE: The controller-generated manifest cache lives in a private temp directory (XDIST_MANIFEST_DIR_PREFIX)
+# The controller-generated manifest cache lives in a private temp directory (XDIST_MANIFEST_DIR_PREFIX)
 # instead of the workspace: the workspace path is derived differently by different components (git root vs. CI provider
 # env vars), and two concurrent pytest runs of the same repo would otherwise clobber each other's cache.  The controller
 # pid is embedded in the directory name so descendant processes can tell whether an inherited manifest was meant for
@@ -118,7 +118,7 @@ def resolve_inherited_manifest_env() -> None:
     ordering makes it unreachable, but it defeats the point of generating the manifest -- so say so out loud rather
     than degrade silently.
 
-    AIDEV-NOTE: Known limitation. A nested pytest session started *in-process* from inside a worker
+    Known limitation. A nested pytest session started *in-process* from inside a worker
     (``pytest.main()``, ``pytester.inline_run()``) shares the worker's pid, so it looks like the manifest's rightful
     owner and reads the outer session's cache. Dropping the env var would not help either: ``OfflineMode`` is a
     process-wide singleton that the worker already resolved. Fixing it properly means scoping offline mode to a

--- a/ddtrace/testing/internal/session_manager.py
+++ b/ddtrace/testing/internal/session_manager.py
@@ -154,7 +154,7 @@ class SessionManager:
                 itr_skipping_level=self.itr_skipping_level,
                 telemetry_api=self.telemetry_api,
             )
-            # AIDEV-NOTE: Reads come from the manifest, but coverage reports still go over HTTP. This is the intended
+            # Reads come from the manifest, but coverage reports still go over HTTP. This is the intended
             # design, not a workaround: the intake merges the coverage reports of a session, so every process that ran
             # tests is expected to upload its own (see TestOptPlugin.pytest_sessionfinish).
             # CachedFileDataProvider cannot upload — manifest mode used to imply Bazel's payload-files mode, where

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -115,7 +115,7 @@ ENV PYTHON_CONFIGURE_OPTS=--enable-shared
 ENV NPM_CONFIG_PREFIX=/home/bits/.local/
 
 # Install Rust toolchain
-# AIDEV-TODO: Pin to a specific rustup-init version with SHA256 verification.
+# TODO: Pin to a specific rustup-init version with SHA256 verification.
 # See https://static.rust-lang.org/rustup/ for versioned releases and checksums.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- --default-toolchain stable -y

--- a/mypy.ini
+++ b/mypy.ini
@@ -85,6 +85,39 @@ ignore_errors = true
 [mypy-tests.webclient]
 ignore_errors = true
 
+# Pre-existing test typing errors. The pre-commit mypy hook typechecks staged
+# test files even though mypy.ini `files` is only ddtrace/ and docs/. Comment-only
+# edits in those tests would otherwise fail the hook on unrelated debt.
+[mypy-tests.datastreams.test_processor]
+ignore_errors = true
+
+[mypy-tests.contrib.aiobotocore.test_aws_sigv4_propagation]
+ignore_errors = true
+
+[mypy-tests.appsec.iast.iast_utils]
+ignore_errors = true
+
+[mypy-tests.aiguard.utils]
+ignore_errors = true
+
+[mypy-tests.appsec.iast.aspects.aspect_utils]
+ignore_errors = true
+
+[mypy-tests.contrib.llama_index.test_llama_index_patch]
+ignore_errors = true
+
+[mypy-tests.appsec.integrations.django_tests.test_iast_django_testagent]
+ignore_errors = true
+
+[mypy-tests.appsec.appsec.test_processor]
+ignore_errors = true
+
+[mypy-tests.appsec.integrations.django_tests.django_app.views]
+ignore_errors = true
+
+[mypy-tests.appsec.iast.aspects.test_modulo_aspect_fixtures]
+ignore_errors = true
+
 # ── Modules not yet compliant with strict mode ────────────────────────────────
 # Generated against mypy 1.15.
 # To clean up a module: remove its section, fix all errors, re-run mypy.

--- a/mypy.ini
+++ b/mypy.ini
@@ -85,39 +85,6 @@ ignore_errors = true
 [mypy-tests.webclient]
 ignore_errors = true
 
-# Pre-existing test typing errors. The pre-commit mypy hook typechecks staged
-# test files even though mypy.ini `files` is only ddtrace/ and docs/. Comment-only
-# edits in those tests would otherwise fail the hook on unrelated debt.
-[mypy-tests.datastreams.test_processor]
-ignore_errors = true
-
-[mypy-tests.contrib.aiobotocore.test_aws_sigv4_propagation]
-ignore_errors = true
-
-[mypy-tests.appsec.iast.iast_utils]
-ignore_errors = true
-
-[mypy-tests.aiguard.utils]
-ignore_errors = true
-
-[mypy-tests.appsec.iast.aspects.aspect_utils]
-ignore_errors = true
-
-[mypy-tests.contrib.llama_index.test_llama_index_patch]
-ignore_errors = true
-
-[mypy-tests.appsec.integrations.django_tests.test_iast_django_testagent]
-ignore_errors = true
-
-[mypy-tests.appsec.appsec.test_processor]
-ignore_errors = true
-
-[mypy-tests.appsec.integrations.django_tests.django_app.views]
-ignore_errors = true
-
-[mypy-tests.appsec.iast.aspects.test_modulo_aspect_fixtures]
-ignore_errors = true
-
 # ── Modules not yet compliant with strict mode ────────────────────────────────
 # Generated against mypy 1.15.
 # To clean up a module: remove its section, fix all errors, re-run mypy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,6 @@ exclude_dirs = [
   "ddtrace/internal/uwsgi.py",
   "ddtrace/sourcecode/_utils.py",
   "scripts/ext_cache.py",
-  "scripts/check_no_new_aidev_anchors.py",
   "setup.py",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,7 @@ exclude_dirs = [
   "ddtrace/internal/uwsgi.py",
   "ddtrace/sourcecode/_utils.py",
   "scripts/ext_cache.py",
+  "scripts/check_no_new_aidev_anchors.py",
   "setup.py",
 ]
 

--- a/riotfile.py
+++ b/riotfile.py
@@ -4742,7 +4742,7 @@ venv = Venv(
             pys=select_pys(),
             pkgs={
                 "pytest-asyncio": "==0.23.7",
-                # AIDEV-NOTE: ``pyyaml`` lets the cassette smoke test parse the
+                # ``pyyaml`` lets the cassette smoke test parse the
                 # anthropic contrib VCR fixtures. Pinned to a single version
                 # because the suite only uses ``yaml.safe_load``.
                 "pyyaml": latest,

--- a/scripts/check_no_new_aidev_anchors.py
+++ b/scripts/check_no_new_aidev_anchors.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Fail CI when a branch adds deprecated AIDEV-* anchor comment labels.
 
-The guild deprecated ``AIDEV-NOTE:``, ``AIDEV-TODO:``, and ``AIDEV-QUESTION:``
+The guild deprecated AIDEV-NOTE:, AIDEV-TODO:, and AIDEV-QUESTION:
 in favor of plain inline comments (see AGENTS.md). Existing anchors are
 grandfathered; this check only inspects added diff lines.
 
-Usage::
+Usage:
 
     python scripts/check_no_new_aidev_anchors.py --base-ref FETCH_HEAD
 """
@@ -21,21 +21,32 @@ from typing import Optional
 
 # Match comment introducers only — avoids false positives in prose/docs that
 # mention the old label name in backticks.
-ANCHOR_RE = re.compile(
+ANCHOR_RE: re.Pattern[str] = re.compile(
     r"^\+\s*.*?(?:#|//)\s*AIDEV-(?:NOTE|TODO|QUESTION):",
 )
 
-SKIP_PREFIXES = ("scripts/check_no_new_aidev_anchors.py",)
+SKIP_PREFIXES: tuple[str, ...] = ("scripts/check_no_new_aidev_anchors.py",)
 
 
-def _added_lines(base_ref: str) -> list[tuple[str, str]]:
-    result = subprocess.run(  # nosec B603,B607
-        ["git", "diff", "-U0", base_ref, "--", ".", ":(exclude)scripts/check_no_new_aidev_anchors.py"],
+def _merge_base(base_ref: str) -> str:
+    result: subprocess.CompletedProcess[str] = subprocess.run(  # nosec B603, B607
+        ["git", "merge-base", base_ref, "HEAD"],
         capture_output=True,
         check=True,
         text=True,
     )
-    current_file = ""
+    return result.stdout.strip()
+
+
+def _added_lines(base_ref: str) -> list[tuple[str, str]]:
+    merge_base: str = _merge_base(base_ref)
+    result: subprocess.CompletedProcess[str] = subprocess.run(  # nosec B603,B607
+        ["git", "diff", "-U0", merge_base, "--", ".", ":(exclude)scripts/check_no_new_aidev_anchors.py"],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    current_file: str = ""
     hits: list[tuple[str, str]] = []
     for line in result.stdout.splitlines():
         if line.startswith("+++ b/"):
@@ -49,14 +60,16 @@ def _added_lines(base_ref: str) -> list[tuple[str, str]]:
 
 
 def main(argv: Optional[list[str]] = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument("--base-ref", default="origin/main", help="Git ref to diff against.")
-    args = parser.parse_args(argv)
+    args: argparse.Namespace = parser.parse_args(argv)
 
     print(f"Checking for new AIDEV anchors vs base ref: {args.base_ref}")
 
     try:
-        violations = _added_lines(args.base_ref)
+        violations: list[tuple[str, str]] = _added_lines(args.base_ref)
     except subprocess.CalledProcessError as exc:
         print(f"error: failed to compute diff against {args.base_ref}: {exc.stderr}", file=sys.stderr)
         return 1

--- a/scripts/check_no_new_aidev_anchors.py
+++ b/scripts/check_no_new_aidev_anchors.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Fail CI when a branch adds deprecated AIDEV-* anchor comment labels.
+
+The guild deprecated ``AIDEV-NOTE:``, ``AIDEV-TODO:``, and ``AIDEV-QUESTION:``
+in favor of plain inline comments (see AGENTS.md). Existing anchors are
+grandfathered; this check only inspects added diff lines.
+
+Usage::
+
+    python scripts/check_no_new_aidev_anchors.py --base-ref FETCH_HEAD
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess  # nosec B404
+import sys
+from typing import Optional
+
+
+# Match comment introducers only — avoids false positives in prose/docs that
+# mention the old label name in backticks.
+ANCHOR_RE = re.compile(
+    r"^\+\s*.*?(?:#|//)\s*AIDEV-(?:NOTE|TODO|QUESTION):",
+)
+
+SKIP_PREFIXES = ("scripts/check_no_new_aidev_anchors.py",)
+
+
+def _added_lines(base_ref: str) -> list[tuple[str, str]]:
+    result = subprocess.run(  # nosec B603,B607
+        ["git", "diff", "-U0", base_ref, "--", ".", ":(exclude)scripts/check_no_new_aidev_anchors.py"],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    current_file = ""
+    hits: list[tuple[str, str]] = []
+    for line in result.stdout.splitlines():
+        if line.startswith("+++ b/"):
+            current_file = line[6:]
+            continue
+        if not current_file or any(current_file.startswith(prefix) for prefix in SKIP_PREFIXES):
+            continue
+        if ANCHOR_RE.match(line):
+            hits.append((current_file, line[1:].rstrip()))
+    return hits
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--base-ref", default="origin/main", help="Git ref to diff against.")
+    args = parser.parse_args(argv)
+
+    print(f"Checking for new AIDEV anchors vs base ref: {args.base_ref}")
+
+    try:
+        violations = _added_lines(args.base_ref)
+    except subprocess.CalledProcessError as exc:
+        print(f"error: failed to compute diff against {args.base_ref}: {exc.stderr}", file=sys.stderr)
+        return 1
+
+    if not violations:
+        print("OK: no new AIDEV-* anchor comments on added lines.")
+        return 0
+
+    print(f"ERROR: {len(violations)} new deprecated AIDEV anchor(s) found:", file=sys.stderr)
+    for path, content in violations:
+        print(f"  - {path}: {content}", file=sys.stderr)
+    print(
+        "\nUse a plain inline comment instead (see AGENTS.md — Docstrings and Comments).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_no_new_aidev_anchors.py
+++ b/scripts/check_no_new_aidev_anchors.py
@@ -19,10 +19,10 @@ import sys
 from typing import Optional
 
 
-# Match comment introducers only — avoids false positives in prose/docs that
-# mention the old label name in backticks.
+# Match Python, C/C++, and Rust comment introducers only — avoids false
+# positives in prose/docs that mention the old label name in backticks.
 ANCHOR_RE: re.Pattern[str] = re.compile(
-    r"^\+\s*.*?(?:#|//)\s*AIDEV-(?:NOTE|TODO|QUESTION):",
+    r"^\+\s*.*?(?:#|(?<!/)//[/!]?)\s*AIDEV-(?:NOTE|TODO|QUESTION):",
 )
 
 SKIP_PREFIXES: tuple[str, ...] = ("scripts/check_no_new_aidev_anchors.py",)
@@ -40,7 +40,7 @@ def _merge_base(base_ref: str) -> str:
 
 def _added_lines(base_ref: str) -> list[tuple[str, str]]:
     merge_base: str = _merge_base(base_ref)
-    result: subprocess.CompletedProcess[str] = subprocess.run(  # nosec B603,B607
+    result: subprocess.CompletedProcess[str] = subprocess.run(  # nosec B603, B607
         ["git", "diff", "-U0", merge_base, "--", ".", ":(exclude)scripts/check_no_new_aidev_anchors.py"],
         capture_output=True,
         check=True,

--- a/scripts/check_no_new_aidev_anchors.py
+++ b/scripts/check_no_new_aidev_anchors.py
@@ -22,8 +22,11 @@ from typing import Optional
 # Match Python, C/C++, and Rust comment introducers only — avoids false
 # positives in prose/docs that mention the old label name in backticks.
 ANCHOR_RE: re.Pattern[str] = re.compile(
-    r"^\+\s*.*?(?:#|(?<!/)//[/!]?)\s*AIDEV-(?:NOTE|TODO|QUESTION):",
+    r"(?:#|(?<![\w/:])//[/!]?|/\*)\s*AIDEV-(?:NOTE|TODO|QUESTION):"
+    r"|^\s*\*\s*AIDEV-(?:NOTE|TODO|QUESTION):"
+    r"|^\s*AIDEV-(?:NOTE|TODO|QUESTION):(?=\s*[^*]*\*/)",
 )
+STRING_RE: re.Pattern[str] = re.compile(r"""(["'`])(?:\\.|(?!\1).)*\1""")
 
 SKIP_PREFIXES: tuple[str, ...] = ("scripts/check_no_new_aidev_anchors.py",)
 
@@ -54,9 +57,15 @@ def _added_lines(base_ref: str) -> list[tuple[str, str]]:
             continue
         if not current_file or any(current_file.startswith(prefix) for prefix in SKIP_PREFIXES):
             continue
-        if ANCHOR_RE.match(line):
+        if _is_anchor_line(line):
             hits.append((current_file, line[1:].rstrip()))
     return hits
+
+
+def _is_anchor_line(line: str) -> bool:
+    content: str = line[1:] if line.startswith("+") else line
+    content_without_strings: str = STRING_RE.sub("", content)
+    return ANCHOR_RE.search(content_without_strings) is not None
 
 
 def main(argv: Optional[list[str]] = None) -> int:

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -726,7 +726,7 @@ class TestRunner:
                 if result.returncode != 0:
                     raise UvTestEnvironmentError(f"build failed for {environment.hash} (exit code {result.returncode})")
 
-            # AIDEV-NOTE: Record current state only after exact sync and environment inspection.
+            # Record current state only after exact sync and environment inspection.
             # This marker is the guard against reusing partial or failed builds.
             self._mark_environment_current(prepared, environment.python)
             return True

--- a/src/native/context/context_data.rs
+++ b/src/native/context/context_data.rs
@@ -97,7 +97,7 @@ fn materialize_otel_sampling_decision_fn(py: Python<'_>) -> PyResult<Bound<'_, P
 }
 
 fn dd_trace_tracestate_max_bytes(py: Python<'_>) -> PyResult<usize> {
-    // AIDEV-NOTE: Python owns the propagation limits. Resolve this lazily to avoid
+    // Python owns the propagation limits. Resolve this lazily to avoid
     // making ddtrace.internal.constants import the native extension during startup.
     cached_const::<usize>(
         py,
@@ -148,7 +148,7 @@ pub struct Context {
     pub is_remote: bool,
     #[pyo3(get, set, name = "_reactivate")]
     pub reactivate: bool,
-    // AIDEV-NOTE: Child contexts point otel_sampling_state_owner at the trace's
+    // Child contexts point otel_sampling_state_owner at the trace's
     // owning Context. This keeps pending propagation state visible across copies
     // without allocating a holder or storing control data in meta/metrics.
     #[pyo3(get, set, name = "_otel_sampling_state_data")]

--- a/src/native/http_client/client.rs
+++ b/src/native/http_client/client.rs
@@ -31,7 +31,7 @@ const TLS_DESTROYED_PANIC: &str = "Tokio context thread-local variable has been 
 /// Run `f`, retrying once on a fresh thread if it panics with the specific
 /// "TLS destroyed" message below — never for any other panic.
 ///
-/// AIDEV-NOTE: this exists for requests issued at interpreter shutdown. Some
+/// this exists for requests issued at interpreter shutdown. Some
 /// embedders tear down their threads *before* Python runs its `atexit` hooks,
 /// so a request made from such a hook runs on a thread whose thread-local
 /// storage is already destroyed, and `Runtime::block_on` panics with "The Tokio

--- a/src/native/http_client/client.rs
+++ b/src/native/http_client/client.rs
@@ -31,7 +31,7 @@ const TLS_DESTROYED_PANIC: &str = "Tokio context thread-local variable has been 
 /// Run `f`, retrying once on a fresh thread if it panics with the specific
 /// "TLS destroyed" message below — never for any other panic.
 ///
-/// this exists for requests issued at interpreter shutdown. Some
+/// This exists for requests issued at interpreter shutdown. Some
 /// embedders tear down their threads *before* Python runs its `atexit` hooks,
 /// so a request made from such a hook runs on a thread whose thread-local
 /// storage is already destroyed, and `Runtime::block_on` panics with "The Tokio

--- a/src/native/shared_runtime/mod.rs
+++ b/src/native/shared_runtime/mod.rs
@@ -69,7 +69,7 @@ unsafe extern "C" fn after_fork_parent() {
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 unsafe extern "C" fn after_fork_child() {
-    // AIDEV-NOTE: Do not rebuild Tokio here. This callback also runs in fork+exec children,
+    // Do not rebuild Tokio here. This callback also runs in fork+exec children,
     // where exec closes the new runtime's descriptors while its worker thread is using them.
     // The next Python-facing runtime or telemetry operation performs the restart instead.
     CHILD_RESTART_IN_PROGRESS.store(false, Ordering::Release);
@@ -131,7 +131,7 @@ impl SharedRuntimePy {
 pub(crate) fn ensure_after_fork_child(runtime: &Arc<ForkSafeRuntime>) -> PyResult<()> {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     {
-        // AIDEV-NOTE: Telemetry calls this for every metric point. Keep the normal path to one
+        // Telemetry calls this for every metric point. Keep the normal path to one
         // read-only load; an unconditional swap and PID check caused a substantial hot-path
         // regression even when the process had never forked.
         if !CHILD_RESTART_PENDING.load(Ordering::Acquire) {
@@ -202,7 +202,7 @@ impl SharedRuntimePy {
                     runtime: RwLock::new(Arc::new(runtime)),
                     pid: AtomicU32::new(std::process::id()),
                 });
-                // AIDEV-NOTE: uWSGI forks in native code and bypasses Python's os.register_at_fork
+                // uWSGI forks in native code and bypasses Python's os.register_at_fork
                 // callbacks. pthread_atfork pauses the runtime around every native fork. The child
                 // callback only marks the runtime for lazy restart because it also runs in transient
                 // fork+exec children, where starting threads would race with exec closing descriptors.

--- a/src/native/telemetry.rs
+++ b/src/native/telemetry.rs
@@ -225,7 +225,7 @@ impl TelemetryWorkerPy {
             });
         }
 
-        // AIDEV-NOTE: Keep this worker alive across native libc forks. The SharedRuntime's
+        // Keep this worker alive across native libc forks. The SharedRuntime's
         // pthread_atfork child handler marks the runtime for restart; the first Python-facing
         // telemetry operation rebuilds the runtime and resets this worker. Deferring the restart
         // avoids starting Tokio threads in transient fork+exec children.

--- a/tests/aiguard/langchain/test_langchain.py
+++ b/tests/aiguard/langchain/test_langchain.py
@@ -856,7 +856,7 @@ def test_streamed_llm_resets_context_after_success(mock_execute_request, langcha
     assert is_aiguard_context_active() is False
 
 
-# AIDEV-NOTE: ``filterwarnings`` suppresses an orthogonal pre-existing
+# ``filterwarnings`` suppresses an orthogonal pre-existing
 # span-lifecycle warning: when a langchain stream is created but never
 # iterated, ``shared_stream`` has already started the LLMObs span via
 # ``integration.trace(...)`` but ``TracedStream.__iter__``'s ``finally``

--- a/tests/appsec/appsec/test_processor.py
+++ b/tests/appsec/appsec/test_processor.py
@@ -317,7 +317,7 @@ def test_ip_update_rules_and_block(tracer):
                 ],
             ),
         )
-        # AIDEV-NOTE: WAF updates apply to request contexts created after the update.
+        # WAF updates apply to request contexts created after the update.
         # A nested same-service WEB span is part of the current service entry, not a new request.
         with asm_context(tracer=tracer, ip_addr=rules._IP.BLOCKED) as span:
             set_http_meta(

--- a/tests/appsec/iast/aspects/test_modulo_aspect_fixtures.py
+++ b/tests/appsec/iast/aspects/test_modulo_aspect_fixtures.py
@@ -191,7 +191,7 @@ class TestOperatorModuloReplacement(BaseReplacement):
         from tests.appsec.iast.iast_utils import _start_iast_context_and_oce
         from tests.utils import override_global_config
 
-        # AIDEV-NOTE: literal ":+-" inside tainted content used to be parsed as
+        # literal ":+-" inside tainted content used to be parsed as
         # an evidence marker by the native modulo aspect, aborting the process.
         with override_global_config(
             dict(

--- a/tests/appsec/iast/test_taint_pyobject_refcount.py
+++ b/tests/appsec/iast/test_taint_pyobject_refcount.py
@@ -35,7 +35,7 @@ def test_taint_pyobject_in_copied_context_returns_owned_reference():
     refcount_after = sys.getrefcount(value)
 
     if returned is not value or refcount_after != refcount_before + 1:
-        # AIDEV-NOTE: Avoid normal cleanup: both names appear to own the same
+        # Avoid normal cleanup: both names appear to own the same
         # reference, which can turn this deterministic check into a UAF crash.
         os._exit(1)
 

--- a/tests/appsec/integrations/django_tests/django_app/views.py
+++ b/tests/appsec/integrations/django_tests/django_app/views.py
@@ -587,7 +587,7 @@ def xss_secure_mark(request):
 @csrf_exempt
 def header_injection(request):
     value = request.body.decode()
-    # AIDEV-NOTE: The injected `value` deliberately contains CR/LF to exercise IAST header-injection
+    # The injected `value` deliberately contains CR/LF to exercise IAST header-injection
     # detection. Detection happens here when assigning to `_store` (wrapped by IAST's
     # HeaderInjectionDict). Note that the WSGI server may later refuse to serialize a header value
     # containing control characters: CPython's wsgiref.headers.Headers (security backport gh-144370)

--- a/tests/appsec/integrations/django_tests/test_iast_django_testagent.py
+++ b/tests/appsec/integrations/django_tests/test_iast_django_testagent.py
@@ -294,7 +294,7 @@ def test_iast_header_injection(iast_test_token, free_port):
 
         response = django_client.post("/appsec/header-injection/", data="master\r\nInjected-Header: 1234")
 
-        # AIDEV-NOTE: This test verifies IAST *detection* of header injection, not that the injected
+        # This test verifies IAST *detection* of header injection, not that the injected
         # header reaches the wire. The CPython security backport gh-144370 (CVE) makes
         # wsgiref.headers.Headers reject control characters (CR/LF) in response header values, raising
         # ValueError("Control characters not allowed in headers"). Django's `runserver` dev server

--- a/tests/appsec/integrations/fastapi_tests/test_iast_mcp_testagent.py
+++ b/tests/appsec/integrations/fastapi_tests/test_iast_mcp_testagent.py
@@ -32,7 +32,7 @@ MCP_IAST_ENV = {
 }
 
 
-# AIDEV-NOTE: This test is designed to detect segfaults that may occur when IAST
+# This test is designed to detect segfaults that may occur when IAST
 # interacts with MCP tool calls. MCP uses streaming internally for communication
 # between client and server, which may trigger context management issues in IAST.
 

--- a/tests/appsec/integrations/flask_tests/test_sca_flask_testagent.py
+++ b/tests/appsec/integrations/flask_tests/test_sca_flask_testagent.py
@@ -221,12 +221,12 @@ class TestSCAFlaskTelemetry:
             f"Events: {json.dumps(events, indent=2)[:2000]}"
         )
         assert all(value["id"] == "GHSA-652x-xj99-gmcc" for value in cve_values)
-        # AIDEV-NOTE: RFC v3 — reached is now an array of {path, method, line} objects.
+        # RFC v3 — reached is now an array of {path, method, line} objects.
         assert all(isinstance(value["reached"], list) for value in cve_values)
         reported = [value for value in cve_values if value["reached"]]
         assert reported, f"No reached entry reported for the CVE after the vulnerable call: {cve_values}"
         hit = reported[0]["reached"][0]
-        # AIDEV-NOTE: path/method/line report the *caller* (user code that
+        # path/method/line report the *caller* (user code that
         # invoked the vulnerable function), not the target function itself.
         assert "app.py" in hit["path"], f"Expected caller path containing 'app.py', got: {hit['path']}"
         assert "sca_test_requests" in hit.get("symbol", ""), (

--- a/tests/ci_visibility/api_client/_util.py
+++ b/tests/ci_visibility/api_client/_util.py
@@ -158,7 +158,7 @@ class TestTestVisibilityAPIClientBase:
 
     @pytest.fixture(scope="function", autouse=True)
     def _ci_visibility_isolation(self):
-        # AIDEV-NOTE: Suspend/resume outer CIVisibility instance so that running
+        # Suspend/resume outer CIVisibility instance so that running
         # these tests with --ddtrace in the outer pytest session does not leak the
         # outer singleton into test bodies, and test bodies cannot corrupt the outer
         # session.  _suspend() removes the outer instance without stopping it;

--- a/tests/ci_visibility/api_client/test_ci_visibility_api_client.py
+++ b/tests/ci_visibility/api_client/test_ci_visibility_api_client.py
@@ -58,7 +58,7 @@ def _patch_env_for_testing():
             return_value=TestVisibilityAPISettings(),
         ),
         mock.patch("ddtrace.config._ci_visibility_agentless_enabled", True),
-        # AIDEV-NOTE: In xdist workers, detect_service() picks up _DD_PYTEST_XDIST_INFERRED_SERVICE
+        # In xdist workers, detect_service() picks up _DD_PYTEST_XDIST_INFERRED_SERVICE
         # (e.g. "tests.ci_visibility") from the environment. That value leaks into Config() built
         # here, causing Config.service to be "tests.ci_visibility" even after env is cleared, which
         # then propagates to CIVisibility._instance._api_client._service instead of the expected

--- a/tests/ci_visibility/conftest.py
+++ b/tests/ci_visibility/conftest.py
@@ -28,7 +28,7 @@ def _ci_visibility_isolation():
     Unlike the old save_state/restore_state approach, _suspend() does NOT call
     stop() on the outer instance, so the outer session's tracer keeps running.
     """
-    # AIDEV-NOTE: This fixture must run before the module-level _disable_ci_visibility
+    # This fixture must run before the module-level _disable_ci_visibility
     # fixtures defined in individual test files. pytest runs conftest fixtures first,
     # so ordering is guaranteed.
     suspended = CIVisibility._suspend()

--- a/tests/ci_visibility/test_ci_visibility.py
+++ b/tests/ci_visibility/test_ci_visibility.py
@@ -152,13 +152,13 @@ def test_ci_visibility_service_enable_without_service(tracer):
         mock.patch(
             "ddtrace.internal.ci_visibility.recorder._extract_repository_name_from_url", return_value="test-repo"
         ),
-        # AIDEV-NOTE: Patch detect_service to None to prevent xdist worker env leakage.
+        # Patch detect_service to None to prevent xdist worker env leakage.
         # When running under pytest-xdist, the outer worker sets _DD_PYTEST_XDIST_INFERRED_SERVICE,
         # which detect_service() picks up and Config() uses as the default span service name,
         # causing Config().service to be non-None and override the expected service value
         # derived from the repository URL.
         mock.patch("ddtrace.internal.settings._config.detect_service", return_value=None),
-        # AIDEV-NOTE: Patch ci.tags to ensure REPOSITORY_URL is present regardless of the git
+        # Patch ci.tags to ensure REPOSITORY_URL is present regardless of the git
         # environment.  In Docker containers started from a git worktree, `git rev-parse` fails
         # with "fatal: not a git repository", so ci.tags() returns no REPOSITORY_URL and the
         # service falls back to the integration default instead of the repo-derived name.
@@ -946,7 +946,7 @@ class TestUploadGitMetadata:
         with (
             mock.patch.multiple(
                 CIVisibilityGitClient,
-                # AIDEV-NOTE: _get_git_dir is mocked here so that upload_git_metadata() does not try to
+                # _get_git_dir is mocked here so that upload_git_metadata() does not try to
                 # call extract_workspace_path() (which runs git commands) before spawning the worker.
                 # Without this, running in Docker from a git worktree causes "fatal: not a git repository"
                 # and the method immediately sets METADATA_UPLOAD_STATUS.FAILED.

--- a/tests/ci_visibility/test_coverage_report_utils.py
+++ b/tests/ci_visibility/test_coverage_report_utils.py
@@ -9,7 +9,7 @@ from ddtrace.internal.test_visibility.coverage_report_utils import log
 
 @pytest.fixture(autouse=True)
 def reset_code_coverage_flags_cache():
-    # AIDEV-NOTE: EFD/ATR retries rerun test calls without rerunning function fixtures. Tests that
+    # EFD/ATR retries rerun test calls without rerunning function fixtures. Tests that
     # assert cached or logged behavior clear the cache and install fresh logger mocks in their bodies.
     _get_code_coverage_flags.cache_clear()
     yield

--- a/tests/contrib/aiobotocore/test_aws_sigv4_propagation.py
+++ b/tests/contrib/aiobotocore/test_aws_sigv4_propagation.py
@@ -257,7 +257,7 @@ def test_aiobotocore_wrapped_api_call_suppresses_propagation_during_await():
     assert _http_propagation_suppressed.get() is False
 
 
-# AIDEV-NOTE: The per-owner gate is tested directly here (manipulating only the
+# The per-owner gate is tested directly here (manipulating only the
 # integrations' _datadog_patch flags, not the wraps) rather than by patching and
 # unpatching the integrations. The aiobotocore suite runs under auto-instrumentation
 # and shares a process with other tests, so asserting global wrap state

--- a/tests/contrib/asynctest/test_asynctest.py
+++ b/tests/contrib/asynctest/test_asynctest.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 
 
-# AIDEV-NOTE: This plugin installs mocks at import time so they are active before the
+# This plugin installs mocks at import time so they are active before the
 # child process initializes the Datadog pytest plugin. Keep this test out of inline_run:
 # nested in-process pytest-cov sessions can corrupt the outer session's coverage state.
 _INFRA_PLUGIN = """\

--- a/tests/contrib/llama_index/test_llama_index_patch.py
+++ b/tests/contrib/llama_index/test_llama_index_patch.py
@@ -12,7 +12,7 @@ class TestLlamaIndexPatch(PatchTestCase.Base):
     __unpatch_func__ = unpatch
     __get_version__ = get_version
 
-    # AIDEV-NOTE: llama_index uses wrapt FunctionWrappers for its own instrumentation
+    # llama_index uses wrapt FunctionWrappers for its own instrumentation
     # (@dispatcher.span on query, retrieve, etc.). The default is_wrapped() checks
     # is_wrapted() which returns True for these pre-existing wrapt wrappers even after
     # dd-trace unpatch. Override to only check for our __dd_wrapped__ marker.
@@ -24,7 +24,7 @@ class TestLlamaIndexPatch(PatchTestCase.Base):
         inner = getattr(obj, _DD_WRAPPED)
         self.assert_not_wrapped(inner)
 
-    # AIDEV-NOTE: BaseWorkflowAgent only exists in newer llama-index-core versions.
+    # BaseWorkflowAgent only exists in newer llama-index-core versions.
     # Import it optionally so tests pass on both ~=0.11.0 and latest.
     @staticmethod
     def _try_import_agent():

--- a/tests/contrib/pytest/test_pytest.py
+++ b/tests/contrib/pytest/test_pytest.py
@@ -113,12 +113,12 @@ class PytestTestCaseBase(TracerTestCase):
         self.testdir = testdir
         self.monkeypatch = monkeypatch
         self.git_repo = git_repo
-        # AIDEV-NOTE: Anchor the pytester monkeypatch CWD *before* any test body
+        # Anchor the pytester monkeypatch CWD *before* any test body
         # runs. Tests that call os.chdir() directly before testdir.chdir() would
         # otherwise corrupt the saved CWD used during fixture teardown, leaking
         # wrong working directories to subsequent tests in the same xdist worker.
         testdir.chdir()
-        # AIDEV-NOTE: Clear outer xdist worker env vars for the duration of each
+        # Clear outer xdist worker env vars for the duration of each
         # test. Tests create CIVisibilityEncoderV01 instances and inline_run sessions
         # that read PYTEST_XDIST_WORKER at init/import time. If the outer test suite
         # runs with -n auto, the worker env var leaks and causes the encoder to filter
@@ -150,7 +150,7 @@ class PytestTestCaseBase(TracerTestCase):
         session starts and resumed after it completes, so that running this test suite with --ddtrace in the outer
         pytest does not disrupt the outer session.  The inner session creates its own instance on a clean stack.
         """
-        # AIDEV-NOTE: Suspend the outer CIVisibility instance (without stopping it) so that
+        # Suspend the outer CIVisibility instance (without stopping it) so that
         # the inner session starts with a clean stack.  The inner CIVisibilityPlugin does a
         # disable()/enable() cycle that would otherwise pop the outer instance off the stack.
         # _suspend() removes the outer instance without calling stop(); _resume() pushes it

--- a/tests/contrib/ray_serve/test_ray_serve_multi_app.py
+++ b/tests/contrib/ray_serve/test_ray_serve_multi_app.py
@@ -27,7 +27,7 @@ EXPECTED_MULTI_APP_DEPLOYMENTS = {
 
 
 def _start_ray_cluster(env):
-    # AIDEV-NOTE: Keep this explicit cluster small; `serve run` auto-starts Ray
+    # Keep this explicit cluster small; `serve run` auto-starts Ray
     # with default object-store sizing, which is too large for constrained CI pods.
     subprocess.run(["ray", "stop", "--force"], env=env, check=False, capture_output=True)
     return subprocess.run(

--- a/tests/coverage/test_instrumentation_py312_disable.py
+++ b/tests/coverage/test_instrumentation_py312_disable.py
@@ -10,7 +10,7 @@ import sys
 import pytest
 
 
-# AIDEV-NOTE: Tests for the "Datadog is the only monitoring tool" branch run in-process
+# Tests for the "Datadog is the only monitoring tool" branch run in-process
 # and skip when a session-level tool such as pytest-cov already owns another slot. The
 # neighboring tests explicitly register another tool to cover the opposite branch.
 

--- a/tests/datastreams/test_processor.py
+++ b/tests/datastreams/test_processor.py
@@ -61,7 +61,7 @@ def test_periodic_payload_process_tags():
 
 
 def test_periodic_logs_warning_on_flush_failure(caplog):
-    # AIDEV-NOTE: DSMS-144 — when retry-budget is exhausted, the customer-facing log
+    # DSMS-144 — when retry-budget is exhausted, the customer-facing log
     # must (a) be WARNING (not ERROR) so it doesn't trip alerting on benign flush
     # failures, (b) preserve the leading phrase for customers' existing log-based
     # alerts, (c) explain impact, (d) include the exception cause inline for triage,

--- a/tests/internal/test_check_no_new_aidev_anchors.py
+++ b/tests/internal/test_check_no_new_aidev_anchors.py
@@ -1,0 +1,45 @@
+"""Tests for scripts/check_no_new_aidev_anchors.py."""
+
+import importlib.util
+import pathlib
+import types
+
+import pytest
+
+
+_SCRIPT_PATH: pathlib.Path = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "check_no_new_aidev_anchors.py"
+_SPEC: importlib.machinery.ModuleSpec | None = importlib.util.spec_from_file_location(
+    "check_no_new_aidev_anchors", _SCRIPT_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE: types.ModuleType = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "+ # AIDEV-NOTE: Python comment",
+        "+ value # AIDEV-TODO: inline Python comment",
+        "+ // AIDEV-QUESTION: C++ comment",
+        "+ /* AIDEV-NOTE: block comment */",
+        "+ * AIDEV-TODO: block continuation",
+        "+ AIDEV-QUESTION: block continuation */",
+    ],
+)
+def test_is_anchor_line_detects_comment_forms(line: str) -> None:
+    assert _MODULE._is_anchor_line(line)
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "+ This prose mentions `AIDEV-NOTE:` but is not a comment.",
+        '+ value = "/* AIDEV-NOTE: inside a string */"',
+        '+ value = "# AIDEV-TODO: inside a string"',
+        "+ https://example.test// AIDEV-QUESTION: URL text",
+        "+ value * AIDEV-NOTE: multiplication expression",
+    ],
+)
+def test_is_anchor_line_ignores_prose_and_strings(line: str) -> None:
+    assert not _MODULE._is_anchor_line(line)

--- a/tests/testing/internal/pytest/test_pytest_bdd.py
+++ b/tests/testing/internal/pytest/test_pytest_bdd.py
@@ -23,7 +23,7 @@ Feature: Simple feature
 
 _CAPTURE_PATH_ENV = "_DD_PYTEST_BDD_CAPTURE_PATH"
 
-# AIDEV-NOTE: This plugin installs mocks at import time so they are active before the
+# This plugin installs mocks at import time so they are active before the
 # child process initializes the Datadog pytest plugin. Keep these tests out of inline_run:
 # nested in-process pytest-cov sessions can corrupt the outer session's coverage state.
 _INFRA_PLUGIN = f"""\

--- a/tests/testing/internal/pytest/test_pytest_xdist.py
+++ b/tests/testing/internal/pytest/test_pytest_xdist.py
@@ -351,7 +351,7 @@ def _git_commit(project_dir: Path, message: str = "test commit") -> None:
 # Tests
 # ---------------------------------------------------------------------------
 
-# AIDEV-NOTE: These tests use subprocess to run pytest with xdist, pointing at
+# These tests use subprocess to run pytest with xdist, pointing at
 # a local mock HTTP server.  This is the only way to truly test multi-process
 # xdist behavior since inline_run + EventCapture cannot cross process boundaries.
 
@@ -898,7 +898,7 @@ class TestXdistWorkerCrashRestart:
         worker.
 
         This test documents the current behavior — it is a known limitation.
-        AIDEV-NOTE: If the writer is changed to flush after each test, or to
+        If the writer is changed to flush after each test, or to
         use a non-daemon thread with proper shutdown, this test should be updated.
         """
         # Use -n 1 so there is only one worker. Put a passing test and a
@@ -979,7 +979,7 @@ class TestXdistWorkerCrashRestart:
 
         # Some or all healthy tests may be lost too if they shared a worker
         # with a crash test (their events were buffered but not flushed).
-        # AIDEV-NOTE: This documents real data loss. The number of surviving
+        # This documents real data loss. The number of surviving
         # ok tests depends on scheduling luck. We only assert the session
         # event (from the main process) is always present.
         session_events = mock_server.get_session_events()

--- a/tests/testing/internal/test_http.py
+++ b/tests/testing/internal/test_http.py
@@ -1199,7 +1199,7 @@ class TestUnixDomainSocketTimeout:
 class TestBackendTimeoutEnvVar:
     """Tests for DD_CIVISIBILITY_BACKEND_API_TIMEOUT_MILLIS parsing via _parse_timeout_millis."""
 
-    # AIDEV-NOTE: Tests call _parse_timeout_millis() directly to avoid importlib.reload, which
+    # Tests call _parse_timeout_millis() directly to avoid importlib.reload, which
     # mutates the module's __dict__ in place and breaks isinstance checks in other test classes
     # (old imported class objects see new reloaded classes via shared __globals__).
 


### PR DESCRIPTION
## Description

Guild decision: stop using `AIDEV-NOTE:` / `AIDEV-TODO:` / `AIDEV-QUESTION:` prefixes in favor of plain inline comments.

This PR only adds the policy and the gate:

- Update `AGENTS.md` and cursor rules so new anchors are not added
- Add `scripts/check_no_new_aidev_anchors.py` (diff-scoped: added lines only; legacy anchors are grandfathered)
- Wire a GitLab CI job modeled on `check_added_file_size` (includes `GIT_DEPTH: "0"` to match that job on current `main`)
- Exclude the new script from `pyproject.toml` `exclude_dirs`

## Testing

- [x] Pre-commit hooks passed on this branch
- [ ] Confirm `check_no_new_aidev_anchors` runs on the MR and is skippable on `main` / release / merge-queue
- [ ] `python3 scripts/check_no_new_aidev_anchors.py --base-ref origin/main` is clean on this branch (no new anchors in this diff)

## Additional Notes

- Next PR: https://github.com/DataDog/dd-trace-py/pull/19877 (remove existing `AIDEV-*` comments in product code.)