### PR TITLE
chore(fastapi): remove Pin

### DIFF
--- a/ddtrace/contrib/internal/fastapi/patch.py
+++ b/ddtrace/contrib/internal/fastapi/patch.py
@@ -142,7 +142,7 @@ def patch():
     _w("fastapi.routing", "serialize_response", traced_serialize_response)
 
     if not is_wrapted(fastapi.BackgroundTasks.add_task):
-        _w("fastapi", "BackgroundTasks.add_task", _trace_background_tasks(fastapi))
+        _w("fastapi", "BackgroundTasks.add_task", _trace_background_tasks)
     # We need to check that Starlette instrumentation hasn't already patched these
     if not is_wrapted(fastapi.routing.APIRoute.__init__):
         _w("fastapi.routing", "APIRoute.__init__", traced_route_init)

--- a/ddtrace/contrib/internal/fastapi/patch.py
+++ b/ddtrace/contrib/internal/fastapi/patch.py
@@ -1,24 +1,27 @@
 import copyreg
+import inspect
 
 import fastapi
 import fastapi.routing
 import starlette
+from starlette.concurrency import run_in_threadpool
 import wrapt
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
-from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.asgi.middleware import TraceMiddleware
 from ddtrace.contrib.internal.starlette.patch import _set_route_resource_resolver
-from ddtrace.contrib.internal.starlette.patch import _trace_background_tasks
 from ddtrace.contrib.internal.starlette.patch import traced_handler
 from ddtrace.contrib.internal.starlette.patch import traced_route_init
+from ddtrace.contrib.internal.trace_utils import is_tracing_enabled
 from ddtrace.internal.compat import is_wrapted
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.settings import env
 from ddtrace.internal.settings.asm import config as asm_config
 from ddtrace.internal.telemetry import get_config as _get_config
+from ddtrace.internal.utils import get_argument_value
+from ddtrace.internal.utils import set_argument_value
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.internal.utils.wrappers import unwrap as _u
@@ -122,12 +125,32 @@ async def traced_serialize_response(wrapped, instance, args, kwargs):
     added by creating spans will be higher than desired for
     the result.
     """
-    pin = Pin.get_from(fastapi)
-    if not pin or not pin.enabled():
+    if not is_tracing_enabled():
         return await wrapped(*args, **kwargs)
 
     with tracer.trace("fastapi.serialize_response"):
         return await wrapped(*args, **kwargs)
+
+
+def traced_background_tasks(wrapped, instance, args, kwargs):
+    if not is_tracing_enabled():
+        return wrapped(*args, **kwargs)
+
+    task = get_argument_value(args, kwargs, 0, "func")
+    current_span = tracer.current_span()
+    task_name = getattr(task, "__name__", "<unknown>")
+
+    async def traced_task(*args, **kwargs):
+        with tracer.start_span("fastapi.background_task", resource=task_name, child_of=None, activate=True) as span:
+            if current_span:
+                span.link_span(current_span.context)
+            if inspect.iscoroutinefunction(task):
+                await task(*args, **kwargs)
+            else:
+                await run_in_threadpool(task, *args, **kwargs)
+
+    args, kwargs = set_argument_value(args, kwargs, 0, "func", traced_task)
+    return wrapped(*args, **kwargs)
 
 
 def patch():
@@ -137,12 +160,11 @@ def patch():
     _register_wrapt_pickle_reducers()
 
     fastapi._datadog_patch = True
-    Pin().onto(fastapi)
     _w("fastapi.applications", "FastAPI.build_middleware_stack", wrap_middleware_stack)
     _w("fastapi.routing", "serialize_response", traced_serialize_response)
 
     if not is_wrapted(fastapi.BackgroundTasks.add_task):
-        _w("fastapi", "BackgroundTasks.add_task", _trace_background_tasks(fastapi))
+        _w("fastapi", "BackgroundTasks.add_task", traced_background_tasks)
     # We need to check that Starlette instrumentation hasn't already patched these
     if not is_wrapted(fastapi.routing.APIRoute.__init__):
         _w("fastapi.routing", "APIRoute.__init__", traced_route_init)

--- a/ddtrace/contrib/internal/starlette/patch.py
+++ b/ddtrace/contrib/internal/starlette/patch.py
@@ -10,11 +10,10 @@ from starlette.middleware import Middleware
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
-from ddtrace._trace.pin import Pin
 from ddtrace.contrib import trace_utils
 from ddtrace.contrib.internal.asgi.middleware import _DD_ROUTE_RESOURCE_RESOLVER
 from ddtrace.contrib.internal.asgi.middleware import TraceMiddleware
-from ddtrace.contrib.internal.trace_utils import with_traced_module
+from ddtrace.contrib.internal.trace_utils import is_tracing_enabled
 from ddtrace.ext import http
 from ddtrace.internal import core
 from ddtrace.internal._exceptions import BlockingException
@@ -207,7 +206,6 @@ def patch():
     starlette._datadog_patch = True
 
     _w("starlette.applications", "Starlette.__init__", traced_init)
-    Pin().onto(starlette)
 
     core.on("asgi.collect_routes", _collect_routes_from_app)
 
@@ -220,7 +218,7 @@ def patch():
         _w("starlette.routing", "Mount.handle", traced_handler)
 
     if not is_wrapted(starlette.background.BackgroundTasks.add_task):
-        _w("starlette.background", "BackgroundTasks.add_task", _trace_background_tasks(starlette))
+        _w("starlette.background", "BackgroundTasks.add_task", _trace_background_tasks)
 
 
 def unpatch():
@@ -363,17 +361,16 @@ def traced_handler(wrapped, instance, args, kwargs):
     return wrapped(*args, **kwargs)
 
 
-@with_traced_module
-def _trace_background_tasks(module, pin, wrapped, instance, args, kwargs):
+def _trace_background_tasks(wrapped, instance, args, kwargs):
+    if not is_tracing_enabled():
+        return wrapped(*args, **kwargs)
+
     task = get_argument_value(args, kwargs, 0, "func")
     current_span = tracer.current_span()
-    module_name = getattr(module, "__name__", "<unknown>")
     task_name = getattr(task, "__name__", "<unknown>")
 
     async def traced_task(*args, **kwargs):
-        with tracer.start_span(
-            f"{module_name}.background_task", resource=task_name, child_of=None, activate=True
-        ) as span:
+        with tracer.start_span("starlette.background_task", resource=task_name, child_of=None, activate=True) as span:
             if current_span:
                 span.link_span(current_span.context)
             if inspect.iscoroutinefunction(task):
@@ -382,4 +379,4 @@ def _trace_background_tasks(module, pin, wrapped, instance, args, kwargs):
                 await run_in_threadpool(task, *args, **kwargs)
 
     args, kwargs = set_argument_value(args, kwargs, 0, "func", traced_task)
-    wrapped(*args, **kwargs)
+    return wrapped(*args, **kwargs)

--- a/ddtrace/contrib/internal/starlette/patch.py
+++ b/ddtrace/contrib/internal/starlette/patch.py
@@ -367,10 +367,13 @@ def _trace_background_tasks(wrapped, instance, args, kwargs):
 
     task = get_argument_value(args, kwargs, 0, "func")
     current_span = tracer.current_span()
+    module_name = getattr(starlette, "__name__", "<unknown>")
     task_name = getattr(task, "__name__", "<unknown>")
 
     async def traced_task(*args, **kwargs):
-        with tracer.start_span("starlette.background_task", resource=task_name, child_of=None, activate=True) as span:
+        with tracer.start_span(
+            f"{module_name}.background_task", resource=task_name, child_of=None, activate=True
+        ) as span:
             if current_span:
                 span.link_span(current_span.context)
             if inspect.iscoroutinefunction(task):


### PR DESCRIPTION
## Summary

Removes FastAPI Pin state and uses `is_tracing_enabled()` for response serialization. Background-task tracing reuses Starlette's Pin-free module-aware wrapper with the FastAPI module context.

Depends on #20179.

## Backward compatibility

The undocumented private Pin override on the fastapi module is removed. Default tracing behavior, including disabled tracing, standalone mode, and `fastapi.background_task` span naming, is preserved.

## Testing

- `scripts/lint checks`
- `scripts/run-tests --venv 86e9f67` (74 passed)
