### PR TITLE
chore(integrations): backfill messaging, cache, and protocol manifests

### DIFF
--- a/ddtrace/contrib/internal/aredis/aredis.manifest.yaml
+++ b/ddtrace/contrib/internal/aredis/aredis.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: aredis
+display_name: aredis
+description: Instruments asynchronous Redis command and pipeline execution through aredis clients, recording command text
+  and connection metadata.
+packages:
+- name: aredis
+category:
+- db.client
+systems:
+- redis
+creation_date: '2021-10-06'

--- a/ddtrace/contrib/internal/avro/avro.manifest.yaml
+++ b/ddtrace/contrib/internal/avro/avro.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: avro
+display_name: Avro
+description: Instruments Avro serialization and deserialization to attach schema metadata and sampled schema definitions to
+  active spans for Data Streams Monitoring.
+packages:
+- name: avro
+category:
+- other
+systems: []
+creation_date: '2024-09-10'

--- a/ddtrace/contrib/internal/celery/celery.manifest.yaml
+++ b/ddtrace/contrib/internal/celery/celery.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: celery
+display_name: Celery
+description: Instruments Celery task publication, worker execution, and beat scheduling, with task metadata, errors, and optional
+  distributed trace propagation.
+packages:
+- name: celery
+category:
+- messaging.consumer
+- messaging.producer
+systems: []
+creation_date: '2017-02-15'

--- a/ddtrace/contrib/internal/dogpile_cache/dogpile_cache.manifest.yaml
+++ b/ddtrace/contrib/internal/dogpile_cache/dogpile_cache.manifest.yaml
@@ -1,0 +1,13 @@
+_v: 1
+name: dogpile_cache
+display_name: dogpile.cache
+description: Instruments dogpile.cache single- and multi-key cache lookups and population, recording backend, hit, and expiration
+  details.
+packages:
+- name: dogpile-cache
+- name: dogpile.cache
+- name: dogpile_cache
+category:
+- db.client
+systems: []
+creation_date: '2019-12-04'

--- a/ddtrace/contrib/internal/dramatiq/dramatiq.manifest.yaml
+++ b/ddtrace/contrib/internal/dramatiq/dramatiq.manifest.yaml
@@ -1,0 +1,10 @@
+_v: 1
+name: dramatiq
+display_name: Dramatiq
+description: Instruments sending Dramatiq actor tasks to brokers, tracing enqueue calls without tracing background task execution.
+packages:
+- name: dramatiq
+category:
+- messaging.producer
+systems: []
+creation_date: '2024-03-27'

--- a/ddtrace/contrib/internal/flask_cache/flask_cache.manifest.yaml
+++ b/ddtrace/contrib/internal/flask_cache/flask_cache.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: flask_cache
+display_name: Flask Cache
+description: Instruments cache reads, writes, additions, deletions, clears, and bulk operations through Flask-Cache and Flask-Caching
+  APIs.
+packages:
+- name: flask-cache
+- name: flask-caching
+category:
+- db.client
+systems: []
+creation_date: '2016-08-18'

--- a/ddtrace/contrib/internal/google_cloud_pubsub/google_cloud_pubsub.manifest.yaml
+++ b/ddtrace/contrib/internal/google_cloud_pubsub/google_cloud_pubsub.manifest.yaml
@@ -1,0 +1,14 @@
+_v: 1
+name: google_cloud_pubsub
+display_name: Google Cloud Pub/Sub
+description: Instruments Google Cloud Pub/Sub message publishing and consumption, including pull and push delivery, plus topic,
+  subscription, and schema administration.
+packages:
+- name: google-cloud-pubsub
+category:
+- messaging.consumer
+- messaging.producer
+- rpc.client
+systems:
+- gcp.pubsub
+creation_date: '2026-03-17'

--- a/ddtrace/contrib/internal/graphql/graphql.manifest.yaml
+++ b/ddtrace/contrib/internal/graphql/graphql.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: graphql
+display_name: GraphQL
+description: Instruments graphql-core GraphQL request parsing, validation, operation execution, and optional field resolution
+  with error details.
+packages:
+- name: graphql-core
+category:
+- graphql.server
+systems: []
+creation_date: '2022-07-29'

--- a/ddtrace/contrib/internal/grpc/grpc.manifest.yaml
+++ b/ddtrace/contrib/internal/grpc/grpc.manifest.yaml
@@ -1,0 +1,13 @@
+_v: 1
+name: grpc
+display_name: gRPC
+description: Instruments synchronous and asynchronous gRPC client calls and server handlers, including unary and streaming
+  RPCs.
+packages:
+- name: grpcio
+category:
+- rpc.client
+- rpc.server
+systems:
+- grpc
+creation_date: '2018-10-19'

--- a/ddtrace/contrib/internal/kafka/kafka.manifest.yaml
+++ b/ddtrace/contrib/internal/kafka/kafka.manifest.yaml
@@ -1,0 +1,13 @@
+_v: 1
+name: kafka
+display_name: Kafka
+description: Instruments confluent-kafka message production and consumption with tracing, context propagation, Data Streams
+  Monitoring, and consumer offset tracking.
+packages:
+- name: confluent-kafka
+category:
+- messaging.consumer
+- messaging.producer
+systems:
+- kafka
+creation_date: '2023-03-28'

--- a/ddtrace/contrib/internal/kombu/kombu.manifest.yaml
+++ b/ddtrace/contrib/internal/kombu/kombu.manifest.yaml
@@ -8,6 +8,5 @@ packages:
 category:
 - messaging.consumer
 - messaging.producer
-systems:
-- rabbitmq
+systems: []
 creation_date: '2018-11-06'

--- a/ddtrace/contrib/internal/kombu/kombu.manifest.yaml
+++ b/ddtrace/contrib/internal/kombu/kombu.manifest.yaml
@@ -1,0 +1,13 @@
+_v: 1
+name: kombu
+display_name: Kombu
+description: Instruments Kombu message publishing and consumer processing, including distributed trace propagation and data-stream
+  pathway checkpoints.
+packages:
+- name: kombu
+category:
+- messaging.consumer
+- messaging.producer
+systems:
+- rabbitmq
+creation_date: '2018-11-06'

--- a/ddtrace/contrib/internal/protobuf/protobuf.manifest.yaml
+++ b/ddtrace/contrib/internal/protobuf/protobuf.manifest.yaml
@@ -1,0 +1,11 @@
+_v: 1
+name: protobuf
+display_name: Protobuf
+description: Instruments Google Protobuf message serialization and deserialization to attach sampled schema definitions and
+  metadata to active spans.
+packages:
+- name: protobuf
+category:
+- other
+systems: []
+creation_date: '2024-09-12'

--- a/ddtrace/contrib/internal/pylibmc/pylibmc.manifest.yaml
+++ b/ddtrace/contrib/internal/pylibmc/pylibmc.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: pylibmc
+display_name: pylibmc
+description: Instruments pylibmc client operations against Memcached, tracing single-key and multi-key cache reads, writes,
+  mutations, and deletions.
+packages:
+- name: pylibmc
+category:
+- db.client
+systems:
+- memcached
+creation_date: '2016-09-16'

--- a/ddtrace/contrib/internal/pymemcache/pymemcache.manifest.yaml
+++ b/ddtrace/contrib/internal/pymemcache/pymemcache.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: pymemcache
+display_name: pymemcache
+description: Instruments pymemcache client cache commands sent to Memcached, including reads, writes, mutations, administrative
+  operations, and errors.
+packages:
+- name: pymemcache
+category:
+- db.client
+systems:
+- memcached
+creation_date: '2018-08-06'

--- a/ddtrace/contrib/internal/redis/redis.manifest.yaml
+++ b/ddtrace/contrib/internal/redis/redis.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: redis
+display_name: Redis
+description: Instruments synchronous and asynchronous Redis command and pipeline execution across standalone and clustered
+  redis-py clients.
+packages:
+- name: redis
+category:
+- db.client
+systems:
+- redis
+creation_date: '2016-06-27'

--- a/ddtrace/contrib/internal/rediscluster/rediscluster.manifest.yaml
+++ b/ddtrace/contrib/internal/rediscluster/rediscluster.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: rediscluster
+display_name: redis-py-cluster
+description: Instruments Redis Cluster client commands and clustered pipeline execution performed through the redis-py-cluster
+  Python library.
+packages:
+- name: redis-py-cluster
+category:
+- db.client
+systems:
+- redis
+creation_date: '2018-10-03'

--- a/ddtrace/contrib/internal/rq/rq.manifest.yaml
+++ b/ddtrace/contrib/internal/rq/rq.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: rq
+display_name: RQ
+description: Instruments RQ job enqueueing, fetching, and execution across queues and workers, including distributed trace
+  context propagation.
+packages:
+- name: rq
+category:
+- messaging.consumer
+- messaging.producer
+systems: []
+creation_date: '2021-09-16'

--- a/ddtrace/contrib/internal/valkey/valkey.manifest.yaml
+++ b/ddtrace/contrib/internal/valkey/valkey.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: valkey
+display_name: Valkey
+description: Instruments synchronous and asynchronous Valkey client command and pipeline execution across standalone and clustered
+  connections.
+packages:
+- name: valkey
+category:
+- db.client
+systems:
+- valkey
+creation_date: '2025-02-05'

--- a/ddtrace/contrib/internal/yaaredis/yaaredis.manifest.yaml
+++ b/ddtrace/contrib/internal/yaaredis/yaaredis.manifest.yaml
@@ -1,0 +1,12 @@
+_v: 1
+name: yaaredis
+display_name: yaaredis
+description: Instruments asynchronous Redis command and pipeline execution through yaaredis clients, capturing command resources,
+  connection details, and result metrics.
+packages:
+- name: yaaredis
+category:
+- db.client
+systems:
+- redis
+creation_date: '2021-11-05'


### PR DESCRIPTION
## Description

This change adds structured, machine-readable [instrumentation manifests](https://datadoghq.atlassian.net/wiki/x/vYQbrAE) for:

- Messaging and task queues: `kafka`, `kombu`, `celery`, `dramatiq`, `rq`, and `google_cloud_pubsub`
- Redis-compatible clients: `aredis`, `redis`, `rediscluster`, `valkey`, and `yaaredis`
- Cache clients: `dogpile_cache`, `flask_cache`, `pylibmc`, and `pymemcache`
- Serialization and RPC protocols: `avro`, `graphql`, `grpc`, and `protobuf`

This is declarative metadata only. Runtime instrumentation and public APIs are unchanged.

Detailed field-level review evidence for every manifest is provided below.
It has the same information as the changed file, so reviewing this description is enough to understand the changes being proposed.

| Integration | Categories | Systems | Creation date |
|---|---|---|---|
| `kafka` | `messaging.consumer`, `messaging.producer` | `kafka` | 2023-03-28 |
| `kombu` | `messaging.consumer`, `messaging.producer` | none | 2018-11-06 |
| `celery` | `messaging.consumer`, `messaging.producer` | none | 2017-02-15 |
| `dramatiq` | `messaging.producer` | none | 2024-03-27 |
| `rq` | `messaging.consumer`, `messaging.producer` | none | 2021-09-16 |
| `google_cloud_pubsub` | `messaging.consumer`, `messaging.producer`, `rpc.client` | `gcp.pubsub` | 2026-03-17 |
| `aredis` | `db.client` | `redis` | 2021-10-06 |
| `redis` | `db.client` | `redis` | 2016-06-27 |
| `rediscluster` | `db.client` | `redis` | 2018-10-03 |
| `valkey` | `db.client` | `valkey` | 2025-02-05 |
| `yaaredis` | `db.client` | `redis` | 2021-11-05 |
| `dogpile_cache` | `db.client` | none | 2019-12-04 |
| `flask_cache` | `db.client` | none | 2016-08-18 |
| `pylibmc` | `db.client` | `memcached` | 2016-09-16 |
| `pymemcache` | `db.client` | `memcached` | 2018-08-06 |
| `avro` | `other` | none | 2024-09-10 |
| `graphql` | `graphql.server` | none | 2022-07-29 |
| `grpc` | `rpc.client`, `rpc.server` | `grpc` | 2018-10-19 |
| `protobuf` | `other` | none | 2024-09-12 |

### Field-level review evidence

Taxonomy links define the publication labels. Tracer links show the instrumented behavior that satisfies those definitions. Tracer links are pinned to the reviewed source revision. Taxonomy links use the generator revision identified in Additional Notes as a review reference.

<details>
<summary><code>kafka</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `kafka` | [_monkey.py:169][s1] · [patch.py:5][s2] — Canonical identity. |
| `display_name`: `Kafka` | [__init__.py:2][s3] · [kafka.py:1][s4] — Established spelling. |
| `description`: `Instruments confluent-kafka message production and consumption with tracing, context propagation, Data Streams Monitoring, and consumer offset tracking.` | [patch.py:134][s5] · [patch.py:234][s6] · [kafka.py:156][s7] · [kafka.py:145][s8] — Sources cover every described operation. |
| `packages`: `confluent-kafka` | [_monkey.py:169][s1] · [patch.py:63][s9] — Registry binding and activation. |
| `category: messaging.consumer`: `messaging.consumer` | [policy][tax-cat] · [schema][s11] · [patch.py:274][s10] — Qualifies as `messaging.consumer`. |
| `category: messaging.producer`: `messaging.producer` | [policy][tax-cat] · [schema][s13] · [patch.py:197][s12] — Qualifies as `messaging.producer`. |
| `systems: kafka`: `kafka` | [policy][tax-sys] · [schema][s14] · [kafka.py:1][s4] — Statically bounded to `kafka`. |
| `creation_date`: `2023-03-28` | [commit][c15] · [patch.py:121][s16] — First working instrumentation: `2023-03-28`. |

</details>

<details>
<summary><code>kombu</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `kombu` | [patch.py:72][s17] · [patch.py:2][s18] — Canonical identity. |
| `display_name`: `Kombu` | [__init__.py:3][s19] — Established spelling. |
| `description`: `Instruments Kombu message publishing and consumer processing, including distributed trace propagation and data-stream pathway checkpoints.` | [patch.py:138][s20] · [patch.py:105][s21] · [patch.py:164][s22] · [kombu.py:40][s23] — Sources cover every described operation. |
| `packages`: `kombu` | [patch.py:37][s24] — Registry binding and activation. |
| `category: messaging.consumer`: `messaging.consumer` | [policy][tax-cat] · [schema][s11] · [patch.py:116][s25] — Qualifies as `messaging.consumer`. |
| `category: messaging.producer`: `messaging.producer` | [policy][tax-cat] · [schema][s13] · [patch.py:144][s26] — Qualifies as `messaging.producer`. |
| `systems`: `[]` | [policy][tax-sys] · [patch.py:72][s17] — No qualifying statically bounded system. |
| `creation_date`: `2018-11-06` | [commit][c29] · [patch.py:57][s30] — First working instrumentation: `2018-11-06`. |

</details>

<details>
<summary><code>celery</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `celery` | [patch.py:40][s31] — Canonical identity. |
| `display_name`: `Celery` | [patch.py:1][s32] — Established spelling. |
| `description`: `Instruments Celery task publication, worker execution, and beat scheduling, with task metadata, errors, and optional distributed trace propagation.` | [signals.py:134][s33] · [app.py:48][s34] · [utils.py:58][s35] · [signals.py:249][s36] · [patch.py:17][s37] — Sources cover every described operation. |
| `packages`: `celery` | [patch.py:31][s38] — Registry binding and activation. |
| `category: messaging.consumer`: `messaging.consumer` | [policy][tax-cat] · [schema][s11] · [signals.py:62][s39] — Qualifies as `messaging.consumer`. |
| `category: messaging.producer`: `messaging.producer` | [policy][tax-cat] · [schema][s13] · [signals.py:143][s40] — Qualifies as `messaging.producer`. |
| `systems`: `[]` | [policy][tax-sys] · [signals.py:189][s41] — No qualifying statically bounded system. |
| `creation_date`: `2017-02-15` | [commit][c42] · [patch.py:34][s43] — First working instrumentation: `2017-02-15`. |

</details>

<details>
<summary><code>dramatiq</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `dramatiq` | [registry.yaml:332][s44] · [patch.py:4][s45] — Canonical identity. |
| `display_name`: `Dramatiq` | [__init__.py:4][s46] — Established spelling. |
| `description`: `Instruments sending Dramatiq actor tasks to brokers, tracing enqueue calls without tracing background task execution.` | [patch.py:32][s47] · [patch.py:53][s48] — Sources cover every described operation. |
| `packages`: `dramatiq` | [registry.yaml:335][s49] — Registry binding and activation. |
| `category: messaging.producer`: `messaging.producer` | [policy][tax-cat] · [schema][s13] · [patch.py:69][s50] — Qualifies as `messaging.producer`. |
| `systems`: `[]` | [policy][tax-sys] · [patch.py:32][s47] — No qualifying statically bounded system. |
| `creation_date`: `2024-03-27` | [commit][c51] · [patch.py:32][s47] — First working instrumentation: `2024-03-27`. |

</details>

<details>
<summary><code>rq</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `rq` | [_monkey.py:69][s52] · [patch.py:19][s53] — Canonical identity. |
| `display_name`: `RQ` | [__init__.py:2][s54] — Established spelling. |
| `description`: `Instruments RQ job enqueueing, fetching, and execution across queues and workers, including distributed trace context propagation.` | [patch.py:51][s55] · [patch.py:91][s56] · [patch.py:110][s57] · [patch.py:86][s58] — Sources cover every described operation. |
| `packages`: `rq` | [supported_versions.json:3281][s59] · [patch.py:41][s60] — Registry binding and activation. |
| `category: messaging.consumer`: `messaging.consumer` | [policy][tax-cat] · [schema][s11] · [patch.py:127][s61] — Qualifies as `messaging.consumer`. |
| `category: messaging.producer`: `messaging.producer` | [policy][tax-cat] · [schema][s13] · [patch.py:76][s62] — Qualifies as `messaging.producer`. |
| `systems`: `[]` | [policy][tax-sys] · [patch.py:197][s63] — No qualifying statically bounded system. |
| `creation_date`: `2021-09-16` | [commit][c64] · [patch.py:1][s65] — First working instrumentation: `2021-09-16`. |

</details>

<details>
<summary><code>google_cloud_pubsub</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `google_cloud_pubsub` | [patch.py:5][s66] · [_monkey.py:171][s67] — Canonical identity. |
| `display_name`: `Google Cloud Pub/Sub` | [__init__.py:2][s68] — Established spelling. |
| `description`: `Instruments Google Cloud Pub/Sub message publishing and consumption, including pull and push delivery, plus topic, subscription, and schema administration.` | [patch.py:183][s69] · [patch.py:186][s70] · [trace_handlers.py:298][s71] — Sources cover every described operation. |
| `packages`: `google-cloud-pubsub` | [patch.py:75][s72] — Registry binding and activation. |
| `category: messaging.consumer`: `messaging.consumer` | [policy][tax-cat] · [schema][s11] · [trace_handlers.py:288][s73] — Qualifies as `messaging.consumer`. |
| `category: messaging.producer`: `messaging.producer` | [policy][tax-cat] · [schema][s13] · [trace_handlers.py:1535][s74] — Qualifies as `messaging.producer`. |
| `category: rpc.client`: `rpc.client` | [policy][tax-cat] · [schema][s76] · [trace_handlers.py:1525][s75] — Qualifies as `rpc.client`. |
| `systems: gcp.pubsub`: `gcp.pubsub` | [policy][tax-sys] · [schema][s78] · [trace_handlers.py:290][s77] — Statically bounded to `gcp.pubsub`. |
| `creation_date`: `2026-03-17` | [commit][c79] · [patch.py:1][s80] — First working instrumentation: `2026-03-17`. |

</details>

<details>
<summary><code>aredis</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `aredis` | [patch.py:1][s81] · [_monkey.py:30][s82] — Canonical identity. |
| `display_name`: `aredis` | [__init__.py:2][s83] — Established spelling. |
| `description`: `Instruments asynchronous Redis command and pipeline execution through aredis clients, recording command text and connection metadata.` | [patch.py:42][s84] · [patch.py:59][s85] · [redis_utils.py:139][s86] · [redis_utils.py:81][s87] — Sources cover every described operation. |
| `packages`: `aredis` | [patch.py:1][s81] — Registry binding and activation. |
| `category: db.client`: `db.client` | [policy][tax-cat] · [schema][s89] · [redis_utils.py:137][s88] — Qualifies as `db.client`. |
| `systems: redis`: `redis` | [policy][tax-sys] · [schema][s91] · [redis.py:2][s90] — Statically bounded to `redis`. |
| `creation_date`: `2021-10-06` | [commit][c92] · [patch.py:34][s93] — First working instrumentation: `2021-10-06`. |

</details>

<details>
<summary><code>redis</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `redis` | [patch.py:19][s94] · [patch.py:33][s95] — Canonical identity. |
| `display_name`: `Redis` | [patch.py:53][s96] — Established spelling. |
| `description`: `Instruments synchronous and asynchronous Redis command and pipeline execution across standalone and clustered redis-py clients.` | [patch.py:53][s96] · [patch.py:59][s97] · [asyncio_patch.py:8][s98] — Sources cover every described operation. |
| `packages`: `redis` | [patch.py:1][s99] — Registry binding and activation. |
| `category: db.client`: `db.client` | [policy][tax-cat] · [schema][s89] · [redis_utils.py:137][s88] — Qualifies as `db.client`. |
| `systems: redis`: `redis` | [policy][tax-sys] · [schema][s91] · [redis.py:2][s90] — Statically bounded to `redis`. |
| `creation_date`: `2016-06-27` | [commit][c100] · [patch.py:36][s101] — First working instrumentation: `2016-06-27`. |

</details>

<details>
<summary><code>rediscluster</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `rediscluster` | [registry.yaml:910][s102] · [patch.py:2][s103] — Canonical identity. |
| `display_name`: `redis-py-cluster` | [registry.yaml:914][s104] — Established spelling. |
| `description`: `Instruments Redis Cluster client commands and clustered pipeline execution performed through the redis-py-cluster Python library.` | [patch.py:57][s105] · [patch.py:81][s106] — Sources cover every described operation. |
| `packages`: `redis-py-cluster` | [registry.yaml:914][s104] — Registry binding and activation. |
| `category: db.client`: `db.client` | [policy][tax-cat] · [schema][s89] · [patch.py:96][s107] — Qualifies as `db.client`. |
| `systems: redis`: `redis` | [policy][tax-sys] · [schema][s91] · [patch.py:96][s107] · [redis.py:2][s90] — Statically bounded to `redis`. |
| `creation_date`: `2018-10-03` | [commit][c108] · [patch.py:49][s109] — First working instrumentation: `2018-10-03`. |

</details>

<details>
<summary><code>valkey</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `valkey` | [registry.yaml:1032][s110] · [patch.py:1][s111] — Canonical identity. |
| `display_name`: `Valkey` | [add-valkey-support-6cc9f41351dc0cd9.yaml:3][s112] — Established spelling. |
| `description`: `Instruments synchronous and asynchronous Valkey client command and pipeline execution across standalone and clustered connections.` | [patch.py:53][s113] · [asyncio_patch.py:9][s114] — Sources cover every described operation. |
| `packages`: `valkey` | [registry.yaml:1035][s115] · [patch.py:1][s111] — Registry binding and activation. |
| `category: db.client`: `db.client` | [policy][tax-cat] · [schema][s89] · [utils_valkey.py:38][s116] — Qualifies as `db.client`. |
| `systems: valkey`: `valkey` | [policy][tax-sys] · [schema][s118] · [utils_valkey.py:40][s117] — Statically bounded to `valkey`. |
| `creation_date`: `2025-02-05` | [commit][c119] · [patch.py:37][s120] — First working instrumentation: `2025-02-05`. |

</details>

<details>
<summary><code>yaaredis</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `yaaredis` | [registry.yaml:1084][s121] · [patch.py:2][s122] — Canonical identity. |
| `display_name`: `yaaredis` | [__init__.py:2][s123] — Established spelling. |
| `description`: `Instruments asynchronous Redis command and pipeline execution through yaaredis clients, capturing command resources, connection details, and result metrics.` | [patch.py:51][s124] · [redis_utils.py:178][s125] · [redis_utils.py:81][s87] · [redis_utils.py:62][s126] — Sources cover every described operation. |
| `packages`: `yaaredis` | [registry.yaml:1088][s127] — Registry binding and activation. |
| `category: db.client`: `db.client` | [policy][tax-cat] · [schema][s89] · [redis_utils.py:137][s88] — Qualifies as `db.client`. |
| `systems: redis`: `redis` | [policy][tax-sys] · [schema][s91] · [redis.py:2][s90] — Statically bounded to `redis`. |
| `creation_date`: `2021-11-05` | [commit][c128] · [patch.py:51][s124] — First working instrumentation: `2021-11-05`. |

</details>

<details>
<summary><code>dogpile_cache</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `dogpile_cache` | [registry.yaml:314][s129] · [_monkey.py:158][s130] — Canonical identity. |
| `display_name`: `dogpile.cache` | [patch.py:31][s131] · [__init__.py:24][s132] — Established spelling. |
| `description`: `Instruments dogpile.cache single- and multi-key cache lookups and population, recording backend, hit, and expiration details.` | [region.py:14][s133] · [region.py:35][s134] · [lock.py:36][s135] — Sources cover every described operation. |
| `packages`: `dogpile-cache`, `dogpile.cache`, `dogpile_cache` | [registry.yaml:318][s136] · [patch.py:2][s137] — Registry binding and activation. |
| `category: db.client`: `db.client` | [policy][tax-cat] · [schema][s89] · [region.py:20][s138] — Qualifies as `db.client`. |
| `systems`: `[]` | [policy][tax-sys] · [region.py:29][s139] — No qualifying statically bounded system. |
| `creation_date`: `2019-12-04` | [commit][c140] · [region.py:14][s133] — First working instrumentation: `2019-12-04`. |

</details>

<details>
<summary><code>flask_cache</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `flask_cache` | [registry.yaml:410][s141] · [patch.py:52][s142] — Canonical identity. |
| `display_name`: `Flask Cache` | [flask_cache.py:2][s143] — Established spelling. |
| `description`: `Instruments cache reads, writes, additions, deletions, clears, and bulk operations through Flask-Cache and Flask-Caching APIs.` | [patch.py:119][s144] · [flask_cache.py:2][s143] — Sources cover every described operation. |
| `packages`: `flask-cache`, `flask-caching` | [registry.yaml:414][s145] · [patch.py:74][s146] — Registry binding and activation. |
| `category: db.client`: `db.client` | [policy][tax-cat] · [schema][s89] · [patch.py:96][s147] — Qualifies as `db.client`. |
| `systems`: `[]` | [policy][tax-sys] · [patch.py:105][s148] · [utils.py:29][s149] — No qualifying statically bounded system. |
| `creation_date`: `2016-08-18` | [commit][c150] · [patch.py:1][s151] — First working instrumentation: `2016-08-18`. |

</details>

<details>
<summary><code>pylibmc</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `pylibmc` | [registry.yaml:774][s152] · [patch.py:1][s153] — Canonical identity. |
| `display_name`: `pylibmc` | [patch.py:1][s153] — Established spelling. |
| `description`: `Instruments pylibmc client operations against Memcached, tracing single-key and multi-key cache reads, writes, mutations, and deletions.` | [client.py:88][s154] · [client.py:121][s155] · [client.py:188][s156] — Sources cover every described operation. |
| `packages`: `pylibmc` | [patch.py:33][s157] · [registry.yaml:778][s158] — Registry binding and activation. |
| `category: db.client`: `db.client` | [policy][tax-cat] · [schema][s89] · [client.py:180][s159] — Qualifies as `db.client`. |
| `systems: memcached`: `memcached` | [policy][tax-sys] · [schema][s160] · [client.py:188][s156] — Statically bounded to `memcached`. |
| `creation_date`: `2016-09-16` | [commit][c161] · [client.py:36][s162] — First working instrumentation: `2016-09-16`. |

</details>

<details>
<summary><code>pymemcache</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `pymemcache` | [patch.py:1][s163] — Canonical identity. |
| `display_name`: `pymemcache` | [__init__.py:1][s164] — Established spelling. |
| `description`: `Instruments pymemcache client cache commands sent to Memcached, including reads, writes, mutations, administrative operations, and errors.` | [client.py:98][s165] · [client.py:339][s166] — Sources cover every described operation. |
| `packages`: `pymemcache` | [patch.py:8][s167] — Registry binding and activation. |
| `category: db.client`: `db.client` | [policy][tax-cat] · [schema][s89] · [client.py:300][s168] — Qualifies as `db.client`. |
| `systems: memcached`: `memcached` | [policy][tax-sys] · [schema][s160] · [client.py:305][s169] — Statically bounded to `memcached`. |
| `creation_date`: `2018-08-06` | [commit][c170] · [client.py:65][s171] — First working instrumentation: `2018-08-06`. |

</details>

<details>
<summary><code>avro</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `avro` | [patch.py:1][s172] · [supported_versions.json:412][s173] — Canonical identity. |
| `display_name`: `Avro` | [__init__.py:1][s174] — Established spelling. |
| `description`: `Instruments Avro serialization and deserialization to attach schema metadata and sampled schema definitions to active spans for Data Streams Monitoring.` | [patch.py:34][s175] · [schema_iterator.py:89][s176] — Sources cover every described operation. |
| `packages`: `avro` | [patch.py:1][s172] · [supported_versions.json:411][s177] — Registry binding and activation. |
| `category: other`: `other` | [policy][tax-cat] · [schema][s179] · [patch.py:62][s178] — Qualifies as `other`. |
| `systems`: `[]` | [policy][tax-sys] · [patch.py:34][s175] — No qualifying statically bounded system. |
| `creation_date`: `2024-09-10` | [commit][c180] · [patch.py:1][s172] — First working instrumentation: `2024-09-10`. |

</details>

<details>
<summary><code>graphql</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `graphql` | [registry.yaml:468][s181] · [patch.py:10][s182] — Canonical identity. |
| `display_name`: `GraphQL` | [patch.py:12][s183] · [__init__.py:2][s184] — Established spelling. |
| `description`: `Instruments graphql-core GraphQL request parsing, validation, operation execution, and optional field resolution with error details.` | [patch.py:132][s185] · [patch.py:152][s186] · [patch.py:181][s187] · [patch.py:210][s188] · [patch.py:170][s189] · [patch.py:312][s190] — Sources cover every described operation. |
| `packages`: `graphql-core` | [registry.yaml:472][s191] · [patch.py:10][s182] — Registry binding and activation. |
| `category: graphql.server`: `graphql.server` | [policy][tax-cat] · [schema][s193] · [patch.py:101][s192] — Qualifies as `graphql.server`. |
| `systems`: `[]` | [policy][tax-sys] · [patch.py:101][s192] — No qualifying statically bounded system. |
| `creation_date`: `2022-07-29` | [commit][c194] · [patch.py:1][s195] — First working instrumentation: `2022-07-29`. |

</details>

<details>
<summary><code>grpc</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `grpc` | [registry.yaml:478][s196] · [patch.py:1][s197] — Canonical identity. |
| `display_name`: `gRPC` | [__init__.py:2][s198] — Established spelling. |
| `description`: `Instruments synchronous and asynchronous gRPC client calls and server handlers, including unary and streaming RPCs.` | [patch.py:94][s199] · [client_interceptor.py:244][s200] · [server_interceptor.py:130][s201] — Sources cover every described operation. |
| `packages`: `grpcio` | [registry.yaml:482][s202] · [patch.py:1][s197] — Registry binding and activation. |
| `category: rpc.client`: `rpc.client` | [policy][tax-cat] · [schema][s76] · [client_interceptor.py:220][s203] — Qualifies as `rpc.client`. |
| `category: rpc.server`: `rpc.server` | [policy][tax-cat] · [schema][s205] · [server_interceptor.py:100][s204] — Qualifies as `rpc.server`. |
| `systems: grpc`: `grpc` | [policy][tax-sys] · [schema][s207] · [patch.py:118][s206] — Statically bounded to `grpc`. |
| `creation_date`: `2018-10-19` | [commit][c208] · [client_interceptor.py:244][s200] — First working instrumentation: `2018-10-19`. |

</details>

<details>
<summary><code>protobuf</code> — accepted field evidence</summary>

| Field/value | Evidence |
|---|---|
| `_v`: `1` | [schema][schema-v] — Schema validation passed. |
| `name`: `protobuf` | [registry.yaml:740][s209] · [patch.py:1][s210] — Canonical identity. |
| `display_name`: `Protobuf` | [__init__.py:1][s211] — Established spelling. |
| `description`: `Instruments Google Protobuf message serialization and deserialization to attach sampled schema definitions and metadata to active spans.` | [patch.py:68][s212] · [schema_iterator.py:74][s213] — Sources cover every described operation. |
| `packages`: `protobuf` | [registry.yaml:743][s214] · [patch.py:1][s210] — Registry binding and activation. |
| `category: other`: `other` | [policy][tax-cat] · [schema][s179] · [schema_iterator.py:66][s215] — Qualifies as `other`. |
| `systems`: `[]` | [policy][tax-sys] · [patch.py:38][s216] — No qualifying statically bounded system. |
| `creation_date`: `2024-09-12` | [commit][c217] · [patch.py:30][s218] — First working instrumentation: `2024-09-12`. |

</details>

## Testing

- Generator review artifacts: all 19 manifests are accepted and grounded against dd-trace-py `5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6`; candidate, reviewed, and installed bytes match.
- Review provenance: 8 current runs passed schema, grounding, review, and workspace-integrity gates. For 11 September 7 runs whose final summaries were not preserved, the recovered root manifest, accepted verdict, candidate, recovery metadata, candidate hash, integration name, and tracer revision agree.
- Grounding validation with `uv run manifest-validate --grounding python`: all 19 installed manifests passed with no findings.
- Test discovery with `scripts/run-tests --list` on all 19 installed paths mapped the changes to 20 latest-environment integration checks.
- The mapped `scripts/run-tests --venv` run across those 20 environments was blocked before test execution because Docker was not running and the runner could not start Redis/test-agent services.
- `scripts/lint checks`: passed.
- `git diff --check`: passed.

## Risks

Low runtime risk: the change only adds declarative YAML metadata. The remaining validation risk is the mapped integration test run, which requires Docker-backed services and did not execute in the current environment.

[schema-v]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L19
[tax-cat]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/docs/category-taxonomy/manifest-publication-policy.md#category-contract
[tax-sys]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/docs/category-taxonomy/manifest-publication-policy.md#system-and-provider-contract
[s1]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_monkey.py#L169
[s2]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/kafka/patch.py#L5
[s3]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/kafka/__init__.py#L2
[s4]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/ext/kafka.py#L1
[s5]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/kafka/patch.py#L134
[s6]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/kafka/patch.py#L234
[s7]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/internal/datastreams/kafka.py#L156
[s8]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/internal/datastreams/kafka.py#L145
[s9]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/kafka/patch.py#L63
[s10]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/kafka/patch.py#L274
[s11]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L183
[s12]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/kafka/patch.py#L197
[s13]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L190
[s14]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L585
[c15]: /DataDog/dd-trace-py/commit/aa3a538e0b39d77a5ca625c5625ecb1c1a32c108
[s16]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/kafka/patch.py#L121
[s17]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/kombu/patch.py#L72
[s18]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/kombu/patch.py#L2
[s19]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/kombu/__init__.py#L3
[s20]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/kombu/patch.py#L138
[s21]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/kombu/patch.py#L105
[s22]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/kombu/patch.py#L164
[s23]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/internal/datastreams/kombu.py#L40
[s24]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/kombu/patch.py#L37
[s25]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/kombu/patch.py#L116
[s26]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/kombu/patch.py#L144
[s27]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/internal/datastreams/kombu.py#L53
[s28]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L676
[c29]: /DataDog/dd-trace-py/commit/519596012096918174fbd28fb4f0354a1330a743
[s30]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/kombu/patch.py#L57
[s31]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/celery/patch.py#L40
[s32]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/celery/patch.py#L1
[s33]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/celery/signals.py#L134
[s34]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/celery/app.py#L48
[s35]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/celery/utils.py#L58
[s36]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/celery/signals.py#L249
[s37]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/celery/patch.py#L17
[s38]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/celery/patch.py#L31
[s39]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/celery/signals.py#L62
[s40]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/celery/signals.py#L143
[s41]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/celery/signals.py#L189
[c42]: /DataDog/dd-trace-py/commit/707a43256e4e39428b76420d0ba76d7ca3bcb2f1
[s43]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/celery/patch.py#L34
[s44]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L332
[s45]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/dramatiq/patch.py#L4
[s46]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/dramatiq/__init__.py#L4
[s47]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/dramatiq/patch.py#L32
[s48]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/dramatiq/patch.py#L53
[s49]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L335
[s50]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/dramatiq/patch.py#L69
[c51]: /DataDog/dd-trace-py/commit/be880c17c8aa13a899af727f4aafa8373c0eb3ee
[s52]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_monkey.py#L69
[s53]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/rq/patch.py#L19
[s54]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/rq/__init__.py#L2
[s55]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/rq/patch.py#L51
[s56]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/rq/patch.py#L91
[s57]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/rq/patch.py#L110
[s58]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/rq/patch.py#L86
[s59]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/supported_versions.json#L3281
[s60]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/rq/patch.py#L41
[s61]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/rq/patch.py#L127
[s62]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/rq/patch.py#L76
[s63]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/rq/patch.py#L197
[c64]: /DataDog/dd-trace-py/commit/a2d52d5ca75939d72064de60b2b38ef32d1836dc
[s65]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/rq/patch.py#L1
[s66]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/google_cloud_pubsub/patch.py#L5
[s67]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_monkey.py#L171
[s68]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/google_cloud_pubsub/__init__.py#L2
[s69]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/google_cloud_pubsub/patch.py#L183
[s70]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/google_cloud_pubsub/patch.py#L186
[s71]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_trace/trace_handlers.py#L298
[s72]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/google_cloud_pubsub/patch.py#L75
[s73]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_trace/trace_handlers.py#L288
[s74]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_trace/trace_handlers.py#L1535
[s75]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_trace/trace_handlers.py#L1525
[s76]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L211
[s77]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_trace/trace_handlers.py#L290
[s78]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L482
[c79]: /DataDog/dd-trace-py/commit/78b0edcaf67e7a009f84bfbeada791e5003a5ff2
[s80]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/google_cloud_pubsub/patch.py#L1
[s81]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aredis/patch.py#L1
[s82]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_monkey.py#L30
[s83]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aredis/__init__.py#L2
[s84]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aredis/patch.py#L42
[s85]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aredis/patch.py#L59
[s86]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/redis_utils.py#L139
[s87]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/redis_utils.py#L81
[s88]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/redis_utils.py#L137
[s89]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L113
[s90]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/ext/redis.py#L2
[s91]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L681
[c92]: /DataDog/dd-trace-py/commit/49db1211b5184c25a36d4524d50123cc50d99f34
[s93]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/aredis/patch.py#L34
[s94]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/redis/patch.py#L19
[s95]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/redis/patch.py#L33
[s96]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/redis/patch.py#L53
[s97]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/redis/patch.py#L59
[s98]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/redis/asyncio_patch.py#L8
[s99]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/redis/patch.py#L1
[c100]: /DataDog/dd-trace-py/commit/cd519af93fd2393a58eb6922310c2ca1e513d24c
[s101]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/redis/patch.py#L36
[s102]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L910
[s103]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/rediscluster/patch.py#L2
[s104]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L914
[s105]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/rediscluster/patch.py#L57
[s106]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/rediscluster/patch.py#L81
[s107]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/rediscluster/patch.py#L96
[c108]: /DataDog/dd-trace-py/commit/9f73e8566b60b43c74099ba80bb6dcc964f9a109
[s109]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/rediscluster/patch.py#L49
[s110]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1032
[s111]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/valkey/patch.py#L1
[s112]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/releasenotes/notes/add-valkey-support-6cc9f41351dc0cd9.yaml#L3
[s113]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/valkey/patch.py#L53
[s114]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/valkey/asyncio_patch.py#L9
[s115]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1035
[s116]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_trace/utils_valkey.py#L38
[s117]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_trace/utils_valkey.py#L40
[s118]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L742
[c119]: /DataDog/dd-trace-py/commit/135ae7ce157dba342640384b8833d1c0bc17516b
[s120]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/valkey/patch.py#L37
[s121]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1084
[s122]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/yaaredis/patch.py#L2
[s123]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/yaaredis/__init__.py#L2
[s124]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/yaaredis/patch.py#L51
[s125]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/redis_utils.py#L178
[s126]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/redis_utils.py#L62
[s127]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L1088
[c128]: /DataDog/dd-trace-py/commit/638d46b56c49f761bc4a70b9cafe576ca248b063
[s129]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L314
[s130]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/_monkey.py#L158
[s131]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/dogpile_cache/patch.py#L31
[s132]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/dogpile_cache/__init__.py#L24
[s133]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/dogpile_cache/region.py#L14
[s134]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/dogpile_cache/region.py#L35
[s135]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/dogpile_cache/lock.py#L36
[s136]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L318
[s137]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/dogpile_cache/patch.py#L2
[s138]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/dogpile_cache/region.py#L20
[s139]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/dogpile_cache/region.py#L29
[c140]: /DataDog/dd-trace-py/commit/b50462e62e5db968dfe8205fe4dd6a8d2a6e4797
[s141]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L410
[s142]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/flask_cache/patch.py#L52
[s143]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/flask_cache.py#L2
[s144]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/flask_cache/patch.py#L119
[s145]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L414
[s146]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/flask_cache/patch.py#L74
[s147]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/flask_cache/patch.py#L96
[s148]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/flask_cache/patch.py#L105
[s149]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/flask_cache/utils.py#L29
[c150]: /DataDog/dd-trace-py/commit/72d2c9e364957f7cd0eb3ee620fc080ea7fb90fa
[s151]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/flask_cache/patch.py#L1
[s152]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L774
[s153]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pylibmc/patch.py#L1
[s154]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pylibmc/client.py#L88
[s155]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pylibmc/client.py#L121
[s156]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pylibmc/client.py#L188
[s157]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pylibmc/patch.py#L33
[s158]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L778
[s159]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pylibmc/client.py#L180
[s160]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L599
[c161]: /DataDog/dd-trace-py/commit/ef8ca5a59302a06cd9fa0643379e564249a2432b
[s162]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pylibmc/client.py#L36
[s163]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pymemcache/patch.py#L1
[s164]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pymemcache/__init__.py#L1
[s165]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pymemcache/client.py#L98
[s166]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pymemcache/client.py#L339
[s167]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pymemcache/patch.py#L8
[s168]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pymemcache/client.py#L300
[s169]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pymemcache/client.py#L305
[c170]: /DataDog/dd-trace-py/commit/ec8d8d50ee6a2a302a3a1b68d7e6efe199fe6f04
[s171]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/pymemcache/client.py#L65
[s172]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/avro/patch.py#L1
[s173]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/supported_versions.json#L412
[s174]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/avro/__init__.py#L1
[s175]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/avro/patch.py#L34
[s176]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/avro/schema_iterator.py#L89
[s177]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/supported_versions.json#L411
[s178]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/avro/patch.py#L62
[s179]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L204
[c180]: /DataDog/dd-trace-py/commit/755e74467a5bc3b8f9fc82f811812c7b4b2d2307
[s181]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L468
[s182]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/graphql/patch.py#L10
[s183]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/graphql/patch.py#L12
[s184]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/graphql/__init__.py#L2
[s185]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/graphql/patch.py#L132
[s186]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/graphql/patch.py#L152
[s187]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/graphql/patch.py#L181
[s188]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/graphql/patch.py#L210
[s189]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/graphql/patch.py#L170
[s190]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/graphql/patch.py#L312
[s191]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L472
[s192]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/graphql/patch.py#L101
[s193]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L141
[c194]: /DataDog/dd-trace-py/commit/e618c0fb2756a90e6532808aa45edcd5aa1a7a65
[s195]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/graphql/patch.py#L1
[s196]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L478
[s197]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/grpc/patch.py#L1
[s198]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/grpc/__init__.py#L2
[s199]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/grpc/patch.py#L94
[s200]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/grpc/client_interceptor.py#L244
[s201]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/grpc/server_interceptor.py#L130
[s202]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L482
[s203]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/grpc/client_interceptor.py#L220
[s204]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/grpc/server_interceptor.py#L100
[s205]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L218
[s206]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/grpc/patch.py#L118
[s207]: /ddoghq/apm-instrumentation-manifest-generator/blob/f9f9e35bf86f7f5c260710c1f6a67bc4a3616a59/instrumentation_manifest/schema/manifest.schema.json#L507
[c208]: /DataDog/dd-trace-py/commit/60d6038c5bbacca1ea960cd77cae65d3204a0dfc
[s209]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L740
[s210]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/protobuf/patch.py#L1
[s211]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/protobuf/__init__.py#L1
[s212]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/protobuf/patch.py#L68
[s213]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/protobuf/schema_iterator.py#L74
[s214]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/scripts/integration_registry/registry.yaml#L743
[s215]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/protobuf/schema_iterator.py#L66
[s216]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/protobuf/patch.py#L38
[c217]: /DataDog/dd-trace-py/commit/11e58292e4d7d567d0d77e05b9dd589a8a5a80b4
[s218]: /DataDog/dd-trace-py/blob/5d04027dcd5ccdb2104aeedc36e3d1d0b179f6d6/ddtrace/contrib/internal/protobuf/patch.py#L30
