### PR TITLE
ci: update system-tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -95,11 +95,11 @@ jobs:
   serverless-system-tests:
     needs: [serverless-system-tests-build-layer]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@4f13cf1b6222d42804d012326fd4f6881026ba46
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@6bcdc71f0db7d262a02541a07546630784e7acdf
     secrets: inherit
     with:
       library: python_lambda
-      ref: '4f13cf1b6222d42804d012326fd4f6881026ba46'
+      ref: '6bcdc71f0db7d262a02541a07546630784e7acdf'
       binaries_artifact: serverless_system_tests_binaries
       scenarios_groups: lambda_end_to_end
       skip_empty_scenarios: true
@@ -126,11 +126,11 @@ jobs:
     if: github.event_name != 'schedule' || github.event.repository.fork == false
     needs: [integration-frameworks-combine-wheels]
     # Automatically managed, use scripts/update-system-tests-version to update
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@4f13cf1b6222d42804d012326fd4f6881026ba46
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@6bcdc71f0db7d262a02541a07546630784e7acdf
     secrets: inherit
     with:
       library: python
-      ref: '4f13cf1b6222d42804d012326fd4f6881026ba46'
+      ref: '6bcdc71f0db7d262a02541a07546630784e7acdf'
       scenarios: INTEGRATION_FRAMEWORKS
       binaries_artifact: integration-frameworks-wheels
       push_to_test_optimization: true
@@ -138,10 +138,10 @@ jobs:
   tracer-release:
     needs:
       - download-s3-wheels
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@4f13cf1b6222d42804d012326fd4f6881026ba46
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@6bcdc71f0db7d262a02541a07546630784e7acdf
     with:
       library: python
-      ref: '4f13cf1b6222d42804d012326fd4f6881026ba46'
+      ref: '6bcdc71f0db7d262a02541a07546630784e7acdf'
       binaries_artifact: wheels-manylinux_x86_64
       desired_execution_time: 900
       scenarios_groups: tracer-release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ variables:
   DD_VPA_TEMPLATE: "vpa-template-cpu-p70-10percent-2x-oom-min-cap"
   # CI_DEBUG_SERVICES: "true"
   # Automatically managed, use scripts/update-system-tests-version to update
-  SYSTEM_TESTS_REF: "4f13cf1b6222d42804d012326fd4f6881026ba46"
+  SYSTEM_TESTS_REF: "6bcdc71f0db7d262a02541a07546630784e7acdf"
 
   # Profiling native build image (built from dd/images/dd-trace-py/profiling_native)
   PROFILING_NATIVE_IMAGE: "registry.ddbuild.io/dd-trace-py:v103334885-be1888c-profiling_native"


### PR DESCRIPTION
## Description

Bumps the pinned `system-tests` SHA from `4f13cf1b62` (Sep 3) to `6bcdc71f0d` (current `main`, "Unfreeze (#7677)").

Generated by `scripts/update-system-tests-version.py`, which updates all 7 pin sites: six in `.github/workflows/system-tests.yml` (the three `uses:` refs and their matching `ref:` inputs) plus `SYSTEM_TESTS_REF` in `.gitlab-ci.yml`.

