### PR TITLE
chore(psycopg): remove Pin

### DIFF
--- a/ddtrace/contrib/internal/psycopg/async_connection.py
+++ b/ddtrace/contrib/internal/psycopg/async_connection.py
@@ -1,11 +1,11 @@
 from ddtrace import config
-from ddtrace._trace.pin import Pin
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import dbapi_async
 from ddtrace.contrib.internal.psycopg.async_cursor import Psycopg3FetchTracedAsyncCursor
 from ddtrace.contrib.internal.psycopg.async_cursor import Psycopg3TracedAsyncCursor
 from ddtrace.contrib.internal.psycopg.connection import patch_conn
 from ddtrace.contrib.internal.trace_utils import ext_service
+from ddtrace.contrib.internal.trace_utils import is_tracing_enabled
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import db
@@ -45,21 +45,18 @@ def patched_connect_async_factory(psycopg_module):
     async def patched_connect_async(connect_func, _, args, kwargs):
         traced_conn_cls = Psycopg3TracedAsyncConnection
 
-        pin = Pin.get_from(psycopg_module)
-
-        if not pin or not pin.enabled() or not pin._config.trace_connect:
+        if not is_tracing_enabled() or not config.psycopg.trace_connect:
             conn = await connect_func(*args, **kwargs)
         else:
             with core.context_with_data(
                 "psycopg.patched_connect",
                 span_name="{}.{}".format(connect_func.__module__, connect_func.__name__),
-                service=ext_service(pin, pin._config),
+                service=ext_service(None, config.psycopg),
                 span_type=SpanTypes.SQL,
-                pin=pin,
                 tags={
                     SPAN_KIND: SpanKind.CLIENT,
-                    COMPONENT: pin._config.integration_name,
-                    db.SYSTEM: pin._config.dbms_name,
+                    COMPONENT: config.psycopg.integration_name,
+                    db.SYSTEM: config.psycopg.dbms_name,
                 },
                 measured=True,
                 integration_config=config.psycopg,

--- a/ddtrace/contrib/internal/psycopg/connection.py
+++ b/ddtrace/contrib/internal/psycopg/connection.py
@@ -1,5 +1,4 @@
 from ddtrace import config
-from ddtrace._trace.pin import Pin
 from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import dbapi
 from ddtrace.contrib.internal.psycopg.cursor import Psycopg2FetchTracedCursor
@@ -8,6 +7,7 @@ from ddtrace.contrib.internal.psycopg.cursor import Psycopg3FetchTracedCursor
 from ddtrace.contrib.internal.psycopg.cursor import Psycopg3TracedCursor
 from ddtrace.contrib.internal.psycopg.extensions import _patch_extensions
 from ddtrace.contrib.internal.trace_utils import ext_service
+from ddtrace.contrib.internal.trace_utils import is_tracing_enabled
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.ext import db
@@ -99,21 +99,18 @@ def patched_connect_factory(psycopg_module):
     def patched_connect(connect_func, _, args, kwargs):
         traced_conn_cls = Psycopg3TracedConnection if psycopg_module.__name__ == "psycopg" else Psycopg2TracedConnection
 
-        pin = Pin.get_from(psycopg_module)
-
-        if not pin or not pin.enabled() or not pin._config.trace_connect:
+        if not is_tracing_enabled() or not config.psycopg.trace_connect:
             conn = connect_func(*args, **kwargs)
         else:
             with core.context_with_data(
                 "psycopg.patched_connect",
                 span_name="{}.{}".format(connect_func.__module__, connect_func.__name__),
-                service=ext_service(pin, pin._config),
+                service=ext_service(None, config.psycopg),
                 span_type=SpanTypes.SQL,
-                pin=pin,
                 tags={
                     SPAN_KIND: SpanKind.CLIENT,
-                    COMPONENT: pin._config.integration_name,
-                    db.SYSTEM: pin._config.dbms_name,
+                    COMPONENT: config.psycopg.integration_name,
+                    db.SYSTEM: config.psycopg.dbms_name,
                 },
                 measured=True,
                 integration_config=config.psycopg,

--- a/ddtrace/contrib/internal/psycopg/patch.py
+++ b/ddtrace/contrib/internal/psycopg/patch.py
@@ -4,7 +4,6 @@ import inspect
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
-from ddtrace._trace.pin import Pin
 from ddtrace.contrib import dbapi
 from ddtrace.contrib.internal.psycopg.async_connection import patched_connect_async_factory
 from ddtrace.contrib.internal.psycopg.async_cursor import Psycopg3FetchTracedAsyncCursor
@@ -114,8 +113,6 @@ def _patch(psycopg_module):
         return
     psycopg_module._datadog_patch = True
 
-    Pin(_config=config.psycopg).onto(psycopg_module)
-
     if psycopg_module.__name__ == "psycopg2":
         # patch all psycopg2 extensions
         _psycopg2_extensions = get_psycopg2_extensions(psycopg_module)
@@ -163,10 +160,6 @@ def _unpatch(psycopg_module):
                 psycopg_module.Connection.connect = _original_connect
             if _original_async_connect is not None:
                 psycopg_module.AsyncConnection.connect = _original_async_connect
-
-        pin = Pin.get_from(psycopg_module)
-        if pin:
-            pin.remove_from(psycopg_module)
 
 
 def init_cursor_from_connection_factory(psycopg_module):


### PR DESCRIPTION
## Description

Remove module-level Pin attachment and lookup from psycopg2 and psycopg3 instrumentation. Sync and async connect tracing now use tracer and psycopg integration configuration directly, while traced connection and cursor wrappers retain their existing DB metadata flow.

## Testing

- scripts/lint fmt -- the three changed psycopg files
- scripts/run-tests --venv ac7fe2b -- tests/contrib/psycopg (not executed because the configured Colima Docker socket was absent and PostgreSQL/test-agent services could not start)

## Risks

Moderate. Psycopg2, psycopg3, classmethod connect, and async connect paths were updated together. Public connect, connection, cursor, and patch/unpatch APIs are unchanged.

## Additional Notes

Pin-based module overrides were internal integration behavior and are intentionally removed. No release note is needed.