### PR TITLE
chore(botocore): remove Pin

### DIFF
--- a/ddtrace/contrib/internal/botocore/patch.py
+++ b/ddtrace/contrib/internal/botocore/patch.py
@@ -3,6 +3,7 @@ Trace queries to aws api done via botocore client
 """
 
 import collections
+from functools import partial
 import json
 from typing import Union  # noqa:F401
 
@@ -14,7 +15,6 @@ import wrapt
 
 import ddtrace
 from ddtrace import config
-from ddtrace._trace.pin import Pin
 
 # AIDEV-NOTE: _http_propagation_suppressed is the shared seam telling the
 # urllib3-layer subscriber to skip its own injection during AWS calls. See the
@@ -22,8 +22,8 @@ from ddtrace._trace.pin import Pin
 from ddtrace._trace.subscribers.http_client import _http_propagation_suppressed
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib.internal.trace_utils import ext_service
+from ddtrace.contrib.internal.trace_utils import is_tracing_enabled
 from ddtrace.contrib.internal.trace_utils import unwrap
-from ddtrace.contrib.internal.trace_utils import with_traced_module
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.internal import core
@@ -137,7 +137,7 @@ def _inject_trace_headers_handler(request, **kwargs):
         return
 
     # AIDEV-NOTE: Uses the global tracer's current_span() because the before-sign
-    # event hands us the AWSRequest, not the client, so there's no Pin to read here.
+    # event hands us the AWSRequest rather than the client that initiated it.
     span = ddtrace.tracer.current_span()
     if span is None:
         return
@@ -247,10 +247,8 @@ def patch():
     botocore.client._datadog_patch = True
 
     botocore._datadog_integration = BedrockIntegration(integration_config=config.botocore)
-    wrapt.wrap_function_wrapper("botocore.client", "BaseClient._make_api_call", patched_api_call(botocore))
-    Pin().onto(botocore.client.BaseClient)
+    wrapt.wrap_function_wrapper("botocore.client", "BaseClient._make_api_call", partial(patched_api_call, botocore))
     wrapt.wrap_function_wrapper("botocore.parsers", "ResponseParser.parse", patched_lib_fn)
-    Pin().onto(botocore.parsers.ResponseParser)
     _PATCHED_SUBMODULES.clear()
 
 
@@ -275,8 +273,7 @@ def patch_submodules(submodules: Union[list[str], bool]) -> None:
 
 
 def patched_lib_fn(original_func, instance, args, kwargs):
-    pin = Pin.get_from(instance)
-    if not pin or not pin.enabled() or not config.botocore["instrument_internals"]:
+    if not is_tracing_enabled() or not config.botocore["instrument_internals"]:
         return original_func(*args, **kwargs)
 
     # Don't trace response parsing for the internal bedrock:GetInferenceProfile call.
@@ -287,16 +284,14 @@ def patched_lib_fn(original_func, instance, args, kwargs):
             "botocore.instrumented_lib_function",
             span_name="{}.{}".format(original_func.__module__, original_func.__name__),
             tags={COMPONENT: config.botocore.integration_name, SPAN_KIND: SpanKind.CLIENT},
-            pin=pin,
         ) as ctx,
         span_from_context(ctx),
     ):
         return original_func(*args, **kwargs)
 
 
-@with_traced_module
-def patched_api_call(botocore, pin, original_func, instance, args, kwargs):
-    if not pin or not pin.enabled():
+def patched_api_call(botocore, original_func, instance, args, kwargs):
+    if not is_tracing_enabled():
         return original_func(*args, **kwargs)
 
     # Skip tracing the internal bedrock:GetInferenceProfile call we make to resolve an
@@ -325,7 +320,6 @@ def patched_api_call(botocore, pin, original_func, instance, args, kwargs):
         "endpoint_name": endpoint_name,
         "operation": operation,
         "params": params,
-        "pin": pin,
         "trace_operation": trace_operation,
         "integration": botocore._datadog_integration,
     }
@@ -394,7 +388,6 @@ def patched_api_call_fallback(original_func, instance, args, kwargs, function_va
     # default patched api call that is used generally for several services / operations
     params = function_vars.get("params")
     trace_operation = function_vars.get("trace_operation")
-    pin = function_vars.get("pin")
     endpoint_name = function_vars.get("endpoint_name")
     operation = function_vars.get("operation")
 
@@ -407,9 +400,8 @@ def patched_api_call_fallback(original_func, instance, args, kwargs, function_va
             endpoint_name=endpoint_name,
             operation=operation,
             service=schematize_service_name(
-                "{}.{}".format(ext_service(pin, int_config=config.botocore), endpoint_name)
+                "{}.{}".format(ext_service(None, int_config=config.botocore), endpoint_name)
             ),
-            pin=pin,
             span_name=function_vars.get("trace_operation"),
             span_type=SpanTypes.HTTP,
             span_key="instrumented_api_call",

--- a/ddtrace/contrib/internal/botocore/services/bedrock.py
+++ b/ddtrace/contrib/internal/botocore/services/bedrock.py
@@ -593,7 +593,6 @@ def _resolve_application_inference_profile(model_id, model_provider, model_name,
 
 def patched_bedrock_api_call(original_func, instance, args, kwargs, function_vars):
     params = function_vars.get("params")
-    pin = function_vars.get("pin")
     integration = function_vars.get("integration")
     model_id = params.get("modelId")
     model_provider, model_name = parse_model_id(model_id)
@@ -603,10 +602,9 @@ def patched_bedrock_api_call(original_func, instance, args, kwargs, function_var
     submit_to_llmobs = integration.llmobs_enabled and "embed" not in model_name
     with core.context_with_data(
         "botocore.patched_bedrock_api_call",
-        pin=pin,
         span_name=function_vars.get("trace_operation"),
         service=schematize_service_name(
-            "{}.{}".format(ext_service(pin, int_config=config.botocore), function_vars.get("endpoint_name"))
+            "{}.{}".format(ext_service(None, int_config=config.botocore), function_vars.get("endpoint_name"))
         ),
         resource=function_vars.get("operation"),
         span_type=SpanTypes.LLM if submit_to_llmobs else None,

--- a/ddtrace/contrib/internal/botocore/services/kinesis.py
+++ b/ddtrace/contrib/internal/botocore/services/kinesis.py
@@ -76,7 +76,6 @@ def patched_kinesis_api_call(original_func, instance, args, kwargs, function_var
 def _patched_kinesis_api_call(parent_ctx, original_func, instance, args, kwargs, function_vars):
     params = function_vars.get("params")
     trace_operation = function_vars.get("trace_operation")
-    pin = function_vars.get("pin")
     endpoint_name = function_vars.get("endpoint_name")
     operation = function_vars.get("operation")
 
@@ -146,10 +145,9 @@ def _patched_kinesis_api_call(parent_ctx, original_func, instance, args, kwargs,
                 child_of=child_of if child_of is not None else tracer.context_provider.active(),
                 operation=operation,
                 service=schematize_service_name(
-                    "{}.{}".format(ext_service(pin, int_config=config.botocore), endpoint_name)
+                    "{}.{}".format(ext_service(None, int_config=config.botocore), endpoint_name)
                 ),
                 call_trace=False,
-                pin=pin,
                 span_name=span_name,
                 span_type=SpanTypes.HTTP,
                 activate=True,

--- a/ddtrace/contrib/internal/botocore/services/sqs.py
+++ b/ddtrace/contrib/internal/botocore/services/sqs.py
@@ -92,7 +92,6 @@ def patched_sqs_api_call(original_func, instance, args, kwargs, function_vars):
 def _patched_sqs_api_call(parent_ctx, original_func, instance, args, kwargs, function_vars):
     params = function_vars.get("params")
     trace_operation = function_vars.get("trace_operation")
-    pin = function_vars.get("pin")
     endpoint_name = function_vars.get("endpoint_name")
     operation = function_vars.get("operation")
 
@@ -146,7 +145,7 @@ def _patched_sqs_api_call(parent_ctx, original_func, instance, args, kwargs, fun
                 parent=parent_ctx,
                 span_name=call_name,
                 service=schematize_service_name(
-                    "{}.{}".format(ext_service(pin, int_config=config.botocore), endpoint_name)
+                    "{}.{}".format(ext_service(None, int_config=config.botocore), endpoint_name)
                 ),
                 span_type=SpanTypes.HTTP,
                 child_of=child_of if child_of is not None else tracer.context_provider.active(),
@@ -157,7 +156,6 @@ def _patched_sqs_api_call(parent_ctx, original_func, instance, args, kwargs, fun
                 endpoint_name=endpoint_name,
                 operation=operation,
                 call_trace=False,
-                pin=pin,
                 integration_config=config.botocore,
             ) as ctx,
             span_from_context(ctx),

--- a/ddtrace/contrib/internal/botocore/services/stepfunctions.py
+++ b/ddtrace/contrib/internal/botocore/services/stepfunctions.py
@@ -45,7 +45,6 @@ def update_stepfunction_input(ctx: core.ExecutionContext, params: Any) -> None:
 def patched_stepfunction_api_call(original_func, instance, args, kwargs: dict, function_vars: dict):
     params = function_vars.get("params")
     trace_operation = function_vars.get("trace_operation")
-    pin = function_vars.get("pin")
     endpoint_name = function_vars.get("endpoint_name")
     operation = function_vars.get("operation")
 
@@ -66,7 +65,7 @@ def patched_stepfunction_api_call(original_func, instance, args, kwargs: dict, f
             "botocore.patched_stepfunctions_api_call",
             span_name=call_name,
             service=schematize_service_name(
-                "{}.{}".format(ext_service(pin, int_config=config.botocore), endpoint_name)
+                "{}.{}".format(ext_service(None, int_config=config.botocore), endpoint_name)
             ),
             span_type=SpanTypes.HTTP,
             span_key="patched_stepfunctions_api_call",
@@ -75,7 +74,6 @@ def patched_stepfunction_api_call(original_func, instance, args, kwargs: dict, f
             params=params,
             endpoint_name=endpoint_name,
             operation=operation,
-            pin=pin,
             integration_config=config.botocore,
         ) as ctx,
         span_from_context(ctx),


### PR DESCRIPTION
## Description

Remove internal Pin attachment and lookup from botocore client and parser instrumentation. Tracing gates now use tracer configuration directly, while all AWS service-specific contexts retain configured service naming and metadata.

## Testing

- scripts/lint fmt -- the five changed botocore files
- Integration tests intentionally not run for this serverless/cloud-service integration, per maintainer guidance.

## Risks

Moderate. The shared API-call fallback and Bedrock, Kinesis, SQS, and Step Functions paths were updated together. Public botocore and patch/unpatch APIs are unchanged.

## Additional Notes

The existing AIDEV note was updated to describe the remaining global-tracer rationale. No release note is needed for this internal maintenance change.