### PR TITLE
chore(integrations): backfill database and search manifests

### DIFF
--- a/ddtrace/contrib/internal/aiomysql/aiomysql.manifest.yaml
+++ b/ddtrace/contrib/internal/aiomysql/aiomysql.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: aiomysql
+display_name: aiomysql
+description: Instruments asynchronous aiomysql cursor query execution against MySQL databases, capturing SQL statements, row
+  counts, and connection metadata.
+packages:
+- name: aiomysql
+category:
+- db.client
+systems:
+- mysql
+creation_date: '2022-04-22'

--- a/ddtrace/contrib/internal/aiopg/aiopg.manifest.yaml
+++ b/ddtrace/contrib/internal/aiopg/aiopg.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: aiopg
+display_name: aiopg
+description: Instruments aiopg database cursors to trace asynchronous PostgreSQL queries, batch executions, and stored procedure
+  calls.
+packages:
+- name: aiopg
+category:
+- db.client
+systems:
+- postgresql
+creation_date: '2017-07-01'

--- a/ddtrace/contrib/internal/algoliasearch/algoliasearch.manifest.yaml
+++ b/ddtrace/contrib/internal/algoliasearch/algoliasearch.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: algoliasearch
+display_name: Algolia
+description: Instruments Algolia index search operations, capturing configured query details plus processing time and result
+  hit counts.
+packages:
+- name: algoliasearch
+category:
+- db.client
+systems:
+- algolia
+creation_date: '2019-04-24'

--- a/ddtrace/contrib/internal/asyncpg/asyncpg.manifest.yaml
+++ b/ddtrace/contrib/internal/asyncpg/asyncpg.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: asyncpg
+display_name: asyncpg
+description: Instruments asynchronous PostgreSQL connection establishment and query execution through asyncpg, covering direct
+  and pooled connections.
+packages:
+- name: asyncpg
+category:
+- db.client
+systems:
+- postgresql
+creation_date: '2022-03-14'

--- a/ddtrace/contrib/internal/azure_cosmos/azure_cosmos.manifest.yaml
+++ b/ddtrace/contrib/internal/azure_cosmos/azure_cosmos.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: azure_cosmos
+display_name: Azure CosmosDB
+description: Instruments synchronous and asynchronous database requests issued through the Azure CosmosDB Python client library.
+packages:
+- name: azure-cosmos
+category:
+- db.client
+systems:
+- azure.cosmosdb
+creation_date: '2026-04-02'

--- a/ddtrace/contrib/internal/elasticsearch/elasticsearch.manifest.yaml
+++ b/ddtrace/contrib/internal/elasticsearch/elasticsearch.manifest.yaml
@@ -1,0 +1,20 @@
+_v: 1
+name: elasticsearch
+display_name: Elasticsearch
+description: Instruments synchronous and asynchronous Elasticsearch and OpenSearch transport requests, recording query metadata,
+  peer details, response status, errors, and server timing.
+packages:
+- name: elastic-transport
+- name: elasticsearch
+- name: elasticsearch1
+- name: elasticsearch2
+- name: elasticsearch5
+- name: elasticsearch6
+- name: elasticsearch7
+- name: opensearch-py
+category:
+- db.client
+systems:
+- elasticsearch
+- opensearch
+creation_date: '2016-06-22'

--- a/ddtrace/contrib/internal/mariadb/mariadb.manifest.yaml
+++ b/ddtrace/contrib/internal/mariadb/mariadb.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: mariadb
+display_name: MariaDB
+description: Instruments MariaDB database queries, stored procedure calls, transaction commits and rollbacks, and optionally
+  result-fetch operations through traced DB-API connections.
+packages:
+- name: mariadb
+category:
+- db.client
+systems:
+- mariadb
+creation_date: '2021-07-21'

--- a/ddtrace/contrib/internal/mysql/mysql.manifest.yaml
+++ b/ddtrace/contrib/internal/mysql/mysql.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: mysql
+display_name: MySQL Connector/Python
+description: Instruments synchronous and asynchronous MySQL Connector/Python database queries, stored procedures, transactions,
+  and optional result fetching.
+packages:
+- name: mysql-connector-python
+category:
+- db.client
+systems:
+- mysql
+creation_date: '2016-08-23'

--- a/ddtrace/contrib/internal/mysqldb/mysqldb.manifest.yaml
+++ b/ddtrace/contrib/internal/mysqldb/mysqldb.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: mysqldb
+display_name: mysqlclient
+description: Instruments mysqlclient SQL query execution, batches, stored procedures, transactions, and optionally connection
+  establishment and result fetching.
+packages:
+- name: mysqlclient
+category:
+- db.client
+systems:
+- mysql
+creation_date: '2017-11-08'

--- a/ddtrace/contrib/internal/psycopg/psycopg.manifest.yaml
+++ b/ddtrace/contrib/internal/psycopg/psycopg.manifest.yaml
@@ -1,0 +1,13 @@
+_v: 1
+name: psycopg
+display_name: Psycopg
+description: Instruments synchronous and asynchronous Psycopg database connections, queries, transactions, and optional result
+  fetching for PostgreSQL.
+packages:
+- name: psycopg
+- name: psycopg2-binary
+category:
+- db.client
+systems:
+- postgresql
+creation_date: '2016-06-20'

--- a/ddtrace/contrib/internal/pymongo/pymongo.manifest.yaml
+++ b/ddtrace/contrib/internal/pymongo/pymongo.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: pymongo
+display_name: PyMongo
+description: Instruments synchronous and asynchronous PyMongo database commands and queries, plus connection-pool checkouts
+  and Database Monitoring propagation.
+packages:
+- name: pymongo
+category:
+- db.client
+systems:
+- mongodb
+creation_date: '2016-07-28'

--- a/ddtrace/contrib/internal/pymysql/pymysql.manifest.yaml
+++ b/ddtrace/contrib/internal/pymysql/pymysql.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: pymysql
+display_name: PyMySQL
+description: Instruments PyMySQL database queries, stored procedure calls, transaction commits and rollbacks, and optionally
+  row-fetch operations.
+packages:
+- name: pymysql
+category:
+- db.client
+systems:
+- mysql
+creation_date: '2017-06-26'

--- a/ddtrace/contrib/internal/pynamodb/pynamodb.manifest.yaml
+++ b/ddtrace/contrib/internal/pynamodb/pynamodb.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: pynamodb
+display_name: PynamoDB
+description: Instruments PynamoDB connection API calls that perform database operations against Amazon DynamoDB, including
+  region and table context.
+packages:
+- name: pynamodb
+category:
+- db.client
+systems:
+- aws.dynamodb
+creation_date: '2020-09-15'

--- a/ddtrace/contrib/internal/pyodbc/pyodbc.manifest.yaml
+++ b/ddtrace/contrib/internal/pyodbc/pyodbc.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: pyodbc
+display_name: PyODBC
+description: Instruments PyODBC database connections to trace SQL queries, transaction commits and rollbacks, and optionally
+  row-fetch operations.
+packages:
+- name: pyodbc
+category:
+- db.client
+systems: []
+creation_date: '2020-10-16'

--- a/ddtrace/contrib/internal/snowflake/snowflake.manifest.yaml
+++ b/ddtrace/contrib/internal/snowflake/snowflake.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: snowflake
+display_name: Snowflake
+description: Instruments Snowflake database query execution and transaction control operations through the Snowflake Connector
+  for Python.
+packages:
+- name: snowflake-connector-python
+category:
+- db.client
+systems:
+- snowflake
+creation_date: '2021-10-14'

--- a/ddtrace/contrib/internal/sqlalchemy/sqlalchemy.manifest.yaml
+++ b/ddtrace/contrib/internal/sqlalchemy/sqlalchemy.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: sqlalchemy
+display_name: SQLAlchemy
+description: Instruments SQL statement execution through SQLAlchemy engines, tracing query timing, errors, row counts, and
+  database connection metadata.
+packages:
+- name: sqlalchemy
+category:
+- db.client
+systems: []
+creation_date: '2016-08-03'

--- a/ddtrace/contrib/internal/sqlite3/sqlite3.manifest.yaml
+++ b/ddtrace/contrib/internal/sqlite3/sqlite3.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: sqlite3
+display_name: SQLite
+description: Instruments SQLite database queries, transaction commits and rollbacks, and optional row-fetch operations through
+  Python's built-in sqlite3 module.
+packages: []
+category:
+- db.client
+systems:
+- sqlite
+creation_date: '2016-06-20'

--- a/ddtrace/contrib/internal/vertica/vertica.manifest.yaml
+++ b/ddtrace/contrib/internal/vertica/vertica.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: vertica
+display_name: Vertica
+description: Instruments Vertica database queries, bulk copy operations, and cursor result retrieval through the vertica-python
+  client.
+packages:
+- name: vertica-python
+category:
+- db.client
+systems:
+- vertica
+creation_date: '2018-10-11'


### PR DESCRIPTION
## Description

This change adds structured, machine-readable [instrumentation manifests](https://datadoghq.atlassian.net/wiki/x/vYQbrAE) for:

- PostgreSQL clients: `aiopg`, `asyncpg`, and `psycopg`
- MySQL clients: `aiomysql`, `mariadb`, `mysql`, `mysqldb`, and `pymysql`
- Document and search databases: `algoliasearch`, `azure_cosmos`, `elasticsearch`, `pymongo`, and `pynamodb`
- SQL clients and warehouses: `pyodbc`, `snowflake`, `sqlalchemy`, `sqlite3`, and `vertica`

This is declarative metadata only. Runtime instrumentation and public APIs are unchanged.

Detailed field-level review evidence for every manifest is provided below.
It has the same information as the changed file, so reviewing this description
is enough to understand the changes being proposed.

| Integration | Categories | Systems | Creation date |
|---|---|---|---|
| `aiopg` | `db.client` | `postgresql` | 2017-07-01 |
| `asyncpg` | `db.client` | `postgresql` | 2022-03-14 |
| `psycopg` | `db.client` | `postgresql` | 2016-06-20 |
| `aiomysql` | `db.client` | `mysql` | 2022-04-22 |
| `mariadb` | `db.client` | `mariadb` | 2021-07-21 |
| `mysql` | `db.client` | `mysql` | 2016-08-23 |
| `mysqldb` | `db.client` | `mysql` | 2017-11-08 |
| `pymysql` | `db.client` | `mysql` | 2017-06-26 |
| `algoliasearch` | `db.client` | `algolia` | 2019-04-24 |
| `azure_cosmos` | `db.client` | `azure.cosmosdb` | 2026-04-02 |
| `elasticsearch` | `db.client` | `elasticsearch`, `opensearch` | 2016-06-22 |
| `pymongo` | `db.client` | `mongodb` | 2016-07-28 |
| `pynamodb` | `db.client` | `aws.dynamodb` | 2020-09-15 |
| `pyodbc` | `db.client` | `[]` | 2020-10-16 |
| `snowflake` | `db.client` | `snowflake` | 2021-10-14 |
| `sqlalchemy` | `db.client` | `[]` | 2016-08-03 |
| `sqlite3` | `db.client` | `sqlite` | 2016-06-20 |
| `vertica` | `db.client` | `vertica` | 2018-10-11 |

### Field-level review evidence

Taxonomy links define the publication labels. Tracer links show the instrumented
behavior that satisfies those definitions. Tracer links are pinned to the reviewed
source revision. Taxonomy links use the generator revision identified in Additional
Notes as a review reference.

<details>
<summary><code>aiopg</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][_v-schema] | Deterministic schema gate passed. |
| `name` | `aiopg` | dd-trace-py integration registry and offline grounding | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L60) — Canonical registry entry. |
| `display_name` | `aiopg` | Established tracer documentation or source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aiopg/__init__.py#L2) — Docstring reads 'Instrument aiopg to report a span for each executed Postgres. |
| `description` | `Instruments aiopg database cursors to trace asynchronous PostgreSQL queries, batch executions, and stored procedure calls.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aiopg/connection.py#L27) — AIOTracedCursor wraps the psycopg cursor and traces its queries. |
| `packages` | `aiopg` | Registry `dependency_names` and logical-host mapping | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L60) — Registry package set matches the published value. |
| `category: db.client` | `db.client` | [Manifest taxonomy policy][category-policy] · [canonical member definition][category-db.client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aiopg/connection.py#L48) — s._set_attribute(db.SYSTEM, "postgresql") with span_type SpanTypes.SQL (line 44) and. |
| `systems: postgresql` | `postgresql` | [Manifest system publication policy][system-policy] · [canonical member definition][system-postgresql] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aiopg/connection.py#L48) — s._set_attribute(db.SYSTEM, "postgresql") sets the db.system literally. |
| `creation_date` | `2017-07-01` | First commit adding working instrumentation | [first-add commit](https://github.com/DataDog/dd-trace-py/commit/f9c132d65f69333b6da4957050fae300b04746a6) · [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aiopg/connection.py#L27) — git --follow on this integration's connection.py traces back to first-add commit. |

</details>

<details>
<summary><code>asyncpg</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][_v-schema] | Deterministic schema gate passed. |
| `name` | `asyncpg` | dd-trace-py integration registry and offline grounding | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L108) — Canonical registry entry. |
| `display_name` | `asyncpg` | Established tracer documentation or source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/asyncpg/__init__.py#L2) — Docstring spells the library lowercase as ``asyncpg``. |
| `description` | `Instruments asynchronous PostgreSQL connection establishment and query execution through asyncpg, covering direct and pooled connections.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/asyncpg/patch.py#L101) — _traced_connect opens 'postgres.connect' span wrapping asyncpg.connect. |
| `packages` | `asyncpg` | Registry `dependency_names` and logical-host mapping | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L108) — Registry package set matches the published value. |
| `category: db.client` | `db.client` | [Manifest taxonomy policy][category-policy] · [canonical member definition][category-db.client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/asyncpg/patch.py#L162) — Wraps connect plus Protocol execute/bind_execute/query/bind_execute_many. |
| `systems: postgresql` | `postgresql` | [Manifest system publication policy][system-policy] · [canonical member definition][system-postgresql] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/asyncpg/patch.py#L36) — DBMS_NAME = 'postgresql' is statically hardcoded and set as db.SYSTEM on every span. |
| `creation_date` | `2022-03-14` | First commit adding working instrumentation | [first-add commit](https://github.com/DataDog/dd-trace-py/commit/a0515ec7ab02c52c5906df6fe9537ef3eea5663e) · [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/asyncpg/patch.py#L1) — First-add commit a0515ec7ab02c52c5906df6fe9537ef3eea5663e (author date 2022-03-14. |

</details>

<details>
<summary><code>psycopg</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][_v-schema] | Deterministic schema gate passed. |
| `name` | `psycopg` | dd-trace-py integration registry and offline grounding | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L750) — Canonical registry entry. |
| `display_name` | `Psycopg` | Established tracer documentation or source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/psycopg/connection.py#L20) — Public class spelling Psycopg3TracedConnection / Psycopg2TracedConnection. |
| `description` | `Instruments synchronous and asynchronous Psycopg database connections, queries, transactions, and optional result fetching for PostgreSQL.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/psycopg/connection.py#L98) — patched_connect_factory wraps synchronous connect and returns a traced connection. |
| `packages` | `psycopg`, `psycopg2-binary` | Registry `dependency_names` and logical-host mapping | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L750) — Registry package set matches the published value. |
| `category: db.client` | `db.client` | [Manifest taxonomy policy][category-policy] · [canonical member definition][category-db.client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/psycopg/patch.py#L61) — _dbapi_span_operation_name schematizes 'postgres.query' with. |
| `systems: postgresql` | `postgresql` | [Manifest system publication policy][system-policy] · [canonical member definition][system-postgresql] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/psycopg/connection.py#L68) — db.SYSTEM is statically hardcoded to 'postgresql' on every traced connection. |
| `creation_date` | `2016-06-20` | First commit adding working instrumentation | [first-add commit](https://github.com/DataDog/dd-trace-py/commit/fec489b11b93ff12321ea17e30deaf47275be147) · [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/psycopg/patch.py#L104) — First-add commit fec489b (2016-06-20 'initial commit') added. |

</details>

<details>
<summary><code>aiomysql</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][_v-schema] | Deterministic schema gate passed. |
| `name` | `aiomysql` | dd-trace-py integration registry and offline grounding | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L50) — Canonical registry entry. |
| `display_name` | `aiomysql` | Established tracer documentation or source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aiomysql/__init__.py#L1) — The library and integration are spelled all-lowercase 'aiomysql' in the module. |
| `description` | `Instruments asynchronous aiomysql cursor query execution against MySQL databases, capturing SQL statements, row counts, and connection metadata.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aiomysql/patch.py#L117) — AIOTracedCursor.execute (and executemany at 109) is an async coroutine that traces. |
| `packages` | `aiomysql` | Registry `dependency_names` and logical-host mapping | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L50) — Registry package set matches the published value. |
| `category: db.client` | `db.client` | [Manifest taxonomy policy][category-policy] · [canonical member definition][category-db.client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aiomysql/patch.py#L71) — self._self_datadog_name = schematize_database_operation('mysql.query'. |
| `systems: mysql` | `mysql` | [Manifest system publication policy][system-policy] · [canonical member definition][system-mysql] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aiomysql/patch.py#L58) — tags[db.SYSTEM] = 'mysql' is set statically at the instrumented connection/query. |
| `creation_date` | `2022-04-22` | First commit adding working instrumentation | [first-add commit](https://github.com/DataDog/dd-trace-py/commit/9c6213be2df1310711884fecfad6a83038b2c6ef) · [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aiomysql/patch.py#L1) — git log --diff-filter=A --follow on this integration's patch.py resolves to. |

</details>

<details>
<summary><code>mariadb</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][_v-schema] | Deterministic schema gate passed. |
| `name` | `mariadb` | dd-trace-py integration registry and offline grounding | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L642) — Canonical registry entry. |
| `display_name` | `MariaDB` | Established tracer documentation or source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mariadb/__init__.py#L2) — Module docstring reads 'The MariaDB integration instruments the MariaDB library'. |
| `description` | `Instruments MariaDB database queries, stored procedure calls, transaction commits and rollbacks, and optionally result-fetch operations through traced DB-API connections.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/dbapi.py#L164) — TracedCursor.execute (and executemany at line 143) trace query execution. |
| `packages` | `mariadb` | Registry `dependency_names` and logical-host mapping | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L642) — Registry package set matches the published value. |
| `category: db.client` | `db.client` | [Manifest taxonomy policy][category-policy] · [canonical member definition][category-db.client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/dbapi.py#L111) — TracedCursor._trace_method emits SpanTypes.SQL client spans for. |
| `systems: mariadb` | `mariadb` | [Manifest system publication policy][system-policy] · [canonical member definition][system-mariadb] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mariadb/patch.py#L52) — TracedConnection is created with db_tags {db.SYSTEM: 'mariadb'}. |
| `creation_date` | `2021-07-21` | First commit adding working instrumentation | [first-add commit](https://github.com/DataDog/dd-trace-py/commit/c44c1b4543d457f0dd6e781884b13448be79ca21) · [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mariadb/patch.py#L33) — git --no-pager log --follow --diff-filter=A on the integration's original patch.py. |

</details>

<details>
<summary><code>mysql</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][_v-schema] | Deterministic schema gate passed. |
| `name` | `mysql` | dd-trace-py integration registry and offline grounding | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L700) — Canonical registry entry. |
| `display_name` | `MySQL Connector/Python` | Established tracer documentation or source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mysql/__init__.py#L42) — Docstring cites https://dev.mysql.com/doc/connector-python/. |
| `description` | `Instruments synchronous and asynchronous MySQL Connector/Python database queries, stored procedures, transactions, and optional result fetching.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mysql/patch.py#L91) — patch() wraps mysql.connector.connect (sync. |
| `packages` | `mysql-connector-python` | Registry `dependency_names` and logical-host mapping | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L700) — Registry package set matches the published value. |
| `category: db.client` | `db.client` | [Manifest taxonomy policy][category-policy] · [canonical member definition][category-db.client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mysql/patch.py#L63) — patch_conn tags spans with db.SYSTEM='mysql' and wraps the DB connection with. |
| `systems: mysql` | `mysql` | [Manifest system publication policy][system-policy] · [canonical member definition][system-mysql] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mysql/patch.py#L63) — tags[db.SYSTEM]='mysql' (also line 82 for async) and config uses. |
| `creation_date` | `2016-08-23` | First commit adding working instrumentation | [first-add commit](https://github.com/DataDog/dd-trace-py/commit/7dccf96df78fae0bcde2b89a4ca8ef9140cf401c) · [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mysql/patch.py#L86) — First-add commit 7dccf96df78fae0bcde2b89a4ca8ef9140cf401c (2016-08-23. |

</details>

<details>
<summary><code>mysqldb</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][_v-schema] | Deterministic schema gate passed. |
| `name` | `mysqldb` | dd-trace-py integration registry and offline grounding | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L710) — Canonical registry entry. |
| `display_name` | `mysqlclient` | Established tracer documentation or source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mysqldb/__init__.py#L1) — Docstring: 'The mysqldb integration instruments the mysqlclient library'. |
| `description` | `Instruments mysqlclient SQL query execution, batches, stored procedures, transactions, and optionally connection establishment and result fetching.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/dbapi.py#L164) — TracedCursor.execute wraps query execution (batches at executemany:143. |
| `packages` | `mysqlclient` | Registry `dependency_names` and logical-host mapping | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L710) — Registry package set matches the published value. |
| `category: db.client` | `db.client` | [Manifest taxonomy policy][category-policy] · [canonical member definition][category-db.client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mysqldb/patch.py#L113) — patch_conn wraps the MySQL connection in dbapi TracedConnection. |
| `systems: mysql` | `mysql` | [Manifest system publication policy][system-policy] · [canonical member definition][system-mysql] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mysqldb/patch.py#L111) — patch_conn statically sets tags[db.SYSTEM] = 'mysql'. |
| `creation_date` | `2017-11-08` | First commit adding working instrumentation | [first-add commit](https://github.com/DataDog/dd-trace-py/commit/5c0cda558deb3307f6cd7b3cb0ff0d28166c4be6) · [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mysqldb/patch.py#L55) — The mysqldb patch() instrumentation traces to first-add commit. |

</details>

<details>
<summary><code>pymysql</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][_v-schema] | Deterministic schema gate passed. |
| `name` | `pymysql` | dd-trace-py integration registry and offline grounding | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L804) — Canonical registry entry. |
| `display_name` | `PyMySQL` | Established tracer documentation or source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pymysql/__init__.py#L2) — Docstring: 'The pymysql integration instruments the pymysql library'. |
| `description` | `Instruments PyMySQL database queries, stored procedure calls, transaction commits and rollbacks, and optionally row-fetch operations.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/dbapi.py#L164) — TracedCursor.execute (and executemany at line 143) trace SQL queries. |
| `packages` | `pymysql` | Registry `dependency_names` and logical-host mapping | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L804) — Registry package set matches the published value. |
| `category: db.client` | `db.client` | [Manifest taxonomy policy][category-policy] · [canonical member definition][category-db.client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pymysql/patch.py#L65) — patch_conn returns TracedConnection wrapping the DB-API connection. |
| `systems: mysql` | `mysql` | [Manifest system publication policy][system-policy] · [canonical member definition][system-mysql] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pymysql/patch.py#L64) — patch_conn hardcodes tags[db.SYSTEM] = "mysql". |
| `creation_date` | `2017-06-26` | First commit adding working instrumentation | [first-add commit](https://github.com/DataDog/dd-trace-py/commit/f2da11cbb4392e7094f5a1023d5d68031a8cc6b4) · [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pymysql/patch.py#L47) — First-add commit f2da11cbb4392e7094f5a1023d5d68031a8cc6b4 '[pymysql] add pymysql. |

</details>

<details>
<summary><code>algoliasearch</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][_v-schema] | Deterministic schema gate passed. |
| `name` | `algoliasearch` | dd-trace-py integration registry and offline grounding | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L70) — Canonical registry entry. |
| `display_name` | `Algolia` | Established tracer documentation or source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/algoliasearch/__init__.py#L1) — Docstring: 'The Algoliasearch integration will add tracing to your Algolia. |
| `description` | `Instruments Algolia index search operations, capturing configured query details plus processing time and result hit counts.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/algoliasearch/patch.py#L65) — patch() wraps SearchIndex.search (and Index.search at line 60) with _patched_search. |
| `packages` | `algoliasearch` | Registry `dependency_names` and logical-host mapping | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L70) — Registry package set matches the published value. |
| `category: db.client` | `db.client` | [Manifest taxonomy policy][category-policy] · [canonical member definition][category-db.client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/algoliasearch/patch.py#L65) — The only instrumented boundary is the client-side search() query against the Algolia. |
| `systems: algolia` | `algolia` | [Manifest system publication policy][system-policy] · [canonical member definition][system-algolia] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/algoliasearch/patch.py#L127) — schematize_cloud_api_operation('algoliasearch.search'. |
| `creation_date` | `2019-04-24` | First commit adding working instrumentation | [first-add commit](https://github.com/DataDog/dd-trace-py/commit/f3f267866d1c579749f9f10ba1246953a773c4c0) · [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/algoliasearch/patch.py#L1) — git log --diff-filter=A shows the algoliasearch patch file was first added by commit. |

</details>

<details>
<summary><code>azure_cosmos</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][_v-schema] | Deterministic schema gate passed. |
| `name` | `azure_cosmos` | dd-trace-py integration registry and offline grounding | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L152) — Canonical registry entry. |
| `display_name` | `Azure CosmosDB` | Established tracer documentation or source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_cosmos/__init__.py#L3) — Docstring spells the product 'Azure CosmosDB library'. |
| `description` | `Instruments synchronous and asynchronous database requests issued through the Azure CosmosDB Python client library.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_cosmos/patch.py#L42) — Wraps azure.cosmos _synchronized_request.SynchronizedRequest (synchronous request. |
| `packages` | `azure-cosmos` | Registry `dependency_names` and logical-host mapping | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L152) — Registry package set matches the published value. |
| `category: db.client` | `db.client` | [Manifest taxonomy policy][category-policy] · [canonical member definition][category-db.client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_cosmos/patch.py#L63) — Instrumented boundary creates a span with span_type=SpanTypes.COSMOS and span_name. |
| `systems: azure.cosmosdb` | `azure.cosmosdb` | [Manifest system publication policy][system-policy] · [canonical member definition][system-azure.cosmosdb] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_cosmos/patch.py#L63) — Patch statically targets the azure.cosmos client (import at line 1) and tags spans. |
| `creation_date` | `2026-04-02` | First commit adding working instrumentation | [first-add commit](https://github.com/DataDog/dd-trace-py/commit/7850ad40abd06004d00fb40eaeb634132e5a5036) · [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_cosmos/patch.py#L29) — git log --diff-filter=A shows patch.py and __init__.py first added in commit. |

</details>

<details>
<summary><code>elasticsearch</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][_v-schema] | Deterministic schema gate passed. |
| `name` | `elasticsearch` | dd-trace-py integration registry and offline grounding | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L342) — Canonical registry entry. |
| `display_name` | `Elasticsearch` | Established tracer documentation or source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/elasticsearch/__init__.py#L2) — Docstring 'The Elasticsearch integration will trace Elasticsearch queries.' spells. |
| `description` | `Instruments synchronous and asynchronous Elasticsearch and OpenSearch transport requests, recording query metadata, peer details, response status, errors, and server timing.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/elasticsearch/patch.py#L109) — Wraps Transport.perform_request (sync) and AsyncTransport.perform_request (async) at. |
| `packages` | `elastic-transport`, `elasticsearch`, `elasticsearch1`, `elasticsearch2`, `elasticsearch5`, `elasticsearch6`, `elasticsearch7`, `opensearch-py` | Registry `dependency_names` and logical-host mapping | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L342) — Registry package set matches the published value. |
| `category: db.client` | `db.client` | [Manifest taxonomy policy][category-policy] · [canonical member definition][category-db.client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/elasticsearch/patch.py#L141) — tracer.trace("elasticsearch.query", span_type=SpanTypes.ELASTICSEARCH) with. |
| `systems: elasticsearch` | `elasticsearch` | [Manifest system publication policy][system-policy] · [canonical member definition][system-elasticsearch] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/elasticsearch/patch.py#L39) — ES_PACKAGE_TO_MODULE_NAME statically enumerates the elasticsearch/elastic_transport. |
| `systems: opensearch` | `opensearch` | [Manifest system publication policy][system-policy] · [canonical member definition][system-opensearch] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/elasticsearch/patch.py#L49) — ES_PACKAGE_TO_MODULE_NAME statically includes opensearch-py -> opensearchpy. |
| `creation_date` | `2016-06-22` | First commit adding working instrumentation | [first-add commit](https://github.com/DataDog/dd-trace-py/commit/60c51645cee92b4241d574859c9fd97c57910584) · [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/elasticsearch/patch.py#L99) — The elasticsearch integration's transport-patching instrumentation traces back to. |

</details>

<details>
<summary><code>pymongo</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][_v-schema] | Deterministic schema gate passed. |
| `name` | `pymongo` | dd-trace-py integration registry and offline grounding | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L794) — Canonical registry entry. |
| `display_name` | `PyMongo` | Established tracer documentation or source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pymongo/utils.py#L170) — Tracer source uses the official mixed-case product spelling 'PyMongo' in a log. |
| `description` | `Instruments synchronous and asynchronous PyMongo database commands and queries, plus connection-pool checkouts and Database Monitoring propagation.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pymongo/patch.py#L41) — patch() calls patch_pymongo_sync_modules() and, for pymongo >= 4.12. |
| `packages` | `pymongo` | Registry `dependency_names` and logical-host mapping | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L794) — Registry package set matches the published value. |
| `category: db.client` | `db.client` | [Manifest taxonomy policy][category-policy] · [canonical member definition][category-db.client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pymongo/client.py#L120) — Traced MongoDB operations set SPAN_KIND to SpanKind.CLIENT and db.SYSTEM=mongodb. |
| `systems: mongodb` | `mongodb` | [Manifest system publication policy][system-policy] · [canonical member definition][system-mongodb] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/ext/mongo.py#L1) — mongo.SERVICE = "mongodb"; this constant is set as db.SYSTEM on every pymongo span. |
| `creation_date` | `2016-07-28` | First commit adding working instrumentation | [first-add commit](https://github.com/DataDog/dd-trace-py/commit/9d5107a21beca154f6f48a42a7f5f57b1dc98fff) · [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pymongo/patch.py#L37) — git --no-pager log --diff-filter=A over the pymongo contrib paths shows the earliest. |

</details>

<details>
<summary><code>pynamodb</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][_v-schema] | Deterministic schema gate passed. |
| `name` | `pynamodb` | dd-trace-py integration registry and offline grounding | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L814) — Canonical registry entry. |
| `display_name` | `PynamoDB` | Established tracer documentation or source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pynamodb/__init__.py#L8) — Docstring reads 'The PynamoDB integration traces all db calls made with the pynamodb. |
| `description` | `Instruments PynamoDB connection API calls that perform database operations against Amazon DynamoDB, including region and table context.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pynamodb/patch.py#L51) — The integration wraps Connection._make_api_call (the connection API entry point) as. |
| `packages` | `pynamodb` | Registry `dependency_names` and logical-host mapping | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L814) — Registry package set matches the published value. |
| `category: db.client` | `db.client` | [Manifest taxonomy policy][category-policy] · [canonical member definition][category-db.client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pynamodb/patch.py#L72) — Instrumented Connection._make_api_call span sets db.SYSTEM='dynamodb' and. |
| `systems: aws.dynamodb` | `aws.dynamodb` | [Manifest system publication policy][system-policy] · [canonical member definition][system-aws.dynamodb] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pynamodb/patch.py#L67) — schematize_cloud_api_operation is called with cloud_provider='aws'. |
| `creation_date` | `2020-09-15` | First commit adding working instrumentation | [first-add commit](https://github.com/DataDog/dd-trace-py/commit/33fad6f2bdca60eeabe9863b2349f360653e14bb) · [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pynamodb/patch.py#L1) — git --no-pager log --follow on this integration's patch file traces its origin to. |

</details>

<details>
<summary><code>pyodbc</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][_v-schema] | Deterministic schema gate passed. |
| `name` | `pyodbc` | dd-trace-py integration registry and offline grounding | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L824) — Canonical registry entry. |
| `display_name` | `PyODBC` | Established tracer documentation or source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/docs/integrations.rst#L462) — The integration documentation heading is spelled 'PyODBC' (under the .. |
| `description` | `Instruments PyODBC database connections to trace SQL queries, transaction commits and rollbacks, and optionally row-fetch operations.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pyodbc/patch.py#L36) — patch() wraps pyodbc.connect and _connect returns PyODBCTracedConnection (line. |
| `packages` | `pyodbc` | Registry `dependency_names` and logical-host mapping | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L824) — Registry package set matches the published value. |
| `category: db.client` | `db.client` | [Manifest taxonomy policy][category-policy] · [canonical member definition][category-db.client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/dbapi.py#L164) — The pyodbc connection/cursor proxies (PyODBCTracedConnection/PyODBCTracedCursor). |
| `systems` | `[]` | [Manifest system publication policy][system-policy] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pyodbc/patch.py#L53) — The DBMS identity is discovered at runtime via conn.getinfo(pyodbc.SQL_DBMS_NAME). |
| `creation_date` | `2020-10-16` | First commit adding working instrumentation | [first-add commit](https://github.com/DataDog/dd-trace-py/commit/2c19df335cb672f3a997af12a2e46b83f6fab405) · [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pyodbc/patch.py#L36) — git log --diff-filter=A shows the first add of the pyodbc integration. |

</details>

<details>
<summary><code>snowflake</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][_v-schema] | Deterministic schema gate passed. |
| `name` | `snowflake` | dd-trace-py integration registry and offline grounding | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L956) — Canonical registry entry. |
| `display_name` | `Snowflake` | Established tracer documentation or source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/snowflake/__init__.py#L1) — Module docstring refers to the product as 'Snowflake' ('to trace Snowflake. |
| `description` | `Instruments Snowflake database query execution and transaction control operations through the Snowflake Connector for Python.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/dbapi.py#L164) — TracedCursor.execute wraps query execution. |
| `packages` | `snowflake-connector-python` | Registry `dependency_names` and logical-host mapping | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L956) — Registry package set matches the published value. |
| `category: db.client` | `db.client` | [Manifest taxonomy policy][category-policy] · [canonical member definition][category-db.client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/snowflake/patch.py#L97) — patched_connect sets db.SYSTEM='snowflake' and wraps connection/cursor with dbapi. |
| `systems: snowflake` | `snowflake` | [Manifest system publication policy][system-policy] · [canonical member definition][system-snowflake] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/snowflake/patch.py#L97) — The dedicated integration statically sets db.SYSTEM='snowflake' at the instrumented. |
| `creation_date` | `2021-10-14` | First commit adding working instrumentation | [first-add commit](https://github.com/DataDog/dd-trace-py/commit/13e9ab36ded6242805c558dfacb598fbb5de3f75) · [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/snowflake/patch.py#L1) — git log --diff-filter=A shows the snowflake integration files. |

</details>

<details>
<summary><code>sqlalchemy</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][_v-schema] | Deterministic schema gate passed. |
| `name` | `sqlalchemy` | dd-trace-py integration registry and offline grounding | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L966) — Canonical registry entry. |
| `display_name` | `SQLAlchemy` | Established tracer documentation or source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/sqlalchemy.py#L2) — The public integration docstring reads 'Enabling the SQLAlchemy integration...'. |
| `description` | `Instruments SQL statement execution through SQLAlchemy engines, tracing query timing, errors, row counts, and database connection metadata.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/sqlalchemy/engine.py#L85) — EngineTracer listens on before_cursor_execute/after_cursor_execute. |
| `packages` | `sqlalchemy` | Registry `dependency_names` and logical-host mapping | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L966) — Registry package set matches the published value. |
| `category: db.client` | `db.client` | [Manifest taxonomy policy][category-policy] · [canonical member definition][category-db.client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/sqlalchemy/engine.py#L113) — Spans are SpanTypes.SQL with SPAN_KIND=SpanKind.CLIENT. |
| `systems` | `[]` | [Manifest system publication policy][system-policy] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/sqlalchemy/engine.py#L77) — The traced vendor is derived at runtime via sqlx.normalize_vendor(engine.name). |
| `creation_date` | `2016-08-03` | First commit adding working instrumentation | [first-add commit](https://github.com/DataDog/dd-trace-py/commit/8291c1d0d8d99e32f0bc5d39774e81004c3f1b62) · [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/sqlalchemy/engine.py#L55) — engine.py holds the EngineTracer instrumentation. |

</details>

<details>
<summary><code>sqlite3</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][_v-schema] | Deterministic schema gate passed. |
| `name` | `sqlite3` | dd-trace-py integration registry and offline grounding | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L976) — Canonical registry entry. |
| `display_name` | `SQLite` | Established tracer documentation or source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/sqlite3/__init__.py#L2) — Module docstring reads 'to trace SQLite queries'. |
| `description` | `Instruments SQLite database queries, transaction commits and rollbacks, and optional row-fetch operations through Python's built-in sqlite3 module.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/dbapi.py#L164) — TracedCursor.execute (and executemany at line 143) trace query execution. |
| `packages` | `[]` | Registry `dependency_names` and logical-host mapping | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L976) — Registry package set matches the published value. |
| `category: db.client` | `db.client` | [Manifest taxonomy policy][category-policy] · [canonical member definition][category-db.client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/sqlite3/patch.py#L88) — TracedSQLite wraps the sqlite3 connection with db_tags={db.SYSTEM: 'sqlite'} and. |
| `systems: sqlite` | `sqlite` | [Manifest system publication policy][system-policy] · [canonical member definition][system-sqlite] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/sqlite3/patch.py#L88) — db_tags={db.SYSTEM: 'sqlite'} statically binds the instrumented boundary to the. |
| `creation_date` | `2016-06-20` | First commit adding working instrumentation | [first-add commit](https://github.com/DataDog/dd-trace-py/commit/fec489b11b93ff12321ea17e30deaf47275be147) · [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/sqlite3/patch.py#L61) — First-add commit fec489b (2016-06-20 'initial commit') added. |

</details>

<details>
<summary><code>vertica</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][_v-schema] | Deterministic schema gate passed. |
| `name` | `vertica` | dd-trace-py integration registry and offline grounding | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1056) — Canonical registry entry. |
| `display_name` | `Vertica` | Established tracer documentation or source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vertica/__init__.py#L1) — Docstring repeatedly capitalizes the product as 'Vertica' ('The Vertica integration. |
| `description` | `Instruments Vertica database queries, bulk copy operations, and cursor result retrieval through the vertica-python client.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vertica/patch.py#L97) — Cursor.execute routine wrapped with operation_name 'vertica.query' (SQL query. |
| `packages` | `vertica-python` | Registry `dependency_names` and logical-host mapping | [registry source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1056) — Registry package set matches the published value. |
| `category: db.client` | `db.client` | [Manifest taxonomy policy][category-policy] · [canonical member definition][category-db.client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vertica/patch.py#L253) — Wrapper sets db.SYSTEM='vertica' and SpanKind.CLIENT (line 256) with SpanTypes.SQL. |
| `systems: vertica` | `vertica` | [Manifest system publication policy][system-policy] · [canonical member definition][system-vertica] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vertica/patch.py#L253) — span._set_attribute(dbx.SYSTEM, "vertica") statically binds the instrumented. |
| `creation_date` | `2018-10-11` | First commit adding working instrumentation | [first-add commit](https://github.com/DataDog/dd-trace-py/commit/6c1bbf606f77bf99146a0ca19fb197f48a207116) · [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/vertica/patch.py#L1) — First-add commit 6c1bbf606f77bf99146a0ca19fb197f48a207116 'Add Vertica Integration. |

</details>

## Testing

- Common reviewed tracer source: `DataDog/dd-trace-py@5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6`
- Generation gates:
  - Standard runs (`psycopg`, `pymysql`, `pymongo`, `pynamodb`, `pyodbc`, `snowflake`, `sqlalchemy`, `sqlite3`, `vertica`): schema, offline grounding, semantic review, and workspace integrity passed.
  - Recovered runs (`aiopg`, `asyncpg`, `aiomysql`, `mariadb`, `mysql`, `mysqldb`, `algoliasearch`, `azure_cosmos`, `elasticsearch`): accepted candidate, root manifest, reviewer verdict, deterministic validator baseline, and recovery metadata agree; original summaries and workspace-integrity records were unavailable.
- Exact installed-file validation: all 18 installed manifests passed `uv run manifest-validate`; installed bytes match their accepted candidates.
- Mapped tracer suites: `scripts/run-tests --list` succeeded and mapped 21 suites to one latest-Python environment each. Execution was attempted without skip-install but stopped before running tests because the Docker API was unavailable; Docker Desktop is not installed locally. Test count: 0.
- `scripts/lint checks`: passed.
- `git diff --check`: passed.

## Risks

The added YAML is declarative metadata and introduces no runtime instrumentation or public API change. Metadata can become stale if later instrumentation changes do not update its manifest. Source-distribution packaging behavior is unchanged. 


[_v-schema]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L19
[category-policy]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/docs/category-taxonomy/manifest-publication-policy.md#category-contract
[system-policy]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/docs/category-taxonomy/manifest-publication-policy.md#system-and-provider-contract
[category-db.client]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L113
[system-algolia]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L311
[system-aws.dynamodb]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L329
[system-azure.cosmosdb]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L381
[system-elasticsearch]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L452
[system-mariadb]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L594
[system-mongodb]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L614
[system-mysql]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L628
[system-opensearch]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L647
[system-postgresql]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L662
[system-snowflake]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L706
[system-sqlite]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L719
[system-vertica]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L746

