### PR TITLE
test(tracing): isolate platform mock from writer config override

### DIFF
--- a/tests/tracer/test_writer.py
+++ b/tests/tracer/test_writer.py
@@ -1177,15 +1177,54 @@ def test_writer_telemetry_enabled_on_linux(
     ]:
         getattr(mock_builder, method_name).return_value = mock_builder
 
-    with mock_sys_platform(platform):
-        with override_global_config(dict(_telemetry_enabled=config_value)):
+    # override_global_config must enter under the real platform. Mocking sys.platform first
+    # can make a cold AppSec import fail, which recreates the tracer writer and double-counts
+    # builder.set_restart_after_fork on the patched TraceExporterBuilder.
+    with override_global_config(dict(_telemetry_enabled=config_value)):
+        with mock_sys_platform(platform):
             _writer = NativeWriter("http://localhost:8126/v0.5/traces", sync_mode=True)
 
-            if expected_enabled:
-                mock_builder.enable_telemetry.assert_called_once_with(60000, get_runtime_id(), config._debug_mode)
-            else:
-                mock_builder.enable_telemetry.assert_not_called()
-            mock_builder.set_restart_after_fork.assert_called_once_with(False)
+        if expected_enabled:
+            mock_builder.enable_telemetry.assert_called_once_with(60000, get_runtime_id(), config._debug_mode)
+        else:
+            mock_builder.enable_telemetry.assert_not_called()
+        mock_builder.set_restart_after_fork.assert_called_once_with(False)
+
+
+@pytest.mark.subprocess(err=None, env={"DD_APPSEC_ENABLED": "false"})
+def test_writer_telemetry_platform_mock_does_not_rebuild_exporter_on_import_cold():
+    """Import-cold: override_global_config must not construct NativeWriter before the test writer."""
+    import sys
+    from unittest import mock
+
+    from ddtrace.internal.writer import NativeWriter
+    from tests.utils import override_global_config
+
+    with mock.patch("ddtrace.internal.native.TraceExporterBuilder") as builder_class:
+        builder = mock.Mock()
+        builder_class.return_value = builder
+        builder.build.return_value = mock.Mock()
+        for method_name in (
+            "set_url",
+            "set_hostname",
+            "set_language",
+            "set_language_version",
+            "set_language_interpreter",
+            "set_tracer_version",
+            "set_git_commit_sha",
+            "set_client_computed_top_level",
+            "set_input_format",
+            "set_output_format",
+            "enable_telemetry",
+        ):
+            getattr(builder, method_name).return_value = builder
+
+        with override_global_config(dict(_telemetry_enabled=False)):
+            assert builder.set_restart_after_fork.call_count == 0
+            with mock.patch.object(sys, "platform", "darwin"):
+                NativeWriter("http://localhost:8126/v0.5/traces", sync_mode=True)
+            builder.set_restart_after_fork.assert_called_once_with(False)
+            builder.enable_telemetry.assert_not_called()
 
 
 @pytest.mark.subprocess(


### PR DESCRIPTION
## Description

The `set_restart_after_fork(False)` assertion added in #20043 is correct. The `test_writer_telemetry_enabled_on_linux[darwin-False-False]` failure on Linux is an order-dependent test-isolation bug, not a writer regression.

The test used to mock `sys.platform` before entering `override_global_config`. On an import-cold run, that helper imports AppSec while the Linux runner is pretending to be Darwin. The import failure calls `tracer.configure()`, which recreates the writer and produces the first `set_restart_after_fork(False)` call; the test's explicit `NativeWriter` produces the second.

This change enters `override_global_config` under the real platform and scopes the platform mock around `NativeWriter` construction. An import-cold subprocess regression locks the invariant so the test no longer depends on suite order.

## Testing

- `scripts/run-tests --venv 18c79d5 -- -- tests/tracer/test_writer.py -k writer_telemetry`
- 7 passed, including the originally failing `test_writer_telemetry_enabled_on_linux[darwin-False-False][py3.14]` and the new import-cold regression

## Risks

None. Test-only change; no product behavior change.

## Additional Notes

No release note; this does not change customer-facing behavior. Please apply `changelog/no-changelog`.

Context:

- Introducing PR: https://github.com/DataDog/dd-trace-py/pull/20043
- Root-cause report: https://chonk.us1.prod.dog/v2/get/chonk-uploads-prod/brian.marks/8955f2a7-4e48-4912-b916-8913d07ac37f
- Reproduction-only diff: https://github.com/DataDog/dd-trace-py/compare/93fed02913d93253d66be4b3edb19856bd9493ce...brian.marks/repro-238623623-1788900000
- Failed job: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/2021699298
