### PR TITLE
chore(integrations): backfill CI, ASM, and serverless manifests

### DIFF
--- a/ddtrace/contrib/internal/azure_eventhubs/azure_eventhubs.manifest.yaml
+++ b/ddtrace/contrib/internal/azure_eventhubs/azure_eventhubs.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: azure_eventhubs
+display_name: Azure Event Hubs
+description: Instruments synchronous and asynchronous Azure Event Hubs producer operations for creating and sending events,
+  with distributed context propagation and batch span links.
+packages:
+- name: azure-eventhub
+category:
+- messaging.producer
+systems:
+- eventhubs
+creation_date: '2025-10-09'

--- a/ddtrace/contrib/internal/azure_servicebus/azure_servicebus.manifest.yaml
+++ b/ddtrace/contrib/internal/azure_servicebus/azure_servicebus.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: azure_servicebus
+display_name: Azure Service Bus
+description: Instruments synchronous and asynchronous Azure Service Bus message production, including immediate and scheduled
+  sends, distributed trace propagation, and batch span links.
+packages:
+- name: azure-servicebus
+category:
+- messaging.producer
+systems:
+- servicebus
+creation_date: '2025-06-26'

--- a/ddtrace/contrib/internal/coverage/coverage.manifest.yaml
+++ b/ddtrace/contrib/internal/coverage/coverage.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: coverage
+display_name: Coverage.py
+description: Instruments Coverage.py collection and report generation to capture test code-coverage percentages and produce
+  LCOV reports for upload.
+packages:
+- name: coverage
+category:
+- other
+systems: []
+creation_date: '2023-12-19'

--- a/ddtrace/contrib/internal/pytest/pytest.manifest.yaml
+++ b/ddtrace/contrib/internal/pytest/pytest.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: pytest
+display_name: pytest
+description: Instruments pytest test sessions and executions, recording their hierarchy, outcomes, retries, and code coverage
+  for Datadog Test Optimization.
+packages:
+- name: pytest
+category:
+- test.execution
+systems: []
+creation_date: '2020-11-13'

--- a/ddtrace/contrib/internal/pytest_bdd/pytest_bdd.manifest.yaml
+++ b/ddtrace/contrib/internal/pytest_bdd/pytest_bdd.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: pytest_bdd
+display_name: pytest-bdd
+description: Instruments pytest-bdd scenario and step execution, enriching scenario test metadata and tracing step parameters,
+  code ownership, and failures.
+packages:
+- name: pytest-bdd
+category:
+- test.execution
+systems: []
+creation_date: '2022-06-02'

--- a/ddtrace/contrib/internal/pytest_benchmark/pytest_benchmark.manifest.yaml
+++ b/ddtrace/contrib/internal/pytest_benchmark/pytest_benchmark.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: pytest_benchmark
+display_name: pytest-benchmark
+description: Instruments pytest-benchmark results by attaching timing statistics and benchmark identity to pytest test spans
+  and events.
+packages:
+- name: pytest_benchmark
+category:
+- other
+systems: []
+creation_date: '2023-08-07'

--- a/ddtrace/contrib/internal/subprocess/subprocess.manifest.yaml
+++ b/ddtrace/contrib/internal/subprocess/subprocess.manifest.yaml
@@ -1,0 +1,10 @@
+_v: 1
+name: subprocess
+display_name: Subprocess
+description: Instruments child-process creation and execution for command tracing and security inspection, and propagates
+  runtime lineage context to children.
+packages: []
+category:
+- task.execution
+systems: []
+creation_date: '2023-06-13'

--- a/ddtrace/contrib/internal/unittest/unittest.manifest.yaml
+++ b/ddtrace/contrib/internal/unittest/unittest.manifest.yaml
@@ -1,0 +1,10 @@
+_v: 1
+name: unittest
+display_name: unittest
+description: Instruments unittest test execution, recording session, module, suite, and test spans, outcomes, intelligent
+  skipping, and optional code coverage.
+packages: []
+category:
+- test.execution
+systems: []
+creation_date: '2023-08-28'

--- a/ddtrace/contrib/internal/urllib/urllib.manifest.yaml
+++ b/ddtrace/contrib/internal/urllib/urllib.manifest.yaml
@@ -1,0 +1,10 @@
+_v: 1
+name: urllib
+display_name: urllib
+description: Instruments outbound HTTP requests through urllib.request for SSRF vulnerability detection, exploit prevention,
+  and response analysis.
+packages: []
+category:
+- http.client
+systems: []
+creation_date: '2024-05-13'

--- a/ddtrace/contrib/internal/webbrowser/webbrowser.manifest.yaml
+++ b/ddtrace/contrib/internal/webbrowser/webbrowser.manifest.yaml
@@ -1,0 +1,10 @@
+_v: 1
+name: webbrowser
+display_name: Webbrowser
+description: Instruments Python's webbrowser URL-opening operation to detect and help prevent server-side request forgery
+  vulnerabilities in applications.
+packages: []
+category:
+- other
+systems: []
+creation_date: '2024-05-13'


### PR DESCRIPTION
## Description

This change adds structured, machine-readable [instrumentation manifests](https://datadoghq.atlassian.net/wiki/x/vYQbrAE) for CI Visibility and test tooling, Python standard-library helpers, and Azure messaging integrations:

- CI Visibility and test tooling: `coverage`, `pytest`, `pytest_bdd`, `pytest_benchmark`, and `unittest`
- Python standard-library helpers: `subprocess`, `urllib`, and `webbrowser`
- Azure messaging: `azure_eventhubs` and `azure_servicebus`

This is declarative metadata only. Runtime instrumentation and public APIs are unchanged.

Detailed field-level review evidence for every manifest is provided below.
It has the same information as the changed file, so reviewing this description is enough to understand the changes being proposed.

| Integration | Categories | Systems | Creation date |
|---|---|---|---|
| `coverage` | `other` | none | `2023-12-19` |
| `pytest` | `test.execution` | none | `2020-11-13` |
| `pytest_bdd` | `test.execution` | none | `2022-06-02` |
| `pytest_benchmark` | `other` | none | `2023-08-07` |
| `unittest` | `test.execution` | none | `2023-08-28` |
| `subprocess` | `task.execution` | none | `2023-06-13` |
| `urllib` | `http.client` | none | `2024-05-13` |
| `webbrowser` | `other` | none | `2024-05-13` |
| `azure_eventhubs` | `messaging.producer` | `eventhubs` | `2025-10-09` |
| `azure_servicebus` | `messaging.producer` | `servicebus` | `2025-06-26` |

### Field-level review evidence

Taxonomy links define the publication labels. Tracer links show the instrumented behavior that satisfies those definitions. All links are pinned to the reviewed source revisions.

<details>
<summary><code>coverage</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][schema] | Deterministic schema gate passed. |
| `name` | `coverage` | [integration registry](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L280) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_monkey.py#L119) — PATCH_MODULES registers "coverage": False, establishing 'coverage' as the real integration key.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/coverage/patch.py#L46) — patch() wraps coverage.Coverage.report, confirming the integration instruments the coverage.py library under the name 'coverage'. |
| `display_name` | `Coverage.py` | Established tracer source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/coverage/__init__.py#L2) — Public docstring reads 'The Coverage.py integration traces test code coverage...', matching the capitalized spelling 'Coverage.py'. |
| `description` | `Instruments Coverage.py collection and report generation to capture test code-coverage percentages and produce LCOV reports for upload.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/coverage/patch.py#L66) — coverage_report_wrapper caches the pct_covered returned by Coverage.report, confirming capture of coverage percentages during report generation.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/coverage/patch.py#L168) — start_coverage()/stop_coverage() wrap Coverage() creation and start()/stop(), instrumenting collection.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/coverage/utils.py#L240) — handle_coverage_report generates an LCOV report and passes its bytes to upload_func, confirming 'produce LCOV reports for upload'. |
| `packages` | [`coverage`] | [registry identity and `dependency_names`](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L280) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/coverage/patch.py#L11) — The patch imports the 'coverage' distribution ('import coverage'; 'from coverage import Coverage'), which activates the integration. |
| `category: other` | `other` | [Manifest category policy][category-policy] · [canonical member definition][category-other] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/coverage/patch.py#L46) — The only instrumented boundary is Coverage.report (plus collection/LCOV helpers) measuring code-coverage percentages; no admitted category (e.g. test.execution requires owning test execution, which this does not) applies, so 'other' is the correct exclusive value. |
| `systems` | `[]` | [Manifest system publication policy][system-policy] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/coverage/patch.py#L46) — The patch surface only wraps coverage.py's own API; no concrete statically bounded system, protocol, provider, or service identity is instrumented, so no schema system definition qualifies and [] is correct. |
| `creation_date` | `2023-12-19` | [first commit adding working instrumentation](https://github.com/DataDog/dd-trace-py/commit/5c349421e4aa5753b31b150e8f30ba3bc8436f02) | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/coverage/patch.py#L40) — git log --diff-filter=A shows the first-add commit for the coverage integration is the linked commit (2023-12-19) 'feat(civis): add code coverage v0 support for pytest and unittest (#7833)', which introduces working instrumentation (not a move/autopatch); later commits f476e67 and fce31fc only relocate files. Author date 2023-12-19 equals the manifest date. |

</details>

<details>
<summary><code>pytest</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][schema] | Deterministic schema gate passed. |
| `name` | `pytest` | [integration registry](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L844) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest/__init__.py#L5) — Module docstring: 'The pytest integration traces test executions.' — canonical integration directory ddtrace/contrib/internal/pytest/.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest/plugin.py#L18) — 'import pytest' and registration of pytest_addoption/pytest_configure hooks confirm this is the real pytest integration, not a helper or neighbor. |
| `display_name` | `pytest` | Established tracer source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest/plugin.py#L5) — Source consistently spells the framework as lowercase 'pytest' (e.g. 'tracing for pytest'), matching pytest's own project styling. |
| `description` | `Instruments pytest test sessions and executions, recording their hierarchy, outcomes, retries, and code coverage for Datadog Test Optimization.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest/_plugin_v2.py#L547) — InternalTestSession.discover(...) plus InternalTestModule.discover (620), InternalTestSuite.discover (621), and InternalTest.discover (637) establish the session/module/suite/test hierarchy.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest/_plugin_v2.py#L711) — _process_reports_dict + InternalTest.prepare_for_finish(test_id, test_outcome.status, ...) records per-test outcomes.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest/_plugin_v2.py#L93) — Imports efd_handle_retries / atr_handle_retries (98) / attempt_to_fix_handle_retries (106) implement Early Flake Detection, Auto Test Retries, and attempt-to-fix retries.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest/_plugin_v2.py#L267) — InternalTestSession.should_collect_coverage() and _handle_collected_coverage (704) collect per-test/suite code coverage; all reported under Datadog Test Optimization (CI Visibility). |
| `packages` | [`pytest`] | [registry identity and `dependency_names`](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L844) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest/plugin.py#L63) — The integration is a pytest plugin (pytest_addoption/--ddtrace, pytest_configure, pytest_addhooks); it activates only when the 'pytest' distribution is installed and running. |
| `category: test.execution` | `test.execution` | [Manifest category policy][category-policy] · [canonical member definition][category-test-execution] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest/_plugin_v2.py#L637) — InternalTest.discover(...) and InternalTest.prepare_for_finish/finish (712-718) instrument the running and outcome-reporting of tests — a deliberate test-execution operation boundary. No db/http/rpc/messaging boundary is wrapped; coverage/retries are sub-features of the same test-execution surface, so test.execution is the complete category set. |
| `systems` | `[]` | [Manifest system publication policy][system-policy] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest/_plugin_v2.py#L77) — All instrumented boundaries target pytest test-visibility APIs (InternalTest/InternalTestModule/InternalTestSession/InternalTestSuite); no concrete, statically bounded RPC/DB/cache/messaging system identity is contacted, so an empty systems set is affirmatively grounded. |
| `creation_date` | `2020-11-13` | [first commit adding working instrumentation](https://github.com/DataDog/dd-trace-py/commit/95be7d37475938ca1cb81a4a1636a7e339c878f4) | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest/plugin.py#L1) — First-add of the pytest integration verified via git log --diff-filter=A --follow: commit the linked commit, author date 2020-11-13, subject 'feat: pytest integration (#1741)'; it is the earliest add across the historical ddtrace/contrib/pytest and current ddtrace/contrib/internal/pytest paths and introduces working instrumentation. |

</details>

<details>
<summary><code>pytest_bdd</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][schema] | Deterministic schema gate passed. |
| `name` | `pytest_bdd` | [integration registry](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L854) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest_bdd/constants.py#L1) — FRAMEWORK = "pytest_bdd" defines the integration identity used on spans.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest_bdd/patch.py#L9) — _supported_versions returns {"pytest_bdd": "*"}, confirming pytest_bdd is the registered integration name, not a helper or import alias. |
| `display_name` | `pytest-bdd` | Established tracer source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest_bdd/__init__.py#L2) — Module docstring reads 'The pytest-bdd integration traces executions of scenarios and steps.', confirming lowercase hyphenated spelling pytest-bdd. |
| `description` | `Instruments pytest-bdd scenario and step execution, enriching scenario test metadata and tracing step parameters, code ownership, and failures.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest_bdd/_plugin.py#L78) — pytest_bdd_before_scenario sets test.NAME=scenario.name and test.SUITE=feature location (lines 83-84), enriching scenario test metadata.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest_bdd/_plugin.py#L89) — pytest_bdd_before_step starts a span per step (step.type/step.name), and after_step (line 112) finishes it, tracing step execution; test.PARAMETERS set from step_func_args at lines 117/127 traces step parameters.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest_bdd/_plugin.py#L106) — _CIVisibility.set_codeowners_of records code ownership (also line 86); pytest_bdd_step_error (line 121) calls span.set_exc_info recording failures. |
| `packages` | [`pytest-bdd`] | [registry identity and `dependency_names`](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L854) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest_bdd/patch.py#L5) — get_version() returns importlib_metadata.version("pytest-bdd"), binding the integration to the pytest-bdd distribution. |
| `category: test.execution` | `test.execution` | [Manifest category policy][category-policy] · [canonical member definition][category-test-execution] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest_bdd/_plugin.py#L89) — The plugin hooks pytest-bdd test lifecycle (before_scenario/before_step/after_step/step_error), creating spans for scenario and step execution through the test framework runner, matching test.execution 'Executes test cases or test lifecycle hooks through a test framework or runner'; no cicd.pipeline orchestration contract applies. |
| `systems` | `[]` | [Manifest system publication policy][system-policy] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest_bdd/_plugin.py#L72) — The entire patch surface only wraps pytest-bdd test-framework hooks and CI Visibility tagging; no concrete statically bounded database, messaging, RPC, or provider system is instrumented, so no x-system-definitions identity qualifies and systems: [] is affirmatively grounded. |
| `creation_date` | `2022-06-02` | [first commit adding working instrumentation](https://github.com/DataDog/dd-trace-py/commit/a65f529e8a61207c42f268a5c0895068d1ddff91) | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest_bdd/_plugin.py#L1) — git log --diff-filter=A over pytest_bdd paths shows the first-add commit the linked commit 'feat(ciapp): add pytest-bdd integration (#3700)' authored 2022-06-02, introducing the working scenario/step instrumentation; later commits only relocate (internal move) or gate imports. |

</details>

<details>
<summary><code>pytest_benchmark</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][schema] | Deterministic schema gate passed. |
| `name` | `pytest_benchmark` | [integration registry](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L864) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L864) — Registry row 'integration_name: pytest_benchmark' declares the canonical integration name, matching the contrib package ddtrace/contrib/internal/pytest_benchmark/. |
| `display_name` | `pytest-benchmark` | Established tracer source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest_benchmark/__init__.py#L2) — Module docstring reads 'The pytest-benchmark integration traces executions of pytest benchmarks.', confirming the hyphenated 'pytest-benchmark' spelling and capitalization. |
| `description` | `Instruments pytest-benchmark results by attaching timing statistics and benchmark identity to pytest test spans and events.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest_benchmark/_plugin.py#L21) — In pytest_runtest_makereport the plugin extracts the pytest span and sets TEST_TYPE='benchmark' (benchmark identity) then applies PLUGIN_METRICS benchmark.duration.* timing statistics via _set_attribute/set_tag onto the test span.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest/_benchmark_utils.py#L34) — The v2 path builds BenchmarkDurationData from the fixture stats and calls InternalTest.set_benchmark_data(test_id, ..., is_benchmark=True), attaching timing statistics and benchmark identity to test-visibility test events. |
| `packages` | [`pytest_benchmark`] | [registry identity and `dependency_names`](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L864) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L868) — The pytest_benchmark registry row lists dependency_names: [pytest_benchmark] with is_external_package: true, the import name of the pytest-benchmark distribution that activates the integration. |
| `category: other` | `other` | [Manifest category policy][category-policy] · [canonical member definition][category-other] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest_benchmark/_plugin.py#L22) — The plugin only decorates an already-created pytest span/test event with benchmark timing metrics and a benchmark marker; it does not own test discovery, case execution, or lifecycle. This exercises no admitted category: test.execution's reject_when ('The target only measures benchmark timing... without owning test execution') and cicd.pipeline's rejection both apply, so per x-category-definitions the exclusive 'other' is the only fit for a completed review. |
| `systems` | `[]` | [Manifest system publication policy][system-policy] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest_benchmark/constants.py#L39) — The full patch surface only maps pytest-benchmark statistics attributes to benchmark.duration.* tags; there is no database, messaging, RPC, provider, or other concrete statically bounded system identity, so per x-system-applicability the array is affirmatively empty. |
| `creation_date` | `2023-08-07` | [first commit adding working instrumentation](https://github.com/DataDog/dd-trace-py/commit/2898a2403ad9cf47d1d7f49f9334cff0b3ede35a) | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pytest_benchmark/plugin.py#L1) — git log --diff-filter=A shows the first-add commit the linked commit 'feat(pytest-benchmark): implement pytest-benchmark support (#6375)' dated 2023-08-07, which added the original ddtrace/contrib/pytest_benchmark/{constants.py,plugin.py} instrumentation and tests (later relocated to this internal path); author date equals the manifest creation_date. |

</details>

<details>
<summary><code>unittest</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][schema] | Deterministic schema gate passed. |
| `name` | `unittest` | [integration registry](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1014) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/unittest/__init__.py#L2) — Docstring 'The unittest integration traces test executions.' establishes this canonical integration under ddtrace/contrib/internal/unittest/.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/unittest/patch.py#L5) — patch.py imports the stdlib 'unittest' module and wraps its APIs, confirming identity is the unittest framework and not a helper or neighbor. |
| `display_name` | `unittest` | Established tracer source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/unittest/constants.py#L2) — FRAMEWORK = "unittest" and COMPONENT_VALUE = "unittest" (line 1) confirm the lowercase framework spelling used across the integration.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/unittest/__init__.py#L8) — Documentation refers to it as 'The unittest integration', matching the lowercase Python module name. |
| `description` | `Instruments unittest test execution, recording session, module, suite, and test spans, outcomes, intelligent skipping, and optional code coverage.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/unittest/patch.py#L647) — _start_test_session_span / _start_test_module_span (688) / _start_test_suite_span (731) / _start_test_span (771) create the session, module, suite, and test spans named in the description.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/unittest/patch.py#L434) — TextTestResult.addSuccess/addFailure/addError/addSkip/addExpectedFailure/addUnexpectedSuccess wrappers (434-439) record PASS/FAIL/SKIP/XFAIL/XPASS outcomes, supporting 'outcomes'.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/unittest/patch.py#L592) — _should_be_skipped_by_itr and ITR test-skipping logic (579-601) implement Datadog Intelligent Test Runner 'intelligent skipping'.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/unittest/patch.py#L612) — _is_test_coverage_enabled / _start_coverage / _report_coverage_to_span (612-619) implement the optional code-coverage collection described. |
| `packages` | `[]` | [registry identity and `dependency_names`](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1014) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_monkey.py#L118) — Registry maps "unittest": True as an auto-patched stdlib integration; no external distribution is required to activate it.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/unittest/patch.py#L76) — _supported_versions() returns {"unittest": "*"} and get_version() (line 72) returns "", consistent with a versionless stdlib module rather than a PyPI package. |
| `category: test.execution` | `test.execution` | [Manifest category policy][category-policy] · [canonical member definition][category-test-execution] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/unittest/patch.py#L441) — patch() wraps TestCase.run (441), TestSuite.run (442), TextTestRunner.run (443), and TestProgram.runTests (444), owning the test-case and test-runner execution lifecycle; matches test.execution definition 'Executes test cases or test lifecycle hooks through a test framework or runner' and no reject_when applies (it owns execution, not mere CI/benchmark timing). |
| `systems` | `[]` | [Manifest system publication policy][system-policy] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/unittest/patch.py#L422) — The entire patch surface (422-464) wraps only Python's unittest classes; no admitted x-system-definitions identity (db/messaging/RPC/provider/service) is established at any instrumented boundary, so systems: [] is affirmatively grounded. |
| `creation_date` | `2023-08-28` | [first commit adding working instrumentation](https://github.com/DataDog/dd-trace-py/commit/056f0a38c77ddd5c15b284ee3b7942ddfe796d76) | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/unittest/patch.py#L422) — git log --diff-filter=A --follow on this integration file yields a single first-add commit the linked commit dated 2023-08-28 'feat(unittest): add unittest support for test visibility (#6559)', which introduces the working instrumentation (not just autopatching). |

</details>

<details>
<summary><code>subprocess</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][schema] | Deterministic schema gate passed. |
| `name` | `subprocess` | [integration registry](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1000) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1000) — Registry row 'integration_name: subprocess' is the canonical integration identity.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/subprocess/patch.py#L65) — patch() imports and wraps the stdlib 'subprocess' module (Popen.__init__/wait), matching the name. |
| `display_name` | `Subprocess` | Established tracer source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/subprocess/__init__.py#L2) — Module docstring refers to 'The subprocess integration'; 'Subprocess' is the correctly capitalized human-facing name of the stdlib subprocess module. |
| `description` | `Instruments child-process creation and execution for command tracing and security inspection, and propagates runtime lineage context to children.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/subprocess/patch.py#L567) — Popen.__init__ / wait / os.system / os.fork / os._spawnvef are wrapped and open a 'command_execution' span with the resolved binary, covering child-process creation and execution.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/subprocess/patch.py#L459) — SubprocessCommandEvent is dispatched and command lines are scrubbed (scrub_arguments/scrub_env_vars) for ASM security inspection.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/subprocess/patch.py#L552) — Popen.__init__ merges get_runtime_propagation_envs() into the child env so exec-based children inherit runtime lineage context. |
| `packages` | `[]` | [registry identity and `dependency_names`](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1000) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1001) — Registry marks subprocess is_external_package: false; it instruments the Python stdlib subprocess/os modules, so an empty packages array is correct. |
| `category: task.execution` | `task.execution` | [Manifest category policy][category-policy] · [canonical member definition][category-task-execution] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/subprocess/patch.py#L489) — os.fork / os._spawnvef / os.system / Popen are wrapped to spawn and execute a child-process unit inside a deliberately instrumented 'command_execution' span boundary, matching task.execution ('spawns, or executes ... a direct task ... unit'); its reject_when (durable workflow, broker, FaaS, context-injection-only) does not apply. cli.internal is excluded because its reject_when covers targets that only launch another process. |
| `systems` | `[]` | [Manifest system publication policy][system-policy] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/subprocess/patch.py#L567) — The span resource is the runtime-arbitrary command binary (shellcmd.binary); the integration wraps generic OS process execution with no concrete, statically bounded system/protocol/provider identity, so systems: [] is affirmatively grounded. |
| `creation_date` | `2023-06-13` | [first commit adding working instrumentation](https://github.com/DataDog/dd-trace-py/commit/5ee7e7ab6cb20a8a20faf0d782ec3d4f0ade69ad) | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/subprocess/patch.py#L51) — git log --diff-filter=A shows the earliest add of the subprocess integration (originally ddtrace/contrib/subprocess/patch.py, constants.py, __init__.py) is commit the linked commit, author date 2023-06-13, subject 'feat(asm): trace subprocess executions (#5803)', which introduces working instrumentation rather than mere wiring/relocation. |

</details>

<details>
<summary><code>urllib</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][schema] | Deterministic schema gate passed. |
| `name` | `urllib` | [integration registry](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1018) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1018) — Registry row 'integration_name: urllib' with is_external_package: false, distinct from the separate 'urllib3' row at line 1022.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/urllib/patch.py#L26) — The integration lives at ddtrace/contrib/internal/urllib and patches urllib.request.urlopen, confirming 'urllib' is the canonical integration, not urllib3. |
| `display_name` | `urllib` | Established tracer source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/urllib/__init__.py#L2) — Docstring refers to 'the standard library ``urllib.request`` library'; the stdlib module/import name is the lowercase 'urllib', matching the display_name spelling.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1018) — Registry integration_name 'urllib' matches the display_name capitalization. |
| `description` | `Instruments outbound HTTP requests through urllib.request for SSRF vulnerability detection, exploit prevention, and response analysis.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/urllib/patch.py#L26) — patch() wraps urllib.request.urlopen with the ASM SSRF wrapper, confirming instrumentation of outbound HTTP requests through urllib.request.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/urllib/__init__.py#L4) — Docstring states the integration traces urllib.request 'to trace HTTP requests and detect SSRF vulnerabilities', supporting the SSRF detection and exploit-prevention (IAST/ASM) claims.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/appsec/_common_module_patches.py#L301) — Wrapper inspects response status_code/headers/body and issues a SSRF_RES WAF callback (lines 301-311), grounding the 'response analysis' claim; line 280 gates on the 'ssrf' RASP capability for exploit prevention. |
| `packages` | `[]` | [registry identity and `dependency_names`](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1018) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1019) — The urllib row has is_external_package: false and no dependency_names, i.e. a stdlib integration for which empty packages is valid.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/urllib/patch.py#L1) — patch.py imports the built-in urllib.request; no third-party distribution activates the integration. |
| `category: http.client` | `http.client` | [Manifest category policy][category-policy] · [canonical member definition][category-http-client] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/appsec/_common_module_patches.py#L291) — Wrapper reads the request URL (args[1]/kwargs['url']) and analyzes response status/headers (lines 301-305), matching http.client positive_concepts (URL/URI, response status) for the outbound-request boundary; reject_when (private transport for a more specific contract) does not apply since generic HTTP is the contract. |
| `systems` | `[]` | [Manifest system publication policy][system-policy] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/appsec/_common_module_patches.py#L291) — The wrapped urlopen sends to a runtime-supplied URL with no statically bounded database, messaging, provider, or RPC system identity; per x-system-applicability the array is empty when no concrete identity is established. |
| `creation_date` | `2024-05-13` | [first commit adding working instrumentation](https://github.com/DataDog/dd-trace-py/commit/2ac33639667f4025dee8c379a9e5c8a47ce2fc8d) | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/urllib/patch.py#L17) — The urllib integration's patch() SSRF instrumentation; git first-add of ddtrace/contrib/urllib/__init__.py and patch.py is commit the linked commit, 'chore(asm): add SSRF support for urllib.request (#9224)', author date 2024-05-13, which introduces the working instrumentation (later commits only move it to internal). |

</details>

<details>
<summary><code>webbrowser</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][schema] | Deterministic schema gate passed. |
| `name` | `webbrowser` | [integration registry](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1076) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/webbrowser/patch.py#L26) — patch() wraps 'webbrowser'.'open' via wrap_function_wrapper, confirming a dedicated integration named webbrowser rooted at ddtrace/contrib/internal/webbrowser/.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/webbrowser/__init__.py#L2) — Module docstring identifies this as tracing the standard library webbrowser library; the canonical integration name is webbrowser, not a helper or neighbor. |
| `display_name` | `Webbrowser` | Established tracer source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/webbrowser/__init__.py#L2) — Source names the single-word stdlib module 'webbrowser'; 'Webbrowser' is its natural display capitalization with no competing canonical spelling (no 'WebBrowser'/'Web Browser') present in source. |
| `description` | `Instruments Python's webbrowser URL-opening operation to detect and help prevent server-side request forgery vulnerabilities in applications.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/webbrowser/patch.py#L26) — The only wrapped boundary is webbrowser.open (URL-opening), routed through the appsec SSRF request wrapper wrapped_request_D8CB81E472AF98A2.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/appsec/_iast/taint_sinks/ssrf.py#L28) — webbrowser is registered as an SSRF sink (url argument at index 0), supporting the 'detect ... SSRF' claim via IAST.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/appsec/_common_module_patches.py#L113) — The wrapper raises BlockingException on SSRF exploit-prevention WAF decisions, supporting the 'help prevent SSRF' claim via ASM/RASP; description covers the single boundary at operation-family grain. |
| `packages` | `[]` | [registry identity and `dependency_names`](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1076) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/webbrowser/patch.py#L1) — The integration imports and patches the Python standard-library 'webbrowser' module (no third-party distribution), so an empty packages list is correct for a stdlib integration.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/webbrowser/patch.py#L14) — _supported_versions returns {'webbrowser': '*'}, a stdlib module with no PyPI distribution to bind. |
| `category: other` | `other` | [Manifest category policy][category-policy] · [canonical member definition][category-other] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/webbrowser/patch.py#L26) — The only instrumented boundary is a security wrap of webbrowser.open for SSRF detection/prevention; it emits no first-class APM operation span. webbrowser.open launches a browser rather than sending an outbound HTTP request through a client API, so http.client (and every other admitted category) rejects. A completed review finds behavior but no admitted category fits, so exclusive lowercase 'other' applies. |
| `systems` | `[]` | [Manifest system publication policy][system-policy] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/appsec/_common_module_patches.py#L291) — The wrapped webbrowser.open takes an arbitrary runtime URL (url = args/kwargs) with no statically bounded backend, database, RPC protocol, cloud provider, or admitted OTel system identity; no x-system-definitions member qualifies, so systems: [] is affirmatively grounded. |
| `creation_date` | `2024-05-13` | [first commit adding working instrumentation](https://github.com/DataDog/dd-trace-py/commit/78f361ac2384ac7bfe5b0621e74c3d2834bec43c) | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/webbrowser/patch.py#L1) — git --no-pager log --follow --diff-filter=A on this integration file resolves the first-add to commit the linked commit 'chore(asm): add SSRF support for webbrowser.open (#9209)', author date 2024-05-13. The subject/diff introduces working SSRF instrumentation for webbrowser.open (not a mere move/registration), and the date equals the manifest creation_date. |

</details>

<details>
<summary><code>azure_eventhubs</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][schema] | Deterministic schema gate passed. |
| `name` | `azure_eventhubs` | [integration registry](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L176) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_eventhubs/__init__.py#L19) — config._add("azure_eventhubs", ...) registers the integration under this exact canonical name.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_monkey.py#L164) — "azure_eventhubs": ("azure.eventhub",) maps the integration name to the azure.eventhub import, confirming identity (not a helper or neighbor). |
| `display_name` | `Azure Event Hubs` | Established tracer source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_eventhubs/__init__.py#L2) — Module docstring: 'traces all events sent by the Azure Event Hubs client.' matches the exact product spelling/capitalization. |
| `description` | `Instruments synchronous and asynchronous Azure Event Hubs producer operations for creating and sending events, with distributed context propagation and batch span links.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_eventhubs/patch.py#L50) — Both azure.eventhub (sync) and azure.eventhub.aio (async) EventHubProducerClient are patched (loop over both modules; async branch at line 50), grounding 'synchronous and asynchronous ... producer'.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_eventhubs/patch.py#L63) — create_batch and send_event/send_batch wrappers use CREATE and SEND operation names, grounding 'creating and sending events'.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_eventhubs/utils.py#L82) — HTTPPropagator.inject injects trace context into event properties (distributed context propagation), gated on distributed_tracing config.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_eventhubs/utils.py#L64) — span.link_span(parent_context) adds span links for events inside an EventDataBatch (batch span links), gated on batch_links config; no consumer/receive behavior is instrumented, so producer-only scope is accurate and complete. |
| `packages` | [`azure-eventhub`] | [registry identity and `dependency_names`](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L176) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_eventhubs/patch.py#L1) — import azure.eventhub as azure_eventhub — the integration patches the azure.eventhub module, whose PyPI distribution is azure-eventhub.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_eventhubs/__init__.py#L33) — _supported_versions returns {"azure.eventhub": ">=5.12.0"}, confirming the azure-eventhub distribution activates the integration. |
| `category: messaging.producer` | `messaging.producer` | [Manifest category policy][category-policy] · [canonical member definition][category-messaging-producer] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_eventhubs/patch.py#L64) — Wraps EventHubProducerClient.send_event/send_batch (SEND) and create_batch/EventDataBatch.add (CREATE) on the producer side only — matches messaging.producer definition ('Creates, publishes, or sends messages as a producer'); no receive/consume path is instrumented (RECEIVE constant unused), so messaging.consumer's reject_when does not apply and no other category fits. |
| `systems: eventhubs` | `eventhubs` | [Manifest system policy][system-policy] · [canonical member definition][system-eventhubs] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/ext/azure_eventhubs.py#L2) — SERVICE = "eventhubs" and CLOUD = "azure" — the integration is a dedicated, statically bounded Azure Event Hubs client, matching the schema's 'eventhubs' (Azure Event Hubs messaging.system) definition. |
| `creation_date` | `2025-10-09` | [first commit adding working instrumentation](https://github.com/DataDog/dd-trace-py/commit/b88a06d00d574b39ba4b218e0019f3f4009174c9) | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_eventhubs/patch.py#L36) — First-add commit the linked commit (git log --diff-filter=A) 'feat(azure_eventhubs): add azure eventhubs integration (#14636)', author date 2025-10-09, introduces this patch.py with working instrumentation (not merely autopatch/registration); date equals manifest creation_date. |

</details>

<details>
<summary><code>azure_servicebus</code> — accepted field evidence</summary>

| Field or member | Published value | Derivation authority | Accepted evidence |
|---|---|---|---|
| `_v` | `1` | [canonical manifest schema][schema] | Deterministic schema gate passed. |
| `name` | `azure_servicebus` | [integration registry](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L196) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_servicebus/patch.py#L40) — The internal contrib module azure_servicebus patches azure.servicebus modules; config._add key is 'azure_servicebus' (line 18). |
| `display_name` | `Azure Service Bus` | Established tracer source spelling | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_servicebus/patch.py#L50) — Patches the public azure.servicebus API classes ServiceBusSender/ServiceBusMessageBatch, whose 'Service Bus' product spelling with the 'azure' cloud prefix (ext constant CLOUD='azure') yields the product display name 'Azure Service Bus'.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/ext/azure_servicebus.py#L1) — CLOUD='azure' and SERVICE='servicebus' confirm the Azure Service Bus product identity spelling. |
| `description` | `Instruments synchronous and asynchronous Azure Service Bus message production, including immediate and scheduled sends, distributed trace propagation, and batch span links.` | Complete Datadog patch-surface inventory | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_servicebus/patch.py#L36) — patch() wraps both azure.servicebus (sync) and azure.servicebus.aio (async) modules, grounding 'synchronous and asynchronous'.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_servicebus/patch.py#L107) — send_messages (immediate) and schedule_messages (scheduled, line 143) are wrapped on ServiceBusSender — producer-side 'immediate and scheduled sends'.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_servicebus/utils.py#L77) — inject_context injects HTTP propagation headers into message.application_properties (gated by distributed_tracing), grounding 'distributed trace propagation'.<br>[source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_servicebus/utils.py#L64) — For a ServiceBusMessageBatch, extracted parent context is added via span.link_span (gated by batch_links config), grounding 'batch span links'. |
| `packages` | [`azure-servicebus`] | [registry identity and `dependency_names`](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L196) | [source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_servicebus/patch.py#L1) — Imports 'import azure.servicebus', the import namespace provided by the azure-servicebus distribution. |
| `category: messaging.producer` | `messaging.producer` | [Manifest category policy][category-policy] · [canonical member definition][category-messaging-producer] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_servicebus/patch.py#L59) — All wrapped boundaries are producer-side ServiceBusSender.send_messages/schedule_messages/create_message_batch and ServiceBusMessageBatch.add_message; no receive/consumer wrapping exists (the RECEIVE ext constant is unused), so messaging.producer applies and messaging.consumer is correctly absent. |
| `systems: servicebus` | `servicebus` | [Manifest system policy][system-policy] · [canonical member definition][system-servicebus] | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/ext/azure_servicebus.py#L2) — SERVICE='servicebus' with CLOUD='azure' fixes a concrete, statically bounded Azure Service Bus messaging identity; the patch is dedicated to azure.servicebus, matching the schema 'servicebus' definition (messaging.system=servicebus). |
| `creation_date` | `2025-06-26` | [first commit adding working instrumentation](https://github.com/DataDog/dd-trace-py/commit/dcfc159261af08cb6119fb0fc36f4028b31a2c6b) | [instrumentation source](https://github.com/DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/azure_servicebus/patch.py#L35) — First-add commit the linked commit (2025-06-26) 'feat(azure_servicebus): add azure servicebus integration and function trigger distributed tracing (#13691)' introduces the working instrumentation in this file; it is the oldest commit for the integration directory, not a mere autopatch/registry wiring commit. |

</details>

## Testing

- Common tracer source: `DataDog/dd-trace-py@5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6`
- Generation gates: schema, offline grounding, and independent semantic review passed for all ten manifests. Workspace-integrity checks passed for the seven complete run records; see Additional Notes for the three recovered historical artifacts.
- Exact installed-file validation: `manifest-validate --grounding python` passed for all ten installed manifest paths, with no findings.
- Mapped tracer suites: `scripts/run-tests` discovery selected nine pinned environments. Execution was attempted, but prolonged Docker-layer setup was interrupted while preparing the first environment; 0 tests executed. `ci_visibility::ci_visibility` (Python 3.13) reached environment preparation; `ci_visibility::pytest` (Python 3.13), `ci_visibility::pytest_bdd` (Python 3.14), `ci_visibility::pytest_benchmark` (Python 3.14), `ci_visibility::unittest` (Python 3.14), `contrib::azure_eventhubs` (Python 3.13), `contrib::azure_servicebus` (Python 3.14), `contrib::subprocess` (Python 3.14), and `appsec::urllib` (Python 3.14) were not reached. The skipped `appsec::webbrowser` suite has no runnable environment.
- `scripts/lint checks`: passed.
- `git diff --check`: passed.

## Risks

The added YAML is declarative metadata and introduces no runtime instrumentation or public API change. Metadata can become stale if later instrumentation changes do not update its manifest. Source-distribution packaging behavior is unchanged.

[schema]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L19
[category-policy]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/docs/category-taxonomy/manifest-publication-policy.md#L15
[system-policy]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/docs/category-taxonomy/manifest-publication-policy.md#L76
[category-http-client]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L148
[category-messaging-producer]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L190
[category-other]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L204
[category-task-execution]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L232
[category-test-execution]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L246
[system-eventhubs]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L462
[system-servicebus]: https://github.com/ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L701
