### PR TITLE
feat(llmobs): support message placeholders in managed prompts

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -2129,7 +2129,7 @@ class LLMObs(Service):
     def create_prompt(
         cls,
         prompt_id: str,
-        template: list[ChatTemplateItem],
+        template: Sequence[ChatTemplateItem],
         *,
         title: str = "",
         description: str = "",
@@ -2172,7 +2172,7 @@ class LLMObs(Service):
     def create_prompt_version(
         cls,
         prompt_id: str,
-        template: list[ChatTemplateItem],
+        template: Sequence[ChatTemplateItem],
         *,
         description: str = "",
         user_version: str = "",

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -183,7 +183,7 @@ from ddtrace.llmobs._writer import LLMObsSpanEvent
 from ddtrace.llmobs._writer import LLMObsSpanWriter
 from ddtrace.llmobs._writer import should_use_agentless
 from ddtrace.llmobs.types import Agent
-from ddtrace.llmobs.types import ChatMessage
+from ddtrace.llmobs.types import ChatTemplateItem
 from ddtrace.llmobs.types import DeletedPromptResponse
 from ddtrace.llmobs.types import ExportedLLMObsSpan
 from ddtrace.llmobs.types import FeedbackSubmitter
@@ -2129,7 +2129,7 @@ class LLMObs(Service):
     def create_prompt(
         cls,
         prompt_id: str,
-        template: list[ChatMessage],
+        template: list[ChatTemplateItem],
         *,
         title: str = "",
         description: str = "",
@@ -2172,7 +2172,7 @@ class LLMObs(Service):
     def create_prompt_version(
         cls,
         prompt_id: str,
-        template: list[ChatMessage],
+        template: list[ChatTemplateItem],
         *,
         description: str = "",
         user_version: str = "",

--- a/ddtrace/llmobs/_prompts/manager.py
+++ b/ddtrace/llmobs/_prompts/manager.py
@@ -609,7 +609,7 @@ class PromptManager:
         labels: Optional[list[str]] = None,
         env_ids: Optional[list[str]] = None,
     ) -> PromptResponse:
-        body: dict[str, Any] = {"prompt_id": prompt_id, "template": template}
+        body: dict[str, Any] = {"prompt_id": prompt_id, "template": list(template)}
         if title:
             body["title"] = title
         if description:
@@ -635,7 +635,7 @@ class PromptManager:
         env_ids: Optional[list[str]] = None,
     ) -> PromptVersionResponse:
         escaped_id = quote(prompt_id, safe="")
-        body: dict[str, Any] = {"template": template}
+        body: dict[str, Any] = {"template": list(template)}
         if description:
             body["description"] = description
         if user_version:

--- a/ddtrace/llmobs/_prompts/manager.py
+++ b/ddtrace/llmobs/_prompts/manager.py
@@ -6,6 +6,7 @@ import json
 from typing import Any
 from typing import Literal
 from typing import Optional
+from typing import Sequence
 from typing import Union
 from urllib.parse import quote
 from urllib.parse import urlencode
@@ -600,7 +601,7 @@ class PromptManager:
     def create_prompt(
         self,
         prompt_id: str,
-        template: list[ChatTemplateItem],
+        template: Sequence[ChatTemplateItem],
         *,
         title: str = "",
         description: str = "",
@@ -626,7 +627,7 @@ class PromptManager:
     def create_prompt_version(
         self,
         prompt_id: str,
-        template: list[ChatTemplateItem],
+        template: Sequence[ChatTemplateItem],
         *,
         description: str = "",
         user_version: str = "",

--- a/ddtrace/llmobs/_prompts/manager.py
+++ b/ddtrace/llmobs/_prompts/manager.py
@@ -27,7 +27,7 @@ from ddtrace.llmobs._prompts.cache import WarmCache
 from ddtrace.llmobs._prompts.prompt import ManagedPrompt
 from ddtrace.llmobs._prompts.utils import extract_error_detail
 from ddtrace.llmobs._prompts.utils import extract_template
-from ddtrace.llmobs.types import ChatMessage
+from ddtrace.llmobs.types import ChatTemplateItem
 from ddtrace.llmobs.types import DeletedPromptResponse
 from ddtrace.llmobs.types import PromptAPIError
 from ddtrace.llmobs.types import PromptAuthError
@@ -600,7 +600,7 @@ class PromptManager:
     def create_prompt(
         self,
         prompt_id: str,
-        template: list[ChatMessage],
+        template: list[ChatTemplateItem],
         *,
         title: str = "",
         description: str = "",
@@ -626,7 +626,7 @@ class PromptManager:
     def create_prompt_version(
         self,
         prompt_id: str,
-        template: list[ChatMessage],
+        template: list[ChatTemplateItem],
         *,
         description: str = "",
         user_version: str = "",

--- a/ddtrace/llmobs/_prompts/prompt.py
+++ b/ddtrace/llmobs/_prompts/prompt.py
@@ -4,6 +4,7 @@ from typing import Any
 from typing import Literal
 from typing import Optional
 from typing import Union
+from typing import cast
 
 from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.internal.utils.deprecations import deprecate
@@ -11,6 +12,7 @@ from ddtrace.llmobs._prompts.utils import extract_template
 from ddtrace.llmobs._prompts.utils import render_chat
 from ddtrace.llmobs._prompts.utils import safe_substitute
 from ddtrace.llmobs._utils import attach_prompt
+from ddtrace.llmobs.types import ChatTemplateItem
 from ddtrace.llmobs.types import Message
 from ddtrace.llmobs.types import Prompt
 from ddtrace.llmobs.types import PromptFallback
@@ -33,7 +35,7 @@ class ManagedPrompt:
     version: str
     label: Optional[str]
     source: Literal["registry", "cache", "fallback", "ff", "resolve"]
-    template: Union[str, list[Message]]
+    template: Union[str, list[ChatTemplateItem]]
     _uuid: Optional[str] = None
     _version_uuid: Optional[str] = None
 
@@ -45,7 +47,7 @@ class ManagedPrompt:
             )
         return object.__getattribute__(self, name)
 
-    def format(self, **variables: str) -> Union[str, list[Message]]:
+    def format(self, **variables: Any) -> Union[str, list[Message]]:
         """
         Render the template with variables.
 
@@ -55,7 +57,7 @@ class ManagedPrompt:
         Uses safe substitution: missing variables are left as placeholders.
 
         Args:
-            **variables: Template variables to substitute
+            **variables: Text variables and message-list placeholder values.
 
         Returns:
             str (for text templates) or list[Message] (for chat templates)
@@ -83,7 +85,14 @@ class ManagedPrompt:
             "version": self.version,
         }
         if variables:
-            result["variables"] = variables
+            placeholder_names = (
+                set()
+                if isinstance(self.template, str)
+                else {item.get("name") for item in self.template if item.get("type") == "placeholder"}
+            )
+            scalar_variables = {name: value for name, value in variables.items() if name not in placeholder_names}
+            if scalar_variables:
+                result["variables"] = scalar_variables
         label = object.__getattribute__(self, "label")
         if label:
             result["label"] = label
@@ -149,7 +158,7 @@ class ManagedPrompt:
         Returns:
             A ManagedPrompt with source="fallback" and label=None.
         """
-        template: Union[str, list[Message]] = ""
+        template: Union[str, list[ChatTemplateItem]] = ""
         version = "fallback"
 
         if fallback is not None:
@@ -158,7 +167,7 @@ class ManagedPrompt:
                 template = extract_template(value)
                 version = value.get("version") or "fallback"
             else:
-                template = value
+                template = cast(Union[str, list[ChatTemplateItem]], value)
 
         return cls(
             id=prompt_id,

--- a/ddtrace/llmobs/_prompts/prompt.py
+++ b/ddtrace/llmobs/_prompts/prompt.py
@@ -104,7 +104,7 @@ class ManagedPrompt:
         if isinstance(self.template, str):
             result["template"] = self.template
         else:
-            result["chat_template"] = self.template
+            result["chat_template"] = cast(Union[list[dict[str, str]], list[Message]], self.template)
 
         return result
 

--- a/ddtrace/llmobs/_prompts/utils.py
+++ b/ddtrace/llmobs/_prompts/utils.py
@@ -1,13 +1,17 @@
 import json
 import re
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Mapping
 from typing import Optional
 from typing import Union
-from typing import cast
 
 from ddtrace.llmobs.types import ChatTemplateItem
 from ddtrace.llmobs.types import Message
+
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeGuard
 
 
 _VARIABLE_PATTERN = re.compile(r"\{\{?\s*(\w+)\s*\}\}?")
@@ -45,6 +49,21 @@ def cache_key(prompt_id: str, label: Optional[str]) -> str:
     return f"{prompt_id}:{label or ''}"
 
 
+def _is_message(value: object) -> "TypeGuard[Message]":
+    if not isinstance(value, dict) or not isinstance(value.get("role"), str):
+        return False
+    if value.get("type") == "placeholder":
+        return False
+    content = value.get("content")
+    if content is not None:
+        return isinstance(content, str)
+    for field in ("tool_calls", "tool_results"):
+        items = value.get(field)
+        if isinstance(items, list) and items:
+            return True
+    return False
+
+
 def render_chat(messages: list[ChatTemplateItem], variables: dict[str, Any]) -> list[Message]:
     """Render authored messages and expand named runtime message lists."""
     rendered: list[Message] = []
@@ -59,27 +78,18 @@ def render_chat(messages: list[ChatTemplateItem], variables: dict[str, Any]) -> 
             if not isinstance(value, list):
                 raise ValueError(f"Message placeholder '{name}' must be a list of messages")
             for message in value:
-                content = message.get("content") if isinstance(message, dict) else None
-                if (
-                    not isinstance(message, dict)
-                    or not isinstance(message.get("role"), str)
-                    or message.get("type") == "placeholder"
-                    or ("content" in message and content is not None and not isinstance(content, str))
-                    or (
-                        not isinstance(content, str)
-                        and not any(
-                            isinstance(message.get(field), list) and message[field]
-                            for field in ("tool_calls", "tool_results")
-                        )
-                    )
-                ):
+                if not _is_message(message):
                     raise ValueError(
                         f"Message placeholder '{name}' must contain messages with "
                         "a string role and text or tool content"
                     )
-                rendered.append(cast(Message, dict(message)))
+                rendered.append(message.copy())
             continue
-        role = cast(str, msg.get("role") or "")
-        content = cast(str, msg.get("content") or "")
+        role = msg.get("role")
+        content = msg.get("content")
+        if not isinstance(role, str):
+            role = ""
+        if not isinstance(content, str):
+            content = ""
         rendered.append({"role": role, "content": safe_substitute(content, variables)})
     return rendered

--- a/ddtrace/llmobs/_prompts/utils.py
+++ b/ddtrace/llmobs/_prompts/utils.py
@@ -4,19 +4,23 @@ from typing import Any
 from typing import Mapping
 from typing import Optional
 from typing import Union
+from typing import cast
 
+from ddtrace.llmobs.types import ChatTemplateItem
 from ddtrace.llmobs.types import Message
 
 
 _VARIABLE_PATTERN = re.compile(r"\{\{?\s*(\w+)\s*\}\}?")
 
 
-def extract_template(data: Mapping[str, Any], default: Union[str, list[Message]] = "") -> Union[str, list[Message]]:
+def extract_template(
+    data: Mapping[str, Any], default: Union[str, list[ChatTemplateItem]] = ""
+) -> Union[str, list[ChatTemplateItem]]:
     """Extract template from a dict, checking both 'template' and 'chat_template' keys."""
     return data.get("template") or data.get("chat_template") or default
 
 
-def safe_substitute(template: str, variables: dict[str, str]) -> str:
+def safe_substitute(template: str, variables: Mapping[str, Any]) -> str:
     """
     Substitute {variable} or {{variable}} placeholders with values from variables dict.
 
@@ -41,11 +45,30 @@ def cache_key(prompt_id: str, label: Optional[str]) -> str:
     return f"{prompt_id}:{label or ''}"
 
 
-def render_chat(messages: list[Message], variables: dict[str, str]) -> list[Message]:
-    """Render each message's content with safe substitution."""
+def render_chat(messages: list[ChatTemplateItem], variables: dict[str, Any]) -> list[Message]:
+    """Render authored messages and expand named runtime message lists."""
     rendered: list[Message] = []
     for msg in messages:
-        role = msg.get("role") or ""
-        content = msg.get("content") or ""
+        if msg.get("type") == "placeholder":
+            name = msg.get("name")
+            if not isinstance(name, str) or not name:
+                raise ValueError("Message placeholder must have a non-empty string name")
+            if name not in variables:
+                raise ValueError(f"Missing value for message placeholder '{name}'")
+            value = variables[name]
+            if not isinstance(value, list):
+                raise ValueError(f"Message placeholder '{name}' must be a list of messages")
+            for message in value:
+                if (
+                    not isinstance(message, dict)
+                    or not isinstance(message.get("role"), str)
+                    or not isinstance(message.get("content"), str)
+                    or message.get("type") == "placeholder"
+                ):
+                    raise ValueError(f"Message placeholder '{name}' must contain messages with string role and content")
+                rendered.append(cast(Message, dict(message)))
+            continue
+        role = cast(str, msg.get("role") or "")
+        content = cast(str, msg.get("content") or "")
         rendered.append({"role": role, "content": safe_substitute(content, variables)})
     return rendered

--- a/ddtrace/llmobs/_prompts/utils.py
+++ b/ddtrace/llmobs/_prompts/utils.py
@@ -59,13 +59,24 @@ def render_chat(messages: list[ChatTemplateItem], variables: dict[str, Any]) -> 
             if not isinstance(value, list):
                 raise ValueError(f"Message placeholder '{name}' must be a list of messages")
             for message in value:
+                content = message.get("content") if isinstance(message, dict) else None
                 if (
                     not isinstance(message, dict)
                     or not isinstance(message.get("role"), str)
-                    or not isinstance(message.get("content"), str)
                     or message.get("type") == "placeholder"
+                    or ("content" in message and content is not None and not isinstance(content, str))
+                    or (
+                        not isinstance(content, str)
+                        and not any(
+                            isinstance(message.get(field), list) and message[field]
+                            for field in ("tool_calls", "tool_results")
+                        )
+                    )
                 ):
-                    raise ValueError(f"Message placeholder '{name}' must contain messages with string role and content")
+                    raise ValueError(
+                        f"Message placeholder '{name}' must contain messages with "
+                        "a string role and text or tool content"
+                    )
                 rendered.append(cast(Message, dict(message)))
             continue
         role = cast(str, msg.get("role") or "")

--- a/ddtrace/llmobs/_utils.py
+++ b/ddtrace/llmobs/_utils.py
@@ -32,8 +32,11 @@ from ddtrace.llmobs._constants import ML_APP_DEFAULT
 from ddtrace.llmobs._constants import PROPAGATED_PARENT_AGENT_ID_KEY
 from ddtrace.llmobs._constants import PROPAGATED_PARENT_AGENT_NAME_KEY
 from ddtrace.llmobs._constants import SESSION_ID
+from ddtrace.llmobs.types import ChatMessage
+from ddtrace.llmobs.types import ChatTemplateItem
 from ddtrace.llmobs.types import Document
 from ddtrace.llmobs.types import Message
+from ddtrace.llmobs.types import MessagePlaceholder
 from ddtrace.llmobs.types import Prompt
 from ddtrace.llmobs.types import ToolDefinition
 from ddtrace.llmobs.types import _Meta
@@ -50,7 +53,9 @@ if TYPE_CHECKING:
 
 log = get_logger(__name__)
 
-ValidatedPromptDict = dict[str, Union[str, dict[str, Any], list[str], list[dict[str, str]], list[Message]]]
+ValidatedPromptDict = dict[
+    str, Union[str, dict[str, Any], list[str], list[dict[str, str]], list[Message], list[ChatTemplateItem]]
+]
 
 
 def resolve_llmobs_git_metadata() -> tuple[str, str]:
@@ -146,12 +151,16 @@ def _validate_prompt(prompt: Union[dict[str, Any], Prompt], strict_validation: b
 
     if chat_template:
         if not isinstance(chat_template, list):
-            raise TypeError("chat_template must be a list of dictionaries with string-string key value pairs.")
+            raise TypeError("chat_template must be a list of message or placeholder dictionaries.")
         for ct in chat_template:
-            if not (isinstance(ct, dict) and all(k in ct for k in ("role", "content"))):
-                raise TypeError(
-                    "Each 'chat_template' entry should be a string-string dictionary with role and content keys."
-                )
+            if not isinstance(ct, dict):
+                raise TypeError("Each 'chat_template' entry must be a message or placeholder dictionary.")
+            item = cast(dict[str, Any], ct)
+            if item.get("type") == "placeholder":
+                if not isinstance(item.get("name"), str) or not item["name"]:
+                    raise TypeError("Each message placeholder must have a non-empty string name.")
+            elif not all(k in item for k in ("role", "content")):
+                raise TypeError("Each 'chat_template' message must have role and content keys.")
 
     if variables:
         if not isinstance(variables, dict):
@@ -161,10 +170,14 @@ def _validate_prompt(prompt: Union[dict[str, Any], Prompt], strict_validation: b
         if not all(isinstance(k, str) for k in variables):
             raise TypeError("Keys of 'variables' must all be strings.")
 
-    final_chat_template = []
+    final_chat_template: list[ChatTemplateItem] = []
     if chat_template:
         for msg in chat_template:
-            final_chat_template.append(Message(role=msg["role"], content=msg["content"]))
+            item = cast(dict[str, Any], msg)
+            if item.get("type") == "placeholder":
+                final_chat_template.append(MessagePlaceholder(type="placeholder", name=item["name"]))
+            else:
+                final_chat_template.append(ChatMessage(role=item["role"], content=item["content"]))
 
     if prompt_uuid and not isinstance(prompt_uuid, str):
         raise TypeError(f"prompt_uuid: {prompt_uuid} must be a string, received {type(prompt_uuid).__name__}")

--- a/ddtrace/llmobs/types.py
+++ b/ddtrace/llmobs/types.py
@@ -131,7 +131,7 @@ class PromptVersionResponse(TypedDict, total=False):
     id: str
     prompt_uuid: str
     prompt_id: str
-    template: Union[str, list[ChatTemplateItem]]
+    template: Union[str, list[ChatMessage]]
     version: int
     user_version: str
     labels: list[str]
@@ -215,7 +215,7 @@ class Prompt(TypedDict, total=False):
     id: str
     label: str
     template: str
-    chat_template: Union[list[Message], list[ChatTemplateItem]]
+    chat_template: Union[list[dict[str, str]], list[Message]]
     variables: dict[str, str]
     tags: dict[str, str]
     rag_context_variables: list[str]

--- a/ddtrace/llmobs/types.py
+++ b/ddtrace/llmobs/types.py
@@ -1,5 +1,6 @@
 from typing import Any
 from typing import Callable
+from typing import Literal
 from typing import Optional
 from typing import TypedDict
 from typing import Union
@@ -97,6 +98,16 @@ class ChatMessage(TypedDict):
     content: str
 
 
+class MessagePlaceholder(TypedDict):
+    """A named insertion point for runtime messages in a chat prompt template."""
+
+    type: Literal["placeholder"]
+    name: str
+
+
+ChatTemplateItem = Union[ChatMessage, MessagePlaceholder]
+
+
 class PromptResponse(TypedDict, total=False):
     # Mirrors the backend PromptTemplate struct (dd-source domain/prompt.go);
     # not all fields are populated by every CRUD route.
@@ -120,7 +131,7 @@ class PromptVersionResponse(TypedDict, total=False):
     id: str
     prompt_uuid: str
     prompt_id: str
-    template: Union[str, list[ChatMessage]]
+    template: Union[str, list[ChatTemplateItem]]
     version: int
     user_version: str
     labels: list[str]
@@ -204,7 +215,7 @@ class Prompt(TypedDict, total=False):
     id: str
     label: str
     template: str
-    chat_template: Union[list[dict[str, str]], list[Message]]
+    chat_template: Union[list[Message], list[ChatTemplateItem]]
     variables: dict[str, str]
     tags: dict[str, str]
     rag_context_variables: list[str]

--- a/releasenotes/notes/message-placeholders-7f3d2a01c4b9.yaml
+++ b/releasenotes/notes/message-placeholders-7f3d2a01c4b9.yaml
@@ -2,4 +2,4 @@
 features:
   - |
     LLM Observability: Managed chat prompts can now include named message placeholders that
-    ``ManagedPrompt.format()`` replaces with caller-provided message lists in their authored position.
+    ``ManagedPrompt.format()`` replaces with caller-provided text or tool message lists in their authored position.

--- a/releasenotes/notes/message-placeholders-7f3d2a01c4b9.yaml
+++ b/releasenotes/notes/message-placeholders-7f3d2a01c4b9.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    LLM Observability: Managed chat prompts can now include named message placeholders that
+    ``ManagedPrompt.format()`` replaces with caller-provided message lists in their authored position.

--- a/tests/llmobs/test_prompts.py
+++ b/tests/llmobs/test_prompts.py
@@ -1,3 +1,4 @@
+from collections import UserList
 from contextlib import contextmanager
 import json
 import os
@@ -883,6 +884,16 @@ class TestPromptManagement:
             call()
 
         assert json.loads(conn.requests[-1]["body"])["env_ids"] == ["env-1"]
+
+    @pytest.mark.parametrize("method", ["create_prompt", "create_prompt_version"])
+    def test_write_prompt_accepts_sequence(self, method):
+        manager = _make_manager()
+        conn, mock_patch = _mock_write_api(200, {})
+        template = UserList([{"role": "user", "content": "hi"}])
+        with mock_patch:
+            getattr(manager, method)("p1", template)
+
+        assert json.loads(conn.requests[-1]["body"])["template"] == list(template)
 
     @pytest.mark.parametrize(
         "status,exc_type",

--- a/tests/llmobs/test_prompts.py
+++ b/tests/llmobs/test_prompts.py
@@ -191,10 +191,22 @@ class TestPrompts:
         ]
         prompt = ManagedPrompt(id="assistant", version="1", label=None, source="registry", template=template)
         history = [{"role": "user", "content": "Keep {{opaque}}", "provider_field": {"id": 1}}]
+        tools = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"name": "lookup", "arguments": {"id": 1}, "tool_id": "call-1"}],
+            },
+            {
+                "role": "tool",
+                "tool_results": [{"name": "lookup", "result": "found", "tool_id": "call-1"}],
+            },
+        ]
 
-        assert prompt.format(persona="concise", question="Help", history=history, examples=[]) == [
+        assert prompt.format(persona="concise", question="Help", history=history, examples=tools) == [
             {"role": "system", "content": "You are concise."},
             {"role": "user", "content": "Keep {{opaque}}", "provider_field": {"id": 1}},
+            *tools,
             {"role": "user", "content": "Keep {{opaque}}", "provider_field": {"id": 1}},
             {"role": "user", "content": "Help"},
         ]
@@ -204,10 +216,16 @@ class TestPrompts:
         [
             ({}, "Missing value"),
             ({"history": "not-a-list"}, "must be a list"),
-            ({"history": [{"role": "user"}]}, "string role and content"),
+            ({"history": [{"role": "user"}]}, "string role and text or tool content"),
+            ({"history": [{"role": "assistant", "content": None}]}, "string role and text or tool content"),
+            ({"history": [{"role": "assistant", "tool_calls": []}]}, "string role and text or tool content"),
+            (
+                {"history": [{"role": "assistant", "content": [{"type": "image"}], "tool_calls": [{}]}]},
+                "string role and text or tool content",
+            ),
             (
                 {"history": [{"type": "placeholder", "name": "nested", "role": "user", "content": "x"}]},
-                "string role and content",
+                "string role and text or tool content",
             ),
         ],
     )

--- a/tests/llmobs/test_prompts.py
+++ b/tests/llmobs/test_prompts.py
@@ -181,6 +181,65 @@ class TestPrompts:
         assert messages[0]["content"] == "You are helpful assistant."
         assert messages[1]["content"] == "What is Python?"
 
+    def test_render_chat_message_placeholders(self):
+        template = [
+            {"role": "system", "content": "You are {{persona}}."},
+            {"type": "placeholder", "name": "history"},
+            {"type": "placeholder", "name": "examples"},
+            {"type": "placeholder", "name": "history"},
+            {"role": "user", "content": "{{question}}"},
+        ]
+        prompt = ManagedPrompt(id="assistant", version="1", label=None, source="registry", template=template)
+        history = [{"role": "user", "content": "Keep {{opaque}}", "provider_field": {"id": 1}}]
+
+        assert prompt.format(persona="concise", question="Help", history=history, examples=[]) == [
+            {"role": "system", "content": "You are concise."},
+            {"role": "user", "content": "Keep {{opaque}}", "provider_field": {"id": 1}},
+            {"role": "user", "content": "Keep {{opaque}}", "provider_field": {"id": 1}},
+            {"role": "user", "content": "Help"},
+        ]
+
+    @pytest.mark.parametrize(
+        "variables, error",
+        [
+            ({}, "Missing value"),
+            ({"history": "not-a-list"}, "must be a list"),
+            ({"history": [{"role": "user"}]}, "string role and content"),
+            (
+                {"history": [{"type": "placeholder", "name": "nested", "role": "user", "content": "x"}]},
+                "string role and content",
+            ),
+        ],
+    )
+    def test_render_chat_message_placeholder_errors(self, variables, error):
+        prompt = ManagedPrompt(
+            id="assistant",
+            version="1",
+            label=None,
+            source="registry",
+            template=[{"type": "placeholder", "name": "history"}],
+        )
+
+        with pytest.raises(ValueError, match=error):
+            prompt.format(**variables)
+
+    def test_message_placeholder_annotation_excludes_runtime_messages(self, tracer):
+        LLMObs.enable(_tracer=tracer, agentless_enabled=False)
+        template = [
+            {"role": "system", "content": "You are {{persona}}."},
+            {"type": "placeholder", "name": "history"},
+        ]
+        prompt = ManagedPrompt(id="assistant", version="1", label=None, source="registry", template=template)
+
+        annotation = prompt.to_annotation_dict(persona="concise", history=[{"role": "user", "content": "private"}])
+
+        with LLMObs.annotation_context(prompt=annotation):
+            with LLMObs.llm(model_name="test-model", name="test") as span:
+                prompt_data = get_llmobs_input_prompt(span)
+
+        assert prompt_data["chat_template"] == template
+        assert prompt_data["variables"] == {"persona": "concise"}
+
     def test_caching_returns_from_cache(self):
         """Second call returns cached prompt without API call."""
         call_count = 0

--- a/tests/llmobs/test_prompts_typing.py
+++ b/tests/llmobs/test_prompts_typing.py
@@ -1,0 +1,19 @@
+from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs.types import ChatMessage
+from ddtrace.llmobs.types import ChatTemplateItem
+
+
+def test_create_prompt_authoring_types_are_source_compatible():
+    def type_checked_calls() -> None:
+        existing_messages: list[ChatMessage] = [{"role": "user", "content": "Hello"}]
+        LLMObs.create_prompt("existing", existing_messages)
+        LLMObs.create_prompt_version("existing", existing_messages)
+
+        placeholder_template: list[ChatTemplateItem] = [
+            {"role": "system", "content": "Be concise"},
+            {"type": "placeholder", "name": "history"},
+        ]
+        LLMObs.create_prompt("placeholder", placeholder_template)
+        LLMObs.create_prompt_version("placeholder", placeholder_template)
+
+    assert callable(type_checked_calls)


### PR DESCRIPTION
## Why

Managed prompt users need to place caller-owned conversation history at an authored position without manually splicing messages or storing runtime history in Prompt Management.

This PR adds Python SDK authoring, local formatting, and prompt-annotation support for named message placeholders. Empty, repeated, and multiple placeholders expand in place; inserted messages remain opaque and retain additional provider fields. Missing or malformed values fail locally before a model call.

## API / contract changes

**New additive public types:** `MessagePlaceholder` and `ChatTemplateItem`.

**Authoring input:** `create_prompt()` and `create_prompt_version()` accept `Sequence[ChatTemplateItem]`. Existing `list[ChatMessage]` calls continue to type-check unchanged.

```python
[
    ChatMessage(role="system", content="Be concise."),
    MessagePlaceholder(type="placeholder", name="history"),
    ChatMessage(role="user", content="{{question}}"),
]
```

**Existing output contracts:** unchanged. `ChatMessage`, `PromptVersionResponse.template`, `Prompt.chat_template`, and the return annotation of `ManagedPrompt.format()` retain their existing public shapes. The `format()` variable input accepts message lists in addition to scalar values.

The authored wire item is:

```json
{"type":"placeholder","name":"history"}
```

## Compatibility and scope

Prompt annotations preserve the authored placeholder but exclude its runtime message list from scalar variable metadata. Runtime values require a string `role` and either string `content` or non-empty `tool_calls` or `tool_results`; tool messages may omit `content` or set it to `null`. Provider-specific fields remain opaque. Multimodal content values remain deferred without changing the generic placeholder directive. This PR adds no dependency, backend call, provider schema, second formatter, or alternate wire representation. The backend remains responsible only for accepting and preserving the authored directive.


## Initiative stack

**This PR:** Python SDK formatting and annotation.

Merge required phases in order. PRs in the same phase may merge in parallel after their prerequisites. Rows marked **2+** are optional plus deliverables and do not block later phases.

| Phase | Slice | Pull request | Prerequisite |
|---:|---|---|---|
| 0 | Go managed-prompt baseline | [DataDog/dd-trace-go#5298](https://github.com/DataDog/dd-trace-go/pull/5298) | Required only by Go SDK #5334 |
| 0 | JavaScript managed-prompt baseline | [DataDog/dd-trace-js#10015](https://github.com/DataDog/dd-trace-js/pull/10015) | Required only by JavaScript SDK #10269 |
| 1 | Backend acceptance and serving | [ddoghq/dd-source#86350](https://github.com/ddoghq/dd-source/pull/86350) | — |
| 2 | API schema | [DataDog/datadog-api-spec#6674](https://github.com/DataDog/datadog-api-spec/pull/6674) | #86350 |
| 2 | Python SDK | [DataDog/dd-trace-py#20206](https://github.com/DataDog/dd-trace-py/pull/20206) | #86350 |
| **2+** | Go SDK | [DataDog/dd-trace-go#5334](https://github.com/DataDog/dd-trace-go/pull/5334) | #86350 and #5298 |
| **2+** | JavaScript SDK | [DataDog/dd-trace-js#10269](https://github.com/DataDog/dd-trace-js/pull/10269) | #86350 and #10015 |
| 3 | Prompt authoring UI | [ddoghq/web-ui#11327](https://github.com/ddoghq/web-ui/pull/11327) | #86350 and a compatible SDK release |
| 4 | Playground UI | [ddoghq/web-ui#11351](https://github.com/ddoghq/web-ui/pull/11351) | #11327 |
| 4 | Experiment execution | [ddoghq/dd-source#86731](https://github.com/ddoghq/dd-source/pull/86731) | #86350 |
| 5 | Experiment UI | [ddoghq/web-ui#11392](https://github.com/ddoghq/web-ui/pull/11392) | #11351 and #86731 |
| 6 | Customer documentation | [DataDog/documentation#39830](https://github.com/DataDog/documentation/pull/39830) | SDK release versions assigned |

