### PR TITLE
chore(profiling): include Python headers directly before other headers

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/sample.cpp
@@ -1,9 +1,9 @@
-#include "sample.hpp"
-
 #define PY_SSIZE_T_CLEAN
 
 #include <Python.h>
 #include <frameobject.h>
+
+#include "sample.hpp"
 
 #include "libdatadog_helpers.hpp"
 #include "profiler_state.hpp"

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <echion/frame.h>
+#define PY_SSIZE_T_CLEAN
+#define Py_BUILD_CORE
+#include <Python.h>
 
 #include <cstdint>
 #include <optional>
@@ -9,6 +11,7 @@
 #include <unordered_set>
 
 #include <echion/cache.h>
+#include <echion/frame.h>
 #include <echion/strings.h>
 #include <echion/threads.h>
 

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <echion/frame.h>
+
 #include <cstdint>
 #include <optional>
 #include <random>
@@ -7,7 +9,6 @@
 #include <unordered_set>
 
 #include <echion/cache.h>
-#include <echion/frame.h>
 #include <echion/strings.h>
 #include <echion/threads.h>
 

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/mirrors.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/mirrors.h
@@ -4,14 +4,14 @@
 
 #pragma once
 
-#include <memory>
-#include <unordered_set>
-
 #define PY_SSIZE_T_CLEAN
 #define Py_BUILD_CORE
 #include <Python.h>
 #include <dictobject.h>
 #include <setobject.h>
+
+#include <memory>
+#include <unordered_set>
 
 #include <echion/errors.h>
 #include <echion/vm.h>

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_common.h
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_common.h
@@ -11,7 +11,9 @@
 #pragma once
 
 // Establish Python configuration before system headers in every harness.
-#include <echion/frame.h>
+#define PY_SSIZE_T_CLEAN
+#define Py_BUILD_CORE
+#include <Python.h>
 
 #include <algorithm>
 #include <cstddef>

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_common.h
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_common.h
@@ -10,6 +10,9 @@
 
 #pragma once
 
+// Establish Python configuration before system headers in every harness.
+#include <echion/frame.h>
+
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>

--- a/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_common.h
+++ b/ddtrace/internal/datadog/profiling/stack/fuzz/fuzz_common.h
@@ -11,7 +11,6 @@
 
 #pragma once
 
-// Establish Python configuration before system headers in every harness.
 #define PY_SSIZE_T_CLEAN
 #define Py_BUILD_CORE
 #include <Python.h>

--- a/ddtrace/internal/datadog/profiling/stack/include/python_headers.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/python_headers.hpp
@@ -1,7 +1,0 @@
-#define PY_SSIZE_T_CLEAN
-#include <Python.h>
-
-#if PY_VERSION_HEX >= 0x030c0000
-// https://github.com/python/cpython/issues/108216#issuecomment-1696565797
-#undef _PyGC_FINALIZED
-#endif

--- a/ddtrace/internal/datadog/profiling/stack/include/sampler.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/sampler.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Python.h>
+
 #include <algorithm>
 #include <atomic>
 #include <condition_variable>
@@ -16,8 +18,6 @@
 
 #include "echion/task_name.h"
 #include "echion/timing.h"
-
-#include <Python.h>
 
 class EchionSampler;
 

--- a/ddtrace/internal/datadog/profiling/stack/include/stack_renderer.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/stack_renderer.hpp
@@ -1,6 +1,12 @@
 #pragma once
 
-#include "python_headers.hpp"
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#if PY_VERSION_HEX >= 0x030c0000
+// https://github.com/python/cpython/issues/108216#issuecomment-1696565797
+#undef _PyGC_FINALIZED
+#endif
 
 #include <cstdint>
 #include <memory>

--- a/ddtrace/internal/datadog/profiling/stack/include/stack_renderer.hpp
+++ b/ddtrace/internal/datadog/profiling/stack/include/stack_renderer.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
+#include "python_headers.hpp"
+
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
-
-#include "python_headers.hpp"
 
 #include "dd_wrapper/include/sample.hpp"
 

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
@@ -1,6 +1,9 @@
-#include <echion/state.h>
+#define PY_SSIZE_T_CLEAN
+#define Py_BUILD_CORE
+#include <Python.h>
 
 #include <echion/danger.h>
+#include <echion/state.h>
 
 #include <algorithm>
 #include <cassert>

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/danger.cc
@@ -1,5 +1,6 @@
-#include <echion/danger.h>
 #include <echion/state.h>
+
+#include <echion/danger.h>
 
 #include <algorithm>
 #include <cassert>

--- a/ddtrace/internal/datadog/profiling/stack/src/stack.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/stack.cpp
@@ -1,8 +1,15 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#if PY_VERSION_HEX >= 0x030c0000
+// https://github.com/python/cpython/issues/108216#issuecomment-1696565797
+#undef _PyGC_FINALIZED
+#endif
+
 #include "cast_to_pyfunc.hpp"
 #include "dd_wrapper/include/profiler_state.hpp"
 #include "gc_frame_tracker.hpp"
 #include "origin_task_links.hpp"
-#include "python_headers.hpp"
 #include "sampler.hpp"
 #include "thread_span_links.hpp"
 

--- a/ddtrace/profiling/collector/CMakeLists.txt
+++ b/ddtrace/profiling/collector/CMakeLists.txt
@@ -15,8 +15,6 @@ if(APPLE)
     add_compile_definitions(_DARWIN_C_SOURCE)
 endif()
 
-add_compile_definitions(_POSIX_C_SOURCE=200809L)
-
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../cmake")
 include(AbseilDep)
 

--- a/ddtrace/profiling/collector/_memalloc.cpp
+++ b/ddtrace/profiling/collector/_memalloc.cpp
@@ -1,11 +1,11 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #include <atomic>
 #include <mutex>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
-
-#define PY_SSIZE_T_CLEAN
-#include <Python.h>
 
 #include "_memalloc_debug.h"
 #include "_memalloc_heap.h"

--- a/ddtrace/profiling/collector/_memalloc_debug.h
+++ b/ddtrace/profiling/collector/_memalloc_debug.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <cassert>
-
 #include <Python.h>
+
+#include <cassert>
 
 /* Release the GIL. For debugging when GIL release allows memory profiling functions
  * to interleave from different threads. Call near C Python API calls. */

--- a/ddtrace/profiling/collector/_memalloc_heap.cpp
+++ b/ddtrace/profiling/collector/_memalloc_heap.cpp
@@ -1,12 +1,12 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #include <cassert>
 #include <cmath>
 #include <cstdint>
 #include <memory>
 #include <random>
 #include <vector>
-
-#define PY_SSIZE_T_CLEAN
-#include <Python.h>
 
 #include "_memalloc_debug.h"
 #include "_memalloc_gc_guard.hpp"

--- a/ddtrace/profiling/collector/_memalloc_heap.h
+++ b/ddtrace/profiling/collector/_memalloc_heap.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <Python.h>
+
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-
-#include <Python.h>
 
 /* The maximum heap sample size is the maximum value we can store in a heap_tracker_t.allocated_memory */
 #define MAX_HEAP_SAMPLE_SIZE UINT32_MAX

--- a/ddtrace/profiling/collector/_memalloc_tb.cpp
+++ b/ddtrace/profiling/collector/_memalloc_tb.cpp
@@ -1,6 +1,7 @@
+#include "_memalloc_frame.h"
+
 #include <string_view>
 
-#include "_memalloc_frame.h"
 #include "_memalloc_tb.h"
 
 /* Extract a UTF-8 string_view from a Python unicode object without any

--- a/ddtrace/profiling/collector/_memalloc_tb.cpp
+++ b/ddtrace/profiling/collector/_memalloc_tb.cpp
@@ -1,8 +1,9 @@
+// _memalloc_frame.h must set Py_BUILD_CORE before our own header includes Python.h.
 #include "_memalloc_frame.h"
 
-#include <string_view>
-
 #include "_memalloc_tb.h"
+
+#include <string_view>
 
 /* Extract a UTF-8 string_view from a Python unicode object without any
  * CPython API calls that could allocate, free, or touch error state.

--- a/ddtrace/profiling/collector/_memalloc_tb.h
+++ b/ddtrace/profiling/collector/_memalloc_tb.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <Python.h>
+
 #include <cstddef>
 #include <cstdint>
-
-#include <Python.h>
 
 // Include Sample class header to enable calling functions from Sample.cpp
 #include "sample.hpp"


### PR DESCRIPTION
## Description

Respect CPython's requirement to include Python headers before standard/system headers in profiling production code, native tests, and fuzz harnesses. This is a build/portability cleanup, not a reproduced runtime-corruption fix or Python 3.15 enablement.

- Use explicit Python setup blocks in Python-dependent files instead of relying on incidental transitive includes. `echion_sampler.h`, `fuzz_common.h`, and `danger.cc` define the required macros before directly including `Python.h`; ordinary headers then stay in their normal include groups.
- Remove `python_headers.hpp` and inline its setup in its only two users, `stack_renderer.hpp` and `stack.cpp`. Both now directly include `Python.h` first, with `PY_SSIZE_T_CLEAN` defined beforehand and the existing version-gated `_PyGC_FINALIZED` workaround preserved.
- Preserve existing `Py_BUILD_CORE` and `PY_SSIZE_T_CLEAN` prerequisites. Keep `_memalloc_frame.h` first in `_memalloc_tb.cpp`; the source comments why it cannot put its own header first, and `_memalloc_tb.h` follows the prerequisite immediately, before standard headers.
- Remove memalloc's hard-coded `_POSIX_C_SOURCE=200809L`, which conflicts with the newer Python configuration even after include reordering. Keep `_DARWIN_C_SOURCE` and leave Python-independent sources/headers independent.

Follow-up to the include-order audit during #19269, now merged into main, split from the IAST cleanup in #20186 for separate review by the profiling and ASM owners. No unrelated 3.15 support changes are included.

Reference: [CPython 3.14.5 include-file requirement](https://github.com/python/cpython/blob/v3.14.5/Doc/c-api/intro.rst#L68-L72). The rule predates Python 3.15.

## Testing

Validation for follow-up `fd8b292358`:

- `scripts/lint cformat --fix` and `scripts/lint checks`: passed.
- `scripts/run-tests --venv 1f3c3d5 -- -k 'test_ddup or test_stack_locations'`: 6 passed on Python 3.14.5, with a fresh ddtrace build.
- `git diff --cached --check`: passed before committing.
- Confirmed no remaining `python_headers.hpp` references in source, scripts, or tests.
- `scripts/run-benchmarks --list` for the affected files: no matching benchmark suites. No runtime logic changed.

CI needs to validate the new head across the supported build matrix.

## Risks

Low: header setup and include ordering only, with the existing compatibility workaround preserved. No public API or runtime logic changes.

HUMAN-CHECK: confirm release-wheel builds across the supported Python/platform matrix, since local validation covers only Python 3.14.5 on Linux.

## Additional Notes

- Addresses [the review question about the wrapper](https://github.com/DataDog/dd-trace-py/pull/20185#discussion_r3971110870).
- Merged `origin/main` at `a86550ee3b` in `5e9de8a52f`. Kept main's `sample.cpp` include ordering and explanatory comment, so that file is no longer part of this PR's diff. Preserved the explicit Python setup in `fuzz_common.h` alongside main's extracted `fuzz_memory_image.h` helper.
- No release note needed for this internal build cleanup; `changelog/no-changelog` is already applied.
- [Rapid Test Drive `ddtrace-20185`](https://mosaic.us1.ddbuild.io/change-request/2538691241294785661) was deployed for an earlier head. Runtime smoke checks remained blocked by the staging Ticino authentication endpoint (TLS timeouts / HTTP 503); this follow-up has not been validated in staging.
