### PR TITLE
perf(benchmarks): assign microbenchmark configs to cores deterministically

### DIFF
--- a/.gitlab/benchmarks/bp-runner.yml
+++ b/.gitlab/benchmarks/bp-runner.yml
@@ -10,4 +10,9 @@ experiments:
       - name: benchmarks
         cpus: 26-47
         run: shell
-        script: export SCENARIO=$BP_SCENARIO && /platform/steps/run-benchmarks.sh
+        # bp-runner applies `cpus` by wrapping this step in taskset; it does not export
+        # the range, so run-benchmarks.sh cannot discover it. BENCHMARKS_CPU_AFFINITY
+        # carries the same value inward so run.py's own taskset calls stay inside this
+        # step's cpuset instead of reaching cores 24-25, which the datadog-agent setup
+        # step owns. Keep it identical to `cpus` above.
+        script: export SCENARIO=$BP_SCENARIO BENCHMARKS_CPU_AFFINITY=26-47 && /platform/steps/run-benchmarks.sh

--- a/.gitlab/benchmarks/microbenchmarks.yml
+++ b/.gitlab/benchmarks/microbenchmarks.yml
@@ -16,8 +16,12 @@ variables:
   BENCHMARKING_IMAGE_REGISTRY: 486234852809.dkr.ecr.us-east-1.amazonaws.com
   MICROBENCHMARKS_CI_IMAGE: $BENCHMARKING_IMAGE_REGISTRY/ci/benchmarking-platform:dd-trace-py
   PACKAGE_IMAGE: registry.ddbuild.io/images/mirror/pypa/manylinux2014_x86_64:2025-04-12-5990e2d
-  BENCHMARKING_BRANCH: dd-trace-py
-  BENCHMARKING_COMMIT_SHA: dbe21f0dd0f8274c31a006d0482f6836e86446c4
+  # TEMPORARY - REVERT BEFORE MERGE. Points at the benchmarking-platform branch
+  # carrying the other half of this fix, so CI exercises both halves together.
+  # Restore to `dd-trace-py` / dbe21f0dd0f8274c31a006d0482f6836e86446c4 once
+  # https://github.com/DataDog/benchmarking-platform/pull/308 has merged.
+  BENCHMARKING_BRANCH: augusto/dd-trace-py/share-cpu-cores
+  BENCHMARKING_COMMIT_SHA: 0e37fb3145dd54c419d5cddba5da4ccc588499c3
   # Known flaky benchmarks
   FLAKY_BENCHMARKS_REGEX: "^iastaspects-(casefold_aspect|casefold_noaspect|lower_aspect|upper_noaspect|ljust_noaspect|swapcase_aspect|translate_aspect|translate_noaspect|index_aspect|replace_aspect|title_noaspect|rstrip_aspect)$|^httppropagationinject-ids_only$|^iastaspectsospath-ospathbasename_aspect$|^iastaspectssplit-rsplit_aspect$|^packagespackageforrootmodulemapping-cache_(on|off)$|^sethttpmeta-all-enabled$|^span-start$|^telemetryaddmetric-1-count-metric-1-times$|^telemetryaddmetric-record-100-metrics$|^tracer-small$|^errortrackingflasksqli-baseline$|^flasksimple-iast-get$"
 

--- a/benchmarks/base/run.py
+++ b/benchmarks/base/run.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import queue
 import subprocess
 import sys
 import threading
@@ -37,6 +36,18 @@ def cpu_affinity_to_cpu_groups(cpu_affinity: str, cpus_per_run: int) -> list[lis
         raise ValueError(f"CPU count {len(cpu_ids)} not divisible by CPUS_PER_RUN={cpus_per_run}")
     cpu_groups = [cpu_ids[i : i + cpus_per_run] for i in range(0, len(cpu_ids), cpus_per_run)]
     return cpu_groups
+
+
+def assign_configs_to_cpu_groups(
+    config: dict[str, Any], cpu_groups: list[list[int]]
+) -> list[tuple[str, Any, list[int]]]:
+    # The candidate and the baseline are separate run.py invocations. Cores 36-47
+    # measure slower than 24-35, so a config only cancels that per-core offset if it
+    # lands on the same cores in both runs. This mapping is therefore a pure function
+    # of the config names and the core list: sort by name and assign by index, never
+    # by whichever worker happens to free up first, and never by config.yaml's key
+    # order. See https://github.com/DataDog/dd-trace-py/pull/20052.
+    return [(cname, config[cname], cpu_groups[i % len(cpu_groups)]) for i, cname in enumerate(sorted(config))]
 
 
 def run(scenario_py: str, cname: str, cvars: dict[str, Any], output_dir: str, cpus: Optional[list[int]] = None):
@@ -118,27 +129,26 @@ if __name__ == "__main__":
     print(f"CPUs per run: {CPUS_PER_RUN}")
     print(f"CPU groups: {list(cpu_groups)}")
 
-    job_queue = queue.Queue()
-    cpu_queue = queue.Queue()
+    assignments = assign_configs_to_cpu_groups(config, cpu_groups)
 
-    def worker(cpu_queue: queue.Queue, job_queue: queue.Queue):
-        while job_queue.qsize() > 0:
-            cname, cvars = job_queue.get(timeout=1)
+    # One worker per core group, each draining only the configs assigned to that group.
+    # Still len(cpu_groups) configs at a time, but a config can no longer migrate to a
+    # different group between the candidate and the baseline runs. The cost is the loss
+    # of load balancing: the slowest group now gates the run.
+    jobs_by_group: dict[int, list[tuple[str, Any, list[int]]]] = {i: [] for i in range(len(cpu_groups))}
+    for i, assignment in enumerate(assignments):
+        jobs_by_group[i % len(cpu_groups)].append(assignment)
 
-            cpus = cpu_queue.get()
+    def worker(jobs: list[tuple[str, Any, list[int]]]):
+        for cname, cvars, cpus in jobs:
             print(f"Starting run {cname} on CPUs {cpus}")
             run("scenario.py", cname, cvars, output_dir, cpus=cpus)
             print(f"Finished run {cname}")
-            cpu_queue.put(cpus)
-
-    for cname, cvars in config.items():
-        job_queue.put((cname, cvars))
 
     workers = []
     print(f"Starting {len(cpu_groups)} worker threads")
-    for cpus in cpu_groups:
-        cpu_queue.put(cpus)
-        t = threading.Thread(target=worker, args=(cpu_queue, job_queue))
+    for jobs in jobs_by_group.values():
+        t = threading.Thread(target=worker, args=(jobs,))
         t.start()
         workers.append(t)
 

--- a/benchmarks/base/test_run.py
+++ b/benchmarks/base/test_run.py
@@ -1,0 +1,85 @@
+"""Tests for the microbenchmark runner's CPU assignment.
+
+Run directly: python benchmarks/base/test_run.py
+
+These live next to run.py rather than under tests/ because run.py is CI harness
+code for the benchmarking platform, not part of the shipped ddtrace package.
+"""
+
+import sys
+
+from run import assign_configs_to_cpu_groups
+from run import cpu_affinity_to_cpu_groups
+
+
+def test_cpu_affinity_parses_ranges_and_singles():
+    assert cpu_affinity_to_cpu_groups("6-11", 1) == [[6], [7], [8], [9], [10], [11]]
+    assert cpu_affinity_to_cpu_groups("24-27", 2) == [[24, 25], [26, 27]]
+    assert cpu_affinity_to_cpu_groups("6-9,14,15", 2) == [[6, 7], [8, 9], [14, 15]]
+
+
+def test_cpu_affinity_rejects_indivisible_core_count():
+    try:
+        cpu_affinity_to_cpu_groups("24-46", 2)
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for 23 cores with CPUS_PER_RUN=2")
+
+
+def test_assignment_is_identical_across_invocations():
+    # The candidate and the baseline are separate run.py processes. Both must map
+    # every config to the same core group or the per-core offset stops cancelling.
+    config = {"c{}".format(i): {"n": i} for i in range(7)}
+    groups = cpu_affinity_to_cpu_groups("24-47", 2)
+
+    first = assign_configs_to_cpu_groups(config, groups)
+    second = assign_configs_to_cpu_groups(config, groups)
+
+    assert first == second
+
+
+def test_assignment_does_not_depend_on_config_key_order():
+    forward = {"alpha": {}, "beta": {}, "gamma": {}, "delta": {}}
+    reversed_order = {k: forward[k] for k in reversed(list(forward))}
+    groups = cpu_affinity_to_cpu_groups("24-27", 1)
+
+    a = {cname: cpus for cname, _, cpus in assign_configs_to_cpu_groups(forward, groups)}
+    b = {cname: cpus for cname, _, cpus in assign_configs_to_cpu_groups(reversed_order, groups)}
+
+    assert a == b
+    assert a == {"alpha": [24], "beta": [25], "delta": [26], "gamma": [27]}
+
+
+def test_assignment_wraps_when_configs_exceed_groups():
+    config = {"c{}".format(i): {} for i in range(5)}
+    groups = cpu_affinity_to_cpu_groups("24-25", 1)
+
+    assigned = assign_configs_to_cpu_groups(config, groups)
+
+    assert [cpus for _, _, cpus in assigned] == [[24], [25], [24], [25], [24]]
+
+
+def test_assignment_covers_every_config_exactly_once():
+    config = {"c{}".format(i): {"n": i} for i in range(13)}
+    groups = cpu_affinity_to_cpu_groups("24-47", 2)
+
+    assigned = assign_configs_to_cpu_groups(config, groups)
+
+    assert sorted(cname for cname, _, _ in assigned) == sorted(config)
+    for cname, cvars, _ in assigned:
+        assert cvars is config[cname]
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_"):
+            continue
+        try:
+            fn()
+        except Exception as exc:
+            failures += 1
+            print("FAIL {}: {!r}".format(name, exc))
+        else:
+            print("ok   {}".format(name))
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Motivation

Cores 36-47 measure consistently slower than 24-35 for these workloads. The benchmarking-platform side pinned the candidate to one range and the baseline to the other, so the offset was attached permanently to the candidate: across 33 control pull requests that changed no runtime code, the bot reported 616 flagged scenarios and **zero** improvements. Swapping only the two ranges inverted every sign — https://github.com/DataDog/dd-trace-py/pull/20052.

The fix is to run both wheels on the same physical cores so the per-core offset is a constant that cancels. That needs a change here too.

`benchmarks/base/run.py` chunked `CPU_AFFINITY` into per-config groups and handed them out through a work-stealing `queue.Queue`, so which core a config landed on was decided by whichever worker freed up first. The candidate and the baseline are separate `run.py` invocations with separate queues, so the same config could land on a different core in each — **even once both sides share a core range**. That turns the fixed, cancellable offset into per-config noise instead of cancelling it.

## Companion PR — both are required

This is half of a two-repo fix and is **inert on its own**:

- **DataDog/benchmarking-platform#308** makes both sides draw from the same core range.
- **This PR** makes the two sides assign configs to cores identically.

Neither half fixes the defect alone. Both must land.

## What this does

Replaces the work-stealing assignment with `assign_configs_to_cpu_groups`, a pure function of the config set and the core list: sort `config.items()` by name and assign by index into `cpu_groups`. Two separate invocations given the same config set and the same `CPU_AFFINITY` now produce an identical mapping. Sorting is explicit rather than relying on `config.yaml`'s insertion order.

Preserved:
- the sequential fallback when `CPU_AFFINITY` is unset, with no `taskset` prefix;
- the `len(cpu_ids) % cpus_per_run != 0` `ValueError`;
- concurrency — `len(cpu_groups)` configs still run at a time. Only *which* config goes to which group changes.

Also sets `BENCHMARKS_CPU_AFFINITY=26-47` in `.gitlab/benchmarks/bp-runner.yml`. `bp-runner` applies its `cpus:` by wrapping the step in `taskset` and does not export the range, so `run-benchmarks.sh` cannot discover it. Without this, flask/django scenarios would fall back to the `24-47` default and `run.py`'s inner `taskset` calls would reach cores `24-25`, which that same file assigns to the `datadog-agent` setup step. The value must stay in sync with `cpus:` above it; there is a comment saying so.

## Known cost: loss of load balancing

The slowest group now gates the run instead of work being stolen by whichever worker frees up first. This is inherent to making the mapping deterministic — recovering it with a scheduling heuristic would reintroduce exactly the nondeterminism this PR removes.

## ⚠️ Revert before merge

`299b877179` (`ci: point benchmarks at the benchmarking-platform fix branch [DO NOT MERGE]`) temporarily repoints `BENCHMARKING_BRANCH` / `BENCHMARKING_COMMIT_SHA` at `augusto/dd-trace-py/share-cpu-cores` @ `0e37fb31` so CI exercises both halves together. Without it, the microbenchmark jobs run this PR's deterministic assignment against the old script that still splits the core ranges, and there is nothing to observe.

`git revert 299b877179` once DataDog/benchmarking-platform#308 has merged, restoring `dd-trace-py` / `dbe21f0dd0f8274c31a006d0482f6836e86446c4` (or the new post-merge SHA).

## Wall-clock

**I could not measure this on real hardware.** It needs a 48-core Linux box with `taskset`; I had a 16-core macOS machine. The numbers below are a wave-count model of the benchmarking-platform change, not a timing run, and the load-balancing loss from *this* PR is on top of them and unquantified. This needs a CI run to confirm before merging.

For one multi-config scenario, `appsec_iast_aspects` (59 configs): 5 waves today at 12 cores per side concurrently, 6 waves at 24 cores per side sequentially — about 1.20x.

The model also surfaces something worth flagging: scenarios with ≤12 configs never fill 24 groups, so the second wave is pure serialization with no extra width to pay for it. Those go to **2.00x**, and 27 of 36 scenarios are in that bucket. Details and the resulting design question are in DataDog/benchmarking-platform#308 — it may change which design we want.

## Testing

- `benchmarks/base/test_run.py` (new, 6 tests, runs standalone with `python benchmarks/base/test_run.py`) covers: identical assignment across two invocations, independence from `config.yaml` key order, wrapping when configs exceed groups, every config assigned exactly once, range parsing, and the indivisible-core-count `ValueError`. All pass.
- `python -c "import ast; ast.parse(open('benchmarks/base/run.py').read())"` passes.
- `scripts/lint fmt` / `style` clean on both changed files; `scripts/lint suitespec-check` passes.
- Real wall-clock is unverified, as described above.

## Checklist

- [x] PR author has checked that all the criteria below are met
- [x] The PR description includes an overview of the change
- [x] The PR description articulates the motivation for the change
- [x] The change includes tests OR the PR description describes a testing strategy
- [x] The PR description notes risks associated with the change, if any
- [x] Newly-added code is easy to change
- [x] The change follows the [library release note guidelines](https://ddtrace.readthedocs.io/en/stable/releasenotes.html)
- [x] The change includes or references documentation updates if necessary
- [x] Backport labels are set (if [applicable](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting))

## Reviewer Checklist

- [ ] Reviewer has checked that all the criteria below are met
- [ ] Title is accurate
- [ ] All changes are related to the pull request's stated goal
- [ ] Avoids breaking [API](https://ddtrace.readthedocs.io/en/stable/versioning.html#interfaces) changes
- [ ] Testing strategy adequately addresses listed risks
- [ ] Newly-added code is easy to change
- [ ] Release note makes sense to a user of the library
- [ ] If necessary, author has acknowledged and discussed the performance implications of this PR as reported in the benchmarks PR comment
- [ ] Backport labels are set in a manner that is consistent with the [release branch maintenance policy](https://ddtrace.readthedocs.io/en/latest/contributing.html#backporting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
