### PR TITLE
ci: add per-team code freeze enforcement

### DIFF
--- a/.github/workflows/team-freeze-guard.yml
+++ b/.github/workflows/team-freeze-guard.yml
@@ -25,6 +25,8 @@ permissions:
   id-token: write
   contents: read
 
+# Freeze for incident-57565
+# - September 8th 2026 : teams below 95% on test health
 
 jobs:
   team-freeze-guard:
@@ -39,4 +41,9 @@ jobs:
             bug
             CI
             ci-reliability
-          frozen-teams: ""
+          frozen-teams: |
+            @DataDog/apm-core-python
+            @DataDog/debugger-python
+            @DataDog/apm-sdk-capabilities-python
+            @DataDog/apm-python
+            @DataDog/apm-idm-python

--- a/.github/workflows/team-freeze-guard.yml
+++ b/.github/workflows/team-freeze-guard.yml
@@ -1,0 +1,42 @@
+# How to configure:
+#
+# When no team is frozen, set `frozen-teams` to an empty string:
+# frozen-teams: ""
+#
+# When one or more teams are frozen, add them one per line with the @DataDog prefix:
+#
+# frozen-teams: |
+#   @DataDog/team-a
+#   @DataDog/team-b
+
+name: Team freeze guard
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+      - ready_for_review
+
+permissions:
+  id-token: write
+  contents: read
+
+
+jobs:
+  team-freeze-guard:
+    name: Team freeze guard
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: DataDog/team-freeze-guard@29e92069c40f38088e636f27df70d10c24e647b6  # v0.0.2
+        with:
+          bypass-labels: |
+            testing
+            bug
+            CI
+            ci-reliability
+          frozen-teams: ""


### PR DESCRIPTION
## Description

* Adds a github action that will fail if ever the PR author or last committer is part of a frozen team. Please read https://github.com/DataDog/team-freeze-guard on how it works
* Freeze teams : 

@DataDog/apm-core-python
@DataDog/debugger-python
@DataDog/apm-sdk-capabilities-python
@DataDog/apm-python
@DataDog/apm-idm-python

Based on Test health computed here https://app.datadoghq.com/dashboard/x2n-g4i-n4x/ci-health-shift-investigation?tpl_var_repository%5B0%5D=%2A%2Fdd-trace-py with the basic rule : SLI lower than `95%` (to be adjusted if needed).

## Testing

The workflow runs on `pull_request_target` (read DataDog/team-freeze-guard  to understand why), so you can't test it on this PR. I've tested a lot on DataDog/team-freeze-guard  itself, and system-tests, and I'll closely monitor actions once merged

## Risks

Freeze the entire repo if I mess up. But easy to revert.

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
