### PR TITLE
ci: move low-churn test matrices off pull requests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -134,6 +134,7 @@ run-tests-trigger:
    strategy: depend
 
 serverless lambda tests:
+  extends: .serverless_rules
   stage: tests
   trigger:
     project: DataDog/datadog-lambda-python
@@ -613,6 +614,16 @@ lib_injection_tests:
   stage: tests
   tags: [ "arch:amd64" ]
   image: registry.ddbuild.io/dd-trace-py:v106957811-b912d74-lib_injection@sha256:d381042ec0c5d8ba617453feec7ccdffefca8ef0e3011d980728fe1a7a9425eb
+  rules:
+    - if: $NIGHTLY_BUILD == "true"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "main"
+    - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+    - if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+$/
+    - changes:
+        - .gitlab-ci.yml
+        - lib-injection/**/*
+    - when: never
   script: |
     echo -e "\e[0Ksection_start:`date +%s`:info[collapsed=true]\r\e[0KPython versions"
     pyenv --version
@@ -730,9 +741,49 @@ package-oci:
     - job: "download_dependency_wheels"
       artifacts: true
 
+.full_system_test_changes: &full_system_test_changes
+  - .gitlab-ci.yml
+  - .gitlab/one-pipeline.locked.yml
+  - .gitlab/package.yml
+  - .gitlab/system-tests.yml
+  - .gitlab/scripts/build-sdist.sh
+  - .gitlab/scripts/build-wheel.sh
+  - setup.py
+  - pyproject.toml
+  - MANIFEST.in
+  - ddtrace/**/*.c
+  - ddtrace/**/*.cpp
+  - ddtrace/**/*.h
+  - ddtrace/**/*.pxd
+  - ddtrace/**/*.pyx
+  - lib-injection/**/*
+  - src/native/**/*
+  - src/native_heap_gotter/**/*
+
+.product_system_test_changes: &product_system_test_changes
+  - ddtrace/appsec/**/*
+  - ddtrace/internal/datadog/profiling/**/*
+  - ddtrace/profiling/**/*
+  - tests/appsec/**/*
+  - tests/profiling/**/*
+
 configure_system_tests:
+  needs: []
   variables:
     SYSTEM_TESTS_SCENARIOS_GROUPS: "simple_onboarding,simple_onboarding_profiling,simple_onboarding_appsec,docker-ssi,lib-injection"
+  rules:
+    - if: $NIGHTLY_BUILD == "true"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: !reference [.is_main]
+    - if: !reference [.is_release]
+    - if: !reference [.is_release_branch]
+    - changes: *full_system_test_changes
+    - changes: *product_system_test_changes
+      variables:
+        SYSTEM_TESTS_SCENARIOS_GROUPS: "simple_onboarding,simple_onboarding_profiling,simple_onboarding_appsec"
+    - when: on_success
+      variables:
+        SYSTEM_TESTS_SCENARIOS_GROUPS: "simple_onboarding"
 
 system_tests:
   needs: ["configure_system_tests", "oci-internal-test-publish", "kubernetes-injection-test-ecr-publish"]

--- a/.gitlab/benchmarks/serverless.yml
+++ b/.gitlab/benchmarks/serverless.yml
@@ -2,6 +2,17 @@ variables:
   SLS_CI_IMAGE: registry.ddbuild.io/ci/serverless-tools:1
   SLS_CI_BRANCH: v1.3.0
 
+.serverless_benchmark_changes: &serverless_benchmark_changes
+  - .gitlab-ci.yml
+  - .gitlab/benchmarks/serverless.yml
+  - .gitlab/package.yml
+  - .gitlab/scripts/build-wheel.sh
+  - setup.py
+  - pyproject.toml
+  - ddtrace/internal/serverless/**/*
+  - ddtrace/contrib/internal/aws_lambda/**/*
+  - tests/contrib/aws_lambda/**/*
+
 benchmark-serverless:
   stage: benchmarks
   trigger:
@@ -11,9 +22,14 @@ benchmark-serverless:
   needs:
     - job: "upload serverless"
   rules:
-    - if: $RELEASE_ALLOW_BENCHMARK_FAILURES == "true"
+    - if: '$RELEASE_ALLOW_BENCHMARK_FAILURES == "true" && ($NIGHTLY_BUILD == "true" || $CI_PIPELINE_SOURCE == "schedule" || $CI_COMMIT_REF_NAME == "main" || $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/ || $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+$/)'
       allow_failure: true
-    - allow_failure: false
+    - if: '$NIGHTLY_BUILD == "true" || $CI_PIPELINE_SOURCE == "schedule" || $CI_COMMIT_REF_NAME == "main" || $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/ || $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+$/'
+    - if: '$RELEASE_ALLOW_BENCHMARK_FAILURES == "true"'
+      changes: *serverless_benchmark_changes
+      allow_failure: true
+    - changes: *serverless_benchmark_changes
+    - when: never
   variables:
     DD_TAGS: "SLS_CI_BRANCH:$SLS_CI_BRANCH"
     UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID

--- a/.gitlab/multi-os-tests.yml
+++ b/.gitlab/multi-os-tests.yml
@@ -1,10 +1,36 @@
-# Multi-OS Test Suite
-# Tests the application across Ubuntu, macOS, and Windows with multiple Python versions
+.multi_os_changes: &multi_os_changes
+  - .gitlab-ci.yml
+  - .gitlab/multi-os-tests.yml
+  - .gitlab/package.yml
+  - .gitlab/requirements/multi-os-tests.txt
+  - .gitlab/scripts/build-wheel.sh
+  - .gitlab/scripts/build-wheel-windows.sh
+  - .gitlab/scripts/multi-os-tests.ps1
+  - .gitlab/scripts/multi-os-tests.sh
+  - setup.py
+  - pyproject.toml
+  - ddtrace/**/*.c
+  - ddtrace/**/*.cpp
+  - ddtrace/**/*.h
+  - ddtrace/**/*.pxd
+  - ddtrace/**/*.pyx
+  - ddtrace/appsec/**/*
+  - src/native/**/*
+  - src/native_heap_gotter/**/*
+  - tests/appsec/architectures/**/*
+  - tests/internal/service_name/**/*
 
 .multi_os_test_base:
   stage: tests
-  # multi-OS runners (especially windows) are prone to flaky infra/test failures
   retry: 2
+  rules:
+    - if: $NIGHTLY_BUILD == "true"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "main"
+    - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+    - if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+$/
+    - changes: *multi_os_changes
+    - when: never
   variables:
     DD_IAST_ENABLED: "false"
     DD_REMOTE_CONFIGURATION_ENABLED: "false"

--- a/.gitlab/native.yml
+++ b/.gitlab/native.yml
@@ -1,12 +1,51 @@
 include:
   - local: ".gitlab/testrunner.yml"
 
+.rust_changes: &rust_changes
+  - .gitlab-ci.yml
+  - .gitlab/native.yml
+  - setup.py
+  - pyproject.toml
+  - src/native/**/*
+  - src/native_heap_gotter/**/*
+
+.profiling_native_changes: &profiling_native_changes
+  - .gitlab-ci.yml
+  - .gitlab/native.yml
+  - setup.py
+  - pyproject.toml
+  - ddtrace/internal/datadog/profiling/**/*.cc
+  - ddtrace/internal/datadog/profiling/**/*.cmake
+  - ddtrace/internal/datadog/profiling/**/*.cpp
+  - ddtrace/internal/datadog/profiling/**/*.h
+  - ddtrace/internal/datadog/profiling/**/*.hpp
+  - ddtrace/internal/datadog/profiling/**/*.pyx
+  - ddtrace/internal/datadog/profiling/**/CMakeLists.txt
+  - ddtrace/internal/datadog/profiling/**/*.sh
+  - ddtrace/internal/datadog/profiling/**/*.supp
+  - ddtrace/profiling/**/*.cpp
+  - ddtrace/profiling/**/*.h
+  - ddtrace/profiling/**/*.hpp
+  - ddtrace/profiling/**/*.pxd
+  - ddtrace/profiling/**/*.pyx
+  - ddtrace/profiling/**/CMakeLists.txt
+  - src/native/**/*
+  - src/native_heap_gotter/**/*
+
 "rust ci":
   stage: tests
   image: !reference [.testrunner, image]
   tags: !reference [.testrunner, tags]
   timeout: 10m
   needs: []
+  rules:
+    - if: $NIGHTLY_BUILD == "true"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "main"
+    - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+    - if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+$/
+    - changes: *rust_changes
+    - when: never
   before_script: cd src/native
   script:
     - |
@@ -43,6 +82,14 @@ include:
   tags: ["arch:amd64"]
   timeout: 20m
   needs: []
+  rules:
+    - if: $NIGHTLY_BUILD == "true"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "main"
+    - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+    - if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+$/
+    - changes: *profiling_native_changes
+    - when: never
   before_script:
     - pyenv global 3.12
   script:

--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -29,6 +29,43 @@ variables:
   - "v133965508-8f84bce-manylinux2014_x86_64"
   - "v133965497-8f84bce-musllinux_1_2_x86_64"
 
+.serverless_changes: &serverless_changes
+  - .gitlab-ci.yml
+  - .gitlab/benchmarks/serverless.yml
+  - .gitlab/package.yml
+  - .gitlab/scripts/build-wheel.sh
+  - setup.py
+  - pyproject.toml
+  - ddtrace/internal/serverless/**/*
+  - ddtrace/contrib/internal/aws_lambda/**/*
+  - tests/contrib/aws_lambda/**/*
+
+.package_build_changes: &package_build_changes
+  - .gitlab-ci.yml
+  - .gitlab/package.yml
+  - .gitlab/scripts/build-sdist.sh
+  - .gitlab/scripts/build-wheel.sh
+  - setup.py
+  - pyproject.toml
+  - MANIFEST.in
+  - ddtrace/**/*.c
+  - ddtrace/**/*.cpp
+  - ddtrace/**/*.h
+  - ddtrace/**/*.pxd
+  - ddtrace/**/*.pyx
+  - src/native/**/*
+  - src/native_heap_gotter/**/*
+
+.serverless_rules:
+  rules:
+    - if: $NIGHTLY_BUILD == "true"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "main"
+    - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+    - if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+$/
+    - changes: *serverless_changes
+    - when: never
+
 .build_base:
   stage: package
   variables:
@@ -128,6 +165,15 @@ variables:
 
 "build linux serverless":
   extends: "build linux"
+  rules:
+    - if: '$PYTHON_TAG == "cp315-cp315" && ($NIGHTLY_BUILD == "true" || $CI_PIPELINE_SOURCE == "schedule" || $CI_COMMIT_REF_NAME == "main" || $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/ || $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+$/)'
+      allow_failure: true
+    - if: '$NIGHTLY_BUILD == "true" || $CI_PIPELINE_SOURCE == "schedule" || $CI_COMMIT_REF_NAME == "main" || $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/ || $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+$/'
+    - if: '$PYTHON_TAG == "cp315-cp315"'
+      changes: *serverless_changes
+      allow_failure: true
+    - changes: *serverless_changes
+    - when: never
   parallel:
     matrix:
       - ARCH_TAG: "amd64"
@@ -294,7 +340,9 @@ variables:
 
 # Only the limited artifacts needed by downstream serverless jobs
 "upload serverless":
-  extends: .upload_wheels_base
+  extends:
+    - .upload_wheels_base
+    - .serverless_rules
   needs:
     - job: "build linux serverless"
       artifacts: true
@@ -336,6 +384,14 @@ variables:
   needs:
     - job: "build sdist"
       artifacts: true
+  rules:
+    - if: $NIGHTLY_BUILD == "true"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "main"
+    - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$/
+    - if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+$/
+    - changes: *package_build_changes
+    - when: never
   script:
     - SDIST_FILE=$(ls ${CI_PROJECT_DIR}/pywheels/*.tar.gz | head -n 1)
     - TMP_DIR=$(mktemp -d) && cd $TMP_DIR
@@ -543,7 +599,9 @@ download_dependency_wheels:
     - .gitlab/validate-ddtrace-package.py pywheels
 
 "ddtrace package serverless":
-  extends: .package_base
+  extends:
+    - .package_base
+    - .serverless_rules
   needs:
     - "build linux serverless"
     - "package version"


### PR DESCRIPTION
## Description

### Decision summary

The slow tail of recent PR pipelines is 138% longer than the median [97.7 minutes vs. 41.1 minutes]. This proposal reduces compatibility work on ordinary PRs while leaving the main test pipeline unchanged.

“Required” below means this PR does not make the job conditional. “Not required” means an unrelated ordinary PR skips it; the job still runs for relevant changes and on nightly, main, and release pipelines.

> [!IMPORTANT]
> Management requires full coverage in merge queue. The current commit does not yet add a merge-queue override, so its conditional compatibility jobs can still be skipped there. This draft should not be marked ready until that gap is resolved.

```mermaid
flowchart LR
    PR["Ordinary PR"] --> Required["Required<br/>All suitespec-generated tests<br/>Primary package builds<br/>Baseline onboarding"]
    PR --> Paths{"Relevant paths changed?"}
    Paths -->|Yes| Conditional["Run matching compatibility jobs"]
    Paths -->|No| Skip["Not required on this PR<br/>Covered by full pipelines"]

    Full["Nightly / main / release"] --> All["Run all compatibility jobs"]

    MQ["Merge queue"] --> Gap["Current commit: path-selected<br/>Required policy: run everything<br/>Gap not yet implemented"]

    style Required fill:#d7f5df,stroke:#248a3d
    style All fill:#d7f5df,stroke:#248a3d
    style Gap fill:#fff0c2,stroke:#b7791f
```

### What is required on every ordinary PR?

This PR leaves these paths unchanged:

- All suitespec-generated unit and integration tests through tests-gen and run-tests-trigger.
- Primary Linux, macOS, Windows, and source-distribution builds and package validation.
- Baseline simple_onboarding System Tests.
- Existing static analysis, metadata, and policy checks.

### What is not required on an unrelated ordinary PR?

| Job group | Runs when | Work avoided when unrelated |
|---|---|---:|
| Extra System Test scenarios | AppSec, profiling, packaging, native, injection, or System Test paths change | **90% fewer jobs** [136 → 14] and **91% less runner time** [about 13.4 → 1.2 runner-hours] for the default path |
| Serverless chain | Serverless, Lambda, wheel-build, or packaging paths change | **100% fewer jobs** [32 → 0] and about **3.0 runner-hours** |
| Multi-OS tests | Native, packaging, AppSec architecture, or multi-OS paths change | **100% fewer jobs** [7 → 0] and about **0.31 runner-hours** |
| Source-distribution smoke test | Packaging or compiled-extension paths change | **100% fewer jobs** [1 → 0] and about **0.20 runner-hours** |
| Rust checks | Rust/native or packaging configuration changes | **100% fewer jobs** [1 → 0] and about **0.02 runner-hours** |
| Profiling clang-tidy | Profiling native or build configuration changes | **100% fewer jobs** [1 → 0] and about **0.15 runner-hours** |
| Standalone library injection | Injection configuration or implementation changes | **100% fewer jobs** [1 → 0] and about **0.02 runner-hours** |

### Big-picture impact

The estimates use a 90-day selector backtest [706 mainline commits] and runner duration from recent merged-PR pipelines [24 pipelines].

- **72% lower runner consumption across the targeted workload** [about 17.1 → 4.8 runner-hours per ordinary PR; about 12.3 hours avoided].
- **72% lower runner consumption per 100 ordinary PR pipelines** [about 1,710 → 475 runner-hours; about 1,235 hours avoided].
- **74% of the projected savings comes from System Tests** [about 9.1 of 12.3 runner-hours per PR].
- **22% of the projected savings comes from the serverless chain** [about 2.7 of 12.3 runner-hours per PR].
- **4% of the projected savings comes from the remaining compatibility jobs** [about 0.5 of 12.3 runner-hours per PR].

#### Expected CI time

Runner-hours do not translate one-to-one into wall-clock time because these jobs run in parallel. The clearest expected benefit is lower tail latency and less runner contention:

- The System Test path currently finishes within 9% of the median pipeline end [37.6 vs. 41.1 minutes].
- It finishes within 4% of the slow-tail pipeline end [93.6 vs. 97.7 minutes].

That makes System Tests a likely contributor to the slow tail, but this PR should not claim an exact wall-clock reduction before rollout. Its own pipeline also takes the full path because it edits .gitlab-ci.yml. A follow-up measurement should compare ordinary PR p50 and p90 before and after the change.

#### Cost

The cost proxy is **72% lower targeted runner usage** [about 12.3 runner-hours avoided per ordinary PR]. A dollar estimate needs the internal blended hourly rates for amd64, arm64, Windows, and macOS runners.

The calculation is:

```text
estimated savings = 12.3 runner-hours × ordinary PR pipelines × blended runner cost/hour
```

This avoids presenting all runner types as equally priced.

### Coverage retained

- Relevant ordinary PRs still run the matching compatibility jobs.
- Nightly, scheduled, main, release-tag, and release-branch pipelines run all compatibility jobs.
- Suitespec selection is unchanged.
- Full merge-queue coverage is a stated requirement, but is not implemented in the current commit.

## Testing

- scripts/lint checks
- scripts/run-tests --venv d7f4942
- Parsed every edited YAML file
- Checked the diff for whitespace errors

## Risks

The main risk is a missing path selector deferring a compatibility failure. Nightly, main, and release pipelines remain the fallback. Merge queue needs an explicit full-coverage rule before this draft is ready.

## Additional Notes

Cumulative timing in the earlier analysis included queue and dependency wait. The runner-hour estimates above use GitLab job duration instead, which is the better compute and cost proxy.

No release note is needed because this only changes CI behavior.
