### PR TITLE
chore(integrations): backfill ML observability manifests

### DIFF
--- a/ddtrace/contrib/internal/anthropic/anthropic.manifest.yaml
+++ b/ddtrace/contrib/internal/anthropic/anthropic.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: anthropic
+display_name: Anthropic
+description: Instruments synchronous and asynchronous Anthropic Messages API calls, including streamed responses, to capture
+  prompts, model outputs, tool activity, and token usage.
+packages:
+- name: anthropic
+category:
+- gen_ai
+systems:
+- anthropic
+creation_date: '2024-06-04'

--- a/ddtrace/contrib/internal/anthropic/anthropic.manifest.yaml
+++ b/ddtrace/contrib/internal/anthropic/anthropic.manifest.yaml
@@ -1,12 +1,14 @@
 _v: 1
 name: anthropic
 display_name: Anthropic
-description: Instruments synchronous and asynchronous Anthropic Messages API calls, including streamed responses, to capture
-  prompts, model outputs, tool activity, and token usage.
+description: Instruments synchronous and asynchronous Anthropic message generation, including standard and beta APIs, streamed
+  responses, model inputs, outputs, and token usage.
 packages:
 - name: anthropic
 category:
 - gen_ai
 systems:
 - anthropic
+- aws.bedrock
+- gcp.vertex_ai
 creation_date: '2024-06-04'

--- a/ddtrace/contrib/internal/claude_agent_sdk/claude_agent_sdk.manifest.yaml
+++ b/ddtrace/contrib/internal/claude_agent_sdk/claude_agent_sdk.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: claude_agent_sdk
+display_name: Claude Agent SDK
+description: Instruments Claude Agent SDK queries and streamed sessions, capturing agent, model-turn, step, and tool execution
+  telemetry.
+packages:
+- name: claude-agent-sdk
+category:
+- gen_ai
+systems:
+- anthropic
+creation_date: '2026-02-17'

--- a/ddtrace/contrib/internal/crewai/crewai.manifest.yaml
+++ b/ddtrace/contrib/internal/crewai/crewai.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: crewai
+display_name: CrewAI
+description: Instruments CrewAI crews, tasks, agents, tools, and flows with tracing, LLM Observability metadata, and causal
+  span links.
+packages:
+- name: crewai
+category:
+- gen_ai
+systems: []
+creation_date: '2025-04-08'

--- a/ddtrace/contrib/internal/google_adk/google_adk.manifest.yaml
+++ b/ddtrace/contrib/internal/google_adk/google_adk.manifest.yaml
@@ -1,0 +1,10 @@
+_v: 1
+name: google_adk
+display_name: Google ADK
+description: Instruments Google ADK agent runs, tool calls, and code execution for distributed tracing and LLM Observability.
+packages:
+- name: google-adk
+category:
+- gen_ai
+systems: []
+creation_date: '2025-09-24'

--- a/ddtrace/contrib/internal/google_genai/google_genai.manifest.yaml
+++ b/ddtrace/contrib/internal/google_genai/google_genai.manifest.yaml
@@ -1,0 +1,13 @@
+_v: 1
+name: google_genai
+display_name: Google GenAI
+description: Instruments Google GenAI content generation, streaming responses, and embedding operations for Gemini and Vertex
+  AI models.
+packages:
+- name: google-genai
+category:
+- gen_ai
+systems:
+- gcp.gemini
+- gcp.vertex_ai
+creation_date: '2025-06-25'

--- a/ddtrace/contrib/internal/langchain/langchain.manifest.yaml
+++ b/ddtrace/contrib/internal/langchain/langchain.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: langchain
+display_name: LangChain
+description: Instruments LangChain model generation, embeddings, retrieval, tools, chains, and runnable workflows across synchronous,
+  asynchronous, and streaming operations.
+packages:
+- name: langchain-core
+category:
+- gen_ai
+systems: []
+creation_date: '2023-07-13'

--- a/ddtrace/contrib/internal/langgraph/langgraph.manifest.yaml
+++ b/ddtrace/contrib/internal/langgraph/langgraph.manifest.yaml
@@ -1,0 +1,13 @@
+_v: 1
+name: langgraph
+display_name: LangGraph
+description: Instruments synchronous, asynchronous, and streaming LangGraph graph and node executions for APM tracing and
+  LLM Observability.
+packages:
+- name: langgraph
+- name: langgraph-checkpoint
+- name: langgraph-prebuilt
+category:
+- gen_ai
+systems: []
+creation_date: '2025-01-17'

--- a/ddtrace/contrib/internal/litellm/litellm.manifest.yaml
+++ b/ddtrace/contrib/internal/litellm/litellm.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: litellm
+display_name: LiteLLM
+description: Instruments synchronous and asynchronous LiteLLM chat and text completion calls, including router operations
+  and streamed model responses.
+packages:
+- name: litellm
+category:
+- gen_ai
+systems: []
+creation_date: '2025-04-07'

--- a/ddtrace/contrib/internal/llama_index/llama_index.manifest.yaml
+++ b/ddtrace/contrib/internal/llama_index/llama_index.manifest.yaml
@@ -1,0 +1,13 @@
+_v: 1
+name: llama_index
+display_name: LlamaIndex
+description: Instruments LlamaIndex LLM calls, query and retrieval workflows, embeddings, agent runs, and tool calls, including
+  synchronous, asynchronous, and streamed operations.
+packages:
+- name: llama-index
+- name: llama-index-core
+- name: llama_index
+category:
+- gen_ai
+systems: []
+creation_date: '2026-04-08'

--- a/ddtrace/contrib/internal/mcp/mcp.manifest.yaml
+++ b/ddtrace/contrib/internal/mcp/mcp.manifest.yaml
@@ -1,0 +1,16 @@
+_v: 1
+name: mcp
+display_name: MCP
+description: Instruments MCP client sessions and requests, server initialization and tool execution, and distributed trace
+  propagation between clients and servers.
+packages:
+- name: mcp
+category:
+- gen_ai
+- mcp.client
+- mcp.server
+- rpc.client
+- rpc.server
+systems:
+- jsonrpc
+creation_date: '2025-07-15'

--- a/ddtrace/contrib/internal/mistralai/mistralai.manifest.yaml
+++ b/ddtrace/contrib/internal/mistralai/mistralai.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: mistralai
+display_name: Mistral AI
+description: Instruments synchronous and asynchronous Mistral AI chat completions, streamed responses, and embedding generation
+  for tracing and LLM Observability.
+packages:
+- name: mistralai
+category:
+- gen_ai
+systems:
+- mistral_ai
+creation_date: '2026-06-29'

--- a/ddtrace/contrib/internal/mlflow/mlflow.manifest.yaml
+++ b/ddtrace/contrib/internal/mlflow/mlflow.manifest.yaml
@@ -1,0 +1,13 @@
+_v: 1
+name: mlflow
+display_name: MLflow
+description: Instruments MLflow run lifecycles and step progression, captures logged metrics and parameters, and correlates
+  spans and logs with run IDs.
+packages:
+- name: mlflow
+- name: mlflow-skinny
+- name: mlflow-tracing
+category:
+- other
+systems: []
+creation_date: '2026-03-25'

--- a/ddtrace/contrib/internal/openai/openai.manifest.yaml
+++ b/ddtrace/contrib/internal/openai/openai.manifest.yaml
@@ -1,0 +1,14 @@
+_v: 1
+name: openai
+display_name: OpenAI
+description: Instruments OpenAI and Azure OpenAI API operations plus OpenAI Realtime WebSocket conversations, capturing model
+  inputs, outputs, streams, and tool calls.
+packages:
+- name: openai
+category:
+- gen_ai
+- websocket.client
+systems:
+- azure.ai.openai
+- openai
+creation_date: '2023-04-26'

--- a/ddtrace/contrib/internal/openai_agents/openai_agents.manifest.yaml
+++ b/ddtrace/contrib/internal/openai_agents/openai_agents.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: openai_agents
+display_name: OpenAI Agents
+description: Instruments OpenAI Agents SDK workflows, agent invocations, model responses, tool calls, handoffs, guardrails,
+  and custom operations.
+packages:
+- name: openai-agents
+category:
+- gen_ai
+systems:
+- openai
+creation_date: '2025-04-04'

--- a/ddtrace/contrib/internal/pydantic_ai/pydantic_ai.manifest.yaml
+++ b/ddtrace/contrib/internal/pydantic_ai/pydantic_ai.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: pydantic_ai
+display_name: PydanticAI
+description: Instruments PydanticAI agent runs and user-defined tool executions, including streamed agent outputs, for tracing
+  and LLM observability.
+packages:
+- name: pydantic-ai-slim
+category:
+- gen_ai
+systems: []
+creation_date: '2025-07-01'

--- a/ddtrace/contrib/internal/pytorch/pytorch.manifest.yaml
+++ b/ddtrace/contrib/internal/pytorch/pytorch.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: pytorch
+display_name: PyTorch
+description: Instruments PyTorch distributed training lifecycles and optional optimizer-step boundaries, emitting per-rank
+  spans with job, framework, and device context.
+packages:
+- name: torch
+category:
+- other
+systems: []
+creation_date: '2026-06-16'

--- a/ddtrace/contrib/internal/ray/ray.manifest.yaml
+++ b/ddtrace/contrib/internal/ray/ray.manifest.yaml
@@ -1,0 +1,14 @@
+_v: 1
+name: ray
+display_name: Ray
+description: Instruments Ray job lifecycles, remote task and actor method submission and execution, optional core object APIs,
+  and Ray Serve inbound HTTP and gRPC proxy requests, deployment handle calls, and deployment execution.
+packages:
+- name: ray
+category:
+- http.server
+- rpc.server
+- task.execution
+systems:
+- grpc
+creation_date: '2025-10-02'

--- a/ddtrace/contrib/internal/ray_serve/ray_serve.manifest.yaml
+++ b/ddtrace/contrib/internal/ray_serve/ray_serve.manifest.yaml
@@ -1,0 +1,15 @@
+_v: 1
+name: ray_serve
+display_name: Ray Serve
+description: Instruments inbound HTTP and gRPC proxy requests, deployment-handle calls, request routing and replica handling,
+  and Ray Serve deployment execution.
+packages:
+- name: ray
+category:
+- http.server
+- rpc.client
+- rpc.server
+- task.execution
+systems:
+- grpc
+creation_date: '2026-06-19'

--- a/ddtrace/contrib/internal/vertexai/vertexai.manifest.yaml
+++ b/ddtrace/contrib/internal/vertexai/vertexai.manifest.yaml
@@ -1,0 +1,13 @@
+_v: 1
+name: vertexai
+display_name: Vertex AI
+description: Instruments synchronous and asynchronous generative content and chat operations, including streamed responses,
+  made through the Vertex AI Python SDK.
+packages:
+- name: google-cloud-aiplatform
+- name: vertexai
+category:
+- gen_ai
+systems:
+- gcp.vertex_ai
+creation_date: '2024-11-21'

--- a/ddtrace/contrib/internal/vllm/vllm.manifest.yaml
+++ b/ddtrace/contrib/internal/vllm/vllm.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: vllm
+display_name: vLLM
+description: Instruments completed vLLM V1 engine inference and embedding requests, capturing inputs, outputs, token and latency
+  metrics, and propagating trace context.
+packages:
+- name: vllm
+category:
+- gen_ai
+systems: []
+creation_date: '2025-12-22'


### PR DESCRIPTION
## Description

This change adds structured, machine-readable [instrumentation manifests](https://docs.google.com/document/d/18za_vEcA-hH4IEwRhebDhoQxQKSylCtwMeVDB3rYM4Y/edit?usp=sharing) for:

- Model and provider SDKs: `anthropic`, `google_genai`, `litellm`, `mistralai`, `openai`, `vertexai`, and `vllm`
- Agent frameworks: `claude_agent_sdk`, `crewai`, `google_adk`, `openai_agents`, and `pydantic_ai`
- Orchestration: `langchain`, `langgraph`, and `mcp`
- ML platforms and runtimes: `mlflow` and `ray`
- Related ML integrations: `llama_index`, `pytorch`, and `ray_serve`

This is declarative metadata only. Runtime instrumentation and public APIs are unchanged.

Detailed field-level review evidence for every manifest is provided below.
It has the same information as the changed file, so reviewing this description is enough to understand the changes being proposed.

| Integration | Categories | Systems | Creation date |
|---|---|---|---|
| `anthropic` | `gen_ai` | `anthropic`, `aws.bedrock`, `gcp.vertex_ai` | 2024-06-04 |
| `google_genai` | `gen_ai` | `gcp.gemini`, `gcp.vertex_ai` | 2025-06-25 |
| `litellm` | `gen_ai` | none | 2025-04-07 |
| `mistralai` | `gen_ai` | `mistral_ai` | 2026-06-29 |
| `openai` | `gen_ai`, `websocket.client` | `azure.ai.openai`, `openai` | 2023-04-26 |
| `vertexai` | `gen_ai` | `gcp.vertex_ai` | 2024-11-21 |
| `vllm` | `gen_ai` | none | 2025-12-22 |
| `claude_agent_sdk` | `gen_ai` | `anthropic` | 2026-02-17 |
| `crewai` | `gen_ai` | none | 2025-04-08 |
| `google_adk` | `gen_ai` | none | 2025-09-24 |
| `openai_agents` | `gen_ai` | `openai` | 2025-04-04 |
| `pydantic_ai` | `gen_ai` | none | 2025-07-01 |
| `langchain` | `gen_ai` | none | 2023-07-13 |
| `langgraph` | `gen_ai` | none | 2025-01-17 |
| `mcp` | `gen_ai`, `mcp.client`, `mcp.server`, `rpc.client`, `rpc.server` | `jsonrpc` | 2025-07-15 |
| `mlflow` | `other` | none | 2026-03-25 |
| `ray` | `http.server`, `rpc.server`, `task.execution` | `grpc` | 2025-10-02 |
| `llama_index` | `gen_ai` | none | 2026-04-08 |
| `pytorch` | `other` | none | 2026-06-16 |
| `ray_serve` | `http.server`, `rpc.client`, `rpc.server`, `task.execution` | `grpc` | 2026-06-19 |

### Field-level review evidence

Taxonomy links define the publication labels. Tracer links show the instrumented behavior that satisfies those definitions. Tracer links are pinned to the reviewed source revision. Taxonomy links use the generator revision identified in Additional Notes as a review reference.

<details>
<summary><code>anthropic</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `anthropic` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L80) — Canonical identity. |
| `display_name`: `Anthropic` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/anthropic/__init__.py#L6) — Established spelling. |
| `description`: `Instruments synchronous and asynchronous Anthropic message generation, including standard and beta APIs, streamed responses, model inputs, outputs, and token usage.` | [source1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/anthropic/patch.py#L129) · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/anthropic/_streaming.py#L40) · [source3](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/anthropic.py#L101) — Sources cover every described operation. |
| `packages`: `anthropic` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L84) — Registry binding and activation. |
| `category: gen_ai`: `gen_ai` | [policy][r2] · [schema][r3] · [source][r9] — Qualifies as `gen_ai`. |
| `systems: anthropic`: `anthropic` | [policy][r4] · [schema][r10] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/anthropic.py#L270) — Explicitly recognized provider endpoint. |
| `systems: aws.bedrock`: `aws.bedrock` | [policy][r4] · [schema](/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L324) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/anthropic.py#L266) — Explicitly recognized Bedrock endpoint. |
| `systems: gcp.vertex_ai`: `gcp.vertex_ai` | [policy][r4] · [schema][r13] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/anthropic.py#L268) — Explicitly recognized Vertex AI endpoint. |
| `creation_date`: `2024-06-04` | [commit](/DataDog/dd-trace-py/commit/1447e974dff8162bc42efa72e8bbbd8ec62042f5) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/anthropic/patch.py#L115) — First working instrumentation: `2024-06-04`. |

</details>

<details>
<summary><code>google_genai</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `google_genai` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L458) — Canonical identity. |
| `display_name`: `Google GenAI` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/google_genai/__init__.py#L1) — Established spelling. |
| `description`: `Instruments Google GenAI content generation, streaming responses, and embedding operations for Gemini and Vertex AI models.` | [source1][r11] · [source2][r12] — Sources cover every described operation. |
| `packages`: `google-genai` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L462) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/google_genai/patch.py#L2) — Registry binding and activation. |
| `category: gen_ai`: `gen_ai` | [policy][r2] · [schema][r3] · [source][r11] — Qualifies as `gen_ai`. |
| `systems: gcp.gemini`: `gcp.gemini` | [policy][r4] · [schema](/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L472) · [source][r12] — Statically bounded to `gcp.gemini`. |
| `systems: gcp.vertex_ai`: `gcp.vertex_ai` | [policy][r4] · [schema][r13] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/google_utils.py#L30) — Statically bounded to `gcp.vertex_ai`. |
| `creation_date`: `2025-06-25` | [commit](/DataDog/dd-trace-py/commit/c335af97f527e97442dff7f7d5dd41ba0631eb53) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/google_genai/patch.py#L132) — First working instrumentation: `2025-06-25`. |

</details>

<details>
<summary><code>litellm</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `litellm` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L580) — Canonical identity. |
| `display_name`: `LiteLLM` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/litellm/__init__.py#L1) — Established spelling. |
| `description`: `Instruments synchronous and asynchronous LiteLLM chat and text completion calls, including router operations and streamed model responses.` | [source1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/litellm/patch.py#L180) · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/litellm/patch.py#L63) — Sources cover every described operation. |
| `packages`: `litellm` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L583) — Registry binding and activation. |
| `category: gen_ai`: `gen_ai` | [policy][r2] · [schema][r3] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/litellm/patch.py#L177) — Qualifies as `gen_ai`. |
| `systems`: `[]` | [policy][r4] · [source1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/litellm/patch.py#L167) · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/litellm/utils.py#L54) — No qualifying statically bounded system. |
| `creation_date`: `2025-04-07` | [commit](/DataDog/dd-trace-py/commit/e606dcb54633a003d0d03b923194d2a50de9b749) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/litellm/patch.py#L171) — First working instrumentation: `2025-04-07`. |

</details>

<details>
<summary><code>mistralai</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `mistralai` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L662) — Canonical identity. |
| `display_name`: `Mistral AI` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mistralai/__init__.py#L2) — Established spelling. |
| `description`: `Instruments synchronous and asynchronous Mistral AI chat completions, streamed responses, and embedding generation for tracing and LLM Observability.` | [source1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mistralai/patch.py#L211) · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mistralai/patch.py#L61) — Sources cover every described operation. |
| `packages`: `mistralai` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L666) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mistralai/patch.py#L6) — Registry binding and activation. |
| `category: gen_ai`: `gen_ai` | [policy][r2] · [schema][r3] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mistralai/patch.py#L172) — Qualifies as `gen_ai`. |
| `systems: mistral_ai`: `mistral_ai` | [policy][r4] · [schema](/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L609) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/mistralai_utils.py#L8) — Statically bounded to `mistral_ai`. |
| `creation_date`: `2026-06-29` | [commit](/DataDog/dd-trace-py/commit/dc7951eb2235afcfbb0e7701664f1d1fca361d62) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mistralai/patch.py#L203) — First working instrumentation: `2026-06-29`. |

</details>

<details>
<summary><code>openai</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `openai` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L720) — Canonical identity. |
| `display_name`: `OpenAI` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/openai/__init__.py#L1) — Established spelling. |
| `description`: `Instruments OpenAI and Azure OpenAI API operations plus OpenAI Realtime WebSocket conversations, capturing model inputs, outputs, streams, and tool calls.` | [source1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/openai/patch.py#L39) · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/openai/_realtime.py#L1) · [source3](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/openai/__init__.py#L19) — Sources cover every described operation. |
| `packages`: `openai` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L723) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/openai/patch.py#L33) — Registry binding and activation. |
| `category: gen_ai`: `gen_ai` | [policy][r2] · [schema][r3] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/openai/patch.py#L45) — Qualifies as `gen_ai`. |
| `category: websocket.client`: `websocket.client` | [policy][r2] · [schema](/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L253) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/openai/_realtime.py#L1310) — Qualifies as `websocket.client`. |
| `systems: azure.ai.openai`: `azure.ai.openai` | [policy][r4] · [schema](/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L376) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/openai/patch.py#L115) — Statically bounded to `azure.ai.openai`. |
| `systems: openai`: `openai` | [policy][r4] · [schema][r14] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/openai/patch.py#L113) — Statically bounded to `openai`. |
| `creation_date`: `2023-04-26` | [commit](/DataDog/dd-trace-py/commit/abd45420faf6e49eb7127b6c3127a877019b020a) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/openai/patch.py#L97) — First working instrumentation: `2023-04-26`. |

</details>

<details>
<summary><code>vertexai</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `vertexai` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1042) — Canonical identity. |
| `display_name`: `Vertex AI` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vertexai/__init__.py#L1) — Established spelling. |
| `description`: `Instruments synchronous and asynchronous generative content and chat operations, including streamed responses, made through the Vertex AI Python SDK.` | [source1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vertexai/patch.py#L124) · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vertexai/patch.py#L61) · [source3](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vertexai/_utils.py#L21) — Sources cover every described operation. |
| `packages`: `google-cloud-aiplatform`, `vertexai` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1045) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vertexai/patch.py#L3) — Registry binding and activation. |
| `category: gen_ai`: `gen_ai` | [policy][r2] · [schema][r3] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vertexai/patch.py#L50) — Qualifies as `gen_ai`. |
| `systems: gcp.vertex_ai`: `gcp.vertex_ai` | [policy][r4] · [schema][r13] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vertexai/__init__.py#L6) — Statically bounded to `gcp.vertex_ai`. |
| `creation_date`: `2024-11-21` | [commit](/DataDog/dd-trace-py/commit/351d9c45e72a5096da0b5b60934040fb5ff5a8be) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vertexai/patch.py#L115) — First working instrumentation: `2024-11-21`. |

</details>

<details>
<summary><code>vllm</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `vllm` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1066) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/vllm.py#L32) — Canonical identity. |
| `display_name`: `vLLM` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vllm/__init__.py#L1) — Established spelling. |
| `description`: `Instruments completed vLLM V1 engine inference and embedding requests, capturing inputs, outputs, token and latency metrics, and propagating trace context.` | [source1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vllm/patch.py#L124) · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/vllm.py#L90) · [source3](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vllm/utils.py#L63) — Sources cover every described operation. |
| `packages`: `vllm` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1069) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vllm/patch.py#L7) — Registry binding and activation. |
| `category: gen_ai`: `gen_ai` | [policy][r2] · [schema][r3] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/vllm.py#L122) — Qualifies as `gen_ai`. |
| `systems`: `[]` | [policy][r4] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vllm/patch.py#L222) — No qualifying statically bounded system. |
| `creation_date`: `2025-12-22` | [commit](/DataDog/dd-trace-py/commit/3841a702dbe647ace2da6840eaff398ab0376329) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vllm/patch.py#L184) — First working instrumentation: `2025-12-22`. |

</details>
<details>
<summary><code>claude_agent_sdk</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `claude_agent_sdk` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L260) — Canonical identity. |
| `display_name`: `Claude Agent SDK` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/claude_agent_sdk.py#L159) — Established spelling. |
| `description`: `Instruments Claude Agent SDK queries and streamed sessions, capturing agent, model-turn, step, and tool execution telemetry.` | [source1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/claude_agent_sdk/patch.py#L102) · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py#L284) · [source3](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/claude_agent_sdk/_streaming.py#L587) — Sources cover every described operation. |
| `packages`: `claude-agent-sdk` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L263) — Registry binding and activation. |
| `category: gen_ai`: `gen_ai` | [policy][r5] · [schema][r3] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/claude_agent_sdk/patch.py#L106) — Qualifies as `gen_ai`. |
| `systems: anthropic`: `anthropic` | [policy][r6] · [schema][r10] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/claude_agent_sdk.py#L98) — Statically bounded to `anthropic`. |
| `creation_date`: `2026-02-17` | [commit](/DataDog/dd-trace-py/commit/f24d420048bf81c5ba428028f0a1228f1d2fd1a0) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/claude_agent_sdk/patch.py#L209) — First working instrumentation: `2026-02-17`. |

</details>

<details>
<summary><code>crewai</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `crewai` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L290) — Canonical identity. |
| `display_name`: `CrewAI` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/crewai/__init__.py#L1) — Established spelling. |
| `description`: `Instruments CrewAI crews, tasks, agents, tools, and flows with tracing, LLM Observability metadata, and causal span links.` | [source1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/crewai/patch.py#L178) · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/crewai/patch.py#L36) · [source3](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/crewai.py#L126) — Sources cover every described operation. |
| `packages`: `crewai` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L293) — Registry binding and activation. |
| `category: gen_ai`: `gen_ai` | [policy][r5] · [schema][r3] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/crewai/patch.py#L97) — Qualifies as `gen_ai`. |
| `systems`: `[]` | [policy][r6] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/crewai.py#L42) — No qualifying statically bounded system. |
| `creation_date`: `2025-04-08` | [commit](/DataDog/dd-trace-py/commit/52d40ac7c7790a34da61832ee6d03eac3bb8dad8) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/crewai.py#L1) — First working instrumentation: `2025-04-08`. |

</details>

<details>
<summary><code>google_adk</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `google_adk` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L438) — Canonical identity. |
| `display_name`: `Google ADK` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/google_adk/__init__.py#L6) — Established spelling. |
| `description`: `Instruments Google ADK agent runs, tool calls, and code execution for distributed tracing and LLM Observability.` | [source1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/google_adk/patch.py#L284) · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/google_adk/patch.py#L288) · [source3](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/google_adk/patch.py#L293) — Sources cover every described operation. |
| `packages`: `google-adk` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L442) — Registry binding and activation. |
| `category: gen_ai`: `gen_ai` | [policy][r5] · [schema][r3] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/google_adk/patch.py#L51) — Qualifies as `gen_ai`. |
| `systems`: `[]` | [policy][r6] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/google_utils.py#L66) — No qualifying statically bounded system. |
| `creation_date`: `2025-09-24` | [commit](/DataDog/dd-trace-py/commit/1e4559643c9dfd373da2f5679b5c4ed3deb95800) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/google_adk/patch.py#L273) — First working instrumentation: `2025-09-24`. |

</details>

<details>
<summary><code>openai_agents</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `openai_agents` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L730) — Canonical identity. |
| `display_name`: `OpenAI Agents` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/openai_agents/__init__.py#L2) — Established spelling. |
| `description`: `Instruments OpenAI Agents SDK workflows, agent invocations, model responses, tool calls, handoffs, guardrails, and custom operations.` | [source1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/utils.py#L1571) · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/openai_agents/processor.py#L37) — Sources cover every described operation. |
| `packages`: `openai-agents` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L733) — Registry binding and activation. |
| `category: gen_ai`: `gen_ai` | [policy][r5] · [schema][r3] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/openai_agents.py#L34) — Qualifies as `gen_ai`. |
| `systems: openai`: `openai` | [policy][r6] · [schema][r14] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/openai_agents.py#L235) — Statically bounded to `openai`. |
| `creation_date`: `2025-04-04` | [commit](/DataDog/dd-trace-py/commit/534fa86c8761b6d876688beb33c0a697f10f2026) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/openai_agents/patch.py#L1) — First working instrumentation: `2025-04-04`. |

</details>

<details>
<summary><code>pydantic_ai</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `pydantic_ai` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L764) — Canonical identity. |
| `display_name`: `PydanticAI` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/pydantic_ai.py#L38) — Established spelling. |
| `description`: `Instruments PydanticAI agent runs and user-defined tool executions, including streamed agent outputs, for tracing and LLM observability.` | [source1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pydantic_ai/patch.py#L121) · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pydantic_ai/patch.py#L82) · [source3](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pydantic_ai/utils.py#L65) — Sources cover every described operation. |
| `packages`: `pydantic-ai-slim` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L768) — Registry binding and activation. |
| `category: gen_ai`: `gen_ai` | [policy][r5] · [schema][r3] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pydantic_ai/patch.py#L44) — Qualifies as `gen_ai`. |
| `systems`: `[]` | [policy][r6] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/pydantic_ai.py#L127) — No qualifying statically bounded system. |
| `creation_date`: `2025-07-01` | [commit](/DataDog/dd-trace-py/commit/f4ac9fddab9eee60988496b07c131b153e585ba5) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pydantic_ai/patch.py#L113) — First working instrumentation: `2025-07-01`. |

</details>

<details>
<summary><code>langchain</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `langchain` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L552) — Canonical identity. |
| `display_name`: `LangChain` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/langchain/__init__.py#L2) — Established spelling. |
| `description`: `Instruments LangChain model generation, embeddings, retrieval, tools, chains, and runnable workflows across synchronous, asynchronous, and streaming operations.` | [source1][r15] · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/langchain/patch.py#L534) · [source3](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/langchain/patch.py#L583) · [source4](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/langchain/patch.py#L398) · [source5](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/langchain/patch.py#L218) · [source6](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/langchain/patch.py#L705) — Sources cover every described operation. |
| `packages`: `langchain-core` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L556) — Registry binding and activation. |
| `category: gen_ai`: `gen_ai` | [policy][r5] · [schema][r3] · [source][r15] — Qualifies as `gen_ai`. |
| `systems`: `[]` | [policy][r6] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/langchain/patch.py#L83) — No qualifying statically bounded system. |
| `creation_date`: `2023-07-13` | [commit](/DataDog/dd-trace-py/commit/e5883bb21db782f1f23225002a4577ef3f392752) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/langchain/patch.py#L1) — First working instrumentation: `2023-07-13`. |

</details>

<details>
<summary><code>langgraph</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `langgraph` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L562) — Canonical identity. |
| `display_name`: `LangGraph` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/langgraph/__init__.py#L1) — Established spelling. |
| `description`: `Instruments synchronous, asynchronous, and streaming LangGraph graph and node executions for APM tracing and LLM Observability.` | [source1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/langgraph/patch.py#L114) · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/langgraph/patch.py#L131) · [source3](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/langgraph/patch.py#L156) · [source4](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/langgraph/patch.py#L250) — Sources cover every described operation. |
| `packages`: `langgraph`, `langgraph-checkpoint`, `langgraph-prebuilt` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L565) — Registry binding and activation. |
| `category: gen_ai`: `gen_ai` | [policy][r5] · [schema][r3] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/langgraph/patch.py#L265) — Qualifies as `gen_ai`. |
| `systems`: `[]` | [policy][r6] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/langgraph/patch.py#L413) — No qualifying statically bounded system. |
| `creation_date`: `2025-01-17` | [commit](/DataDog/dd-trace-py/commit/b6146554a47f727c8da49260387c5cfc879d6bf9) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/langgraph/patch.py#L1) — First working instrumentation: `2025-01-17`. |

</details>

<details>
<summary><code>mcp</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `mcp` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L652) — Canonical identity. |
| `display_name`: `MCP` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mcp/__init__.py#L1) — Established spelling. |
| `description`: `Instruments MCP client sessions and requests, server initialization and tool execution, and distributed trace propagation between clients and servers.` | [source1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mcp/patch.py#L291) · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mcp/patch.py#L211) · [source3](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mcp/patch.py#L51) — Sources cover every described operation. |
| `packages`: `mcp` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L655) — Registry binding and activation. |
| `category: gen_ai`: `gen_ai` | [policy][r5] · [schema][r3] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/mcp.py#L145) — Qualifies as `gen_ai`. |
| `category: mcp.client`: `mcp.client` | [policy][r16] · [schema](/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L169) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mcp/patch.py#L294) — Qualifies as `mcp.client`. |
| `category: mcp.server`: `mcp.server` | [policy][r16] · [schema](/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L176) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mcp/patch.py#L297) — Qualifies as `mcp.server`. |
| `category: rpc.client`: `rpc.client` | [policy][r17] · [schema][r18] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mcp/patch.py#L293) — Qualifies as `rpc.client`. |
| `category: rpc.server`: `rpc.server` | [policy][r17] · [schema][r7] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mcp/patch.py#L231) — Qualifies as `rpc.server`. |
| `systems: jsonrpc`: `jsonrpc` | [policy][r6] · [schema](/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L580) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_integrations/mcp.py#L250) — Statically bounded to `jsonrpc`. |
| `creation_date`: `2025-07-15` | [commit](/DataDog/dd-trace-py/commit/0232394836da406e30d1fd3bea8548b272651a5e) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mcp/patch.py#L280) — First working instrumentation: `2025-07-15`. |

</details>
<details>
<summary><code>mlflow</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `mlflow` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L672) — Canonical identity. |
| `display_name`: `MLflow` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mlflow/__init__.py#L2) — Established spelling. |
| `description`: Instruments MLflow run lifecycles and step progression, captures logged metrics and parameters, and correlates spans and logs with run IDs. | [source1][r19] · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mlflow/patch.py#L182) · [source3](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mlflow/patch.py#L215) · [source4](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mlflow/patch.py#L190) — Sources cover every described operation. |
| `packages`: `mlflow`, `mlflow-skinny`, `mlflow-tracing` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L675) — Registry binding and activation. |
| `category: other`: `other` | [policy][r2] · [schema][r20] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mlflow/patch.py#L105) — Qualifies as `other`. |
| `systems`: `[]` | [policy][r4] · [source][r19] — No qualifying statically bounded system. |
| `creation_date`: `2026-03-25` | [commit](/DataDog/dd-trace-py/commit/8ff3ccb99c8457b1c2e7ee71ace472d16930844b) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mlflow/patch.py#L196) — First working instrumentation: `2026-03-25`. |

</details>

<details>
<summary><code>ray</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `ray` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L880) — Canonical identity. |
| `display_name`: `Ray` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ray/__init__.py#L2) — Established spelling. |
| `description`: Instruments Ray job lifecycles, remote task and actor method submission and execution, optional core object APIs, and Ray Serve inbound HTTP and gRPC proxy requests, deployment handle calls, and deployment execution. | [source1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ray/patch.py#L236) · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ray/core/api.py#L16) · [source3][r21] — Sources cover every described operation. |
| `packages`: `ray` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L883) — Registry binding and activation. |
| `category: http.server`: `http.server` | [policy][r2] · [schema][r22] · [source][r23] — Qualifies as `http.server`. |
| `category: rpc.server`: `rpc.server` | [policy][r2] · [schema][r7] · [source][r8] — Qualifies as `rpc.server`. |
| `category: task.execution`: `task.execution` | [policy][r2] · [schema][r24] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ray/core/remote_function.py#L96) — Qualifies as `task.execution`. |
| `systems: grpc`: `grpc` | [policy][r4] · [schema][r25] · [source][r8] — Statically bounded to `grpc`. |
| `creation_date`: `2025-10-02` | [commit](/DataDog/dd-trace-py/commit/0a204ccff1584ad83ba810c07831fbfc3c037cbb) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ray/patch.py#L215) — First working instrumentation: `2025-10-02`. |

</details>

<details>
<summary><code>llama_index</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `llama_index` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L590) — Canonical identity. |
| `display_name`: `LlamaIndex` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/llama_index/__init__.py#L2) — Established spelling. |
| `description`: Instruments LlamaIndex LLM calls, query and retrieval workflows, embeddings, agent runs, and tool calls, including synchronous, asynchronous, and streamed operations. | [source1][r26] · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/llama_index/patch.py#L213) · [source3](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/llama_index/patch.py#L223) · [source4](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/llama_index/patch.py#L238) — Sources cover every described operation. |
| `packages`: `llama-index`, `llama-index-core`, `llama_index` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L593) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_monkey.py#L174) — Registry binding and activation. |
| `category: gen_ai`: `gen_ai` | [policy][r2] · [schema][r3] · [source][r26] — Qualifies as `gen_ai`. |
| `systems`: `[]` | [policy][r4] · [source1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/llama_index/_utils.py#L12) · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/llama_index/patch.py#L298) — No qualifying statically bounded system. |
| `creation_date`: `2026-04-08` | [commit](/DataDog/dd-trace-py/commit/5438644ca1893835647eadbc0b87147e8a77d6a9) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/llama_index/patch.py#L287) — First working instrumentation: `2026-04-08`. |

</details>

<details>
<summary><code>pytorch</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `pytorch` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L870) — Canonical identity. |
| `display_name`: `PyTorch` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytorch/__init__.py#L2) — Established spelling. |
| `description`: Instruments PyTorch distributed training lifecycles and optional optimizer-step boundaries, emitting per-rank spans with job, framework, and device context. | [source1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytorch/_distributed.py#L406) · [source2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytorch/_distributed.py#L365) · [source3][r27] — Sources cover every described operation. |
| `packages`: `torch` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L873) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_monkey.py#L182) — Registry binding and activation. |
| `category: other`: `other` | [policy][r2] · [schema][r20] · [source][r27] — Qualifies as `other`. |
| `systems`: `[]` | [policy][r4] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytorch/_utils.py#L134) — No qualifying statically bounded system. |
| `creation_date`: `2026-06-16` | [commit](/DataDog/dd-trace-py/commit/eb068ec4acdc46f61c901e2b3d99729f08942b1e) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytorch/_distributed.py#L1) — First working instrumentation: `2026-06-16`. |

</details>

<details>
<summary><code>ray_serve</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][r1] — Schema validation passed. |
| `name`: `ray_serve` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L890) — Canonical identity. |
| `display_name`: `Ray Serve` | [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ray/__init__.py#L27) — Established spelling. |
| `description`: Instruments inbound HTTP and gRPC proxy requests, deployment-handle calls, request routing and replica handling, and Ray Serve deployment execution. | [source1][r21] · [source2][r28] · [source3](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ray_serve/patch.py#L101) · [source4](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ray_serve/patch.py#L138) · [source5][r29] — Sources cover every described operation. |
| `packages`: `ray` | [registry](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L893) — Registry binding and activation. |
| `category: http.server`: `http.server` | [policy][r2] · [schema][r22] · [source][r23] — Qualifies as `http.server`. |
| `category: rpc.client`: `rpc.client` | [policy][r2] · [schema][r18] · [source][r28] — Qualifies as `rpc.client`. |
| `category: rpc.server`: `rpc.server` | [policy][r2] · [schema][r7] · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ray_serve/patch.py#L171) — Qualifies as `rpc.server`. |
| `category: task.execution`: `task.execution` | [policy][r2] · [schema][r24] · [source][r29] — Qualifies as `task.execution`. |
| `systems: grpc`: `grpc` | [policy][r4] · [schema][r25] · [source][r8] — Statically bounded to `grpc`. |
| `creation_date`: `2026-06-19` | [commit](/DataDog/dd-trace-py/commit/187cfc3700200ec8f33d6f610280924ef17e1696) · [source](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ray_serve/patch.py#L402) — First working instrumentation: `2026-06-19`. |

</details>

[r1]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L19
[r2]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/docs/category-taxonomy/manifest-publication-policy.md#category-contract
[r3]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L134
[r4]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/docs/category-taxonomy/manifest-publication-policy.md#system-and-provider-contract
[r5]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/docs/category-taxonomy/manifest-publication-policy.md#L72
[r6]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/docs/category-taxonomy/manifest-publication-policy.md#L76
[r7]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L218
[r8]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ray_serve/patch.py#L167
[r9]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/anthropic/patch.py#L46
[r10]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L315
[r11]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/google_genai/patch.py#L140
[r12]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/google_genai/__init__.py#L2
[r13]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L492
[r14]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L642
[r15]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/langchain/patch.py#L93
[r16]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/docs/category-taxonomy/manifest-publication-policy.md#L54
[r17]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/docs/category-taxonomy/manifest-publication-policy.md#L15
[r18]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L211
[r19]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mlflow/patch.py#L204
[r20]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L204
[r21]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ray_serve/patch.py#L162
[r22]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L155
[r23]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ray_serve/patch.py#L176
[r24]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L232
[r25]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L507
[r26]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/llama_index/patch.py#L202
[r27]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytorch/_rank_root.py#L44
[r28]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ray_serve/patch.py#L120
[r29]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ray_serve/patch.py#L239

## Testing

- Common tracer source: `DataDog/dd-trace-py@5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6`
- Completed generation runs: `openai`, `vertexai`, `vllm`, `openai_agents`, `pydantic_ai`, `ray`, `pytorch`, and `ray_serve` passed schema, offline-grounding, semantic-review, and workspace-integrity gates with no violations.
- Recovered candidates: `google_genai`, `litellm`, `mistralai`, `claude_agent_sdk`, `crewai`, `google_adk`, `langchain`, `langgraph`, `mcp`, `mlflow`, and `llama_index` have byte-identical final candidates, passing retained schema and grounding baselines, and accepted independent reviewer verdicts. Their original terminal summaries and final historical workspace-integrity results were not recoverable.
- Anthropic correction: the updated manifest passed schema validation, offline Python grounding, and an independent semantic review with member-level evidence for `anthropic`, `aws.bedrock`, and `gcp.vertex_ai` against the PR source revision.
- Exact installed-file validation: all 20 installed manifests passed schema validation and offline Python grounding with `manifest-validate --grounding python`.
- Mapped tracer suites: `scripts/run-tests --list` completed successfully. Python 3.14 `detect_global_locks` (`4a90061`) and `llmobs::anthropic` (`18ab9e9`) were selected; Docker image and environment setup began, but the run was intentionally stopped before suite completion. Integration runtime suites were otherwise not run because these manifests are declarative metadata and are not loaded by the tracer at runtime.
- `scripts/lint checks`: passed.
- `git diff --check`: passed for the 20 added manifests.

## Risks

The added YAML is declarative metadata and introduces no runtime instrumentation or public API change. Metadata can become stale if later instrumentation changes do not update its manifest. Source-distribution packaging behavior is unchanged.

## Additional Notes

- Taxonomy and schema links use `ddoghq/apm-instrumentation-manifest-generator@f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59` as the review reference, not as generation provenance for the recovered candidates.
- The recovered-run limitation is disclosed in Testing; no missing historical result is reported as passed.
- `llama_index`, `pytorch`, and `ray_serve` are included for ML-review cohesion but also require IDM/Core review under the current ownership rules.
