### PR TITLE
chore(integrations): backfill runtime and long-tail manifests

### DIFF
--- a/ddtrace/contrib/internal/aiohttp_jinja2/aiohttp_jinja2.manifest.yaml
+++ b/ddtrace/contrib/internal/aiohttp_jinja2/aiohttp_jinja2.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: aiohttp_jinja2
+display_name: aiohttp-jinja2
+description: Instruments aiohttp-jinja2 template rendering, recording the resolved template path and any rendering errors
+  on the resulting span.
+packages:
+- name: aiohttp-jinja2
+- name: aiohttp_jinja2
+category:
+- template.render
+systems: []
+creation_date: '2017-02-01'

--- a/ddtrace/contrib/internal/asyncio/asyncio.manifest.yaml
+++ b/ddtrace/contrib/internal/asyncio/asyncio.manifest.yaml
@@ -1,0 +1,10 @@
+_v: 1
+name: asyncio
+display_name: asyncio
+description: Instruments asyncio task creation and callback context switches to propagate Datadog trace, LLM observation,
+  and OpenTelemetry context across concurrent execution.
+packages: []
+category:
+- task.execution
+systems: []
+creation_date: '2017-01-27'

--- a/ddtrace/contrib/internal/consul/consul.manifest.yaml
+++ b/ddtrace/contrib/internal/consul/consul.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: consul
+display_name: Consul
+description: Instruments synchronous Consul key-value store read, write, and delete operations performed through the Python
+  client.
+packages:
+- name: python-consul
+category:
+- db.client
+systems:
+- consul
+creation_date: '2019-09-04'

--- a/ddtrace/contrib/internal/ddtrace_api/ddtrace_api.manifest.yaml
+++ b/ddtrace/contrib/internal/ddtrace_api/ddtrace_api.manifest.yaml
@@ -1,0 +1,10 @@
+_v: 1
+name: ddtrace_api
+display_name: ddtrace-api
+description: Instruments the ddtrace-api tracing facade by proxying tracer and span operations to Datadog tracing while recording
+  API usage telemetry.
+packages: []
+category:
+- other
+systems: []
+creation_date: '2025-02-24'

--- a/ddtrace/contrib/internal/futures/futures.manifest.yaml
+++ b/ddtrace/contrib/internal/futures/futures.manifest.yaml
@@ -1,0 +1,10 @@
+_v: 1
+name: futures
+display_name: futures
+description: Instruments ThreadPoolExecutor task submission and execution to propagate tracing and LLM Observability contexts
+  and link profiler samples to originating asyncio tasks.
+packages: []
+category:
+- task.execution
+systems: []
+creation_date: '2017-10-24'

--- a/ddtrace/contrib/internal/gevent/gevent.manifest.yaml
+++ b/ddtrace/contrib/internal/gevent/gevent.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: gevent
+display_name: gevent
+description: Instruments gevent greenlet creation, execution, and context switches to propagate active trace context across
+  spawned and pooled greenlet tasks.
+packages:
+- name: gevent
+category:
+- task.execution
+systems: []
+creation_date: '2016-10-16'

--- a/ddtrace/contrib/internal/gunicorn/gunicorn.manifest.yaml
+++ b/ddtrace/contrib/internal/gunicorn/gunicorn.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: gunicorn
+display_name: Gunicorn
+description: Instruments Gunicorn-hosted applications by bootstrapping Datadog tracing and optional profiling before worker
+  application code loads.
+packages:
+- name: gunicorn
+category:
+- other
+systems: []
+creation_date: '2017-01-31'

--- a/ddtrace/contrib/internal/jinja2/jinja2.manifest.yaml
+++ b/ddtrace/contrib/internal/jinja2/jinja2.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: jinja2
+display_name: Jinja2
+description: Instruments Jinja2 template loading, compilation, and rendering, including streamed template generation, with
+  template identity metadata.
+packages:
+- name: jinja2
+category:
+- template.render
+systems: []
+creation_date: '2018-10-19'

--- a/ddtrace/contrib/internal/logbook/logbook.manifest.yaml
+++ b/ddtrace/contrib/internal/logbook/logbook.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: logbook
+display_name: Logbook
+description: Instruments Logbook record processing to inject Datadog trace correlation identifiers and configured service,
+  environment, and version metadata.
+packages:
+- name: logbook
+category:
+- other
+systems: []
+creation_date: '2023-11-13'

--- a/ddtrace/contrib/internal/logging/logging.manifest.yaml
+++ b/ddtrace/contrib/internal/logging/logging.manifest.yaml
@@ -1,0 +1,10 @@
+_v: 1
+name: logging
+display_name: Logging
+description: Instruments Python log record creation and formatting to inject active trace correlation and configured service,
+  version, and environment metadata.
+packages: []
+category:
+- other
+systems: []
+creation_date: '2019-01-08'

--- a/ddtrace/contrib/internal/loguru/loguru.manifest.yaml
+++ b/ddtrace/contrib/internal/loguru/loguru.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: loguru
+display_name: Loguru
+description: Instruments Loguru log records by injecting Datadog trace correlation identifiers and configured service metadata
+  for trace-log correlation.
+packages:
+- name: loguru
+category:
+- other
+systems: []
+creation_date: '2023-10-25'

--- a/ddtrace/contrib/internal/mako/mako.manifest.yaml
+++ b/ddtrace/contrib/internal/mako/mako.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: mako
+display_name: Mako
+description: Instruments Mako template rendering operations and records each rendered template's file or definition identity
+  as the span resource.
+packages:
+- name: mako
+category:
+- template.render
+systems: []
+creation_date: '2019-01-04'

--- a/ddtrace/contrib/internal/selenium/selenium.manifest.yaml
+++ b/ddtrace/contrib/internal/selenium/selenium.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: selenium
+display_name: Selenium
+description: Instruments Selenium WebDriver navigation and shutdown to enrich test spans with browser metadata, correlate
+  RUM sessions, and flush replay data.
+packages:
+- name: selenium
+category:
+- other
+systems: []
+creation_date: '2024-12-09'

--- a/ddtrace/contrib/internal/structlog/structlog.manifest.yaml
+++ b/ddtrace/contrib/internal/structlog/structlog.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: structlog
+display_name: Structlog
+description: Instruments structlog processor chains to inject Datadog trace correlation context into structured log event
+  dictionaries.
+packages:
+- name: structlog
+category:
+- other
+systems: []
+creation_date: '2023-10-17'


### PR DESCRIPTION
## Description

This change adds structured, machine-readable [instrumentation manifests](https://datadoghq.atlassian.net/wiki/x/vYQbrAE) for:

- Logging: `logbook`, `logging`, `loguru`, and `structlog`
- Runtime and concurrency: `asyncio`, `futures`, `gevent`, and `gunicorn`
- Template rendering: `aiohttp_jinja2`, `jinja2`, and `mako`
- Internal and control-plane: `ddtrace_api` and `consul`
- Browser testing: `selenium`

This is declarative metadata only. Runtime instrumentation and public APIs are unchanged.

Detailed field-level review evidence for every manifest is provided below.
It has the same information as the changed file, so reviewing this description is enough to understand the changes being proposed.

| Integration | Categories | Systems | Creation date |
|---|---|---|---|
| `logbook` | `other` | none | 2023-11-13 |
| `logging` | `other` | none | 2019-01-08 |
| `loguru` | `other` | none | 2023-10-25 |
| `structlog` | `other` | none | 2023-10-17 |
| `asyncio` | `task.execution` | none | 2017-01-27 |
| `futures` | `task.execution` | none | 2017-10-24 |
| `gevent` | `task.execution` | none | 2016-10-16 |
| `gunicorn` | `other` | none | 2017-01-31 |
| `aiohttp_jinja2` | `template.render` | none | 2017-02-01 |
| `jinja2` | `template.render` | none | 2018-10-19 |
| `mako` | `template.render` | none | 2019-01-04 |
| `ddtrace_api` | `other` | none | 2025-02-24 |
| `consul` | `db.client` | `consul` | 2019-09-04 |
| `selenium` | `other` | none | 2024-12-09 |

### Field-level review evidence

Taxonomy links define the publication labels. Tracer links show the instrumented behavior that satisfies those definitions. Tracer links are pinned to the reviewed tracer revision; taxonomy links use the generator revision identified in Additional Notes as a review reference.

<details>
<summary><code>logbook</code> — accepted field evidence</summary>

| Field and published value | Accepted evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — deterministic schema validation passed. |
| `name`: `logbook` | [registry.yaml:608](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L608) — Registry row 'integration_name: logbook' with is_external_package: true declares the canonical integration identity. |
| `display_name`: `Logbook` | [__init__.py:1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/logbook/__init__.py#L1) — Integration docstring refers to the ``logbook`` module; 'Logbook' is the canonical brand spelling of the library, matching the registry integration_name capitalized. |
| `description`: `Instruments Logbook record processing to inject Datadog trace correlation identifiers and configured service, environment, and version metadata.` | [patch.py:24](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/logbook/patch.py#L24) — _w_process_record wraps RecordDispatcher.process_record and calls record.extra.update(ddtrace.tracer.get_log_correlation_context()), i.e. injects correlation data into the log record during record processing.<br>[tracer.py:320](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_trace/tracer.py#L320) — get_log_correlation_context returns trace_id and span_id (trace correlation identifiers) plus configured service, version, and env, exactly matching the described injected metadata. |
| `packages`: `logbook` | [registry.yaml:612](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L612) — dependency_names lists 'logbook' as the sole distribution activating the integration. |
| `category`: `other` | [policy][category-policy] · [definition][cat-other]; [patch.py:28](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/logbook/patch.py#L28) — The only instrumented boundary updates record.extra with correlation context; the integration injects trace context into logs and does not own log emission, RPC, DB, messaging, or any other admitted operation, so log.emission's reject_when applies and no admitted category fits, leaving the exclusive 'other'. |
| `systems`: `[]` | [policy][system-policy]; [patch.py:41](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/logbook/patch.py#L41) — The patch wraps only logbook.base.RecordDispatcher.process_record for log correlation injection; there is no concrete, statically bounded database, messaging, RPC, or provider identity at the instrumented boundary, so no x-system-definitions member qualifies and [] is affirmatively grounded. |
| `creation_date`: `2023-11-13` | [first-add commit](/DataDog/dd-trace-py/commit/b4eb548f03acf07ba3657e70db8cf9396f088e59) · [patch.py:41](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/logbook/patch.py#L41) — First working instrumentation; author date matches the published date. |

</details>

<details>
<summary><code>logging</code> — accepted field evidence</summary>

| Field and published value | Accepted evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — deterministic schema validation passed. |
| `name`: `logging` | [registry.yaml:618](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L618) — Registry row 'integration_name: logging' is the canonical integration name. |
| `display_name`: `Logging` | [__init__.py:15](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/logging/__init__.py#L15) — Module docstring section 'Patch ``logging``' documents this as the stdlib logging integration; 'Logging' is the correct capitalized display form of the module name. |
| `description`: `Instruments Python log record creation and formatting to inject active trace correlation and configured service, version, and environment metadata.` | [patch.py:97](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/logging/patch.py#L97) — patch() wraps logging.Logger.makeRecord (record creation) and logging.StrFormatStyle._format (formatting), matching 'log record creation and formatting'.<br>[patch.py:54](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/logging/patch.py#L54) — _w_makeRecord updates record.__dict__ with tracer.get_log_correlation_context(), confirming injection of active trace correlation.<br>[patch.py:73](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/logging/patch.py#L73) — DDLogRecord is populated with service, version, and env from LOG_ATTR_SERVICE/VERSION/ENV, confirming the configured service/version/environment metadata claim. |
| `packages`: `[]` | [registry.yaml:619](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L619) — logging row sets is_external_package: false with no dependency_names, so empty packages is valid for this stdlib integration. |
| `category`: `other` | [policy][category-policy] · [definition][cat-other]; [patch.py:54](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/logging/patch.py#L54) — The patch surface only injects trace-correlation/service/version/env attributes into existing log records and does not own log emission; per log.emission reject_when ('only injects trace context into logs') that category is disqualified, and no other admitted category (db/http/messaging/rpc/etc.) is exercised, so the completed review admits only 'other'. |
| `systems`: `[]` | [policy][system-policy]; [patch.py:1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/logging/patch.py#L1) — The integration wraps only the Python standard-library logging framework; there is no concrete, statically bounded system/protocol/provider/service identity (a logging framework is not an admitted system), so systems: [] is affirmatively grounded. |
| `creation_date`: `2019-01-08` | [first-add commit](/DataDog/dd-trace-py/commit/ee4c72b949df078c275bdf48965fccc2ad95d2a1) · [patch.py:88](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/logging/patch.py#L88) — First working instrumentation; author date matches the published date. |

</details>

<details>
<summary><code>loguru</code> — accepted field evidence</summary>

| Field and published value | Accepted evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — deterministic schema validation passed. |
| `name`: `loguru` | [patch.py:1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/loguru/patch.py#L1) — Executable integration module at ddtrace/contrib/internal/loguru/patch.py imports and patches the real 'loguru' library; a dedicated internal integration package named loguru exists. |
| `display_name`: `Loguru` | [integrations.rst:378](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/docs/integrations.rst#L378) — The integrations documentation heading spells the integration 'Loguru' with a capital L, matching the manifest display_name capitalization. |
| `description`: `Instruments Loguru log records by injecting Datadog trace correlation identifiers and configured service metadata for trace-log correlation.` | [patch.py:28](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/loguru/patch.py#L28) — _tracer_injection updates the loguru record's extra dict with ddtrace.tracer.get_log_correlation_context(), and _w_configure/patch install a patcher that adds these fields to every record for correlation — enrichment of records, not owning emission.<br>[tracer.py:308](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_trace/tracer.py#L308) — get_log_correlation_context returns the trace id and span id (trace correlation identifiers) plus configured service, version, and environment (service metadata), exactly what the description asserts is injected. |
| `packages`: `loguru` | [registry.yaml:626](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L626) — Registry entry for integration loguru lists dependency_names: [loguru] (is_external_package: true), confirming the loguru package binds to and activates this integration. |
| `category`: `other` | [policy][category-policy] · [definition][cat-other]; [patch.py:41](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/loguru/patch.py#L41) — The entire patch surface only wraps loguru.logger.configure to append a patcher that injects trace-correlation fields into each record's extra; it does not own log emission (log.emission reject_when: 'only injects trace context into logs or observes logs without owning emission' applies), and no db/messaging/rpc/http/task/etc. boundary is instrumented, so no admitted category fits and the completed review yields 'other'. |
| `systems`: `[]` | [policy][system-policy]; [patch.py:56](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/loguru/patch.py#L56) — The integration only injects Datadog trace-correlation context into loguru records; it contacts no database, broker, RPC service, cloud provider, or other concrete statically bounded system, so per x-system-applicability no system identity is established and the empty array is affirmatively grounded. |
| `creation_date`: `2023-10-25` | [first-add commit](/DataDog/dd-trace-py/commit/31f62fcba754e0e9ce2c5a8c6ea9ecf999484b1e) · [patch.py:47](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/loguru/patch.py#L47) — First working instrumentation; author date matches the published date. |

</details>

<details>
<summary><code>structlog</code> — accepted field evidence</summary>

| Field and published value | Accepted evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — deterministic schema validation passed. |
| `name`: `structlog` | [patch.py:1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/structlog/patch.py#L1) — Patch module lives at ddtrace/contrib/internal/structlog/ and imports the real 'structlog' library. |
| `display_name`: `Structlog` | [integrations.rst:590](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/docs/integrations.rst#L590) — Documentation section header renders the integration as 'Structlog', matching the candidate spelling and capitalization. |
| `description`: `Instruments structlog processor chains to inject Datadog trace correlation context into structured log event dictionaries.` | [patch.py:27](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/structlog/patch.py#L27) — _tracer_injection processor updates the event_dict with ddtrace.tracer.get_log_correlation_context(), i.e. injecting trace correlation context into the log event dictionary.<br>[patch.py:48](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/structlog/patch.py#L48) — The processor is prepended to structlog's default_processors / configure() processors chains, confirming instrumentation of processor chains and no ownership of log emission (correlation-only). |
| `packages`: `structlog` | [patch.py:1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/structlog/patch.py#L1) — The integration imports the 'structlog' distribution directly and reads structlog.__version__ in get_version(), so the 'structlog' PyPI package activates it. |
| `category`: `other` | [policy][category-policy] · [definition][cat-other]; [patch.py:27](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/structlog/patch.py#L27) — The patch only injects trace correlation context into log event dicts; per schema x-category-definitions, log.emission is rejected because the integration only injects trace context into logs without owning emission, and no other admitted category (db/http/messaging/rpc/etc.) is exercised, so 'other' is the sole fit. |
| `systems`: `[]` | [policy][system-policy]; [patch.py:25](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/structlog/patch.py#L25) — The patch surface only wraps structlog logging APIs to inject trace context; it touches no database, messaging, RPC, provider, or other concrete statically-bounded system, so per x-system-applicability no system identity qualifies and [] is correct. |
| `creation_date`: `2023-10-17` | [first-add commit](/DataDog/dd-trace-py/commit/8928c44299d5ae9c6f87520b24836ed9e14f5247) · [patch.py:1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/structlog/patch.py#L1) — First working instrumentation; author date matches the published date. |

</details>

<details>
<summary><code>asyncio</code> — accepted field evidence</summary>

| Field and published value | Accepted evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — deterministic schema validation passed. |
| `name`: `asyncio` | [registry.yaml:104](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L104) — Registry row 'integration_name: asyncio' establishes asyncio as a real, canonical integration name. |
| `display_name`: `asyncio` | [__init__.py:3](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/asyncio/__init__.py#L3) — Integration docstring references 'asyncio.Task'; the stdlib module spelling is lowercase 'asyncio', matching the candidate display_name exactly. |
| `description`: `Instruments asyncio task creation and callback context switches to propagate Datadog trace, LLM observation, and OpenTelemetry context across concurrent execution.` | [patch.py:56](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/asyncio/patch.py#L56) — _wrapped_create_task captures tracer.current_trace_context() and reactivates it in the scheduled coroutine, propagating Datadog trace context across task creation.<br>[_context_switch.py:50](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/asyncio/_context_switch.py#L50) — install() wraps asyncio.Handle._run (and call_exception_handler / eager task factory) to publish python.context.switch at callback context boundaries.<br>[_llmobs.py:1130](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/llmobs/_llmobs.py#L1130) — _on_asyncio_create_task/_on_asyncio_execute_task listen on the asyncio.create_task/execute_task events dispatched by patch.py, propagating LLMobs trace context across tasks.<br>[thread_context.py:56](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/internal/opentelemetry/thread_context.py#L56) — OpenTelemetry thread-context listener subscribes to PYTHON_CONTEXT_SWITCH_EVENT to sync OTel context, grounding the 'OpenTelemetry context' propagation claim. |
| `packages`: `[]` | [registry.yaml:105](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L105) — Registry row sets is_external_package: false with no dependency_names, confirming asyncio is a stdlib/runtime integration for which empty packages is valid. |
| `category`: `task.execution` | [policy][category-policy] · [definition][cat-task-execution]; [patch.py:30](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/asyncio/patch.py#L30) — wrap(asyncio.BaseEventLoop.create_task, ...) instruments task spawn/schedule boundaries, matching task.execution definition 'Submits, schedules, spawns, or executes a direct task, future...'; reject_when (durable workflow/broker/FaaS/context-injection-without-task-boundary) does not apply because create_task is a real task boundary. |
| `systems`: `[]` | [policy][system-policy]; [_context_switch.py:44](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/asyncio/_context_switch.py#L44) — The entire patch surface instruments asyncio scheduling and context propagation (Handle._run, create_task, exception handler, eager task factory); no database, messaging, RPC, or provider identity from the schema's x-system-definitions is present, so no concrete statically bounded system qualifies and [] is affirmatively grounded. |
| `creation_date`: `2017-01-27` | [first-add commit](/DataDog/dd-trace-py/commit/9431d67c58b7ef60850f9ff14216d482e289696a) · [patch.py:22](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/asyncio/patch.py#L22) — First working instrumentation; author date matches the published date. |

</details>

<details>
<summary><code>futures</code> — accepted field evidence</summary>

| Field and published value | Accepted evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — deterministic schema validation passed. |
| `name`: `futures` | [_monkey.py:160](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_monkey.py#L160) — PATCH_MODULES maps 'futures': ('concurrent.futures.thread',), confirming 'futures' is the canonical integration key that patches the concurrent.futures stdlib module. |
| `display_name`: `futures` | [__init__.py:2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/futures/__init__.py#L2) — Module docstring refers to it as "The ``futures`` integration", establishing the lowercase 'futures' spelling used publicly. |
| `description`: `Instruments ThreadPoolExecutor task submission and execution to propagate tracing and LLM Observability contexts and link profiler samples to originating asyncio tasks.` | [patch.py:30](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/futures/patch.py#L30) — patch() wraps ThreadPoolExecutor.submit (task submission boundary).<br>[threading.py:69](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/futures/threading.py#L69) — _wrap_submit captures ddtrace.tracer.current_trace_context() and _wrap_execution re-activates it in the worker thread (line 121), confirming tracing-context propagation.<br>[threading.py:70](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/futures/threading.py#L70) — llmobs_ctx obtained via core.dispatch_with_results('threading.submit') and re-dispatched via core.dispatch('threading.execution', ...) at line 115, confirming LLM Observability context propagation.<br>[threading.py:119](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/futures/threading.py#L119) — _current_origin_task() records the submitting asyncio task and _wrap_execution calls stack.link_origin_task(origin_task_id, origin_task_name) so profiler samples in worker threads link back to the originating asyncio task, confirming the profiler-linking behavior. |
| `packages`: `[]` | [_monkey.py:160](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_monkey.py#L160) — 'futures': ('concurrent.futures.thread',) — the integration targets the Python standard-library concurrent.futures.thread module, which ships no external distribution, so an empty packages list is correct for this stdlib integration. |
| `category`: `task.execution` | [policy][category-policy] · [definition][cat-task-execution]; [threading.py:62](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/futures/threading.py#L62) — _wrap_submit wraps the Executor.submit method that submits work executed in another thread (returning a Future), and _wrap_execution (line 100) executes that task in the worker thread. This is a task/future submit-and-execute boundary, matching task.execution's definition ('Submits, schedules, spawns, or executes a direct task, future, ...'); reject_when (durable workflow / broker message / FaaS / context injection without a task boundary) does not apply since a real submit/execute task boundary exists. |
| `systems`: `[]` | [policy][system-policy]; [patch.py:22](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/futures/patch.py#L22) — The integration only patches the stdlib concurrent.futures.thread.ThreadPoolExecutor; no concrete, statically bounded system, protocol, provider, service, or platform (per x-system-applicability) is instrumented. asyncio and the thread pool are generic runtime primitives, not enum system identities, so the empty systems array is affirmatively grounded. |
| `creation_date`: `2017-10-24` | [first-add commit](/DataDog/dd-trace-py/commit/74846fc88bc8aa62a7300c0d3a6d74b59d746a1d) · [patch.py:30](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/futures/patch.py#L30) — First working instrumentation; author date matches the published date. |

</details>

<details>
<summary><code>gevent</code> — accepted field evidence</summary>

| Field and published value | Accepted evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — deterministic schema validation passed. |
| `name`: `gevent` | [patch.py:3](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/gevent/patch.py#L3) — Integration source lives under ddtrace/contrib/internal/gevent/ and imports the 'gevent' module directly; not a helper, distribution alias, or neighboring integration. |
| `display_name`: `gevent` | [__init__.py:2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/gevent/__init__.py#L2) — Repository source spells the library lowercase as 'gevent' ('The gevent integration ...'); the all-lowercase styling matches the project's own capitalization. |
| `description`: `Instruments gevent greenlet creation, execution, and context switches to propagate active trace context across spawned and pooled greenlet tasks.` | [greenlet.py:71](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/gevent/greenlet.py#L71) — TracingMixin.__init__ captures tracer.context_provider.active() at greenlet creation and run() re-activates it, propagating active trace context across greenlet execution (creation + execution boundaries).<br>[greenlet.py:33](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/gevent/greenlet.py#L33) — _GreenletTrace dispatches PYTHON_CONTEXT_SWITCH_EVENT on greenlet context switches; installed via ensure_greenlet_context_switch and the _switch_hub wrapper in patch.py, confirming the 'context switches' claim.<br>[patch.py:78](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/gevent/patch.py#L78) — _replace rebinds gevent.spawn/spawn_later and the pool IMap/IMapUnordered classes to traced variants, covering both spawned and pooled greenlet tasks as the description states. |
| `packages`: `gevent` | [patch.py:29](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/gevent/patch.py#L29) — _supported_versions returns {'gevent': '>=21.1.2'} and get_version reads gevent.__version__; the patch imports the 'gevent' package, confirming 'gevent' is the activating distribution. |
| `category`: `task.execution` | [policy][category-policy] · [definition][cat-task-execution]; [greenlet.py:80](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/gevent/greenlet.py#L80) — TracedGreenlet replaces gevent.Greenlet and TracingMixin wraps greenlet __init__/run; the patch spawns and pools greenlet units of execution, matching task.execution's definition which explicitly names the 'greenlet' unit. No db/http/messaging/rpc/serialization boundary exists, so no other category applies; task.execution's reject_when (durable workflow, broker processing, FaaS, or bare context injection) does not apply because an actual greenlet task boundary is wrapped. |
| `systems`: `[]` | [policy][system-policy]; [greenlet.py:71](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/gevent/greenlet.py#L71) — The patch surface only manipulates ddtrace tracer context across gevent greenlet primitives; it touches no database, cache, messaging broker, RPC protocol, cloud provider, or GenAI provider. No concrete, statically bounded system identity from x-system-definitions is established, so an empty systems array is affirmatively grounded. |
| `creation_date`: `2016-10-16` | [first-add commit](/DataDog/dd-trace-py/commit/43a0e89cf61babc8a7b4347ad877cbb43e881cbf) · [greenlet.py:80](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/gevent/greenlet.py#L80) — First working instrumentation; author date matches the published date. |

</details>

<details>
<summary><code>gunicorn</code> — accepted field evidence</summary>

| Field and published value | Accepted evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — deterministic schema validation passed. |
| `name`: `gunicorn` | [registry.yaml:488](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L488) — Registry row 'integration_name: gunicorn' with is_external_package: true, confirming gunicorn is a real, distinct dd-trace-py integration and not a helper or import alias. |
| `display_name`: `Gunicorn` | [__init__.py:2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/gunicorn/__init__.py#L2) — Integration docstring spells the product 'Gunicorn' (capital G), matching the display_name capitalization exactly; line 5 repeats 'Gunicorn server'. |
| `description`: `Instruments Gunicorn-hosted applications by bootstrapping Datadog tracing and optional profiling before worker application code loads.` | [ddtrace_run.py:32](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/commands/ddtrace_run.py#L32) — ddtrace-run usage: 'Execute the given Python command after configuring it to emit Datadog traces and profiles.' with 'ddtrace-run gunicorn myproject.wsgi' at line 38 — grounds the tracing + optional profiling bootstrap for gunicorn-hosted apps.<br>[__init__.py:6](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/gunicorn/__init__.py#L6) — Note directs users to 'import ddtrace.auto as early as possible in your application's lifecycle', grounding the 'before worker application code loads' bootstrap timing; the integration is documentation-only with no gunicorn-specific span wrappers.<br>[profiling.py:494](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/internal/settings/profiling.py#L494) — Profiling settings reference 'gunicorn' (lock-profiling exclusion), confirming profiling is a real, env-gated (optional) capability applied under gunicorn. |
| `packages`: `gunicorn` | [registry.yaml:491](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L491) — Registry lists dependency_names: [gunicorn] with tested_versions gunicorn min 20.0.4 / max 23.0.0; the distribution imports to the 'gunicorn' package, matching the candidate package name exactly. |
| `category`: `other` | [policy][category-policy] · [definition][cat-other]; [__init__.py:1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/gunicorn/__init__.py#L1) — The entire integration is a documentation-only __init__.py with no wrappers, resource tables, event handlers, or span-emitting patch surface; no admitted category (http.server, task.execution, etc.) has an instrumented operation boundary, so per x-category-definitions the exclusive fallback 'other' applies. |
| `systems`: `[]` | [policy][system-policy]; [__init__.py:1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/gunicorn/__init__.py#L1) — No instrumented boundary emits any concrete, statically bounded system/protocol/provider identity; gunicorn itself is a WSGI server package (a framework/package label), which x-system-applicability.reject_when explicitly excludes as a system, so [] is affirmatively grounded. |
| `creation_date`: `2017-01-31` | [first-add commit](/DataDog/dd-trace-py/commit/2dbcfd5041861a43b0bcbc6fed5de9aef091c75f) · [ddtrace_run.py:38](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/commands/ddtrace_run.py#L38) — First working instrumentation; author date matches the published date. |

</details>

<details>
<summary><code>aiohttp_jinja2</code> — accepted field evidence</summary>

| Field and published value | Accepted evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — deterministic schema validation passed. |
| `name`: `aiohttp_jinja2` | [patch.py:52](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aiohttp_jinja2/patch.py#L52) — Integration lives at ddtrace/contrib/internal/aiohttp_jinja2/ and wraps 'aiohttp_jinja2'.'render_template'; matches canonical name. |
| `display_name`: `aiohttp-jinja2` | [patch.py:30](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aiohttp_jinja2/patch.py#L30) — Wrapped upstream distribution's public/PyPI spelling is 'aiohttp-jinja2' (hyphenated); the module import name 'aiohttp_jinja2' is referenced throughout, and the hyphenated public spelling matches the display_name. |
| `description`: `Instruments aiohttp-jinja2 template rendering, recording the resolved template path and any rendering errors on the resulting span.` | [patch.py:46](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aiohttp_jinja2/patch.py#L46) — span._set_attribute("aiohttp.template", template_meta) where template_meta is package_path/template_name — the resolved template path recorded on the span.<br>[patch.py:43](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aiohttp_jinja2/patch.py#L43) — The render call runs inside 'with tracer.trace("aiohttp.template", span_type=SpanTypes.TEMPLATE) as span:', so exceptions raised by func(*args, **kwargs) are captured as errors on that span; description matches the single instrumented render boundary. |
| `packages`: `aiohttp-jinja2, aiohttp_jinja2` | [patch.py:1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aiohttp_jinja2/patch.py#L1) — 'import aiohttp_jinja2' — the import (module) name; the PyPI distribution is 'aiohttp-jinja2'. Both listed names resolve to the same distribution that activates the integration. |
| `category`: `template.render` | [policy][category-policy] · [definition][cat-template-render]; [patch.py:43](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aiohttp_jinja2/patch.py#L43) — The only instrumented boundary is render_template, wrapped in a SpanTypes.TEMPLATE span 'aiohttp.template' recording the template path — a deliberate render boundary matching template.render's definition; reject_when (incidental internal step, no render boundary) does not apply. No other category (http.server/db.client/messaging/etc.) is exercised by the patch surface. |
| `systems`: `[]` | [policy][system-policy]; [patch.py:43](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aiohttp_jinja2/patch.py#L43) — The patch instruments only Jinja2 template rendering; no concrete, statically bounded database/messaging/RPC/provider/platform identity from the x-system-definitions vocabulary is established at the instrumented boundary, so systems: [] is affirmatively grounded. |
| `creation_date`: `2017-02-01` | [first-add commit](/DataDog/dd-trace-py/commit/cd5da0c695caac09c69482606726ec74e6a109ba) · [patch.py:33](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aiohttp_jinja2/patch.py#L33) — First working instrumentation; author date matches the published date. |

</details>

<details>
<summary><code>jinja2</code> — accepted field evidence</summary>

| Field and published value | Accepted evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — deterministic schema validation passed. |
| `name`: `jinja2` | [registry.yaml:522](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L522) — Registry row 'integration_name: jinja2', is_external_package true, dependency_names includes 'jinja2' — canonical integration, not a helper (aiohttp_jinja2 is a separate row at line 26). |
| `display_name`: `Jinja2` | [__init__.py:2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/jinja2/__init__.py#L2) — Module docstring documents the ``jinja2`` integration; 'Jinja2' is the canonical public project/PyPI distribution spelling (capital J, version suffix 2), matching accepted branding rather than mechanical title casing. |
| `description`: `Instruments Jinja2 template loading, compilation, and rendering, including streamed template generation, with template identity metadata.` | [patch.py:47](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/jinja2/patch.py#L47) — patch() wraps Environment._load_template (jinja2.load span, line 104), Environment.compile (jinja2.compile span, line 88), Template.render and Template.generate (jinja2.render span, line 67) — loading, compilation, rendering, and streamed generation all instrumented.<br>[patch.py:111](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/jinja2/patch.py#L111) — Spans set 'jinja2.template_name' (lines 75/95/111) and 'jinja2.template_path' (line 113) attributes — the 'template identity metadata' claimed; every asserted behavior is grounded and no extra behavior is claimed. |
| `packages`: `jinja2` | [registry.yaml:526](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L526) — dependency_names lists 'jinja2' as the distribution that activates the integration; tested_versions jinja2 min 2.10.3 max 3.1.6. |
| `category`: `template.render` | [policy][category-policy] · [definition][cat-template-render]; [patch.py:67](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/jinja2/patch.py#L67) — Wraps Template.render/generate, Environment.compile, Environment._load_template producing jinja2.render/compile/load spans of SpanTypes.TEMPLATE — deliberate template load and render boundaries matching template.render definition ('template load, render call, render context, generated output'); reject_when (incidental internal step) does not apply. No db/serialization/other category boundary is instrumented, so no admitted category is omitted. |
| `systems`: `[]` | [policy][system-policy]; [patch.py:44](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/jinja2/patch.py#L44) — Patch surface instruments only the Jinja2 template engine's render/compile/load methods; Jinja2 is a template-rendering framework/library, which x-system-applicability reject_when explicitly excludes as a system identity. No concrete, statically bounded database/messaging/RPC/provider/service identity is present, so systems: [] is affirmatively grounded. |
| `creation_date`: `2018-10-19` | [first-add commit](/DataDog/dd-trace-py/commit/7c9aef73da64edf7f3b5c9af993d9c7cbb7fd012) · [patch.py:1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/jinja2/patch.py#L1) — First working instrumentation; author date matches the published date. |

</details>

<details>
<summary><code>mako</code> — accepted field evidence</summary>

| Field and published value | Accepted evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — deterministic schema validation passed. |
| `name`: `mako` | [patch.py:1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mako/patch.py#L1) — Patch module lives at ddtrace/contrib/internal/mako/ and imports 'import mako', confirming mako as the canonical integration. |
| `display_name`: `Mako` | [__init__.py:2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mako/__init__.py#L2) — Integration docstring describes the Mako integration for the Mako template engine; 'Mako' is the project's own proper-name capitalization, matching the first-add Git subject '[mako] Add Mako integration (#779)'. |
| `description`: `Instruments Mako template rendering operations and records each rendered template's file or definition identity as the span resource.` | [patch.py:36](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mako/patch.py#L36) — patch() wraps Template.render, render_unicode, and render_context with _wrap_render — the deliberate template rendering boundary.<br>[patch.py:62](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mako/patch.py#L62) — template_name is taken from instance.filename (file identity), or from func_name(instance.callable_) for a DefTemplate (definition identity) at line 60.<br>[patch.py:74](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mako/patch.py#L74) — span.resource = template_name sets the file-or-definition identity as the span resource, exactly as described. |
| `packages`: `mako` | [patch.py:1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mako/patch.py#L1) — The patch imports 'import mako' and get_version reads mako.__version__ (line 21); _supported_versions returns {'mako': '>=1.0.0'} (line 25), confirming the mako distribution activates the integration. |
| `category`: `template.render` | [policy][category-policy] · [definition][cat-template-render]; [patch.py:65](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mako/patch.py#L65) — tracer.trace(..., span_type=SpanTypes.TEMPLATE) wrapping Template.render/render_unicode/render_context is a deliberate template-render boundary matching template.render's definition 'Renders a template into output using a template engine'; reject_when (incidental internal step) does not apply. No db/http/serialization/messaging boundary exists in the patch surface, so no other category qualifies. |
| `systems`: `[]` | [policy][system-policy]; [patch.py:65](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mako/patch.py#L65) — The only instrumented boundary is template rendering (COMPONENT 'mako', SpanTypes.TEMPLATE); no concrete, statically bounded database/messaging/provider/service/RPC identity from the closed system vocabulary is instrumented, so per x-system-applicability the empty array is affirmatively grounded. |
| `creation_date`: `2019-01-04` | [first-add commit](/DataDog/dd-trace-py/commit/f71625f87945530ed2780e663850e2bc7fb190ad) · [patch.py:1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/mako/patch.py#L1) — First working instrumentation; author date matches the published date. |

</details>

<details>
<summary><code>ddtrace_api</code> — accepted field evidence</summary>

| Field and published value | Accepted evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — deterministic schema validation passed. |
| `name`: `ddtrace_api` | [registry.yaml:300](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L300) — Registry row declares 'integration_name: ddtrace_api', the canonical integration identity. |
| `display_name`: `ddtrace-api` | [riotfile.py:1033](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/riotfile.py#L1033) — Test venv installs the distribution as pkgs={'ddtrace-api': '==0.0.1', ...}; the hyphenated 'ddtrace-api' matches the published package spelling used as the display name. |
| `description`: `Instruments the ddtrace-api tracing facade by proxying tracer and span operations to Datadog tracing while recording API usage telemetry.` | [patch.py:98](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ddtrace_api/patch.py#L98) — patch() wraps ddtrace_api.Tracer methods (start_span, trace, set_tags, current_span, current_root_span) and Span methods (finish, set_exc_info, finish_with_ancestors, set_tags, set_traceback, __enter__, __exit__) — the tracer and span operations named in the description.<br>[patch.py:76](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ddtrace_api/patch.py#L76) — _call_on_real_instance invokes the same method on the real ddtrace object mapped via _STUB_TO_REAL — this is the proxying to Datadog tracing.<br>[patch.py:81](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ddtrace_api/patch.py#L81) — telemetry_writer.add_count_metric(namespace=TELEMETRY_NAMESPACE.DD_TRACE_API, name=metric_name, value=1) records API usage telemetry per proxied call. |
| `packages`: `[]` | [registry.yaml:301](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L301) — Registry row for ddtrace_api sets is_external_package: false with no dependency_names, so the integration is registry-declared as not bound to an external distribution; empty packages is consistent with that declaration. |
| `category`: `other` | [policy][category-policy] · [definition][cat-other]; [patch.py:98](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ddtrace_api/patch.py#L98) — The entire patch surface only wraps the ddtrace_api tracing-facade Tracer/Span methods and proxies them to the internal tracer, recording telemetry counters; there is no HTTP, DB, cache, messaging, RPC, web-framework, or gen_ai operation boundary, so no operation-boundary category applies and the exclusive 'other' is correct. |
| `systems`: `[]` | [policy][system-policy]; [patch.py:76](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ddtrace_api/patch.py#L76) — The patch surface proxies calls only to the in-process ddtrace tracer via _STUB_TO_REAL; it contacts no concrete, statically bounded external system (no database engine, protocol, message broker, or cloud service), so an empty systems set is affirmatively grounded. |
| `creation_date`: `2025-02-24` | [first-add commit](/DataDog/dd-trace-py/commit/74b0870123c003ab17de20d35cde50c556dcee4e) · [patch.py:7](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/ddtrace_api/patch.py#L7) — First working instrumentation; author date matches the published date. |

</details>

<details>
<summary><code>consul</code> — accepted field evidence</summary>

| Field and published value | Accepted evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — deterministic schema validation passed. |
| `name`: `consul` | [registry.yaml:270](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L270) — Registry row 'integration_name: consul' with is_external_package: true, confirming consul is the real registered integration, not a helper or import alias. |
| `display_name`: `Consul` | [__init__.py:1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/consul/__init__.py#L1) — Docstring 'Instrument Consul to trace KV queries.' uses the capitalized product spelling 'Consul', matching the display_name. |
| `description`: `Instruments synchronous Consul key-value store read, write, and delete operations performed through the Python client.` | [patch.py:22](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/consul/patch.py#L22) — _KV_FUNCS = ['put', 'get', 'delete'] are the wrapped KV operations = write, read, delete, matching the described operation family.<br>[patch.py:61](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/consul/patch.py#L61) — Guard 'if not isinstance(instance.agent.http, consul.std.HTTPClient)' with comment 'Only patch the synchronous implementation', confirming synchronous-client scope.<br>[__init__.py:3](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/consul/__init__.py#L3) — Docstring 'Only supports tracing for the synchronous client.' corroborates the 'synchronous' qualifier and Python consul client. |
| `packages`: `python-consul` | [registry.yaml:274](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L274) — dependency_names lists 'python-consul' for the consul integration, the distribution that provides the imported 'consul' module. |
| `category`: `db.client` | [policy][category-policy] · [definition][cat-db-client]; [patch.py:42](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/consul/patch.py#L42) — Wraps consul.Consul.KV.{put,get,delete} — first-class client operations against the Consul key-value store, satisfying db.client's OTel database-client family; HTTP is only private transport (schematize_url_operation protocol='http'), so http.client's reject_when applies and it is correctly omitted. |
| `systems`: `consul` | [policy][system-policy] · [definition][sys-consul]; [patch.py:39](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/consul/patch.py#L39) — pin.onto(consul.Consul.KV) with a dedicated, statically bounded import of the 'consul' client — a concrete Consul service-discovery/configuration system identity, matching schema x-system-definitions 'consul' (kind: system). |
| `creation_date`: `2019-09-04` | [first-add commit](/DataDog/dd-trace-py/commit/e63ded748e3fcf03cd47d3901cbf4b959c3b89aa) · [patch.py:1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/consul/patch.py#L1) — First working instrumentation; author date matches the published date. |

</details>

<details>
<summary><code>selenium</code> — accepted field evidence</summary>

| Field and published value | Accepted evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — deterministic schema validation passed. |
| `name`: `selenium` | [patch.py:48](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/selenium/patch.py#L48) — config._add("selenium", ...) and the integration lives at ddtrace/contrib/internal/selenium/, establishing 'selenium' as the canonical integration name. |
| `display_name`: `Selenium` | [__init__.py:2](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/selenium/__init__.py#L2) — Public stub docstring reads 'The Selenium integration enriches Test Visibility data...', matching the exact spelling and capitalization 'Selenium'. |
| `description`: `Instruments Selenium WebDriver navigation and shutdown to enrich test spans with browser metadata, correlate RUM sessions, and flush replay data.` | [patch.py:174](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/selenium/patch.py#L174) — patch() wraps WebDriver.get (navigation) and WebDriver.quit/WebDriver.close (shutdown), matching 'navigation and shutdown'.<br>[patch.py:110](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/selenium/patch.py#L110) — On WebDriver.get return, sets test.is_browser, test.browser.driver/driver_version, test.browser.name/version on the test root span — 'enrich test spans with browser metadata'.<br>[patch.py:108](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/selenium/patch.py#L108) — Adds cookie 'datadog-ci-visibility-test-execution-id' and, on quit/close, runs DD_RUM.stopSession and sets test.is_rum_active — 'correlate RUM sessions'.<br>[patch.py:144](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/selenium/patch.py#L144) — time.sleep(config.selenium.flush_sleep_ms/1000) after stopSession flushes RUM data; stub (__init__.py) explicitly documents 'Real User Monitoring session replays' — 'flush replay data'. |
| `packages`: `selenium` | [patch.py:167](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/selenium/patch.py#L167) — patch() does 'import selenium' and wraps selenium.webdriver.remote.webdriver.WebDriver methods; _supported_versions() returns {'selenium': '*'}, so the 'selenium' PyPI distribution binds the integration. |
| `category`: `other` | [policy][category-policy] · [definition][cat-other]; [patch.py:90](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/selenium/patch.py#L90) — The patch surface creates no spans and instruments no recognized operation boundary (no HTTP/DB/cache/messaging/RPC/GenAI call is traced); it only wraps WebDriver.get/quit/close to tag the pre-existing test root span and set/delete a cookie. No non-'other' category definition is exercised, so the exclusive value 'other' is correct. |
| `systems`: `[]` | [policy][system-policy]; [patch.py:172](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/selenium/patch.py#L172) — The integration only wraps local Selenium WebDriver Python methods (get/quit/close) and reads driver capabilities; no concrete, statically bounded RPC/DB/cache/messaging system or wire protocol is instrumented. Selenium is a browser-automation framework/package name, which the specificity rules exclude, so systems: [] is affirmatively grounded. |
| `creation_date`: `2024-12-09` | [first-add commit](/DataDog/dd-trace-py/commit/7320b6f04511468c9cf4b8da2fda19bd057d82a0) · [patch.py:1](/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/selenium/patch.py#L1) — First working instrumentation; author date matches the published date. |

</details>

## Testing

- Common tracer source: `DataDog/dd-trace-py@5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6`
- Completed generation runs: `structlog` and `selenium` passed schema, offline-grounding, semantic-review, and workspace-integrity gates with no violations.
- Recovered candidates: `logbook`, `logging`, `loguru`, `asyncio`, `futures`, `gevent`, `gunicorn`, `aiohttp_jinja2`, `jinja2`, `mako`, `ddtrace_api`, and `consul` have byte-identical final candidates, passing retained schema and grounding baselines, and accepted independent reviewer verdicts. Their original terminal summaries and final historical workspace-integrity results were not recoverable.
- Exact installed-file validation: all 14 installed manifests passed schema validation and offline Python grounding with `manifest-validate --grounding python`.
- Mapped tracer suites: `scripts/run-tests --list` completed successfully and mapped 20 suites. A Python 3.14 `detect_global_locks` smoke run (`4a90061`) was attempted after starting Colima, but test execution did not begin because the test-runner image pull remained incomplete and was stopped. No runtime tests ran; these manifests are declarative metadata and are not loaded by the tracer at runtime.
- `scripts/lint checks`: passed.
- `git diff --check`: passed for the 14 added manifests.

## Risks

The added YAML is declarative metadata and introduces no runtime instrumentation or public API change. Metadata can become stale if later instrumentation changes do not update its manifest. Source-distribution packaging behavior is unchanged.

[schema-v]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L19
[category-policy]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/docs/category-taxonomy/manifest-publication-policy.md#category-contract
[system-policy]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/docs/category-taxonomy/manifest-publication-policy.md#system-and-provider-contract
[cat-other]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L204
[cat-task-execution]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L232
[cat-template-render]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L239
[cat-db-client]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L113
[sys-consul]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L423
