### PR TITLE
feat(llmobs): add managed prompt configuration

### DIFF
--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -146,6 +146,7 @@ from ddtrace.llmobs._prompt_optimization import validate_task
 from ddtrace.llmobs._prompt_optimization import validate_test_dataset
 from ddtrace.llmobs._prompts import ManagedPrompt
 from ddtrace.llmobs._prompts.cache import WarmCache
+from ddtrace.llmobs._prompts.manager import _UNSET
 from ddtrace.llmobs._prompts.manager import PromptManager
 from ddtrace.llmobs._utils import AnnotationContext
 from ddtrace.llmobs._utils import LinkTracker
@@ -2136,6 +2137,7 @@ class LLMObs(Service):
         user_version: str = "",
         labels: Optional[list[str]] = None,
         env_ids: Optional[list[str]] = None,
+        config: dict[str, JSONType] = _UNSET,
     ) -> PromptResponse:
         """Create a new prompt in the registry.
 
@@ -2147,6 +2149,7 @@ class LLMObs(Service):
             user_version: Optional user-defined version string.
             labels: Optional list containing ``production`` and/or ``development``.
             env_ids: Optional feature-flag environment IDs to deploy the first version to.
+            config: Optional application-consumed JSON configuration stored with this version.
 
         Returns:
             The created prompt.
@@ -2166,6 +2169,7 @@ class LLMObs(Service):
             user_version=user_version,
             labels=labels,
             env_ids=env_ids,
+            config=config,
         )
 
     @classmethod
@@ -2178,6 +2182,7 @@ class LLMObs(Service):
         user_version: str = "",
         labels: Optional[list[str]] = None,
         env_ids: Optional[list[str]] = None,
+        config: dict[str, JSONType] = _UNSET,
     ) -> PromptVersionResponse:
         """Create a new version of an existing prompt.
 
@@ -2188,6 +2193,7 @@ class LLMObs(Service):
             user_version: Optional user-defined version string.
             labels: Optional list containing ``production`` and/or ``development``.
             env_ids: Optional feature-flag environment IDs to deploy this version to.
+            config: Optional application-consumed JSON configuration stored with this version.
 
         Returns:
             The created prompt version.
@@ -2206,6 +2212,7 @@ class LLMObs(Service):
             user_version=user_version,
             labels=labels,
             env_ids=env_ids,
+            config=config,
         )
 
     @classmethod

--- a/ddtrace/llmobs/_llmobs.py
+++ b/ddtrace/llmobs/_llmobs.py
@@ -188,6 +188,7 @@ from ddtrace.llmobs.types import ChatMessage
 from ddtrace.llmobs.types import DeletedPromptResponse
 from ddtrace.llmobs.types import ExportedLLMObsSpan
 from ddtrace.llmobs.types import FeedbackSubmitter
+from ddtrace.llmobs.types import JSONType as PromptJSONType
 from ddtrace.llmobs.types import Message
 from ddtrace.llmobs.types import Prompt
 from ddtrace.llmobs.types import PromptAuthError
@@ -2137,28 +2138,23 @@ class LLMObs(Service):
         user_version: str = "",
         labels: Optional[list[str]] = None,
         env_ids: Optional[list[str]] = None,
-        config: dict[str, JSONType] = _UNSET,
+        config: dict[str, PromptJSONType] = _UNSET,
     ) -> PromptResponse:
         """Create a new prompt in the registry.
 
-        Args:
-            prompt_id: Unique identifier for the prompt.
-            template: List of chat messages defining the prompt template.
-            title: Optional human-readable title.
-            description: Optional description of the prompt.
-            user_version: Optional user-defined version string.
-            labels: Optional list containing ``production`` and/or ``development``.
-            env_ids: Optional feature-flag environment IDs to deploy the first version to.
-            config: Optional application-consumed JSON configuration stored with this version.
-
-        Returns:
-            The created prompt.
-
-        Raises:
-            PromptAuthError: Authentication failed (check DD_API_KEY and DD_APP_KEY).
-            PromptValidationError: Invalid request (bad template, missing fields).
-            PromptConflictError: A prompt with this prompt_id already exists.
-            PromptServerError: Server-side error.
+        :param prompt_id: Unique identifier for the prompt.
+        :param template: List of chat messages defining the prompt template.
+        :param title: Optional human-readable title.
+        :param description: Optional description of the prompt.
+        :param user_version: Optional user-defined version string.
+        :param labels: Optional list containing ``production`` and/or ``development``.
+        :param env_ids: Optional feature-flag environment IDs to deploy the first version to.
+        :param config: Optional application-consumed JSON configuration stored with this version.
+        :returns: The created prompt.
+        :raises PromptAuthError: Authentication failed (check DD_API_KEY and DD_APP_KEY).
+        :raises PromptValidationError: Invalid request (bad template, missing fields).
+        :raises PromptConflictError: A prompt with this prompt_id already exists.
+        :raises PromptServerError: Server-side error.
         """
         prompt_manager = cls._ensure_prompt_manager()
         return prompt_manager.create_prompt(
@@ -2182,27 +2178,22 @@ class LLMObs(Service):
         user_version: str = "",
         labels: Optional[list[str]] = None,
         env_ids: Optional[list[str]] = None,
-        config: dict[str, JSONType] = _UNSET,
+        config: dict[str, PromptJSONType] = _UNSET,
     ) -> PromptVersionResponse:
         """Create a new version of an existing prompt.
 
-        Args:
-            prompt_id: The prompt identifier.
-            template: List of chat messages defining the new version's template.
-            description: Optional description of this version.
-            user_version: Optional user-defined version string.
-            labels: Optional list containing ``production`` and/or ``development``.
-            env_ids: Optional feature-flag environment IDs to deploy this version to.
-            config: Optional application-consumed JSON configuration stored with this version.
-
-        Returns:
-            The created prompt version.
-
-        Raises:
-            PromptAuthError: Authentication failed (check DD_API_KEY and DD_APP_KEY).
-            PromptValidationError: Invalid request.
-            PromptNotFoundError: Prompt does not exist.
-            PromptServerError: Server-side error.
+        :param prompt_id: The prompt identifier.
+        :param template: List of chat messages defining the new version's template.
+        :param description: Optional description of this version.
+        :param user_version: Optional user-defined version string.
+        :param labels: Optional list containing ``production`` and/or ``development``.
+        :param env_ids: Optional feature-flag environment IDs to deploy this version to.
+        :param config: Optional application-consumed JSON configuration stored with this version.
+        :returns: The created prompt version.
+        :raises PromptAuthError: Authentication failed (check DD_API_KEY and DD_APP_KEY).
+        :raises PromptValidationError: Invalid request.
+        :raises PromptNotFoundError: Prompt does not exist.
+        :raises PromptServerError: Server-side error.
         """
         prompt_manager = cls._ensure_prompt_manager()
         return prompt_manager.create_prompt_version(

--- a/ddtrace/llmobs/_prompts/manager.py
+++ b/ddtrace/llmobs/_prompts/manager.py
@@ -7,6 +7,7 @@ from typing import Any
 from typing import Literal
 from typing import Optional
 from typing import Union
+from typing import cast
 from urllib.parse import quote
 from urllib.parse import urlencode
 from urllib.parse import urlparse
@@ -41,6 +42,8 @@ from ddtrace.llmobs.types import PromptVersionResponse
 
 
 log = get_logger(__name__)
+
+_UNSET = cast(dict[str, Any], object())
 
 _STATUS_EXCEPTIONS: dict[int, type[PromptAPIError]] = {
     400: PromptValidationError,
@@ -525,6 +528,7 @@ class PromptManager:
                 template=extract_template(data, default=[]),
                 _uuid=data.get("prompt_uuid"),
                 _version_uuid=data.get("prompt_version_uuid") or data.get("id") or data.get("ID"),
+                _config=data.get("config", {}),
             )
         except (json.JSONDecodeError, KeyError, TypeError) as e:
             log.warning("Failed to parse prompt response: %s", e)
@@ -607,6 +611,7 @@ class PromptManager:
         user_version: str = "",
         labels: Optional[list[str]] = None,
         env_ids: Optional[list[str]] = None,
+        config: dict[str, Any] = _UNSET,
     ) -> PromptResponse:
         body: dict[str, Any] = {"prompt_id": prompt_id, "template": template}
         if title:
@@ -619,6 +624,10 @@ class PromptManager:
             body["labels"] = labels
         if env_ids is not None:
             body["env_ids"] = env_ids
+        if config is not _UNSET:
+            if not isinstance(config, dict):
+                raise PromptValidationError(0, "config must be a dictionary")
+            body["config"] = config
         result: PromptResponse = self._request("POST", PROMPTS_ENDPOINT, body=body)
         self._evict_prompt_caches(prompt_id)
         return result
@@ -632,6 +641,7 @@ class PromptManager:
         user_version: str = "",
         labels: Optional[list[str]] = None,
         env_ids: Optional[list[str]] = None,
+        config: dict[str, Any] = _UNSET,
     ) -> PromptVersionResponse:
         escaped_id = quote(prompt_id, safe="")
         body: dict[str, Any] = {"template": template}
@@ -643,6 +653,10 @@ class PromptManager:
             body["labels"] = labels
         if env_ids is not None:
             body["env_ids"] = env_ids
+        if config is not _UNSET:
+            if not isinstance(config, dict):
+                raise PromptValidationError(0, "config must be a dictionary")
+            body["config"] = config
         result: PromptVersionResponse = self._request("POST", f"{PROMPTS_ENDPOINT}/{escaped_id}/versions", body=body)
         self._evict_prompt_caches(prompt_id)
         return result

--- a/ddtrace/llmobs/_prompts/manager.py
+++ b/ddtrace/llmobs/_prompts/manager.py
@@ -7,7 +7,6 @@ from typing import Any
 from typing import Literal
 from typing import Optional
 from typing import Union
-from typing import cast
 from urllib.parse import quote
 from urllib.parse import urlencode
 from urllib.parse import urlparse
@@ -43,7 +42,7 @@ from ddtrace.llmobs.types import PromptVersionResponse
 
 log = get_logger(__name__)
 
-_UNSET = cast(dict[str, Any], object())
+_UNSET: Any = object()
 
 _STATUS_EXCEPTIONS: dict[int, type[PromptAPIError]] = {
     400: PromptValidationError,
@@ -611,7 +610,7 @@ class PromptManager:
         user_version: str = "",
         labels: Optional[list[str]] = None,
         env_ids: Optional[list[str]] = None,
-        config: dict[str, Any] = _UNSET,
+        config: object = _UNSET,
     ) -> PromptResponse:
         body: dict[str, Any] = {"prompt_id": prompt_id, "template": template}
         if title:
@@ -624,10 +623,10 @@ class PromptManager:
             body["labels"] = labels
         if env_ids is not None:
             body["env_ids"] = env_ids
-        if config is not _UNSET:
-            if not isinstance(config, dict):
-                raise PromptValidationError(0, "config must be a dictionary")
+        if isinstance(config, dict):
             body["config"] = config
+        elif config is not _UNSET:
+            raise PromptValidationError(0, "config must be a dictionary")
         result: PromptResponse = self._request("POST", PROMPTS_ENDPOINT, body=body)
         self._evict_prompt_caches(prompt_id)
         return result
@@ -641,7 +640,7 @@ class PromptManager:
         user_version: str = "",
         labels: Optional[list[str]] = None,
         env_ids: Optional[list[str]] = None,
-        config: dict[str, Any] = _UNSET,
+        config: object = _UNSET,
     ) -> PromptVersionResponse:
         escaped_id = quote(prompt_id, safe="")
         body: dict[str, Any] = {"template": template}
@@ -653,10 +652,10 @@ class PromptManager:
             body["labels"] = labels
         if env_ids is not None:
             body["env_ids"] = env_ids
-        if config is not _UNSET:
-            if not isinstance(config, dict):
-                raise PromptValidationError(0, "config must be a dictionary")
+        if isinstance(config, dict):
             body["config"] = config
+        elif config is not _UNSET:
+            raise PromptValidationError(0, "config must be a dictionary")
         result: PromptVersionResponse = self._request("POST", f"{PROMPTS_ENDPOINT}/{escaped_id}/versions", body=body)
         self._evict_prompt_caches(prompt_id)
         return result

--- a/ddtrace/llmobs/_prompts/prompt.py
+++ b/ddtrace/llmobs/_prompts/prompt.py
@@ -1,4 +1,6 @@
+from copy import deepcopy
 from dataclasses import dataclass
+from dataclasses import field
 from dataclasses import replace
 from typing import Any
 from typing import Literal
@@ -24,6 +26,7 @@ class ManagedPrompt:
     STABLE API:
         - format(**vars) -> str | list[dict]
         - to_annotation_dict(**vars) -> dict[str, Any]
+        - config -> dict[str, Any]
 
     INTERNAL (may change):
         - All fields (id, version, label, source, template)
@@ -36,6 +39,16 @@ class ManagedPrompt:
     template: Union[str, list[Message]]
     _uuid: Optional[str] = None
     _version_uuid: Optional[str] = None
+    _config: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self._config, dict):
+            raise TypeError("config must be a dictionary")
+        object.__setattr__(self, "_config", deepcopy(self._config))
+
+    @property
+    def config(self) -> dict[str, Any]:
+        return deepcopy(self._config)
 
     def __getattribute__(self, name: str) -> Any:
         if name == "label":
@@ -113,6 +126,7 @@ class ManagedPrompt:
             "template": self.template,
             "_uuid": self._uuid,
             "_version_uuid": self._version_uuid,
+            "config": self.config,
         }
 
     @classmethod
@@ -126,6 +140,7 @@ class ManagedPrompt:
             template=data["template"],
             _uuid=data.get("_uuid"),
             _version_uuid=data.get("_version_uuid"),
+            _config=data.get("config", {}),
         )
 
     def _with_source(self, source: Literal["registry", "cache", "fallback"]) -> "ManagedPrompt":
@@ -151,12 +166,14 @@ class ManagedPrompt:
         """
         template: Union[str, list[Message]] = ""
         version = "fallback"
+        config: Any = {}
 
         if fallback is not None:
             value = fallback() if callable(fallback) else fallback
             if isinstance(value, dict):
                 template = extract_template(value)
                 version = value.get("version") or "fallback"
+                config = value.get("config", {})
             else:
                 template = value
 
@@ -166,4 +183,5 @@ class ManagedPrompt:
             label=None,
             source="fallback",
             template=template,
+            _config=config,
         )

--- a/ddtrace/llmobs/_prompts/prompt.py
+++ b/ddtrace/llmobs/_prompts/prompt.py
@@ -39,7 +39,7 @@ class ManagedPrompt:
     template: Union[str, list[Message]]
     _uuid: Optional[str] = None
     _version_uuid: Optional[str] = None
-    _config: dict[str, Any] = field(default_factory=dict, repr=False)
+    _config: dict[str, Any] = field(default_factory=dict, repr=False, hash=False)
 
     def __post_init__(self) -> None:
         if not isinstance(self._config, dict):

--- a/ddtrace/llmobs/types.py
+++ b/ddtrace/llmobs/types.py
@@ -114,6 +114,7 @@ class PromptResponse(TypedDict, total=False):
     ml_apps: list[str]
     last_version_created_at: str
     extracted_from: str
+    config: dict[str, JSONType]
 
 
 class PromptVersionResponse(TypedDict, total=False):
@@ -129,6 +130,7 @@ class PromptVersionResponse(TypedDict, total=False):
     author: str
     description: str
     ml_app: str
+    config: dict[str, JSONType]
 
 
 class DeletedPromptResponse(TypedDict, total=False):

--- a/ddtrace/llmobs/types.py
+++ b/ddtrace/llmobs/types.py
@@ -200,6 +200,7 @@ class Prompt(TypedDict, total=False):
         rag_query_variables: list[str] - a list of variable key names that contains query information
         prompt_uuid: str - the uuid of the prompt (set internally by LLMObs.get_prompt)
         prompt_version_uuid: str - the uuid of the prompt version (set internally by LLMObs.get_prompt)
+        config: dict[str, JSONType] - application-consumed configuration stored with this prompt version
     """
 
     version: str
@@ -213,6 +214,7 @@ class Prompt(TypedDict, total=False):
     rag_query_variables: list[str]
     prompt_uuid: str
     prompt_version_uuid: str
+    config: dict[str, JSONType]
 
 
 class Agent(TypedDict, total=False):

--- a/releasenotes/notes/prompt-config-a494cd09e30f8cbe.yaml
+++ b/releasenotes/notes/prompt-config-a494cd09e30f8cbe.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    LLM Observability: Managed prompts now expose version-owned JSON configuration through
+    ``ManagedPrompt.config`` and accept it through the ``config`` argument when creating prompts or versions.

--- a/tests/llmobs/test_prompts.py
+++ b/tests/llmobs/test_prompts.py
@@ -251,6 +251,13 @@ class TestPrompts:
             assert prompt._serialize()["label"] == "production"
             assert prompt._with_source("cache").source == "cache"
 
+    def test_text_prompt_remains_hashable(self):
+        prompt = ManagedPrompt(id="greeting", version="v1", label=None, source="registry", template="Hello!")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DDTraceDeprecationWarning)
+            assert prompt in {prompt}
+
     def test_string_fallback_on_error(self):
         """String fallback used when API returns 500."""
         with mock_api(500, "Internal Server Error"):

--- a/tests/llmobs/test_prompts.py
+++ b/tests/llmobs/test_prompts.py
@@ -1010,10 +1010,7 @@ class TestPromptManagement:
         )
         cache.set("configured:", original)
 
-        cached = cache.get("configured:")[0]
-        returned_config = cached.config
-        returned_config["nested"]["x"] = 2
-        assert cached.config == {"nested": {"x": 1}}
+        assert cache.get("configured:")[0].config == {"nested": {"x": 1}}
 
     @pytest.mark.parametrize("call", [lambda m: m.update_prompt("p1"), lambda m: m.update_prompt_version("p1", 1)])
     def test_update_requires_a_field(self, call):

--- a/tests/llmobs/test_prompts.py
+++ b/tests/llmobs/test_prompts.py
@@ -40,6 +40,7 @@ TEXT_PROMPT_RESPONSE = {
     "version": "v1",
     "labels": ["development", "production"],
     "template": "Hello {name}!",
+    "config": {"model": {"temperature": 0.2}, "unknown": True},
 }
 
 CHAT_PROMPT_RESPONSE = {
@@ -143,6 +144,7 @@ def assert_prompt_matches_response(prompt, response, expected_source):
     assert prompt.source == expected_source
     assert prompt._uuid == response.get("prompt_uuid")
     assert prompt._version_uuid == response.get("prompt_version_uuid")
+    assert prompt.config == response.get("config", {})
 
 
 class TestPrompts:
@@ -156,6 +158,9 @@ class TestPrompts:
         assert isinstance(prompt, ManagedPrompt)
         assert_prompt_matches_response(prompt, TEXT_PROMPT_RESPONSE, "registry")
         assert prompt.format(name="Alice") == "Hello Alice!"
+        returned_config = prompt.config
+        returned_config["model"]["temperature"] = 1
+        assert prompt.config["model"]["temperature"] == 0.2
 
     def test_get_prompt_reattaches_base_url_path_prefix(self):
         """A base_url with a path prefix (e.g. DD_LLMOBS_OVERRIDE_ORIGIN pointing at a proxy) must
@@ -263,6 +268,7 @@ class TestPrompts:
 
         assert prompt.source == "fallback"
         assert prompt.format(name="Alice") == [{"role": "user", "content": "Hi Alice"}]
+        assert prompt.config == {}
 
     def test_callable_fallback_lazy(self):
         """Callable fallback only invoked when API fails."""
@@ -280,6 +286,15 @@ class TestPrompts:
         assert prompt.source == "fallback"
         assert prompt.version == "local-v1"
         assert prompt.format(name="Bob") == "Lazy: Bob"
+
+    def test_structured_fallback_config(self):
+        with mock_api(404, "Not Found"):
+            prompt = LLMObs.get_prompt(
+                "missing",
+                fallback={"template": "Hello", "config": {"model": {"temperature": 0}}},
+            )
+
+        assert prompt.config == {"model": {"temperature": 0}}
 
     def test_callable_fallback_not_called_on_success(self):
         """Callable fallback NOT invoked when API succeeds."""
@@ -517,7 +532,12 @@ class TestPrompts:
         with _ffe_enabled():
             _deliver_prompt_flag(
                 "greeting",
-                {"prompt_id": "greeting", "version": "ff-v1", "template": "FF Hello!"},
+                {
+                    "prompt_id": "greeting",
+                    "version": "ff-v1",
+                    "template": "FF Hello!",
+                    "config": {"model": "ff-model"},
+                },
             )
             with patch.object(manager, "_get_prompt_http") as http_mock:
                 prompt = manager.get_prompt("greeting")
@@ -525,6 +545,7 @@ class TestPrompts:
         assert prompt.source == "ff"
         assert prompt.version == "ff-v1"
         assert prompt.template == "FF Hello!"
+        assert prompt.config == {"model": "ff-model"}
 
     @pytest.mark.parametrize(
         "source,expected_source,provider_calls,rc_calls",
@@ -808,6 +829,41 @@ class TestPromptManagement:
         assert json.loads(conn.requests[-1]["body"])["env_ids"] == ["env-1"]
 
     @pytest.mark.parametrize(
+        "call",
+        [
+            lambda: LLMObs.create_prompt("p1", [{"role": "user", "content": "hi"}]),
+            lambda: LLMObs.create_prompt_version("p1", [{"role": "user", "content": "hi"}]),
+        ],
+    )
+    def test_write_prompt_omits_unsupplied_config(self, call):
+        manager = _make_manager()
+        conn, mock_patch = _mock_write_api(200, {})
+        with mock_patch, patch.object(LLMObs, "_ensure_prompt_manager", return_value=manager):
+            call()
+
+        assert "config" not in json.loads(conn.requests[-1]["body"])
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda config: LLMObs.create_prompt("p1", [{"role": "user", "content": "hi"}], config=config),
+            lambda config: LLMObs.create_prompt_version("p1", [{"role": "user", "content": "hi"}], config=config),
+        ],
+    )
+    def test_write_prompt_explicit_config(self, call):
+        manager = _make_manager()
+        conn, mock_patch = _mock_write_api(200, {})
+        with mock_patch, patch.object(LLMObs, "_ensure_prompt_manager", return_value=manager):
+            call({})
+
+        assert json.loads(conn.requests[-1]["body"])["config"] == {}
+
+        for invalid in (None, [], "value", 1):
+            with patch.object(LLMObs, "_ensure_prompt_manager", return_value=manager):
+                with pytest.raises(PromptValidationError, match="config must be a dictionary"):
+                    call(invalid)
+
+    @pytest.mark.parametrize(
         "status,exc_type",
         [
             (400, PromptValidationError),
@@ -950,6 +1006,18 @@ class TestPromptManagement:
 
         assert cache.get("a/b:")[0].id == "a/b"
         assert cache.get("a_b:")[0].id == "a_b"
+
+    def test_warm_cache_round_trips_config(self, tmp_path):
+        cache = WarmCache(cache_dir=str(tmp_path), ttl_seconds=60)
+        original = ManagedPrompt(
+            id="configured", version="v1", label=None, source="registry", template="hello", _config={"nested": {"x": 1}}
+        )
+        cache.set("configured:", original)
+
+        cached = cache.get("configured:")[0]
+        returned_config = cached.config
+        returned_config["nested"]["x"] = 2
+        assert cached.config == {"nested": {"x": 1}}
 
     @pytest.mark.parametrize("call", [lambda m: m.update_prompt("p1"), lambda m: m.update_prompt_version("p1", 1)])
     def test_update_requires_a_field(self, call):

--- a/tests/llmobs/test_prompts.py
+++ b/tests/llmobs/test_prompts.py
@@ -277,7 +277,11 @@ class TestPrompts:
         def get_fallback():
             nonlocal call_count
             call_count += 1
-            return {"template": "Lazy: {name}", "version": "local-v1"}
+            return {
+                "template": "Lazy: {name}",
+                "version": "local-v1",
+                "config": {"model": {"temperature": 0}},
+            }
 
         with mock_api(500, "Error"):
             prompt = LLMObs.get_prompt("greeting", fallback=get_fallback)
@@ -286,14 +290,6 @@ class TestPrompts:
         assert prompt.source == "fallback"
         assert prompt.version == "local-v1"
         assert prompt.format(name="Bob") == "Lazy: Bob"
-
-    def test_structured_fallback_config(self):
-        with mock_api(404, "Not Found"):
-            prompt = LLMObs.get_prompt(
-                "missing",
-                fallback={"template": "Hello", "config": {"model": {"temperature": 0}}},
-            )
-
         assert prompt.config == {"model": {"temperature": 0}}
 
     def test_callable_fallback_not_called_on_success(self):


### PR DESCRIPTION
## Description

Add versioned prompt configuration to the existing LLMObs prompt APIs.

- exposes `ManagedPrompt.config` as a defensive deep copy
- decodes config across HTTP and FFE retrieval and preserves it in the warm cache
- carries config in structured fallback values and in the public `Prompt` response type
- accepts config in the existing create APIs while distinguishing omission from explicit `{}` clearing
- adds a customer-facing release note

This depends on the prompt API contract in dd-source draft PR https://github.com/ddoghq/dd-source/pull/86374.

<!-- prompt-config-initiative-context:start -->
## API surface

**No new HTTP endpoint is added.** This PR extends the public Python SDK surface.

| SDK surface | Additive change |
|---|---|
| `ManagedPrompt.config` | Copy-safe dictionary; a missing wire field becomes `{}` |
| `LLMObs.create_prompt(..., config=...)` | Optional configuration; omitted from the request when unsupplied |
| `LLMObs.create_prompt_version(..., config=...)` | Same behavior; an explicit `{}` clears inherited configuration |

The SDK consumes `config` from the existing direct, latest, and environment-resolution responses and preserves it through hot cache, disk cache, and structured fallback.

## Initiative stack

| Stream | Pull request | Scope |
|---|---|---|
| KCFG-S | [pull#4085](https://github.com/ddoghq/k8s-resources/pull/4085) | Staging OrgStore column and object constraint — merged/deployed |
| BCFG | [pull#86374](https://github.com/ddoghq/dd-source/pull/86374) | Backend storage, management responses, SDK retrieval, and opaque FFE delivery |
| **MP1-PY (this PR)** | **[DataDog/dd-trace-py#20210](https://github.com/DataDog/dd-trace-py/pull/20210)** | Python SDK retrieval, caches, fallback, and authoring |
| UICFG | [pull#11271](https://github.com/ddoghq/web-ui/pull/11271) | Prompt authoring, detail, and comparison UI |
| STCFG | [pull#7684](https://github.com/DataDog/system-tests/pull/7684) | Dropped — cassette replay duplicated SDK/backend coverage and did not exercise live FFE |
| KCFG-P | [pull#4124](https://github.com/ddoghq/k8s-resources/pull/4124) | Production OrgStore migration |
| MP1-GO | [pull#5333](https://github.com/DataDog/dd-trace-go/pull/5333) | Go SDK retrieval add-on; stacked on foundation [#5298](https://github.com/DataDog/dd-trace-go/pull/5298) |
| MP1-JS | [pull#10268](https://github.com/DataDog/dd-trace-js/pull/10268) | Node.js SDK retrieval/authoring add-on; stacked on foundation [#10015](https://github.com/DataDog/dd-trace-js/pull/10015) |
| APICFG | [pull#6669](https://github.com/DataDog/datadog-api-spec/pull/6669) | Public OpenAPI request/response contract |
| DOCSCFG | [pull#39823](https://github.com/DataDog/documentation/pull/39823) | Customer documentation |

Go and Node.js are non-blocking add-ons; their foundation merges and later retargeting do not block the core initiative.
<!-- prompt-config-initiative-context:end -->

## Testing

oui

## Risks

Low. The new field is optional on writes, defaults to `{}` on reads, and uses the existing prompt transport and cache paths.

## Additional Notes

Staging smoke passed the complete create, exact/latest retrieval, environment selection, rollback, inheritance, clearing, and invalid-shape sequence
