### PR TITLE
chore(tornado): remove Pin

### DIFF
--- a/ddtrace/contrib/internal/tornado/application.py
+++ b/ddtrace/contrib/internal/tornado/application.py
@@ -1,11 +1,9 @@
 from urllib.parse import urlparse
 
-from tornado import template
 from tornado.routing import PathMatches
 import tornado.web
 
 from ddtrace import config
-from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.tornado import decorators
 from ddtrace.contrib.internal.tornado.constants import CONFIG_KEY
 from ddtrace.contrib.internal.tornado.handlers import _path_for_path_match
@@ -100,7 +98,6 @@ def tracer_config(__init__, app, args, kwargs):
     if tags:
         tracer.set_tags(tags)
 
-    pin = Pin(service=service)
-    pin.onto(template)
+    config.tornado._default_service = service
 
     _collect_endpoints(app)

--- a/ddtrace/contrib/internal/tornado/template.py
+++ b/ddtrace/contrib/internal/tornado/template.py
@@ -1,7 +1,5 @@
-from tornado import template
-
 from ddtrace import config
-from ddtrace._trace.pin import Pin
+from ddtrace.contrib.internal.trace_utils import is_tracing_enabled
 from ddtrace.contrib.internal.trace_utils import set_service_and_source
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.constants import COMPONENT
@@ -14,9 +12,7 @@ def generate(func, renderer, args, kwargs):
     may be called everywhere, the execution is traced in a tracer StackContext that
     inherits the current one if it's already available.
     """
-    # get the module pin
-    pin = Pin.get_from(template)
-    if not pin or not pin.enabled():
+    if not is_tracing_enabled():
         return func(*args, **kwargs)
 
     # change the resource and the template name
@@ -28,7 +24,7 @@ def generate(func, renderer, args, kwargs):
 
     # trace the original call
     with tracer.trace("tornado.template", resource=resource, span_type=SpanTypes.TEMPLATE) as span:
-        set_service_and_source(span, pin.service, config.tornado)
+        set_service_and_source(span, config.tornado._default_service, config.tornado)
         span._set_attribute(COMPONENT, config.tornado.integration_name)
 
         span._set_attribute("tornado.template_name", template_name)


### PR DESCRIPTION
## Summary

Removes Tornado's template Pin state and uses is_tracing_enabled() for the template fast path. The application-configured default service remains the source for template span service names.

## Backward compatibility

The undocumented private Pin attachment on tornado.template is removed. Public Tornado tracing, application default_service configuration, disabled tracing, and standalone mode are preserved.

## Testing

- scripts/lint format_check -- ddtrace/contrib/internal/tornado/application.py ddtrace/contrib/internal/tornado/template.py
- scripts/lint ruff check -- ddtrace/contrib/internal/tornado/application.py ddtrace/contrib/internal/tornado/template.py
- scripts/run-tests --venv 14d4f5c tests/contrib/tornado