### PR TITLE
chore(codeowners): all test file has at least one real owner.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,15 +25,16 @@ tests/integration/                  @DataDog/apm-core-python
 # Files which can be approved by anyone
 # DEV: This helps not requiring apm-core-python to review new files added
 #      or files which changes often with most PRs
+# tests file are kept under @DataDog/apm-core-python to have a real owner.
 ddtrace/constants.py                @DataDog/apm-python
 releasenotes/                       @DataDog/apm-python
-tests/snapshots/                    @DataDog/apm-python
+tests/snapshots/                    @DataDog/apm-core-python @DataDog/apm-python
 riotfile.py                         @DataDog/apm-python
 .riot/requirements/                 @DataDog/apm-python
 .uv/                                @DataDog/python-guild
 CHANGELOG.md                        @DataDog/apm-python
 ddtrace/internal/telemetry/         @DataDog/apm-python
-tests/telemetry                     @DataDog/apm-python
+tests/telemetry                     @DataDog/apm-core-python @DataDog/apm-python
 supported-configurations.json       @DataDog/apm-python
 ddtrace/internal/settings/_supported_configurations.py @DataDog/apm-python
 


### PR DESCRIPTION
Updated CODEOWNERS to assign tests/snapshots and tests/telemetry to @DataDog/apm-core-python.

## Description

<!-- Provide an overview of the change and motivation for the change.
     Implementation detail and rationale belong here, not in the release note -
     release notes are customer-facing (see docs/releasenotes.rst). -->

## Testing

<!-- Describe your testing strategy or note what tests are included -->

## Risks

<!-- Note any risks associated with this change, or "None" if no risks -->

## Additional Notes

<!-- Any other information that would be helpful for reviewers -->
