### PR TITLE
fix(dogstatsd): recreate socket after fork to avoid writing into a recycled fd

### DIFF
--- a/ddtrace/vendor/dogstatsd/base.py
+++ b/ddtrace/vendor/dogstatsd/base.py
@@ -351,6 +351,16 @@ class DogStatsd(object):
         self.telemetry_socket = None
         self.encoding = "utf-8"
 
+        # AIDEV-NOTE: dd-trace-py fork-safety patch (github.com/DataDog/dd-trace-py
+        # issue #19120), not present in upstream datadogpy. A forked child inherits
+        # this process's socket fd verbatim; if the parent later closes it and
+        # something else in the child reuses the same fd number, this cached socket
+        # would send onto whatever now sits behind that fd (see _reset_after_fork
+        # docstring below). Reapply this hook (and the one in _reset_after_fork) if
+        # this file is ever re-vendored from upstream datadogpy.
+        if hasattr(os, "register_at_fork"):
+            os.register_at_fork(after_in_child=self._reset_after_fork)
+
         # Options
         env_tags = [tag for tag in os.environ.get("DATADOG_TAGS", "").split(",") if tag]
         # Inject values of DD_* environment variables as global tags.
@@ -862,6 +872,28 @@ class DogStatsd(object):
         >>> statsd.set("visitors.uniques", 999)
         """
         self._report(metric, "s", value, tags, sample_rate)
+
+    def _reset_after_fork(self):
+        """
+        Discard cached sockets and lock in a forked child (see the fork-safety
+        AIDEV-NOTE in __init__).
+
+        A forked child inherits the parent's socket file descriptors verbatim. If the
+        parent later closes this socket (e.g. after a send error in _xmit_packet) and
+        something else in the child opens a new socket, the OS is free to hand out the
+        same fd number; this cached socket object would otherwise go on sending onto
+        whatever now sits behind that fd instead of raising an error. Dropping the
+        reference here (without closing it, since the parent still owns and uses it)
+        lets get_socket() lazily open a fresh socket scoped to the child on the next
+        call, so the child can never touch the fd number it inherited.
+
+        The lock is also replaced rather than reused: fork() only clones the calling
+        thread, so if another thread held _socket_lock at the moment of the fork, the
+        child would inherit it as permanently locked with no thread left to release it.
+        """
+        self._socket_lock = Lock()
+        self.socket = None
+        self.telemetry_socket = None
 
     def close_socket(self):
         """

--- a/releasenotes/notes/fix-dogstatsd-fork-safety-e8938717eb12f65d.yaml
+++ b/releasenotes/notes/fix-dogstatsd-fork-safety-e8938717eb12f65d.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    internal: Fixes an issue where internal metrics reporting could write into an
+    unrelated network connection after the process forks, disrupting other connections
+    (such as a message broker connection) in long-running worker processes like Celery
+    workers.

--- a/tests/vendor/test_dogstatsd.py
+++ b/tests/vendor/test_dogstatsd.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ddtrace.internal.logger import log_filter
 from ddtrace.vendor.dogstatsd.base import log
 
@@ -5,3 +7,172 @@ from ddtrace.vendor.dogstatsd.base import log
 def test_dogstatsd_logger():
     """Ensure dogstatsd logger is initialized as a rate limited logger"""
     assert log_filter in log.filters
+
+
+@pytest.mark.subprocess
+def test_dogstatsd_socket_reset_after_fork():
+    """Regression test for GH-19120: a forked child must never reuse the parent's
+    cached socket (or its fd number), since the parent can later close and the OS
+    can recycle that fd for something unrelated in the child.
+    """
+    import os
+
+    from ddtrace.vendor.dogstatsd import DogStatsd
+
+    statsd = DogStatsd(host="127.0.0.1", port=9, disable_buffering=True)
+    parent_socket = statsd.get_socket()
+    parent_fd = parent_socket.fileno()
+
+    r, w = os.pipe()
+    pid = os.fork()
+
+    if pid == 0:
+        os.close(r)
+        child_socket = statsd.get_socket()
+        result = "same" if (child_socket is parent_socket or child_socket.fileno() == parent_fd) else "reset"
+        os.write(w, result.encode())
+        os.close(w)
+        os._exit(0)
+
+    os.close(w)
+    _, status = os.waitpid(pid, 0)
+    result = os.read(r, 16).decode()
+    os.close(r)
+
+    assert os.WEXITSTATUS(status) == 0
+    assert result == "reset", "child inherited the parent's cached dogstatsd socket/fd instead of resetting it"
+
+
+@pytest.mark.subprocess
+def test_dogstatsd_uds_socket_reset_after_fork():
+    """Regression test for GH-19120, UDS transport: the fix must also cover
+    socket_path (Unix domain socket) connections, not just UDP.
+    """
+    import os
+    import socket
+    import tempfile
+
+    from ddtrace.vendor.dogstatsd import DogStatsd
+
+    uds_path = os.path.join(tempfile.mkdtemp(prefix="ddtrace-uds-"), "statsd.sock")
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    listener.bind(uds_path)
+
+    statsd = DogStatsd(socket_path=uds_path, disable_buffering=True)
+    parent_socket = statsd.get_socket()
+    parent_fd = parent_socket.fileno()
+
+    r, w = os.pipe()
+    pid = os.fork()
+
+    if pid == 0:
+        os.close(r)
+        child_socket = statsd.get_socket()
+        result = "same" if (child_socket is parent_socket or child_socket.fileno() == parent_fd) else "reset"
+        os.write(w, result.encode())
+        os.close(w)
+        os._exit(0)
+
+    os.close(w)
+    _, status = os.waitpid(pid, 0)
+    result = os.read(r, 16).decode()
+    os.close(r)
+    listener.close()
+
+    assert os.WEXITSTATUS(status) == 0
+    assert result == "reset", "child inherited the parent's cached UDS socket/fd instead of resetting it"
+
+
+@pytest.mark.subprocess
+def test_dogstatsd_telemetry_socket_reset_after_fork():
+    """Regression test for GH-19120, dedicated telemetry destination: the fix must
+    also cover self.telemetry_socket, not just self.socket.
+    """
+    import os
+
+    from ddtrace.vendor.dogstatsd import DogStatsd
+
+    statsd = DogStatsd(
+        host="127.0.0.1",
+        port=9,
+        telemetry_host="127.0.0.1",
+        telemetry_port=10,
+        disable_buffering=True,
+    )
+    parent_socket = statsd.get_socket(telemetry=True)
+    parent_fd = parent_socket.fileno()
+
+    r, w = os.pipe()
+    pid = os.fork()
+
+    if pid == 0:
+        os.close(r)
+        child_socket = statsd.get_socket(telemetry=True)
+        result = "same" if (child_socket is parent_socket or child_socket.fileno() == parent_fd) else "reset"
+        os.write(w, result.encode())
+        os.close(w)
+        os._exit(0)
+
+    os.close(w)
+    _, status = os.waitpid(pid, 0)
+    result = os.read(r, 16).decode()
+    os.close(r)
+
+    assert os.WEXITSTATUS(status) == 0
+    assert result == "reset", "child inherited the parent's cached telemetry socket/fd instead of resetting it"
+
+
+@pytest.mark.subprocess
+def test_dogstatsd_socket_lock_not_deadlocked_after_fork():
+    """Regression test for GH-19120's lock half: if another thread holds
+    _socket_lock at the moment of fork(), the child must not inherit it as
+    permanently locked (fork only clones the calling thread, so no thread
+    remains alive in the child to release an inherited lock).
+    """
+    import os
+    import threading
+    import warnings
+
+    from ddtrace.vendor.dogstatsd import DogStatsd
+
+    # This test deliberately forks while a second thread is alive to exercise the
+    # lock-inheritance scenario; suppress CPython's expected multi-threaded-fork
+    # DeprecationWarning so it doesn't trip this marker's strict stderr check.
+    warnings.filterwarnings("ignore", category=DeprecationWarning, message=".*fork.*")
+
+    statsd = DogStatsd(host="127.0.0.1", port=9, disable_buffering=True)
+    statsd.get_socket()
+
+    lock_acquired = threading.Event()
+    release_lock = threading.Event()
+
+    def holder():
+        with statsd._socket_lock:
+            lock_acquired.set()
+            release_lock.wait(timeout=5)
+
+    t = threading.Thread(target=holder, daemon=True)
+    t.start()
+    assert lock_acquired.wait(timeout=5), "helper thread never acquired _socket_lock"
+
+    r, w = os.pipe()
+    pid = os.fork()
+
+    if pid == 0:
+        os.close(r)
+        # A bounded timeout here means a regression fails the test instead of
+        # hanging the whole suite forever.
+        acquired = statsd._socket_lock.acquire(timeout=5)
+        os.write(w, b"acquired" if acquired else b"deadlock")
+        os.close(w)
+        os._exit(0)
+
+    os.close(w)
+    _, status = os.waitpid(pid, 0)
+    result = os.read(r, 16).decode()
+    os.close(r)
+    release_lock.set()
+    t.join(timeout=5)
+
+    assert os.WEXITSTATUS(status) == 0
+    assert result == "acquired", "child inherited _socket_lock in a permanently locked state"


### PR DESCRIPTION

## Description

Fixes #19120.

`ddtrace.vendor.dogstatsd.DogStatsd` caches a socket object and reuses it for the lifetime of the process, with no fork handling. A forked child (e.g. `celery worker -B`'s embedded Beat) inherits that socket's fd verbatim. If the parent later closes it (`close_socket()`, called from `_xmit_packet()` on a send error) and something unrelated in the child opens a new socket, the OS can hand back the same fd number. `DogStatsd` then sends its next metrics batch into whatever now owns that fd — in the reported incident, an unrelated TLS connection to RabbitMQ (`amqps`), producing `unsupported_record_type,114` on the broker side.

This registers an `os.register_at_fork(after_in_child=...)` hook that discards the cached socket(s) (without closing them, since the parent still owns and uses them) and replaces `_socket_lock` with a fresh, unlocked one. The next `get_socket()` call in the child then lazily opens a socket scoped to its own fd table, and the child can never touch the fd number it inherited. The lock replacement separately guards against a related but distinct hazard: `fork()` only clones the calling thread, so if another thread held `_socket_lock` at the moment of the fork, the child would otherwise inherit it as permanently locked with no thread left alive to release it.

`ddtrace/vendor/dogstatsd/base.py` is a bulk-copied vendor snapshot of upstream `datadog/datadogpy`, not a git-merged one, so a future re-vendoring could silently drop this patch. Both insertion points carry an `AIDEV-NOTE` flagging this for whoever next re-vendors the file.

## Testing

Four new regression tests in `tests/vendor/test_dogstatsd.py`, all using a real `os.fork()` (via the existing `@pytest.mark.subprocess` pattern already used by `tests/internal/test_forksafe.py`):

- `test_dogstatsd_socket_reset_after_fork` — UDP `self.socket` isn't inherited as the same object/fd.
- `test_dogstatsd_uds_socket_reset_after_fork` — saket (`socket_path=...`).
- `test_dogstatsd_telemetry_socket_reset_after_fork` — same, for the dedicated `self.telemetry_socket` destination.
- `test_dogstatsd_socket_lock_not_deadlocked_after_lds `_socket_lock` across the fork; the child muststill be able to acquire it.                                                                                       

Each of the three socket tests was confirmed to fail on the unpatched code (child got the exact same socket/fd as tthe lock test's child `acquire()` timed out unpatchth the fix. Ran via `scripts/run-tests` across all5 Python versions the `vendor` suite covers (3.9–3.13): 76/76 passing on each. Also ran `internal`, `runtime`, and `tracer`/`test_writer.py` suites; all pre-existing ndently confirmed unrelated to this change(reproduced identically with the patch reverted).                                                                  
## Risks                                                                                                           
Low. The change is additive (+32 lines, 0 lines modified) and scoped to `DogStatsd`'s socket/lock state. Buffering (`_flush_thread`) and the background sender (`_sendthreading.Thread`s with the same general fork hazard — are intentionally left untouched, since no internal `dd-trace-py` caller enables either (`disable_buffering=True`, `disable_background_sender=True` everywhere). Not cmonkey-patched fork interaction, and an end-to-endtest through `RuntimeWorker`/`HTTPWriter` rather than `DogStatsd` directly.

## Additional Notes                                                                                                  
Closest prior related issue: #7728 (same subsystem, different errno). The reported regression window (4.4.0 → 4.10.5]consistent with #14163 ("native fork-safe threads")r`'s periodic thread reliably resume sending metrics in a forked child — the precondition for this bug to actually fire.                                                  

This fix was investigated and validated collaboratively with Claude Code: reproducing the reported fd-recycling race deterministically, tracing the regression window tooduced the precondition, confirming the failure mode with a real `os.fork()` (not just the dup2-based repro from the original report), and writing/validating the four regression
tests above against both the unpatched baseline and writing/validating the four regression tests above against both the unpatched baseline and the fix.