### PR TITLE
perf(ci_visibility): reduce pytest overhead

### DIFF
--- a/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
+++ b/.gitlab/benchmarks/bp-runner.microbenchmarks.fail-on-breach.template.yml
@@ -849,6 +849,14 @@ experiments:
             thresholds:
               - execution_time < 3.75 ms
 
+          # pytestplugin
+          - name: pytestplugin-baseline
+            thresholds:
+              - execution_time < 2800 ms
+          - name: pytestplugin-ddtrace
+            thresholds:
+              - execution_time < 3600 ms
+
           # tracer
           - name: tracer-large
             thresholds:

--- a/ddtrace/internal/utils/inspection.py
+++ b/ddtrace/internal/utils/inspection.py
@@ -55,12 +55,6 @@ def undecorated(f: FunctionType, name: str, path: Path) -> FunctionType:
     while q:
         g = q.popleft()
 
-        # Fast path: the current function already matches. This covers the common
-        # case of a plain, undecorated test function (the input ``f`` itself),
-        # avoiding the full BFS + ``__dir__()`` scan below for no-op benefit.
-        if _isinstance(g, FunctionType) and match(g):
-            return g
-
         # Look for a wrapped function. These attributes are generally used by
         # the decorators provided by the standard library (e.g. partial)
         for attr in ("__wrapped__", "func"):
@@ -123,6 +117,13 @@ def undecorated(f: FunctionType, name: str, path: Path) -> FunctionType:
                         return v
             except AttributeError:
                 pass
+
+        # Fast path: the current function already matches and none of the explicit
+        # wrapper relationships above led to an original function. This covers the
+        # common plain-function case while preserving the original precedence for a
+        # same-name function held by a decorator closure or attribute.
+        if _isinstance(g, FunctionType) and match(g):
+            return g
 
         # Last resort
         try:

--- a/ddtrace/testing/internal/tracer_api/context.py
+++ b/ddtrace/testing/internal/tracer_api/context.py
@@ -86,10 +86,10 @@ def _ddtrace_context() -> t.Generator[DDTraceTestContext, None, None]:
     #   1. provide trace_id/span_id for the test run,
     #   2. parent child spans from instrumented libraries inside the test,
     #   3. carry the type=test tag that the Selenium integration checks.
-    # It is never finished through the tracer pipeline: TestOptSpanProcessor discards root
-    # spans anyway (parent_id is None), and child spans are processed independently when
-    # they finish. This saves ~55 us/test vs tracer.trace() + finish() on the per-test
-    # hot path.
+    # It has no finish callbacks, so finishing it only marks it complete; it does not enter
+    # the tracer pipeline. TestOptSpanProcessor discards root spans anyway (parent_id is
+    # None), and child spans are processed independently when they finish. This saves most
+    # of tracer.trace()'s ~55 us/test cost on the per-test hot path.
     root_span = Span(
         name=DDTESTOPT_ROOT_SPAN_RESOURCE,
         resource=DDTESTOPT_ROOT_SPAN_RESOURCE,
@@ -101,6 +101,11 @@ def _ddtrace_context() -> t.Generator[DDTraceTestContext, None, None]:
     try:
         yield DDTraceTestContext(root_span)
     finally:
+        # A copied context (for example, an asyncio task created by the test) can retain
+        # this span after the current context is cleared. Marking it finished lets the
+        # context provider discard that stale reference before creating later spans.
+        # TODO: Keep async-framework coverage for this invariant as context handling evolves.
+        root_span.finish()
         ddtrace.tracer.context_provider.activate(None)
 
 

--- a/tests/internal/test_utils_inspection.py
+++ b/tests/internal/test_utils_inspection.py
@@ -57,8 +57,8 @@ def test_wrapped_decoration():
 
 
 def test_undecorated_plain_function_returns_input_directly():
-    # A plain (undecorated) function is the common case. ``undecorated`` must return it
-    # without descending into the BFS / ``__dir__()`` scan: the input itself already
+    # A plain (undecorated) function is the common case. undecorated must return it
+    # without descending into the BFS / __dir__() scan: the input itself already
     # matches. This is the fast path that keeps per-test source-location discovery cheap.
     def f():
         pass
@@ -71,3 +71,21 @@ def test_undecorated_plain_function_returns_input_directly():
         pass
 
     assert undecorated(g, name="does_not_exist", path=path) is g
+
+
+def test_undecorated_same_name_wrapper_returns_original():
+    def decorate(original):
+        # A decorator wrapper may legitimately share the test's name and source file.
+        def test_target():
+            return original()
+
+        return test_target
+
+    def test_target():
+        pass
+
+    original = test_target
+    wrapper = decorate(original)
+
+    assert wrapper.__code__.co_name == original.__code__.co_name
+    assert undecorated(wrapper, name="test_target", path=Path(__file__).resolve()) is original

--- a/tests/testing/internal/tracer_api/test_context.py
+++ b/tests/testing/internal/tracer_api/test_context.py
@@ -31,7 +31,7 @@ def _reset_tracer_context():
 
 
 @pytest.fixture
-def span_processor(monkeypatch):
+def span_processor():
     """Install a TestOptSpanProcessor with a mock writer and restore config after."""
     from unittest.mock import Mock
 
@@ -116,6 +116,40 @@ def test_trace_context_cleans_up_after_exit():
         assert tracer.current_root_span() is not None
     # After the context exits, the root span should be deactivated.
     assert tracer.current_root_span() is None
+
+
+def test_trace_context_finishes_root_retained_by_async_task():
+    import asyncio
+
+    from ddtrace.trace import tracer
+
+    async def exercise_copied_context():
+        resume = asyncio.Event()
+
+        async def create_span_after_test():
+            await resume.wait()
+            assert tracer.current_root_span() is None
+            child = tracer.trace("after.test")
+            try:
+                return child.parent_id
+            finally:
+                child.finish()
+
+        with _ddtrace_context():
+            root = tracer.current_root_span()
+            task = asyncio.create_task(create_span_after_test())
+
+        resume.set()
+        return root, await task
+
+    root, parent_id = asyncio.run(exercise_copied_context())
+
+    assert root is not None
+    assert root.finished
+    # The test runner may install its own surrounding trace context. The important
+    # invariant is that a task retaining this test's context cannot parent later spans
+    # to this test's finished phantom root.
+    assert parent_id != root.span_id
 
 
 def test_trace_context_clears_leftover_spans():


### PR DESCRIPTION
<!-- dd-meta {"pullId":"e16c106c-43fe-4e4c-ad87-7797d28e8dfb","source":"chat","resourceId":"e5b3564f-7d7e-4ae5-85de-131c302e3ad6","workflowId":"41f87619-2ae7-4e76-90d2-d1a1133b52aa","codeChangeId":"41f87619-2ae7-4e76-90d2-d1a1133b52aa","sourceType":"slack"} -->
## Description

The ddtrace pytest plugin (`ddtrace/testing/internal/pytest/plugin.py`, the `ddtrace.testing` architecture) adds per-test overhead that makes customers reluctant to adopt CI Visibility. This PR reduces that overhead by ~30% on a trivial-test corpus through three targeted, low-risk fixes to the synchronous per-test path — no wire-format or API changes.

### Changes

1. **`undecorated()` fast-path** (`ddtrace/internal/utils/inspection.py`): The function that resolves the original test function behind decorators runs a full BFS + `__dir__()` scan (~40 `safety._isinstance` calls) even for plain, undecorated test functions — the overwhelmingly common case. Added a `match(g)` check after explicit wrapper, closure, attribute, and slot relationships but before the expensive `__dir__()` fallback. Plain functions still return immediately, while a same-name/same-file wrapper correctly resolves to the original function held by its decorator closure. **Micro-benchmark: 27.6 µs → 0.7 µs per call (40×) before the review hardening; the retained fast path still avoids the expensive fallback.**

2. **Gate per-test coverage collection** (`ddtrace/testing/internal/pytest/plugin.py`): The plugin wrapped every test in `coverage_collection()` unconditionally, but `ModuleCodeCollector` is only installed when `settings.coverage_enabled` is true (ITR/line coverage on). With coverage off, the per-test CM did no useful work — ContextVar churn, `sys.monitoring` tool-slot probes, then empty bitmaps that `put_coverage` discards. Added a `_maybe_collect_coverage(coverage_enabled)` helper that yields the real CM when coverage is on, or an empty `CoverageData` when off. Behaviour unchanged: empty bitmaps flow through the same `put_coverage` empty fast path.

3. **Phantom root span** (`ddtrace/testing/internal/tracer_api/context.py`): The plugin created a root span per test via `tracer.trace()` to provide `trace_id`/`span_id` and parent instrumented child spans. But `TestOptSpanProcessor` discards root spans (it skips `parent_id is None`), so the full `tracer.trace()` pipeline — service mapping, span processors, aggregator registration, `core.dispatch`, finish — was pure overhead for a span that's never sent. Now the root `Span` is created directly (bypassing the pipeline, `on_finish=[]`). It's a real `Span` with `type=test`/`span.kind=test` tags, so all downstream features work unchanged. On exit it is marked finished before deactivation; because it has no finish callbacks this does not enter the tracer pipeline, but copied asyncio contexts can recognize and discard the stale root. **Micro-benchmark: 66.9 µs → 12.3 µs per test (5.4×) before the review hardening.**

### Benchmark

Added a `pytest_plugin` macrobenchmark to `benchmarks/suitespec.yml` (with a new `ci_visibility` suitespec component) so per-test overhead changes are detectable in the benchmarking platform. The scenario runs a generated corpus of trivial `assert True` tests through pytest with and without `--ddtrace`, in the plugin's hermetic offline (payload-files) mode (NoOp backend connector, all features off, no network). This isolates the synchronous per-test overhead with zero network variance. Two configs: `baseline` (control, no `--ddtrace`) and `ddtrace` (plugin active). The generated `pytestplugin-baseline` and `pytestplugin-ddtrace` scenarios are now protected by execution-time SLOs (`< 2800 ms` and `< 3600 ms`, respectively), so future regressions fail the benchmark gate.

### Measured impact

Same-session paired benchmark (n=7, 1200 trivial tests, `taskset`-pinned, agentless against a local HTTP sink, all features off):

| | wall | overhead | per-test |
|---|---|---|---|
| no `--ddtrace` | 2.37 s | — | — |
| `--ddtrace` (before) | 3.20 s | +0.83 s | 0.62 ms/test |
| `--ddtrace` (after R1+R2) | 3.09 s | +0.72 s | 0.51 ms/test |
| `--ddtrace` (after R1+R2+R3) | 3.00 s | +0.63 s | ~0.44 ms/test |

**Total: ~0.18 ms/test removed (~25–30% of the original per-test overhead).**

The writer/flush network path (GIL, `http.client`, gzip) does not appear in per-test wall time — flushing is backgrounded. Native-writer work targets GIL contention under concurrent load, which is complementary to these synchronous-path fixes.

## Testing

### Latest review-fix validation

- `scripts/run-tests --venv 12c5734 -- tests/internal/test_utils_inspection.py`: 5 passed, including the same-name wrapper regression.
- `scripts/run-tests --venv 1d2df56 -- -k test_trace_context`: 9 passed, including the copied-async-context regression.
- `scripts/gen_gitlab_config.py --file benchmarks/pytest_plugin/scenario.py --verbose`: generated the `pytest_plugin` benchmark job and both SLO scenarios.
- `scripts/lint suitespec-check`: passed.
- `scripts/lint checks`: passed (formatting, types, security, suite coverage, and repository checks).

### Original PR validation

- **Unit tests** (run via direct pytest against the editable install; the `run-tests`/riot infra couldn't build venvs in this environment — the pyenv 3.12.13 interpreter it targets isn't installed on this machine):
  - `tests/internal/test_utils_inspection.py` — 4 passed (3 existing + 1 new `test_undecorated_plain_function_returns_input_directly`).
  - `tests/testing/internal/pytest/test_plugin.py` — 105 passed (103 existing + 2 new, including `test_coverage_collection_skipped_when_coverage_disabled`). The existing coverage-dispatch tests still pass because they use `with_skipping_enabled(True)` → `coverage_enabled=True` → the patched `coverage_collection` is still invoked.
  - `tests/testing/internal/test_coverage_api.py` — 1 passed.
  - `tests/testing/internal/tracer_api/test_context.py` — 8 new tests (all pass) covering: ID/tag provision, `current_root_span()` visibility, child span parenting, child→event conversion, multiple children, cleanup, leftover-span clearing, disabled-ddtrace mode.
  - `tests/testing/internal/pytest/test_pytest_log_correlation.py` — 10 pre-existing failures (same with and without this PR; pytester subprocess can't find pytest in this environment — not related to these changes).
- **Benchmark**: validated via the full Docker CI flow (Python 3.9, two venvs — PyPI baseline vs local candidate with native extensions compiled in-container); `pyperf compare_to` ran successfully for both configs.

## Risks

- **R1 (undecorated)**: Very low. Explicit wrapper relationships retain precedence, including same-name/same-file functions captured by decorator closures; plain functions still avoid the expensive `__dir__()` fallback. Covered by existing tests plus the new regression.
- **R2 (coverage CM)**: Low. When coverage is disabled, the empty `CoverageData` flows through the same `put_coverage` empty fast path — no behaviour change. When coverage is enabled, the real `coverage_collection()` is used as before. The new test verifies the CM is not entered when disabled.
- **R3 (phantom root span)**: Low. The phantom remains a real `Span` for Selenium, BDD, fixtures, and child parenting. It is marked finished with `on_finish=[]` before deactivation, preventing stale parenting in copied asyncio contexts without invoking span processors or the aggregator. Covered by nine focused context tests.

## Additional Notes

- The benchmark uses the plugin's hermetic offline (payload-files) mode, which gives a NoOp backend connector with all features off — this is the "plugin enabled, no ITR/coverage/EFD/ATR" configuration. With ITR/coverage enabled, the coverage CM does real `sys.monitoring` work and R2's gate keeps the enabled path unchanged.
- A detailed measurement and optimization plan (with ablation methodology, per-component attribution, and ranked future recommendations) is available in `pytest-overhead-plan.md` (not committed; copied to `~/pytest-overhead-plan.md`).
- Future work (not in this PR): R4 (batch per-test telemetry, ~6%), R5 (memoize per-item scans), and a leaner hook strategy to reduce the residual ~0.44 ms/test dominated by pluggy hookwrapper machinery.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/e5b3564f-7d7e-4ae5-85de-131c302e3ad6)

Comment @datadog to request changes