### PR TITLE
fix(serverless): drop stale traces on MicroVM identity refresh

### DIFF
--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -356,6 +356,7 @@ class SpanAggregator(SpanProcessor):
         )
         # Initialize the trace buffer and lock
         self._traces: defaultdict[int, _Trace] = defaultdict(lambda: _Trace())
+        self._buffer_generation = 0
         self._lock: RLock = RLock()
         super(SpanAggregator, self).__init__()
 
@@ -403,6 +404,7 @@ class SpanAggregator(SpanProcessor):
                 return
 
             trace = self._traces[trace_id]
+            buffer_generation = self._buffer_generation
             trace.num_finished += 1
             num_buffered = len(trace.spans)
             is_trace_complete = trace.num_finished >= num_buffered
@@ -482,7 +484,13 @@ class SpanAggregator(SpanProcessor):
                     sampling_mechanism,
                     should_partial_flush,
                 )
-            self.writer.write(spans)
+            # Identity refresh can discard the trace buffer while processors run outside the
+            # aggregator lock. Re-check the generation while holding the same lock as reset so
+            # a pre-refresh trace cannot be written after the discard boundary.
+            with self._lock:
+                if buffer_generation != self._buffer_generation:
+                    return
+                self.writer.write(spans)
 
     def _agent_response_callback(self, resp: AgentResponse) -> None:
         """Handle the response from the agent.
@@ -581,16 +589,22 @@ class SpanAggregator(SpanProcessor):
         Arguments that are None will not override existing values. By default, the writer is
         flushed only when preserving the trace buffer.
         """
-        if flush_writer is None:
+        if drop_buffered_traces:
+            flush_writer = False
+        elif flush_writer is None:
             flush_writer = not reset_buffer
         if flush_writer:
             # Flush any encoded spans in the writer's buffer. This operation ensures encoded spans
             # are not dropped when the writer is recreated. This operation should not be handled after a fork.
             self.writer.flush_queue()
-        elif drop_buffered_traces:
-            self.writer.drop_buffered_traces()
-        # Re-create the writer to ensure it is consistent with updated configurations (ex: api_version)
-        self.writer = self.writer.recreate(appsec_enabled=appsec_enabled, llmobs_enabled=llmobs_enabled)
+
+        with self._lock:
+            if drop_buffered_traces:
+                drop = getattr(self.writer, "drop_buffered_traces", None)
+                if drop is not None:
+                    drop()
+            # Re-create the writer to ensure it is consistent with updated configurations (ex: api_version)
+            self.writer = self.writer.recreate(appsec_enabled=appsec_enabled, llmobs_enabled=llmobs_enabled)
 
         if compute_stats is not None:
             self.sampling_processor._compute_stats_enabled = compute_stats
@@ -605,7 +619,13 @@ class SpanAggregator(SpanProcessor):
         # Useful when forking to prevent sending duplicate spans from parent and child processes.
         if reset_buffer:
             self.reset_trace_buffer_after_fork()
+        else:
+            self._buffer_generation += 1
 
     def reset_trace_buffer_after_fork(self) -> None:
         """Discard inherited traces without touching the fork-unsafe writer."""
+        # This method runs from the post-fork hook and must not acquire a lock
+        # inherited from another thread. The caller that needs synchronization
+        # during identity refresh holds _lock around this operation.
         self._traces = defaultdict(lambda: _Trace())
+        self._buffer_generation += 1

--- a/ddtrace/_trace/tracer.py
+++ b/ddtrace/_trace/tracer.py
@@ -434,7 +434,7 @@ class Tracer(object):
             core.dispatch("ddtrace.context_provider.activate", (self.context_provider, active))
 
     def _refresh_runtime_identity(self, _runtime_id: str) -> None:
-        self._recreate(reset_buffer=True, drop_buffered_traces=True)
+        self._recreate(reset_buffer=True, flush_writer=False, drop_buffered_traces=True)
         self._store_metadata()
 
     def _recreate(

--- a/ddtrace/internal/runtime/__init__.py
+++ b/ddtrace/internal/runtime/__init__.py
@@ -80,14 +80,19 @@ def _set_runtime_id():
 
 
 def refresh_identity() -> None:
-    """Regenerate the runtime ID without recording fork lineage.
+    """Refresh the runtime ID for an AWS Lambda MicroVM start.
 
     Unlike a fork, this does not update _PARENT_RUNTIME_ID / _ANCESTOR_RUNTIME_ID:
     the previous runtime ID was not a real parent process, so recording it there
     would make get_process_role() and friends misreport a fork lineage that never
-    existed. Use this when a new logical process instance is created by a mechanism
-    other than fork().
+    existed.
+
+    This operation is intentionally a no-op outside AWS Lambda MicroVMs. It is
+    tied to the MicroVM /run lifecycle and must not alter ordinary processes.
     """
+    if not in_aws_lambda_microvm():
+        return
+
     # Notify consumers that only need the new ID first. The explicit refresh
     # callbacks below are for components that must rebuild restore-sensitive
     # state, which is different from the fork handling in _set_runtime_id().
@@ -114,7 +119,7 @@ def listen_for_identity_refresh_hooks(
 
 def maybe_refresh_identity(method: t.Optional[str], path: t.Optional[str]) -> None:
     """Call refresh_identity() if this request is the AWS Lambda MicroVM /run hook."""
-    if not method or not path:
+    if not in_aws_lambda_microvm() or not method or not path:
         return
     if method != MICROVM_RUN_HOOK_METHOD or path != MICROVM_RUN_HOOK_PATH:
         return

--- a/ddtrace/internal/runtime/metric_collectors.py
+++ b/ddtrace/internal/runtime/metric_collectors.py
@@ -19,6 +19,10 @@ class RuntimeMetricCollector(ValueCollector):
     value = []  # type: list[tuple[str, str]]
     periodic = True
 
+    def reset(self):
+        """Reset state that must not cross a logical runtime boundary."""
+        return
+
 
 class GCRuntimeMetricCollector(RuntimeMetricCollector):
     """Collector for garbage collection generational counts
@@ -94,6 +98,9 @@ class NativeProcessMetricCollector(RuntimeMetricCollector):
             CTX_SWITCH_INVOLUNTARY: process_metrics.ctx_switches_involuntary,
         }
         self._last_wall_time = time.monotonic()
+
+    def reset(self):
+        self._reset_state()
 
     def collect_fn(self, keys):
         native = self.modules["ddtrace.internal.native"]

--- a/ddtrace/internal/runtime/runtime_metrics.py
+++ b/ddtrace/internal/runtime/runtime_metrics.py
@@ -4,6 +4,7 @@ from typing import Optional  # noqa:F401
 
 from ddtrace.internal import atexit
 from ddtrace.internal.constants import EXPERIMENTAL_FEATURES
+from ddtrace.internal.runtime import on_runtime_identity_refresh
 from ddtrace.internal.settings._agent import config as agent_config
 from ddtrace.internal.settings._config import config
 from ddtrace.internal.threads import Lock
@@ -87,6 +88,7 @@ class RuntimeWorker(periodic.PeriodicService):
         self.dogstatsd_url: Optional[str] = dogstatsd_url
         self._dogstatsd_client: DogStatsd = get_dogstatsd_client(self.dogstatsd_url or agent_config.dogstatsd_url)
         self._runtime_metrics: RuntimeMetrics = RuntimeMetrics()
+        self._metrics_lock = Lock()
         if EXPERIMENTAL_FEATURES.RUNTIME_METRICS in config._experimental_features_enabled:
             # Enables sending runtime metrics as gauges (instead of distributions with a new metric name)
             self.send_metric = self._dogstatsd_client.gauge
@@ -140,20 +142,32 @@ class RuntimeWorker(periodic.PeriodicService):
             cls.enabled = True
 
     def flush(self) -> None:
-        # Refresh runtime-id tags when enabled; service/env/version are collected below via TracerTags().
-        if config._runtime_metrics_runtime_id_enabled:
-            self._platform_tags = self._collect_platform_tags()
-        runtime_tags = self._format_tags(TracerTags()) + self._platform_tags + self._process_tags
-        # Re-add dd.internal.entity_id on every flush, deduping in case it also arrives via
-        # TracerTags() (e.g. a DD_TAGS=dd.internal.entity_id:... workaround).
-        constant_tags = list(dict.fromkeys(self._client_constant_tags + runtime_tags))
-        log.debug("Sending runtime metrics with the following tags: %s", constant_tags)
-        self._dogstatsd_client.constant_tags = constant_tags
+        with self._metrics_lock:
+            # Refresh runtime-id tags when enabled; service/env/version are collected below via TracerTags().
+            if config._runtime_metrics_runtime_id_enabled:
+                self._platform_tags = self._collect_platform_tags()
+            runtime_tags = self._format_tags(TracerTags()) + self._platform_tags + self._process_tags
+            # Re-add dd.internal.entity_id on every flush, deduping in case it also arrives via
+            # TracerTags() (e.g. a DD_TAGS=dd.internal.entity_id:... workaround).
+            constant_tags = list(dict.fromkeys(self._client_constant_tags + runtime_tags))
+            log.debug("Sending runtime metrics with the following tags: %s", constant_tags)
+            self._dogstatsd_client.constant_tags = constant_tags
 
-        with self._dogstatsd_client:
-            for key, value in self._runtime_metrics:
-                log.debug("Sending ddtrace runtime metric %s:%s", key, value)
-                self.send_metric(key, value)
+            with self._dogstatsd_client:
+                for key, value in self._runtime_metrics:
+                    log.debug("Sending ddtrace runtime metric %s:%s", key, value)
+                    self.send_metric(key, value)
+
+    def _refresh_runtime_identity(self, _runtime_id: str) -> None:
+        with self._metrics_lock:
+            self._runtime_metrics.reset()
+            if config._runtime_metrics_runtime_id_enabled:
+                self._platform_tags = self._collect_platform_tags()
+
+    @classmethod
+    def _on_runtime_identity_refresh(cls, runtime_id: str) -> None:
+        if cls._instance is not None:
+            cls._instance._refresh_runtime_identity(runtime_id)
 
     def _collect_platform_tags(self) -> list[str]:
         if config._runtime_metrics_runtime_id_enabled:
@@ -166,3 +180,6 @@ class RuntimeWorker(periodic.PeriodicService):
 
     periodic = flush
     on_shutdown = flush
+
+
+on_runtime_identity_refresh(RuntimeWorker._on_runtime_identity_refresh)

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -141,8 +141,8 @@ class TraceWriter(metaclass=abc.ABCMeta):
         pass
 
     def drop_buffered_traces(self) -> None:
-        """Discard traces buffered by the writer without flushing them."""
-        pass
+        """Discard writer-owned trace buffers without transmitting them."""
+        return
 
 
 class LogWriter(TraceWriter):
@@ -178,6 +178,18 @@ class LogWriter(TraceWriter):
 
     def flush_queue(self) -> None:
         pass
+
+
+def _drop_buffered_encoders(clients: Sequence[WriterClientBase]) -> None:
+    for client in clients:
+        # ListBufferedEncoder exposes get(), while the msgpack encoders expose
+        # flush(). Both operations clear their buffers; their returned payload
+        # is intentionally ignored during identity invalidation.
+        clear = getattr(client.encoder, "get", None)
+        if clear is None:
+            clear = getattr(client.encoder, "flush", None)
+        if clear is not None:
+            clear()
 
 
 class HTTPWriter(periodic.PeriodicService, TraceWriter):
@@ -482,8 +494,7 @@ class HTTPWriter(periodic.PeriodicService, TraceWriter):
             self._set_drop_rate()
 
     def drop_buffered_traces(self) -> None:
-        for client in self._clients:
-            getattr(client.encoder, "get")()
+        _drop_buffered_encoders(self._clients)
 
     def _flush_queue_with_client(self, client: WriterClientBase, raise_exc: bool = False) -> None:
         n_traces = len(client.encoder)
@@ -1164,8 +1175,7 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
             self._set_drop_rate()
 
     def drop_buffered_traces(self) -> None:
-        for client in self._clients:
-            getattr(client.encoder, "flush")()
+        _drop_buffered_encoders(self._clients)
 
     def _flush_queue_with_client(self, client: WriterClientBase, raise_exc: bool = False) -> None:
         n_traces = len(client.encoder)

--- a/tests/runtime/test_runtime_metrics_api.py
+++ b/tests/runtime/test_runtime_metrics_api.py
@@ -232,7 +232,13 @@ def test_runtime_metrics_experimental_runtime_tag():
         )
 
 
-@pytest.mark.subprocess(env={"DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED": "true"}, err=None)
+@pytest.mark.subprocess(
+    env={
+        "DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED": "true",
+        "AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12",
+    },
+    err=None,
+)
 def test_runtime_metrics_refresh_identity_updates_runtime_id_tag():
     """Runtime metrics must not keep reporting the pre-refresh runtime-id tag."""
     from ddtrace.internal import runtime
@@ -252,6 +258,34 @@ def test_runtime_metrics_refresh_identity_updates_runtime_id_tag():
         new_runtime_id = runtime.get_runtime_id()
         assert f"runtime-id:{new_runtime_id}" in worker._platform_tags
         assert f"runtime-id:{old_runtime_id}" not in worker._platform_tags
+    finally:
+        RuntimeWorker.disable()
+
+
+@pytest.mark.subprocess(
+    env={
+        "DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED": "true",
+        "AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12",
+    },
+    err=None,
+)
+def test_runtime_metrics_refresh_identity_rebases_collectors():
+    """MicroVM identity refresh resets runtime metric collector state."""
+    from unittest import mock
+
+    from ddtrace.internal import runtime
+    from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker
+
+    RuntimeWorker.enable()
+    try:
+        worker = RuntimeWorker._instance
+        assert worker is not None
+        collector = worker._runtime_metrics._collectors[1]
+
+        with mock.patch.object(collector, "reset", wraps=collector.reset) as reset:
+            runtime.refresh_identity()
+
+        reset.assert_called_once_with()
     finally:
         RuntimeWorker.disable()
 

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -812,6 +812,8 @@ import opentelemetry
 
 def test_microvm_identity_refresh_rebuilds_worker_with_new_runtime_id(monkeypatch):
     """MicroVM identity refresh must not leave native telemetry on the old runtime ID."""
+    monkeypatch.setenv("AWS_LAMBDA_MICROVM_IMAGE_ARN", "arn:aws:lambda:us-east-1::runtime:python3.12")
+
     from ddtrace.internal import runtime
     import ddtrace.internal.native as native
     from ddtrace.internal.telemetry.writer import TelemetryWriter
@@ -844,6 +846,8 @@ def test_microvm_identity_refresh_rebuilds_worker_with_new_runtime_id(monkeypatc
         mock.patch.object(native, "TelemetryWorker", FakeTelemetryWorker),
         mock.patch("ddtrace.internal.native_runtime.get_native_runtime", return_value=object()),
     ):
+        tracer_refresh_callback = ddtrace.tracer._refresh_runtime_identity
+        runtime._ON_RUNTIME_IDENTITY_REFRESH.discard(tracer_refresh_callback)
         writer = TelemetryWriter(agentless=False)
         monkeypatch.setattr(ddtrace.internal.telemetry, "telemetry_writer", writer)
         try:
@@ -861,6 +865,7 @@ def test_microvm_identity_refresh_rebuilds_worker_with_new_runtime_id(monkeypatc
             assert workers[-1].kwargs["runtime_id"] != first_runtime_id
             assert workers[-1].start_calls == 1
         finally:
+            runtime._ON_RUNTIME_IDENTITY_REFRESH.add(tracer_refresh_callback)
             writer.disable()
 
 

--- a/tests/tracer/runtime/test_metric_collectors.py
+++ b/tests/tracer/runtime/test_metric_collectors.py
@@ -97,6 +97,33 @@ class TestNativeProcessMetricCollector(BaseTestCase):
         # matching `TestRuntimeMetricCollector.test_failed_module_load_collect`'s contract.
         self.assertEqual(collector.collect(), [])
 
+    def test_reset_rebases_delta_metrics(self):
+        """A logical runtime refresh must discard the pre-refresh delta baseline."""
+        with (
+            mock.patch(
+                "ddtrace.internal.native.process_metrics",
+                side_effect=[
+                    (100, 200, 10, 20, 1, 1000),
+                    (150, 250, 15, 25, 1, 1000),
+                    (1000, 2000, 100, 200, 1, 1000),
+                    (1010, 2010, 101, 201, 1, 1000),
+                ],
+            ),
+            mock.patch(
+                "ddtrace.internal.runtime.metric_collectors.time.monotonic",
+                side_effect=[0.0, 1.0, 10.0, 11.0],
+            ),
+        ):
+            collector = NativeProcessMetricCollector()
+            before_refresh = dict(collector.collect_fn(None))
+            collector.reset()
+            after_refresh = dict(collector.collect_fn(None))
+
+        self.assertAlmostEqual(before_refresh["runtime.python.cpu.time.user"], 50e-9)
+        self.assertAlmostEqual(after_refresh["runtime.python.cpu.time.user"], 10e-9)
+        self.assertEqual(before_refresh["runtime.python.cpu.ctx_switch.voluntary"], 5)
+        self.assertEqual(after_refresh["runtime.python.cpu.ctx_switch.voluntary"], 1)
+
 
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork()")
 @pytest.mark.subprocess(env={"PYTHONWARNINGS": "ignore::DeprecationWarning"})

--- a/tests/tracer/runtime/test_runtime_id.py
+++ b/tests/tracer/runtime/test_runtime_id.py
@@ -259,7 +259,9 @@ def test_get_process_role_spawn_child() -> None:
 
 
 def test_refresh_identity_changes_runtime_id(run_python_code_in_subprocess):
-    """refresh_identity() is the non-fork trigger for a new logical process instance."""
+    """refresh_identity() is the MicroVM trigger for a new logical process instance."""
+    import os
+
     code = """
 from ddtrace.internal import runtime
 
@@ -271,7 +273,34 @@ assert isinstance(new_runtime_id, str)
 assert new_runtime_id != runtime_id
 assert new_runtime_id == runtime.get_runtime_id()
 """
-    _, err, status, _ = run_python_code_in_subprocess(code)
+    env = os.environ.copy()
+    env["AWS_LAMBDA_MICROVM_IMAGE_ARN"] = "arn:aws:lambda:us-east-1::runtime:python3.12"
+    _, err, status, _ = run_python_code_in_subprocess(code, env=env)
+    assert status == 0, err
+
+
+def test_refresh_identity_is_noop_outside_microvm(run_python_code_in_subprocess):
+    """Identity refresh must not affect ordinary non-MicroVM processes."""
+    import os
+
+    code = """
+from ddtrace.internal import runtime
+
+seen_id_changes = []
+seen_identity_refreshes = []
+runtime.on_runtime_id_change(seen_id_changes.append)
+runtime.on_runtime_identity_refresh(seen_identity_refreshes.append)
+
+runtime_id = runtime.get_runtime_id()
+runtime.refresh_identity()
+
+assert runtime.get_runtime_id() == runtime_id
+assert seen_id_changes == []
+assert seen_identity_refreshes == []
+"""
+    env = os.environ.copy()
+    env["AWS_LAMBDA_MICROVM_IMAGE_ARN"] = ""
+    _, err, status, _ = run_python_code_in_subprocess(code, env=env)
     assert status == 0, err
 
 
@@ -289,6 +318,7 @@ def test_refresh_identity_does_not_record_fork_lineage(run_python_code_in_subpro
             "_DD_ROOT_PY_SESSION_ID": None,
             "_DD_PARENT_PY_SESSION_ID": None,
             "DD_TRACE_SUBPROCESS_ENABLED": "false",
+            "AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12",
         }
     )
     code = """
@@ -317,6 +347,7 @@ def test_refresh_identity_preserves_spawned_lineage(run_python_code_in_subproces
             "_DD_ROOT_PY_SESSION_ID": "ancestor-session-id",
             "_DD_PARENT_PY_SESSION_ID": "parent-session-id",
             "DD_TRACE_SUBPROCESS_ENABLED": "false",
+            "AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12",
         }
     )
     code = """
@@ -345,6 +376,7 @@ def test_refresh_identity_preserves_fork_lineage(run_python_code_in_subprocess):
             "_DD_ROOT_PY_SESSION_ID": None,
             "_DD_PARENT_PY_SESSION_ID": None,
             "DD_TRACE_SUBPROCESS_ENABLED": "false",
+            "AWS_LAMBDA_MICROVM_IMAGE_ARN": "arn:aws:lambda:us-east-1::runtime:python3.12",
         }
     )
     code = """
@@ -378,6 +410,8 @@ assert os.WEXITSTATUS(status) == 42
 
 
 def test_refresh_identity_notifies_subscribers(run_python_code_in_subprocess):
+    import os
+
     code = """
 from ddtrace.internal import runtime
 
@@ -396,7 +430,9 @@ runtime.refresh_identity()
 
 assert seen == [runtime.get_runtime_id()]
 """
-    _, err, status, _ = run_python_code_in_subprocess(code)
+    env = os.environ.copy()
+    env["AWS_LAMBDA_MICROVM_IMAGE_ARN"] = "arn:aws:lambda:us-east-1::runtime:python3.12"
+    _, err, status, _ = run_python_code_in_subprocess(code, env=env)
     assert status == 0, err
 
 
@@ -629,6 +665,8 @@ assert runtime.get_runtime_id() == runtime_id
 
 
 def test_refresh_identity_notifies_refresh_subscribers(run_python_code_in_subprocess):
+    import os
+
     code = """
 from ddtrace.internal import runtime
 
@@ -647,7 +685,9 @@ runtime.refresh_identity()
 
 assert seen == [runtime.get_runtime_id()]
 """
-    _, err, status, _ = run_python_code_in_subprocess(code)
+    env = os.environ.copy()
+    env["AWS_LAMBDA_MICROVM_IMAGE_ARN"] = "arn:aws:lambda:us-east-1::runtime:python3.12"
+    _, err, status, _ = run_python_code_in_subprocess(code, env=env)
     assert status == 0, err
 
 
@@ -669,7 +709,7 @@ def test_tracer_microvm_identity_refresh_recreates_exporter_without_fork_side_ef
         ):
             tracer._refresh_runtime_identity(runtime.get_runtime_id())
 
-        recreate.assert_called_once_with(reset_buffer=True, drop_buffered_traces=True)
+        recreate.assert_called_once_with(reset_buffer=True, flush_writer=False, drop_buffered_traces=True)
         store_metadata.assert_called_once_with()
         assert tracer._new_process is False
     finally:
@@ -695,7 +735,7 @@ def test_identity_refresh_hook_notifies_global_tracer():
             (runtime.MICROVM_RUN_HOOK_METHOD, runtime.MICROVM_RUN_HOOK_PATH),
         )
 
-    recreate.assert_called_once_with(reset_buffer=True, drop_buffered_traces=True)
+    recreate.assert_called_once_with(reset_buffer=True, flush_writer=False, drop_buffered_traces=True)
     store_metadata.assert_called_once_with()
 
 

--- a/tests/tracer/test_processors.py
+++ b/tests/tracer/test_processors.py
@@ -1,3 +1,5 @@
+from threading import Event
+from threading import Thread
 from typing import Any  # noqa:F401
 
 import mock
@@ -423,6 +425,55 @@ def test_aggregator_reset_with_args():
     assert aggr.sampling_processor._compute_stats_enabled is True
     assert aggr.writer._api_version == "v0.5"
     assert span.trace_id in aggr._traces
+
+
+def test_aggregator_identity_reset_drops_active_trace_and_writer_buffer():
+    writer = mock.Mock()
+    writer.recreate.return_value = writer
+    aggr = SpanAggregator(partial_flush_enabled=False, partial_flush_min_spans=0)
+    aggr.writer = writer
+
+    span = Span("span", on_finish=[aggr.on_span_finish])
+    aggr.on_span_start(span)
+    assert span.trace_id in aggr._traces
+
+    aggr.reset(reset_buffer=True, flush_writer=False, drop_buffered_traces=True)
+
+    writer.drop_buffered_traces.assert_called_once_with()
+    assert span.trace_id not in aggr._traces
+
+    span.finish()
+    writer.write.assert_not_called()
+
+
+def test_aggregator_identity_reset_drops_trace_finishing_during_refresh():
+    processing_started = Event()
+    allow_processing = Event()
+
+    class BlockingProcessor(TraceProcessor):
+        def process_trace(self, trace):
+            processing_started.set()
+            assert allow_processing.wait(5)
+            return trace
+
+    writer = mock.Mock()
+    writer.recreate.return_value = writer
+    aggr = SpanAggregator(partial_flush_enabled=False, partial_flush_min_spans=0, dd_processors=[BlockingProcessor()])
+    aggr.writer = writer
+
+    span = Span("span", on_finish=[aggr.on_span_finish])
+    aggr.on_span_start(span)
+    finish = Thread(target=span.finish)
+    finish.start()
+    try:
+        assert processing_started.wait(5)
+        aggr.reset(reset_buffer=True, flush_writer=False, drop_buffered_traces=True)
+    finally:
+        allow_processing.set()
+        finish.join(5)
+
+    assert not finish.is_alive()
+    writer.write.assert_not_called()
 
 
 def test_aggregator_bad_processor():

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -72,6 +72,22 @@ class DummyOutput:
         pass
 
 
+def test_native_writer_drop_buffered_traces_does_not_flush():
+    writer = NativeWriter("http://asdf:1234")
+    try:
+        writer._encoder.put([Span("buffered")])
+        assert len(writer._encoder) == 1
+
+        with mock.patch.object(writer, "_send_payload") as send_payload:
+            writer.drop_buffered_traces()
+            writer.flush_queue()
+
+        assert len(writer._encoder) == 0
+        send_payload.assert_not_called()
+    finally:
+        writer.shutdown_exporter()
+
+
 class NativeWriterTests(BaseTestCase):
     N_TRACES = 11
     WRITER_CLASS = NativeWriter


### PR DESCRIPTION
## Description

When a Lambda MicroVM refreshes its runtime identity, discard active traces and writer-buffered entities that may still contain the previous runtime ID. Runtime metrics also reset identity-sensitive collector state at the refresh boundary. The reset is enabled only by the MicroVM identity-refresh path; normal configuration and post-fork recreation paths retain their existing behavior.

## Testing

Not run in this turn (push/PR creation only).

## Risks

None beyond the intended discard of pre-refresh trace data and runtime metric baselines.

## Additional Notes

Stacked draft PR on top of #19822. The MicroVM identity-refresh release note is already covered earlier in the stack; this PR should use the changelog/no-changelog label.