### PR TITLE
test: fix agent probe flake in deadlock test

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -419,6 +419,11 @@ s2.finish()
             {
                 "DD_TRACE_LOGS_INJECTION": str(logs_injection).lower(),
                 "DD_TRACE_DEBUG": str(debug_mode).lower(),
+                # DD_TRACE_DEBUG=true makes tracer startup synchronously probe the agent's
+                # /info endpoint.
+                # localhost:8125 has nothing listening so the probe fails instantly and
+                # doesn't block the test / consume timeout budget.
+                "DD_TRACE_AGENT_URL": "http://localhost:8125",
             }
         )
 


### PR DESCRIPTION
## Description

`test_application_does_not_deadlock_when_parent_span_closes_before_child` was flaky with this error.

```
AssertionError: b'Reading stable configuration from files: ...
fetching /info err=Request to /info timed out after 3s
Waiting 5 seconds for tracer to finish. Hit ctrl-c to quit.
assert -15 == 0
```

The problem was that the test did both `DD_TRACE_DEBUG`  `True` then `False`. When `DD_TRACE_DEBUG=true`, `Tracer._generate_diagnostic_logs`  synchronously calls `debug.collect` which calls `agent.is_reachable`, which blocks on a real HTTP request to the agent's `/info` endpoint before the test body even runs.  
The test's subprocess inherited `DD_TRACE_AGENT_URL` pointing at the real CI test agent. If that real agent was slow to respond and the request timed out, it would consume a large part of the test's 5 seconds timeout, resulting in the failure.

What the PR does is adding an explicit `DD_TRACE_AGENT_URL` on `http://localhost:8125` where nothing listens, so that it immediately fails instead of blocking.

