### PR TITLE
chore(tests): prevent GC monitor leaks in tests

### DIFF
--- a/tests/tracer/runtime/test_metric_collectors.py
+++ b/tests/tracer/runtime/test_metric_collectors.py
@@ -277,12 +277,15 @@ class TestGCRuntimeMetricCollector(BaseTestCase):
         from ddtrace.internal.runtime.gc_monitor import gc_pause_monitor
         from ddtrace.internal.runtime.runtime_metrics import RuntimeWorker
 
-        worker: RuntimeWorker = RuntimeWorker()
-        worker.start()
         monitor = gc_pause_monitor()
-        self.assertGreaterEqual(monitor._refcount, 1)
-        worker.stop()
-        self.assertEqual(monitor._refcount, 0)
+        before: int = monitor._refcount
+        worker: RuntimeWorker = RuntimeWorker()
+        try:
+            worker.start()
+            self.assertEqual(monitor._refcount, before + 1)
+        finally:
+            worker.stop()
+        self.assertEqual(monitor._refcount, before)
 
     def test_init_failure_releases_monitor(self) -> None:
         import gc

--- a/tests/tracer/runtime/test_runtime_metrics.py
+++ b/tests/tracer/runtime/test_runtime_metrics.py
@@ -33,6 +33,24 @@ def runtime_metrics_service(tracer=None):
     RuntimeWorker._instance = None
 
 
+@contextlib.contextmanager
+def managed_runtime_worker():
+    worker = RuntimeWorker()
+    try:
+        yield worker
+    finally:
+        worker._runtime_metrics.stop()
+
+
+@contextlib.contextmanager
+def managed_runtime_metrics(enabled=None):
+    metrics = RuntimeMetrics(enabled=enabled)
+    try:
+        yield metrics
+    finally:
+        metrics.stop()
+
+
 class TestRuntimeTags(TracerTestCase):
     def test_all_tags(self):
         with self.override_global_tracer():
@@ -146,19 +164,19 @@ def test_runtime_worker_flush_preserves_entity_id_tag(monkeypatch):
 
     with mock.patch("socket.socket") as sock:
         sock.return_value.getsockopt.return_value = 0
-        worker = RuntimeWorker()
-        assert "dd.internal.entity_id:test-entity-123" in worker._dogstatsd_client.constant_tags
+        with managed_runtime_worker() as worker:
+            assert "dd.internal.entity_id:test-entity-123" in worker._dogstatsd_client.constant_tags
 
-        for _ in range(3):
-            worker.flush()
+            for _ in range(3):
+                worker.flush()
 
-        statsd_socket = worker._dogstatsd_client.socket
-        received = [s.args[0].decode("utf-8") for s in statsd_socket.send.mock_calls]
-        assert received, "expected at least one packet to be sent"
-        gauges = [line for packet in received for line in packet.split("\n") if line]
-        assert gauges, "expected at least one metric line to be sent"
-        for gauge in gauges:
-            assert gauge.count("dd.internal.entity_id:test-entity-123") == 1, gauge
+            statsd_socket = worker._dogstatsd_client.socket
+            received = [s.args[0].decode("utf-8") for s in statsd_socket.send.mock_calls]
+            assert received, "expected at least one packet to be sent"
+            gauges = [line for packet in received for line in packet.split("\n") if line]
+            assert gauges, "expected at least one metric line to be sent"
+            for gauge in gauges:
+                assert gauge.count("dd.internal.entity_id:test-entity-123") == 1, gauge
 
 
 def test_runtime_worker_flush_dedupes_entity_id_tag(monkeypatch):
@@ -171,16 +189,16 @@ def test_runtime_worker_flush_dedupes_entity_id_tag(monkeypatch):
 
     with mock.patch("socket.socket") as sock:
         sock.return_value.getsockopt.return_value = 0
-        worker = RuntimeWorker()
-        worker.flush()
+        with managed_runtime_worker() as worker:
+            worker.flush()
 
-        statsd_socket = worker._dogstatsd_client.socket
-        received = [s.args[0].decode("utf-8") for s in statsd_socket.send.mock_calls]
-        assert received, "expected at least one packet to be sent"
-        gauges = [line for packet in received for line in packet.split("\n") if line]
-        assert gauges, "expected at least one metric line to be sent"
-        for gauge in gauges:
-            assert gauge.count("dd.internal.entity_id:test-entity-123") == 1, gauge
+            statsd_socket = worker._dogstatsd_client.socket
+            received = [s.args[0].decode("utf-8") for s in statsd_socket.send.mock_calls]
+            assert received, "expected at least one packet to be sent"
+            gauges = [line for packet in received for line in packet.split("\n") if line]
+            assert gauges, "expected at least one metric line to be sent"
+            for gauge in gauges:
+                assert gauge.count("dd.internal.entity_id:test-entity-123") == 1, gauge
 
 
 def test_runtime_worker_flush_does_not_leak_stale_service_tag(monkeypatch):
@@ -193,27 +211,29 @@ def test_runtime_worker_flush_does_not_leak_stale_service_tag(monkeypatch):
 
     with mock.patch("socket.socket") as sock:
         sock.return_value.getsockopt.return_value = 0
-        worker = RuntimeWorker()
-        with override_global_config(dict(service="override-service")):
-            worker.flush()
+        with managed_runtime_worker() as worker:
+            with override_global_config(dict(service="override-service")):
+                worker.flush()
 
-            statsd_socket = worker._dogstatsd_client.socket
-            received = [s.args[0].decode("utf-8") for s in statsd_socket.send.mock_calls]
-            assert received, "expected at least one packet to be sent"
-            gauges = [line for packet in received for line in packet.split("\n") if line]
-            assert gauges, "expected at least one metric line to be sent"
-            for gauge in gauges:
-                assert "service:env-service" not in gauge, gauge
-                assert gauge.count("service:override-service") == 1, gauge
+                statsd_socket = worker._dogstatsd_client.socket
+                received = [s.args[0].decode("utf-8") for s in statsd_socket.send.mock_calls]
+                assert received, "expected at least one packet to be sent"
+                gauges = [line for packet in received for line in packet.split("\n") if line]
+                assert gauges, "expected at least one metric line to be sent"
+                for gauge in gauges:
+                    assert "service:env-service" not in gauge, gauge
+                    assert gauge.count("service:override-service") == 1, gauge
 
 
 class TestRuntimeMetrics(BaseTestCase):
     def test_all_metrics(self):
-        metrics = set([k for (k, v) in RuntimeMetrics()])
+        with managed_runtime_metrics() as runtime_metrics:
+            metrics = set([k for (k, v) in runtime_metrics])
         self.assertSetEqual(metrics, DEFAULT_RUNTIME_METRICS)
 
     def test_one_metric(self):
-        metrics = [k for (k, v) in RuntimeMetrics(enabled=[GC_COUNT_GEN0])]
+        with managed_runtime_metrics(enabled=[GC_COUNT_GEN0]) as runtime_metrics:
+            metrics = [k for (k, v) in runtime_metrics]
         self.assertEqual(metrics, [GC_COUNT_GEN0])
 
 


### PR DESCRIPTION
## Description

Ensure tests that instantiate `RuntimeMetrics` or `RuntimeWorker` release their GC runtime metric collectors. Previously, five test-owned collectors remained acquired, leaking references to the process-wide GC pause monitor and causing
an order-dependent failure in `test_runtime_worker_stop_tears_down_gc_collector`.

The lifecycle assertion now verifies that a worker increments the monitor reference count once and restores the pre-existing count when stopped. This tests the worker's ownership without assuming that no other legitimate monitor
owners exist in the process.

## Testing

- Formatted the modified test files with `scripts/lint fmt`.
- Ran the six affected tests with the Python 3.14 tracer environment.
- Result: 6 passed.

## Risks

Low. The changes are limited to test cleanup and assertions; production code is
unchanged.

## Additional Notes

No release note is needed because this is a test-only change.
