### PR TITLE
fix(tracing): discard native buffers on MicroVM identity refresh

### DIFF
--- a/ddtrace/_trace/processor/__init__.py
+++ b/ddtrace/_trace/processor/__init__.py
@@ -606,6 +606,12 @@ class SpanAggregator(SpanProcessor):
             # Re-create the writer to ensure it is consistent with updated configurations (ex: api_version)
             self.writer = self.writer.recreate(appsec_enabled=appsec_enabled, llmobs_enabled=llmobs_enabled)
 
+            # MicroVM identity refresh discards all pre-refresh state. Keep writer replacement
+            # and buffer invalidation in one critical section so an old trace cannot be written
+            # through the replacement writer.
+            if drop_buffered_traces and reset_buffer:
+                self.reset_trace_buffer_after_fork()
+
         if compute_stats is not None:
             self.sampling_processor._compute_stats_enabled = compute_stats
 
@@ -615,11 +621,10 @@ class SpanAggregator(SpanProcessor):
         if user_processors is not None:
             self.user_processors = user_processors
 
-        # Reset the trace buffer.
-        # Useful when forking to prevent sending duplicate spans from parent and child processes.
-        if reset_buffer:
+        # Preserve the existing reset ordering for ordinary reconfiguration and fork handling.
+        if reset_buffer and not drop_buffered_traces:
             self.reset_trace_buffer_after_fork()
-        else:
+        elif not reset_buffer:
             self._buffer_generation += 1
 
     def reset_trace_buffer_after_fork(self) -> None:

--- a/ddtrace/internal/telemetry/writer.py
+++ b/ddtrace/internal/telemetry/writer.py
@@ -923,9 +923,11 @@ class TelemetryWriter:
         was_started = self.started
         if self._worker is not None:
             try:
-                self._worker.stop(send_app_closing=False)
+                self._worker.discard()
             except Exception:
-                log.debug("Failed to stop the native telemetry worker while refreshing runtime identity", exc_info=True)
+                log.debug(
+                    "Failed to discard the native telemetry worker while refreshing runtime identity", exc_info=True
+                )
             self._worker = None
             self.started = False
             _unbind_metric_recorders(self)

--- a/ddtrace/internal/writer/writer.py
+++ b/ddtrace/internal/writer/writer.py
@@ -1176,6 +1176,10 @@ class NativeWriter(periodic.PeriodicService, TraceWriter, AgentWriterInterface):
 
     def drop_buffered_traces(self) -> None:
         _drop_buffered_encoders(self._clients)
+        try:
+            self._exporter.shutdown_without_flush()
+        except Exception:
+            _safelog(log.warning, "failed to discard exporter buffers", exc_info=True)
 
     def _flush_queue_with_client(self, client: WriterClientBase, raise_exc: bool = False) -> None:
         n_traces = len(client.encoder)

--- a/src/native/Cargo.lock
+++ b/src/native/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
 [[package]]
 name = "build_common"
 version = "43.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "cbindgen",
  "serde",
@@ -545,32 +545,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
-name = "datadog-live-debugger"
-version = "0.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
-dependencies = [
- "anyhow",
- "bytes",
- "constcat",
- "futures",
- "http 1.4.2",
- "libdd-capabilities",
- "libdd-capabilities-impl",
- "libdd-common",
- "libdd-data-pipeline",
- "libdd-remote-config",
- "percent-encoding",
- "serde",
- "serde_json",
- "smallvec",
- "strum",
- "strum_macros",
- "sys-info",
- "tokio",
- "uuid",
-]
-
-[[package]]
 name = "ddtrace-native"
 version = "0.1.0"
 dependencies = [
@@ -578,7 +552,6 @@ dependencies = [
  "base64",
  "build_common",
  "bytes",
- "datadog-live-debugger",
  "libc",
  "libdd-capabilities-impl",
  "libdd-common",
@@ -589,6 +562,7 @@ dependencies = [
  "libdd-http-client",
  "libdd-ipc",
  "libdd-library-config",
+ "libdd-live-debugger",
  "libdd-log",
  "libdd-otel-thread-ctx",
  "libdd-profiling-ffi",
@@ -1001,6 +975,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.2",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,6 +1175,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http 1.4.2",
  "http-body",
  "httparse",
@@ -1571,7 +1565,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "libdd-alloc"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "allocator-api2",
  "libc",
@@ -1581,7 +1575,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1594,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1608,7 +1602,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "5.2.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1648,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "libdd-common-ffi"
 version = "43.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1662,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "libdd-crashtracker"
 version = "2.0.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "anyhow",
  "blazesym",
@@ -1698,7 +1692,7 @@ dependencies = [
 [[package]]
 name = "libdd-data-pipeline"
 version = "9.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1709,6 +1703,8 @@ dependencies = [
  "getrandom 0.2.17",
  "http 1.4.2",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "libdd-capabilities",
  "libdd-capabilities-impl",
  "libdd-common",
@@ -1723,12 +1719,14 @@ dependencies = [
  "libdd-trace-protobuf",
  "libdd-trace-stats",
  "libdd-trace-utils",
+ "prost",
  "rmp-serde",
  "serde",
  "serde_json",
  "sha2",
  "tokio",
  "tokio-util",
+ "tonic",
  "tracing",
  "uuid",
  "web-time",
@@ -1736,8 +1734,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline-core"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+version = "0.1.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "http 1.4.2",
  "libdd-capabilities",
@@ -1751,7 +1749,7 @@ dependencies = [
 [[package]]
 name = "libdd-data-pipeline-ffi"
 version = "43.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "build_common",
  "libdd-capabilities-impl",
@@ -1770,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.1.1"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "prost",
 ]
@@ -1778,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "libdd-dogstatsd-client"
 version = "5.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1794,7 +1792,7 @@ dependencies = [
 [[package]]
 name = "libdd-ffe"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "chrono",
  "derive_more",
@@ -1816,7 +1814,7 @@ dependencies = [
 [[package]]
 name = "libdd-gotter"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "libc",
 ]
@@ -1824,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "libdd-http-client"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "bytes",
  "fastrand",
@@ -1840,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "libdd-ipc"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1868,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "libdd-ipc-macros"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1879,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "libdd-library-config"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "anyhow",
  "libc",
@@ -1896,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "libdd-library-config-ffi"
 version = "0.0.2"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1918,9 +1916,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdd-live-debugger"
+version = "0.1.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "constcat",
+ "futures",
+ "http 1.4.2",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common",
+ "libdd-data-pipeline",
+ "libdd-remote-config",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "strum",
+ "strum_macros",
+ "sys-info",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "libdd-log"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "chrono",
  "tracing",
@@ -1931,12 +1955,12 @@ dependencies = [
 [[package]]
 name = "libdd-otel-thread-ctx"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 
 [[package]]
 name = "libdd-otel-thread-ctx-ffi"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "build_common",
  "libdd-common-ffi",
@@ -1946,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1986,7 +2010,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling-ffi"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -2011,7 +2035,7 @@ dependencies = [
 [[package]]
 name = "libdd-profiling-protobuf"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "prost",
 ]
@@ -2019,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "libdd-remote-config"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "anyhow",
  "base64",
@@ -2057,7 +2081,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "async-trait",
  "futures",
@@ -2074,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime-ffi"
 version = "43.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "build_common",
  "libdd-shared-runtime",
@@ -2084,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "libdd-telemetry"
 version = "7.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2115,7 +2139,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.2"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "serde",
 ]
@@ -2123,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf",
@@ -2132,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-obfuscation"
 version = "7.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "anyhow",
  "fluent-uri",
@@ -2148,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "5.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "prost",
  "serde",
@@ -2158,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-stats"
 version = "8.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2187,7 +2211,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-utils"
 version = "11.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "anyhow",
  "base64",
@@ -2224,7 +2248,7 @@ dependencies = [
 [[package]]
 name = "libdd-tracer-flare"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=v43.0.0#8c3d06ba9ff2a61f656782d59b1be00f09138e26"
+source = "git+https://github.com/DataDog/libdatadog?rev=817aa895ef626e50ab909d51aacff32d57d86c5b#817aa895ef626e50ab909d51aacff32d57d86c5b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4021,6 +4045,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4071,6 +4106,26 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "base64",
+ "bytes",
+ "http 1.4.2",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "tower"
@@ -4124,6 +4179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
@@ -4138,6 +4194,17 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/src/native/Cargo.toml
+++ b/src/native/Cargo.toml
@@ -32,20 +32,20 @@ serde = "1.0"
 serde_json = "1.0"
 smallvec = "1"
 tokio = "1"
-libdd-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", optional = true, features = ["pyo3"] }
-libdd-ipc = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", features = ["one_way_shm_futex"] }
-datadog-live-debugger = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
-libdd-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", features = [
+libdd-ffe = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b", optional = true, features = ["pyo3"] }
+libdd-ipc = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b", features = ["one_way_shm_futex"] }
+datadog-live-debugger = { package = "libdd-live-debugger", git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b" }
+libdd-remote-config = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b", features = [
   "agentless",
 ] }
-libdd-telemetry = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
-libdd-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
-libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", optional = true }
-libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", optional = true }
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
-libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
-libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
-libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", features = [
+libdd-telemetry = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b" }
+libdd-tracer-flare = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b" }
+libdd-crashtracker = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b", optional = true }
+libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b", optional = true }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b" }
+libdd-log = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b" }
+libdd-capabilities-impl = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b" }
+libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b", features = [
   "stats-obfuscation",
   "compression"
 ] }
@@ -54,17 +54,17 @@ libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog", rev = "v4
 # hostnames resolved through custom search/ndots resolv.conf setups (e.g.
 # Docker Compose/Kubernetes service names via embedded DNS) — it uses the
 # system resolver instead, like the stdlib http.client this replaces did.
-libdd-http-client = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", default-features = false, features = [
+libdd-http-client = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b", default-features = false, features = [
   "https",
   "hyper-backend",
   "hyper-proxy",
 ] }
-libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
-libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", optional = true, features = [
+libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b" }
+libdd-profiling-ffi = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b", optional = true, features = [
     "cbindgen",
 ] }
-libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b" }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b" }
 native-proc-macro = { path = "native_proc_macro" }
 strum = { version = "0.26", default-features = false }
 percent-encoding = "2.3"
@@ -73,8 +73,8 @@ tracing = { version = "0.1", default-features = false }
 pyo3-ffi = { version = "0.28", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", features = ["otel-thread-ctx"]}
-libdd-otel-thread-ctx = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b", features = ["otel-thread-ctx"]}
+libdd-otel-thread-ctx = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b" }
 libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -82,7 +82,7 @@ libc = "0.2"
 
 [build-dependencies]
 pyo3-build-config = "0.28"
-build_common = { git = "https://github.com/DataDog/libdatadog", rev = "v43.0.0", features = [
+build_common = { git = "https://github.com/DataDog/libdatadog", rev = "817aa895ef626e50ab909d51aacff32d57d86c5b", features = [
     "cbindgen",
 ] }
 

--- a/src/native/data_pipeline/mod.rs
+++ b/src/native/data_pipeline/mod.rs
@@ -355,6 +355,15 @@ impl TraceExporterPy {
         Ok(())
     }
 
+    fn shutdown_without_flush(&mut self) -> PyResult<()> {
+        if let Some(exporter) = self.inner.take() {
+            exporter
+                .shutdown_without_flush()
+                .map_err(TraceExporterErrorPy::from)?;
+        }
+        Ok(())
+    }
+
     fn drop(&mut self) -> PyResult<()> {
         drop(self.inner.take());
         Ok(())

--- a/src/native/telemetry.rs
+++ b/src/native/telemetry.rs
@@ -19,7 +19,10 @@ use libdd_telemetry::worker::{
 use libdd_telemetry::{parse_tags, Tag};
 
 use libdd_capabilities_impl::NativeCapabilities;
-use libdd_shared_runtime::{BlockingRuntime, ForkSafeRuntime, SharedRuntime, WorkerHandle};
+use libdd_shared_runtime::{
+    shared_runtime::runtime_identity_refresh::discard_worker_without_flush, BlockingRuntime,
+    ForkSafeRuntime, SharedRuntime, WorkerHandle,
+};
 use native_proc_macro::ConvertToPyO3Enum;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -271,6 +274,24 @@ impl TelemetryWorkerPy {
             py.detach(|| {
                 let _ = self.shared_runtime.block_on(async {
                     let _ = wh.stop().await;
+                });
+            });
+        }
+        Ok(())
+    }
+
+    /// Discard pending telemetry and stop the worker without flushing it.
+    fn discard(&self, py: Python<'_>) -> PyResult<()> {
+        self.ensure_runtime_after_fork()?;
+        let worker_handle = self
+            .worker_handle
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take();
+        if let Some(wh) = worker_handle {
+            py.detach(|| {
+                let _ = self.shared_runtime.block_on(async {
+                    let _ = discard_worker_without_flush(wh).await;
                 });
             });
         }

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -60,6 +60,34 @@ assert telemetry_writer._worker is not None
     assert stderr == b""
 
 
+def test_native_telemetry_worker_discard_removes_worker_registration(run_python_code_in_subprocess):
+    """The Python binding discards its native worker and makes the operation idempotent."""
+    code = """
+import ddtrace  # enables telemetry
+
+from ddtrace.internal.native_runtime import get_native_runtime
+from ddtrace.internal.telemetry import telemetry_writer
+
+
+worker = telemetry_writer._worker
+assert worker is not None
+runtime = get_native_runtime()
+workers_before = runtime.debug().count("WorkerEntry")
+
+worker.discard()
+assert runtime.debug().count("WorkerEntry") == workers_before - 1
+
+# A refresh/shutdown race must not turn a second discard into an error.
+worker.discard()
+assert runtime.debug().count("WorkerEntry") == workers_before - 1
+"""
+
+    _, stderr, status, _ = run_python_code_in_subprocess(code)
+
+    assert status == 0, stderr
+    assert stderr == b""
+
+
 def test_enable_with_short_heartbeat_does_not_race_imports(test_agent_session, run_python_code_in_subprocess):
     env = os.environ.copy()
     env["DD_TELEMETRY_HEARTBEAT_INTERVAL"] = "0.00001"

--- a/tests/telemetry/test_writer.py
+++ b/tests/telemetry/test_writer.py
@@ -826,6 +826,7 @@ def test_microvm_identity_refresh_rebuilds_worker_with_new_runtime_id(monkeypatc
             self.kwargs = kwargs
             self.start_calls = 0
             self.stop_calls = []
+            self.discard_calls = 0
             workers.append(self)
 
         def start(self):
@@ -833,6 +834,9 @@ def test_microvm_identity_refresh_rebuilds_worker_with_new_runtime_id(monkeypatc
 
         def stop(self, send_app_closing=True):
             self.stop_calls.append(send_app_closing)
+
+        def discard(self):
+            self.discard_calls += 1
 
         def __getattr__(self, name):
             def _noop(*args, **kwargs):
@@ -858,7 +862,8 @@ def test_microvm_identity_refresh_rebuilds_worker_with_new_runtime_id(monkeypatc
 
             runtime.refresh_identity()
 
-            assert first_worker.stop_calls == [False]
+            assert first_worker.stop_calls == []
+            assert first_worker.discard_calls == 1
             assert workers[-1] is writer._worker
             assert workers[-1].kwargs["runtime_id"] == runtime.get_runtime_id()
             assert workers[-1].kwargs["session_id"] == runtime.get_runtime_id()

--- a/tests/tracer/test_processors.py
+++ b/tests/tracer/test_processors.py
@@ -476,6 +476,44 @@ def test_aggregator_identity_reset_drops_trace_finishing_during_refresh():
     writer.write.assert_not_called()
 
 
+def test_aggregator_identity_reset_keeps_writer_recreation_and_buffer_reset_atomic():
+    reset_buffer_entered = Event()
+    allow_buffer_reset = Event()
+
+    writer = mock.Mock()
+    writer.recreate.return_value = writer
+    aggr = SpanAggregator(partial_flush_enabled=False, partial_flush_min_spans=0)
+    aggr.writer = writer
+
+    span = Span("span", on_finish=[aggr.on_span_finish])
+    aggr.on_span_start(span)
+    reset_trace_buffer = aggr.reset_trace_buffer_after_fork
+
+    def delayed_buffer_reset():
+        reset_buffer_entered.set()
+        assert allow_buffer_reset.wait(5)
+        reset_trace_buffer()
+
+    aggr.reset_trace_buffer_after_fork = delayed_buffer_reset
+    reset = Thread(target=lambda: aggr.reset(reset_buffer=True, flush_writer=False, drop_buffered_traces=True))
+    reset.start()
+    try:
+        assert reset_buffer_entered.wait(5)
+
+        finish = Thread(target=span.finish)
+        finish.start()
+        finish.join(0.1)
+        assert finish.is_alive()
+    finally:
+        allow_buffer_reset.set()
+        reset.join(5)
+        finish.join(5)
+
+    assert not reset.is_alive()
+    assert not finish.is_alive()
+    writer.write.assert_not_called()
+
+
 def test_aggregator_bad_processor():
     class Proc(TraceProcessor):
         def process_trace(self, trace):

--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -78,12 +78,22 @@ def test_native_writer_drop_buffered_traces_does_not_flush():
         writer._encoder.put([Span("buffered")])
         assert len(writer._encoder) == 1
 
-        with mock.patch.object(writer, "_send_payload") as send_payload:
+        with (
+            mock.patch.object(writer, "_send_payload") as send_payload,
+            mock.patch.object(
+                writer._exporter,
+                "shutdown_without_flush",
+                wraps=writer._exporter.shutdown_without_flush,
+            ) as discard,
+        ):
             writer.drop_buffered_traces()
             writer.flush_queue()
 
         assert len(writer._encoder) == 0
         send_payload.assert_not_called()
+        discard.assert_called_once_with()
+        assert writer._exporter.debug() == "None"
+        writer.drop_buffered_traces()
     finally:
         writer.shutdown_exporter()
 


### PR DESCRIPTION
## Description

Builds on the MicroVM identity-refresh reset path by using discard-only native lifecycle hooks for libdatadog-backed trace and telemetry buffers. Native trace exporter buffers now shut down without flushing during identity refresh, and the native telemetry worker is discarded instead of stopped/flushed before it is rebuilt with the refreshed runtime ID.

The span aggregator keeps writer replacement and active trace invalidation under the same lock so pre-refresh traces cannot be written through the replacement writer during the refresh boundary.

## Testing
Tested it with the expected libdatadog change ([PR 2478](https://github.com/DataDog/libdatadog/pull/2478/)) and the [logs](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Flambda-microvms$252Fsample-flask-app/log-events/2026$252F09$252F08$255B24.0$255Dmicrovm-34322db1-918a-3ff6-99cf-2291932cde65$3FfilterPattern$3D$2525MicroVM+start+reset+local+buffer$2525$26start$3D1788840000000$26end$3D1788926399000) show the reset is invoked upon MicroVM receives `/run/` event. 

<img width="3256" height="876" alt="image" src="https://github.com/user-attachments/assets/8df39780-f038-4da8-a7cb-029ed77d270a" />

## Risks

The intended behavior drops pre-refresh native trace/telemetry buffers during Lambda MicroVM identity refresh. Rust/native dependency changes may need the native benchmark/build jobs before this leaves draft.

## Additional Notes

Stacked draft PR on top of #20149. The MicroVM identity-refresh release note is already covered earlier in the stack; this PR should use the changelog/no-changelog label.