### PR TITLE
chore(ci): run AIDEV anchor checker on every GitHub PR

### DIFF
--- a/.github/workflows/check-no-new-aidev-anchors.yml
+++ b/.github/workflows/check-no-new-aidev-anchors.yml
@@ -2,12 +2,11 @@ name: check-no-new-aidev-anchors
 on:
   # PR-only counterpart to the GitLab job of the same name. GitLab still
   # covers ordinary non-PR pipelines; this workflow does not run on push.
+  # No paths filter: a new deprecated anchor can land in any file.
   pull_request:
-    paths:
-      - ".github/workflows/check-no-new-aidev-anchors.yml"
-      - "scripts/check_no_new_aidev_anchors.py"
-      - "tests/internal/test_check_no_new_aidev_anchors.py"
-      - "AGENTS.md"
+
+permissions:
+  contents: read
 
 jobs:
   check-no-new-aidev-anchors:

--- a/.github/workflows/check-no-new-aidev-anchors.yml
+++ b/.github/workflows/check-no-new-aidev-anchors.yml
@@ -1,0 +1,28 @@
+name: check-no-new-aidev-anchors
+on:
+  # PR-only counterpart to the GitLab job of the same name. GitLab still
+  # covers ordinary non-PR pipelines; this workflow does not run on push.
+  pull_request:
+    paths:
+      - ".github/workflows/check-no-new-aidev-anchors.yml"
+      - "scripts/check_no_new_aidev_anchors.py"
+      - "tests/internal/test_check_no_new_aidev_anchors.py"
+      - "AGENTS.md"
+
+jobs:
+  check-no-new-aidev-anchors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          # Full history so merge-base against the PR base cannot miss a
+          # common ancestor (same reason the GitLab job sets GIT_DEPTH: "0").
+          fetch-depth: 0
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.12"
+      - name: Fetch PR base
+        run: git fetch origin "${{ github.base_ref }}"
+      - name: Check for new deprecated anchors
+        run: python scripts/check_no_new_aidev_anchors.py --base-ref "origin/${{ github.base_ref }}"


### PR DESCRIPTION
## Description

Adds a `pull_request`-only GitHub Actions workflow that runs `scripts/check_no_new_aidev_anchors.py` (from #20144) against the PR base. Runs on every PR; pins `permissions: contents: read`. Does not run on `push` (GitLab job still covers non-PR pipelines).

| Layer | Meaning | PR |
| --- | --- | --- |
| Checker + GitLab job | `git diff` merge-base for new `AIDEV` on added lines | #20144 |
| GHA PR workflow | Same checker on every GitHub `pull_request` | this |

The checker scans all files but only **added** diff lines, stripping single/double/backtick-quoted spans; `AIDEV` inside string literals is ignored by design.

## Testing

* CI


https://datadoghq.atlassian.net/browse/PROF-16007