### PR TITLE
fix(asm): report RASP wrapping context enter failures

### DIFF
--- a/ddtrace/appsec/_common_module_patches.py
+++ b/ddtrace/appsec/_common_module_patches.py
@@ -20,6 +20,7 @@ from ddtrace.appsec._contrib.stripe.patch import patch as patch_stripe_for_appse
 from ddtrace.appsec._contrib.stripe.patch import unpatch as unpatch_stripe_for_appsec
 from ddtrace.appsec._contrib.subprocess.patch import patch as patch_subprocess_for_appsec
 from ddtrace.appsec._contrib.subprocess.patch import unpatch as unpatch_subprocess_for_appsec
+from ddtrace.appsec._metrics import report_rasp_context_error as _report_rasp_context_error
 from ddtrace.appsec._metrics import report_rasp_skipped
 from ddtrace.appsec._patch_utils import try_unwrap
 from ddtrace.appsec._patch_utils import try_wrap_function_wrapper
@@ -111,6 +112,15 @@ def _parse_http_response_body(response):
 class _RaspContext(WrappingContext):
     """Base for RASP wrapping contexts: reads the wrapped call's arguments by name."""
 
+    # Rule type reported when this hook fails to enter. Subclasses set the rule they enforce.
+    __rasp_rule_type__: Optional[str] = None
+
+    def __on_enter_error__(self, exc: Exception) -> None:
+        """The hook was skipped, so this call ran unprotected. Failing open silently is
+        indistinguishable from having nothing to block, so count it.
+        """
+        _report_rasp_context_error(self.__rasp_rule_type__)
+
     def _locals(self) -> dict[str, Any]:
         """The wrapped call's locals, to read its arguments by name.
 
@@ -159,15 +169,20 @@ class _ScopedRaspContext(_RaspContext):
 class _SsrfOpenerDirectorOpen(_ScopedRaspContext):
     """RASP SSRF analysis around urllib.request.OpenerDirector.open."""
 
+    __rasp_rule_type__ = EXPLOIT_PREVENTION.TYPE.SSRF
+
     def __enter__(self) -> "_SsrfOpenerDirectorOpen":
         super().__enter__()
         try:
             self._handle_enter()
-        except Exception:
+        except Exception as exc:
             # AIDEV-NOTE: a context whose __enter__ raises is left out of the universal context's
             # entered list, so neither __return__ nor __exit__ runs and the core context strands.
             self._close_core_context()
-            log.debug("Error handling SSRF instrumentation enter", exc_info=True)
+            # Handled here rather than propagating, so log and report here too: the universal
+            # context's fail-open path never sees this one.
+            log.warning("Error handling SSRF instrumentation enter", exc_info=True)
+            self.__on_enter_error__(exc)
         return self
 
     def _handle_enter(self) -> None:
@@ -286,6 +301,8 @@ def _absolute_downstream_url(connection: Any, path: str) -> str:
 
 class _SsrfHttpConnectionRequest(_RaspContext):
     """RASP SSRF + API10 downstream-request analysis around http.client.HTTPConnection.request."""
+
+    __rasp_rule_type__ = EXPLOIT_PREVENTION.TYPE.SSRF_REQ
 
     def __enter__(self) -> "_SsrfHttpConnectionRequest":
         super().__enter__()

--- a/ddtrace/appsec/_metrics.py
+++ b/ddtrace/appsec/_metrics.py
@@ -171,6 +171,19 @@ def report_waf_run_error(error: int, rule_version: str, rule_type: Optional[str]
         telemetry.telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.APPSEC, "rasp.error", 1, tags=rasp_tags)
 
 
+@_safe_metric(WARNING_TAGS.TELEMETRY_METRICS, ":rasp:context_error")
+def report_rasp_context_error(rule_type: Optional[str]) -> None:
+    """A RASP hook failed to install itself around a call, so that call ran unprotected.
+
+    The WAF was never reached, hence error_type:context_enter rather than a waf_error code.
+    """
+    rasp_tags = (
+        ("waf_version", asm_config._ddwaf_version),
+        ("error_type", "context_enter"),
+    ) + _TYPES_AND_TAGS.get(rule_type or "", ())
+    telemetry.telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.APPSEC, "rasp.error", 1, tags=rasp_tags)
+
+
 @_safe_metric(WARNING_TAGS.TELEMETRY_METRICS, ":waf:request")
 def set_waf_request_metrics(result: Telemetry_result) -> None:
     truncation = result.truncation

--- a/ddtrace/internal/wrapping/context.py
+++ b/ddtrace/internal/wrapping/context.py
@@ -510,6 +510,12 @@ class BaseWrappingContext(ABC):
 
         return self
 
+    def __on_enter_error__(self, exc: Exception) -> None:
+        """Called when __enter__ raised and this context was skipped; the wrapped call still runs.
+
+        A security control should override this to report the gap. Must not raise.
+        """
+
     def _pop_storage(self) -> dict[str, t.Any]:
         storage = t.cast(t.Optional[WrappingContextStorage], self._storage.get())
         if storage is None:
@@ -803,7 +809,13 @@ class _UniversalWrappingContext(*_UWC_BASES):  # type: ignore[misc]
                         self._pop_storage()
                     # A BaseException (e.g. a deliberate blocking decision) is the caller's to see.
                     raise
-                log.debug("Failed to enter wrapping context %r", context, exc_info=True)
+                # The call proceeds unprotected, so warn and tell the context rather than only
+                # logging at debug. DD_TRACE_LOGGING_RATE caps this at one per minute per site.
+                log.warning("Failed to enter wrapping context %r", context, exc_info=True)
+                try:
+                    context.__on_enter_error__(exc)
+                except Exception:
+                    log.debug("Failed to report enter error for %r", context, exc_info=True)
                 continue
             entered.append(context)
 

--- a/releasenotes/notes/asm-report-rasp-context-enter-failures-b68e41c42067e22f.yaml
+++ b/releasenotes/notes/asm-report-rasp-context-enter-failures-b68e41c42067e22f.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    ASM: Fixes an issue where exploit prevention could stop protecting a downstream request
+    without any signal. When a RASP hook fails to install itself around a call, that call now
+    increments the ``appsec.rasp.error`` telemetry metric and logs a warning, instead of being
+    reported only at debug level.

--- a/tests/appsec/appsec/test_common_modules.py
+++ b/tests/appsec/appsec/test_common_modules.py
@@ -878,3 +878,35 @@ def test_absolute_downstream_url_follows_a_connect_tunnel(tunnel_host, tunnel_po
 )
 def test_carries_a_host(url, carries_host):
     assert cmp._carries_a_host(url) is carries_host
+
+
+def test_rasp_context_enter_failure_is_counted():
+    """A RASP hook that cannot enter leaves the call unprotected, so it must report rasp.error.
+
+    Exploit prevention fails open here by design; the point of the metric is that a silent
+    fail-open is otherwise indistinguishable from "there was nothing to block".
+    """
+    unpatch_common_modules()
+    import http.client
+
+    from ddtrace.contrib.internal.httplib.patch import unpatch as httplib_unpatch
+
+    httplib_unpatch()
+    try:
+        patch_common_modules()
+        with (
+            mock.patch.object(cmp, "get_rasp_capability", return_value=True),
+            # The hook raises an ordinary exception before it can reach the WAF.
+            mock.patch.object(cmp, "get_active_asm_context", side_effect=ValueError("boom")),
+            mock.patch.object(cmp, "_report_rasp_context_error") as report,
+        ):
+            conn = http.client.HTTPConnection("127.0.0.1", 1, timeout=1)
+            # Fail-open: the call is attempted rather than blocked, so it fails on the socket.
+            with pytest.raises(OSError):
+                conn.request("GET", "/")
+
+        report.assert_called_once_with(EXPLOIT_PREVENTION.TYPE.SSRF_REQ)
+    finally:
+        core.discard_item("full_url")
+        httplib_unpatch()
+        unpatch_common_modules()

--- a/tests/internal/test_wrapping.py
+++ b/tests/internal/test_wrapping.py
@@ -1983,3 +1983,54 @@ def test_an_exception_from_enter_is_still_swallowed():
         assert _storage_chain_length(context._storage.get()) == 0
     finally:
         context.unwrap()
+
+
+class FailingEnterWrappingContext(WrappingContext):
+    """A context whose __enter__ raises an ordinary exception, i.e. fails open."""
+
+    def __init__(self, f):
+        super().__init__(f)
+        self.reported = []
+
+    def __enter__(self):
+        super().__enter__()
+        raise ValueError("boom")
+
+    def __on_enter_error__(self, exc):
+        self.reported.append(exc)
+
+
+def test_wrapping_context_enter_error_is_reported():
+    """A swallowed __enter__ still runs the function, but the context is told it was skipped."""
+
+    def foo():
+        return 42
+
+    wc = FailingEnterWrappingContext(foo)
+    wc.wrap()
+
+    # Fail-open is preserved: the wrapped function still returns normally.
+    assert foo() == 42
+
+    assert len(wc.reported) == 1
+    assert isinstance(wc.reported[0], ValueError)
+
+    wc.unwrap()
+
+
+def test_wrapping_context_enter_error_hook_cannot_break_the_call():
+    """A broken __on_enter_error__ must not turn a skipped hook into a failed call."""
+
+    class Exploding(FailingEnterWrappingContext):
+        def __on_enter_error__(self, exc):
+            raise RuntimeError("reporting blew up")
+
+    def foo():
+        return 42
+
+    wc = Exploding(foo)
+    wc.wrap()
+
+    assert foo() == 42
+
+    wc.unwrap()


### PR DESCRIPTION
## Description

Jira: [APPSEC-69878](https://datadoghq.atlassian.net/browse/APPSEC-69878)

Since #19989 moved the RASP SSRF hooks from wrapt wrappers to `WrappingContext`, an ordinary
`Exception` raised inside a context's `__enter__` is caught by
`_UniversalWrappingContext.__enter__`, logged at **debug**, and skipped:

```python
except BaseException as exc:
    ...
    if not isinstance(exc, Exception):
        ...
        raise                  # BlockingException (BaseException) still propagates - correct
    log.debug("Failed to enter wrapping context %r", context, exc_info=True)
    continue                   # ordinary Exception -> hook silently disabled
```

`BlockingException` derives from `DDBlockException(BaseException)`, so a real block still
propagates as intended. But for any other exception the wrapped call proceeds **without** the hook,
so exploit prevention silently stops applying to that call and nothing counts it. The only trace is
a debug line. For a security control that is a silent fail-open.

This PR keeps the fail-open (the customer's request must not break) but makes it observable:

- **New extension point.** `BaseWrappingContext.__on_enter_error__(exc)`, a no-op by default,
  called by `_UniversalWrappingContext.__enter__` when it swallows an enter failure. The call is
  guarded, so a failing reporter cannot turn a skipped hook into a failed call.
- **Telemetry.** `_RaspContext` implements the hook and reports `appsec.rasp.error` with
  `error_type:context_enter` plus the rule tags, via a new `report_rasp_context_error()`. The tag
  keeps it distinguishable from `report_waf_run_error`, where the WAF was actually reached and
  there is a real `waf_error` code.
- **Log level.** `debug` -> `warning` with `exc_info=True`, so the swallowed exception is
  identifiable. `DDLogger` rate limits per name/level/file/line via `DD_TRACE_LOGGING_RATE`
  (60s default), so this cannot spam a hot path.
- `_SsrfOpenerDirectorOpen` catches its own enter exceptions and so never reached the universal
  handler - a second silent fail-open path. It now logs and reports through the same hook.

Layering is unchanged: `ddtrace.internal` defines the extension point, `ddtrace.appsec` supplies the
product behaviour. No product import is added to `ddtrace.internal`.

### How this surfaced

The flaky test
`tests/appsec/appsec/test_common_modules.py::test_a_blocked_request_leaves_no_wrapping_storage_behind[py3.9]`
fails with `[Errno 111] Connection refused`. The test's premise is that the hook blocks at function
entry, before any socket work, so ECONNREFUSED means the hook did not block and
`HTTPConnection.request` dialled `127.0.0.1:1` for real. A swallowed `__enter__` is the only path
that produces a silent no-block.

**The underlying trigger for that skip is not identified yet, and this PR does not claim to fix the
flake.** One failure in 30 days (0.61%, already quarantined), on `main` at b07eb0f9c0. What this PR
does is make the next occurrence diagnosable: the warning names the swallowed exception, and the
metric shows whether it happens in production too. One candidate worth noting is that
`__wrapped__` is a property that raises `RuntimeError` when the wrapped function has been garbage
collected, and `_SsrfHttpConnectionRequest.__enter__` reads `self.__wrapped__.__code__.co_name` -
GC-timing dependent, which would fit a rare flake. Unconfirmed.

## Testing

Three new tests, all passing in their own suites:

- `test_wrapping_context_enter_error_is_reported` - a context whose `__enter__` raises still lets
  the wrapped function return normally (fail-open preserved) and is told it was skipped.
- `test_wrapping_context_enter_error_hook_cannot_break_the_call` - a `__on_enter_error__` that
  itself raises must not break the call.
- `test_rasp_context_enter_failure_is_counted` - a RASP hook that cannot enter reports
  `rasp.error` with the SSRF_REQ rule type, and the call is attempted rather than blocked.

Suite runs (py3.9, the version the flake was seen on):

- `tests/internal/test_wrapping.py` (venv 122c3b6): 59 passed, 2 xfailed
- `tests/appsec/appsec/test_common_modules.py` (venv 9052ab4): 113 passed

`scripts/lint checks` and `scripts/lint error-log-check` are clean for the changed files. Three
`E721` warnings in `test_common_modules.py` are pre-existing on `main` (verified by re-running with
these changes stashed).

## Risks

Low, but not zero:

- **New warning-level log.** Previously debug. Rate limited to one per minute per call site, but a
  deployment where a hook errors constantly will now see a recurring warning it did not see before.
  That is the intent - it was invisible - though it may look like a new problem when it is a
  pre-existing one becoming visible.
- **`appsec.rasp.error` may become non-zero** for orgs where this path fires. Any dashboard or
  monitor reading that metric as "always ~0" should expect a step change. Splitting on the new
  `error_type` tag separates context-enter failures from WAF run errors.
- No behaviour change to blocking itself: `BlockingException` propagation is untouched, and the
  fail-open is deliberately preserved.

## Additional Notes

`_SsrfHttpConnectionGetresponse` only implements `__return__`, so it has no failing `__enter__` and
is out of scope here. It does swallow its own exceptions in `__return__` with `pass  # nosec`; that
is pre-existing and not addressed.

While validating, running `tests/internal/test_wrapping.py` inside the appsec venv alongside the
appsec tests made two storage-recycling tests fail. That combination does not occur in CI (they are
separate suites) and each file passes in its own suite, but it is real cross-file pollution of the
storage-var pool and may deserve a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APPSEC-69878]: https://datadoghq.atlassian.net/browse/APPSEC-69878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ