### PR TITLE
test(llmobs): fix periodic eval metric test

### DIFF
--- a/tests/llmobs/test_llmobs_evaluator_runner.py
+++ b/tests/llmobs/test_llmobs_evaluator_runner.py
@@ -44,13 +44,10 @@ def test_evaluator_runner_buffer_limit(mock_evaluator_logs):
 @pytest.mark.vcr_logs
 def test_evaluator_runner_periodic_enqueues_eval_metric(mock_llmobs_eval_metric_writer, active_evaluator_runner):
     active_evaluator_runner.enqueue({"span_id": "123", "trace_id": "1234"}, DUMMY_SPAN)
-    active_evaluator_runner.periodic()
-
-    # periodic() runs each evaluation on a background executor, so the eval metric is
-    # enqueued asynchronously. Wait for that submission to land before asserting.
-    deadline = time.time() + 5
-    while mock_llmobs_eval_metric_writer.enqueue.call_count == 0 and time.time() < deadline:
-        time.sleep(0.01)
+    # periodic() normally runs each evaluation on a background executor, making the eval metric
+    # enqueue asynchronous and racy to assert on. `_wait_sync=True` runs evaluations inline instead,
+    # so the assertion below is deterministic.
+    active_evaluator_runner.periodic(_wait_sync=True)
 
     mock_llmobs_eval_metric_writer.enqueue.assert_called_once_with(
         _dummy_evaluator_eval_metric_event(span_id="123", trace_id="1234")


### PR DESCRIPTION
## Description

This fixes the very flaky `test_evaluator_runner_periodic_enqueues_eval_metric`. Problem was that `EvaluatorRunner.periodic()` submits each evaluation to a background `ThreadPoolExecutor` and the assertion could race that executor thread.

A prior fix (#20068) tried to close the gap with a `time.sleep`-based polling loop, waiting up to 5 seconds for `enqueue.call_count` to become nonzero before asserting. That fix works but still relies on a busy-wait sleep loop rather than removing the underlying race.

