### PR TITLE
ci: define uv snapshot ddtest templates

### DIFF
--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -135,6 +135,9 @@ include:
 .ddtest_base_uv:
   extends: .test_base_uv
 
+.ddtest_base_uv_snapshot:
+  extends: .test_base_uv_snapshot
+
 .ddtest_plan_uv:
   extends: .ddtest_base_uv
   script:
@@ -188,6 +191,10 @@ include:
           --ci-node "${CI_NODE_INDEX}" --ci-node-workers 1
       rm -f "${requirements}"
       coverage combine || true
+
+.ddtest_run_uv_snapshot:
+  extends: .ddtest_run_uv
+  services: !reference [.ddtest_base_uv_snapshot, services]
 
 # ---------------------------------------------------------------------------
 # ddtest job templates. Used by gen_gitlab_config.py for suites with


### PR DESCRIPTION
## Description

PR #19870 made the DDTest job generator select snapshot-specific templates whenever a suite uses `ddtest: true` and `snapshot: true`. For uv suites, it emits `.ddtest_base_uv_snapshot` and `.ddtest_run_uv_snapshot`, but #19870 only defined the non-snapshot uv templates.

The bug remained hidden until #20034 migrated `integration_testagent` to a suitespec matrix. GitLab then rejected the generated child pipeline because `.ddtest_run_uv_snapshot` did not exist. No test jobs could start. The same issue would affect any future snapshot suite using both DDTest and uv.

## Fix

- Define `.ddtest_base_uv_snapshot` by extending the existing `.test_base_uv_snapshot`. This reuses its Datadog Agent and test-agent services, test-agent URL setup, and project symlink.
- Define `.ddtest_run_uv_snapshot` by extending `.ddtest_run_uv` and taking its services from the snapshot base.
- Keep dependency installation and DDTest execution identical to the normal uv path. Only the snapshot test-agent setup is added.

## Testing

- Generated `integration_testagent` jobs from the #20034 head with this commit applied.
- GitLab CI lint accepted the complete generated child configuration.
- All 17 generator tests passed on Python 3.12 through `scripts/run-tests`.
- `scripts/lint checks` passed.

## Risks

Low. Riot jobs and non-snapshot uv jobs are unchanged. The new templates are only selected for DDTest snapshot suites using uv.

## Additional Notes

No customer-facing change.