### PR TITLE
chore(messaging): migrate kafka and aiokafka to events API

### DIFF
--- a/.claude/skills/apm-integrations/references/reference-integrations.md
+++ b/.claude/skills/apm-integrations/references/reference-integrations.md
@@ -18,7 +18,7 @@ All patch modules live in `ddtrace/contrib/internal/{name}/`.
 | http-client | `httpx/patch.py` | `requests/connection.py` | Outbound HTTP, `http.*` span tags. httpx and requests use `context_with_event` |
 | http-server | `flask/patch.py` | `django/patch.py` | Web frameworks, request/response spans, Pin + `context_with_data` |
 | logging | `logging/patch.py` | `loguru/patch.py` | Log correlation injection (trace ID, span ID) -- no spans created |
-| messaging | `kafka/patch.py` | `kombu/patch.py` | Message brokers, DSM support, Pin + `tracer.trace` |
+| messaging | `kafka/patch.py`, `aiokafka/patch.py` | `kombu/patch.py` | Kafka and aiokafka use shared messaging events; Kombu and RQ still use Pin |
 | object-store | `botocore/patch.py` (S3) | -- | S3 via botocore service-specific handlers |
 | orchestration | `celery/patch.py` | -- | Task orchestration, distributed tracing, Pin + `tracer.trace` via signals |
 | rpc | `grpc/patch.py` | -- | RPC frameworks, client + server spans, Pin + `tracer.trace` |

--- a/ddtrace/_trace/subscribers/__init__.py
+++ b/ddtrace/_trace/subscribers/__init__.py
@@ -1,4 +1,5 @@
 # Import subscriber packages — triggers auto-registration via __init_subclass__
 import ddtrace._trace.subscribers.http_client  # noqa: F401
 import ddtrace._trace.subscribers.llm  # noqa: F401
+import ddtrace._trace.subscribers.messaging  # noqa: F401
 import ddtrace._trace.subscribers.web_framework  # noqa: F401

--- a/ddtrace/_trace/subscribers/_base.py
+++ b/ddtrace/_trace/subscribers/_base.py
@@ -75,7 +75,6 @@ def _start_span(ctx: core.ExecutionContext[TracingEventType]) -> Span:
     span_kwargs: dict[str, Any] = {
         "span_type": event.span_type,
         "resource": event.resource,
-        "service": event.service,
         "activate": event.activate,
     }
 

--- a/ddtrace/_trace/subscribers/_base.py
+++ b/ddtrace/_trace/subscribers/_base.py
@@ -75,6 +75,7 @@ def _start_span(ctx: core.ExecutionContext[TracingEventType]) -> Span:
     span_kwargs: dict[str, Any] = {
         "span_type": event.span_type,
         "resource": event.resource,
+        "service": event.service,
         "activate": event.activate,
     }
 

--- a/ddtrace/_trace/subscribers/messaging.py
+++ b/ddtrace/_trace/subscribers/messaging.py
@@ -1,0 +1,31 @@
+from typing import cast
+
+from ddtrace._trace.subscribers._base import TracingSubscriber
+from ddtrace.contrib import trace_utils
+from ddtrace.contrib._events.messaging import MessagingEvent
+from ddtrace.contrib._events.messaging import MessagingProcessEvent
+from ddtrace.contrib._events.messaging import MessagingProducerEvent
+from ddtrace.internal import core
+from ddtrace.internal.span_bus import span_from_context
+from ddtrace.propagation.http import HTTPPropagator
+
+
+class MessagingTracingSubscriber(TracingSubscriber[MessagingEvent]):
+    event_names = (
+        MessagingProducerEvent.event_name,
+        MessagingProcessEvent.event_name,
+    )
+
+    @classmethod
+    def on_started(cls, ctx: core.ExecutionContext[MessagingEvent]) -> None:
+        event = ctx.event
+
+        if (
+            isinstance(event, MessagingProducerEvent)
+            and event.distributed_headers is not None
+            and trace_utils.distributed_tracing_enabled(event.integration_config)
+        ):
+            HTTPPropagator.inject(
+                span_from_context(ctx).context,
+                cast(dict[str, str], event.distributed_headers),
+            )

--- a/ddtrace/_trace/subscribers/messaging.py
+++ b/ddtrace/_trace/subscribers/messaging.py
@@ -1,3 +1,5 @@
+from types import TracebackType
+from typing import Optional
 from typing import cast
 
 from ddtrace._trace.subscribers._base import TracingSubscriber
@@ -29,3 +31,27 @@ class MessagingTracingSubscriber(TracingSubscriber[MessagingEvent]):
                 span_from_context(ctx).context,
                 cast(dict[str, str], event.distributed_headers),
             )
+
+    @classmethod
+    def on_ended(
+        cls,
+        ctx: core.ExecutionContext[MessagingEvent],
+        _exc_info: tuple[Optional[type], Optional[BaseException], Optional[TracebackType]],
+    ) -> None:
+        event = ctx.event
+        if not isinstance(event, MessagingProcessEvent):
+            return
+
+        span = span_from_context(ctx)
+        for link_ctx in event.span_links:
+            if not link_ctx.trace_id or not link_ctx.span_id:
+                continue
+            span.link_span(link_ctx)
+            for extracted_link in link_ctx._span_links:
+                span.set_link(
+                    trace_id=extracted_link.trace_id,
+                    span_id=extracted_link.span_id,
+                    tracestate=extracted_link.tracestate,
+                    flags=extracted_link.flags,
+                    attributes=extracted_link.attributes,
+                )

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -1356,23 +1356,6 @@ def _on_asgi_request(ctx: core.ExecutionContext) -> None:
         _init_websocket_message_counters(scope)
 
 
-def _on_kafka_consume_link_spans(span: "Span", links: list) -> None:
-    for link_ctx in links:
-        span.link_span(link_ctx)
-        # extract() stores secondary/conflicting propagation styles (e.g. a message
-        # carrying both Datadog and W3C tracecontext with different trace ids) as span
-        # links on the context. link_span only adds the primary context, so copy these
-        # extracted links explicitly to avoid dropping them.
-        for extracted_link in link_ctx._span_links:
-            span.set_link(
-                trace_id=extracted_link.trace_id,
-                span_id=extracted_link.span_id,
-                tracestate=extracted_link.tracestate,
-                flags=extracted_link.flags,
-                attributes=extracted_link.attributes,
-            )
-
-
 def _inject_context_into_ray_serve_grpc_context(span: Span, grpc_context: Any) -> None:
     trace_headers: dict[str, str] = {}
     HTTPPropagator.inject(span.context, trace_headers)
@@ -1858,7 +1841,6 @@ def listen():
     core.on("asgi.websocket.disconnect.message", _on_asgi_websocket_disconnect_message)
     core.on("asgi.websocket.close.message", _on_asgi_websocket_close_message)
     core.on("context.started.asgi.request", _on_asgi_request)
-    core.on("kafka.consume.link_spans", _on_kafka_consume_link_spans)
     core.on("context.started.google_cloud_pubsub.request", _on_pubsub_request_start)
     core.on("context.started.google_cloud_pubsub.send", _on_pubsub_send_start)
     core.on("google_cloud_pubsub.send.completed", _on_pubsub_send_complete)

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -57,12 +57,6 @@ from ddtrace.ext import http
 from ddtrace.ext import net
 from ddtrace.ext import redis as redisx
 from ddtrace.ext import websocket
-from ddtrace.ext.kafka import MESSAGE_KEY
-from ddtrace.ext.kafka import MESSAGE_OFFSET
-from ddtrace.ext.kafka import PARTITION
-from ddtrace.ext.kafka import RECEIVED_MESSAGE
-from ddtrace.ext.kafka import TOMBSTONE
-from ddtrace.ext.kafka import TOPIC
 from ddtrace.internal import core
 from ddtrace.internal import span_bus
 from ddtrace.internal.compat import is_valid_ip
@@ -1362,120 +1356,6 @@ def _on_asgi_request(ctx: core.ExecutionContext) -> None:
         _init_websocket_message_counters(scope)
 
 
-def _on_aiokafka_send_start(
-    _topic: str,
-    send_value: Optional[bytes],
-    send_key: Optional[bytes],
-    headers: list[tuple[str, bytes]],
-    ctx: core.ExecutionContext,
-    partition: Optional[int],
-) -> None:
-    span = span_from_context(ctx)
-
-    span._set_attribute(SPAN_KIND, SpanKind.PRODUCER)
-    span._set_attribute(TOMBSTONE, str(send_value is None))
-    span.set_tag(MESSAGE_KEY, send_key.decode("utf-8") if send_key else None)
-    if partition is not None:
-        span._set_attribute(PARTITION, partition)
-    span._set_attribute(_SPAN_MEASURED_KEY, 1)
-
-    if config.aiokafka.distributed_tracing_enabled:
-        # inject headers with Datadog tags:
-        tracing_headers: dict[str, str] = {}
-        HTTPPropagator.inject(span.context, tracing_headers)
-        for key, value in tracing_headers.items():
-            headers.append((key, value.encode("utf-8")))
-
-
-def _on_aiokafka_send_complete(
-    ctx: core.ExecutionContext,
-    exc_info: tuple[Optional[type], Optional[BaseException], Optional[TracebackType]],
-    record_metadata: Optional[Any],
-) -> None:
-    span = span_from_context(ctx)
-    if span is not None and record_metadata is not None:
-        partition = getattr(record_metadata, "partition", None)
-        offset = getattr(record_metadata, "offset", None)
-        if isinstance(partition, int):
-            span._set_attribute(PARTITION, partition)
-        if isinstance(offset, int):
-            span._set_attribute(MESSAGE_OFFSET, offset)
-    _finish_span(ctx, exc_info)
-
-
-def _on_aiokafka_getone_message(
-    _instance: Any,
-    ctx: core.ExecutionContext,
-    start_ns: int,
-    message: Optional[Any],
-    err: Optional[BaseException],
-) -> None:
-    span = span_from_context(ctx)
-
-    span.start_ns = start_ns
-    span._set_attribute(RECEIVED_MESSAGE, str(message is not None))
-    span._set_attribute(_SPAN_MEASURED_KEY, 1)
-
-    if message is not None:
-        message_key = message.key.decode("utf-8") if message.key else None
-        topic = str(message.topic)
-        span._set_attribute(TOPIC, topic)
-        span._set_attribute(TOMBSTONE, str(message.value is None))
-
-        if isinstance(message_key, str):
-            span.set_tag(MESSAGE_KEY, message_key)
-
-        if message.partition is not None:
-            span._set_attribute(PARTITION, message.partition)
-        if message.offset is not None:
-            span._set_attribute(MESSAGE_OFFSET, message.offset)
-
-    if err is not None:
-        span.set_exc_info(type(err), err, err.__traceback__)
-
-
-def _on_aiokafka_getmany_message(
-    _instance: Any,
-    ctx: core.ExecutionContext,
-    messages: Optional[dict[Any, list[Any]]],
-) -> None:
-    span = span_from_context(ctx)
-
-    span._set_attribute(RECEIVED_MESSAGE, str(messages is not None))
-    span._set_attribute(_SPAN_MEASURED_KEY, 1)
-
-    if messages is not None:
-        first_topic = next(iter(messages)).topic
-        span._set_attribute(MESSAGING_DESTINATION_NAME, first_topic)
-
-        topics_partitions: dict[str, list[int]] = {}
-        for topic_partition in messages.keys():
-            topic = topic_partition.topic
-            partition = topic_partition.partition
-            if topic not in topics_partitions:
-                topics_partitions[topic] = []
-            topics_partitions[topic].append(partition)
-
-        all_topics = list(topics_partitions.keys())
-        span.set_tag(TOPIC, ",".join(all_topics))
-
-        for topic, partitions in topics_partitions.items():
-            partition_list = ",".join(map(str, sorted(partitions)))
-            span._set_attribute(f"kafka.partitions.{topic}", partition_list)
-
-        for topic_partition, records in messages.items():
-            for record in records:
-                if config.aiokafka.distributed_tracing_enabled and record.headers:
-                    dd_headers = {
-                        key: (val.decode("utf-8", errors="ignore") if isinstance(val, (bytes, bytearray)) else str(val))
-                        for key, val in record.headers
-                        if val is not None
-                    }
-                    context = HTTPPropagator.extract(dd_headers)
-
-                    span.link_span(context)
-
-
 def _on_kafka_consume_link_spans(span: "Span", links: list) -> None:
     for link_ctx in links:
         span.link_span(link_ctx)
@@ -1978,10 +1858,6 @@ def listen():
     core.on("asgi.websocket.disconnect.message", _on_asgi_websocket_disconnect_message)
     core.on("asgi.websocket.close.message", _on_asgi_websocket_close_message)
     core.on("context.started.asgi.request", _on_asgi_request)
-    core.on("aiokafka.send.start", _on_aiokafka_send_start)
-    core.on("aiokafka.getone.message", _on_aiokafka_getone_message)
-    core.on("aiokafka.getmany.message", _on_aiokafka_getmany_message)
-    core.on("aiokafka.send.completed", _on_aiokafka_send_complete)
     core.on("kafka.consume.link_spans", _on_kafka_consume_link_spans)
     core.on("context.started.google_cloud_pubsub.request", _on_pubsub_request_start)
     core.on("context.started.google_cloud_pubsub.send", _on_pubsub_send_start)
@@ -2081,9 +1957,6 @@ def listen():
         "azure.servicebus.patched_producer_schedule",
         "azure.servicebus.patched_producer_send",
         "psycopg.patched_connect",
-        "aiokafka.send",
-        "aiokafka.getone",
-        "aiokafka.getmany",
         "mlflow.run",
         "ray.proxy.request",
         "ray.serve.deployment",
@@ -2122,8 +1995,6 @@ def listen():
         "azure.eventhubs.patched_producer_batch",
         "azure.eventhubs.patched_producer_send",
         "azure.eventhubs.patched_producer_send_batch",
-        "aiokafka.getone",
-        "aiokafka.getmany",
         "google_cloud_pubsub.receive",
         "google_cloud_pubsub.request",
         "ray.assign.request",

--- a/ddtrace/contrib/_events/kafka.py
+++ b/ddtrace/contrib/_events/kafka.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from typing import Any
+from typing import Optional
+
+from ddtrace.contrib._events.messaging import MessagingEvent
+from ddtrace.contrib._events.messaging import MessagingProcessEvent
+from ddtrace.contrib._events.messaging import MessagingProducerEvent
+from ddtrace.ext.kafka import GROUP_ID
+from ddtrace.ext.kafka import HOST_LIST
+from ddtrace.ext.kafka import SERVICE
+from ddtrace.ext.kafka import TOPIC
+from ddtrace.internal.constants import MESSAGING_DESTINATION_NAME
+from ddtrace.internal.constants import MESSAGING_SYSTEM
+from ddtrace.internal.core.events import event_field
+
+
+@dataclass
+class KafkaEvent(MessagingEvent):
+    topic: Optional[str] = event_field(default=None)
+    bootstrap_servers: Any = event_field(default=None)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.tags[MESSAGING_SYSTEM] = SERVICE
+        if self.topic is not None:
+            self.tags[TOPIC] = self.topic
+            if self.topic:
+                self.tags[MESSAGING_DESTINATION_NAME] = self.topic
+        if self.bootstrap_servers is not None:
+            self.tags[HOST_LIST] = self.bootstrap_servers
+
+
+@dataclass
+class KafkaProducerEvent(MessagingProducerEvent, KafkaEvent):
+    pass
+
+
+@dataclass
+class KafkaProcessEvent(MessagingProcessEvent, KafkaEvent):
+    group_id: Optional[str] = event_field(default=None)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.group_id is not None:
+            self.tags[GROUP_ID] = self.group_id

--- a/ddtrace/contrib/_events/messaging.py
+++ b/ddtrace/contrib/_events/messaging.py
@@ -41,4 +41,3 @@ class MessagingProcessEvent(MessagingEvent):
     span_type = SpanTypes.WORKER
 
     request_headers: Optional[MutableMapping[str, Any]] = event_field(default=None)
-    activate_distributed_headers: bool = event_field(default=True)

--- a/ddtrace/contrib/_events/messaging.py
+++ b/ddtrace/contrib/_events/messaging.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import MutableMapping
 from typing import Optional
@@ -8,6 +9,10 @@ from ddtrace._trace.events import TracingEvent
 from ddtrace.ext import SpanKind
 from ddtrace.ext import SpanTypes
 from ddtrace.internal.core.events import event_field
+
+
+if TYPE_CHECKING:
+    from ddtrace._trace.context import Context
 
 
 class MessagingEvents(str, Enum):
@@ -41,3 +46,4 @@ class MessagingProcessEvent(MessagingEvent):
     span_type = SpanTypes.WORKER
 
     request_headers: Optional[MutableMapping[str, Any]] = event_field(default=None)
+    span_links: list["Context"] = event_field(default_factory=list)

--- a/ddtrace/contrib/_events/messaging.py
+++ b/ddtrace/contrib/_events/messaging.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+from typing import MutableMapping
+from typing import Optional
+
+from ddtrace._trace.events import TracingEvent
+from ddtrace.ext import SpanKind
+from ddtrace.ext import SpanTypes
+from ddtrace.internal.core.events import event_field
+
+
+class MessagingEvents(str, Enum):
+    PRODUCE = "messaging.produce"
+    PROCESS = "messaging.process"
+
+
+@dataclass
+class MessagingEvent(TracingEvent):
+    """Shared tracing data for messaging operations."""
+
+    operation: str = event_field()
+
+    def __post_init__(self) -> None:
+        self.operation_name = self.operation
+
+
+@dataclass
+class MessagingProducerEvent(MessagingEvent):
+    event_name = MessagingEvents.PRODUCE.value
+    span_kind = SpanKind.PRODUCER
+    span_type = SpanTypes.WORKER
+
+    distributed_headers: Optional[MutableMapping[str, Any]] = event_field(default=None)
+
+
+@dataclass
+class MessagingProcessEvent(MessagingEvent):
+    event_name = MessagingEvents.PROCESS.value
+    span_kind = SpanKind.CONSUMER
+    span_type = SpanTypes.WORKER
+
+    request_headers: Optional[MutableMapping[str, Any]] = event_field(default=None)
+    activate_distributed_headers: bool = event_field(default=True)

--- a/ddtrace/contrib/internal/aiokafka/patch.py
+++ b/ddtrace/contrib/internal/aiokafka/patch.py
@@ -5,21 +5,20 @@ import aiokafka
 from wrapt import wrap_function_wrapper as _w
 
 from ddtrace import config
-from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
-from ddtrace.ext import SpanKind
-from ddtrace.ext import SpanTypes
+from ddtrace.contrib._events.kafka import KafkaProcessEvent
+from ddtrace.contrib._events.kafka import KafkaProducerEvent
 from ddtrace.ext import kafka as kafkax
 from ddtrace.ext.kafka import CONSUME
-from ddtrace.ext.kafka import GROUP_ID
-from ddtrace.ext.kafka import HOST_LIST
+from ddtrace.ext.kafka import MESSAGE_KEY
+from ddtrace.ext.kafka import MESSAGE_OFFSET
+from ddtrace.ext.kafka import PARTITION
 from ddtrace.ext.kafka import PRODUCE
-from ddtrace.ext.kafka import SERVICE
+from ddtrace.ext.kafka import RECEIVED_MESSAGE
+from ddtrace.ext.kafka import TOMBSTONE
 from ddtrace.ext.kafka import TOPIC
 from ddtrace.internal import core
-from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.constants import MESSAGING_DESTINATION_NAME
-from ddtrace.internal.constants import MESSAGING_SYSTEM
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.schema import schematize_messaging_operation
 from ddtrace.internal.schema import schematize_service_name
@@ -58,27 +57,6 @@ def get_version() -> str:
 
 def _supported_versions() -> dict[str, str]:
     return {"aiokafka": ">=0.9.0"}
-
-
-def common_aiokafka_tags(topic, bootstrap_servers):
-    return {
-        COMPONENT: config.aiokafka.integration_name,
-        TOPIC: topic,
-        MESSAGING_DESTINATION_NAME: topic,
-        MESSAGING_SYSTEM: SERVICE,
-        HOST_LIST: bootstrap_servers,
-    }
-
-
-def common_consume_aiokafka_tags(topic, bootstrap_servers, group_id):
-    tags = common_aiokafka_tags(topic, bootstrap_servers)
-    tags.update(
-        {
-            SPAN_KIND: SpanKind.CONSUMER,
-            GROUP_ID: group_id,
-        }
-    )
-    return tags
 
 
 async def _get_cluster_id(client, topic):
@@ -128,36 +106,63 @@ def parse_send(instance, args, kwargs):
     return topic, value, headers, partition, key, servers
 
 
+def _dispatch_send_error(ctx, error):
+    exc_info = (type(error), error, error.__traceback__)
+    core.dispatch("aiokafka.send.completed", (ctx, exc_info, None))
+    ctx.dispatch_ended_event(*exc_info)
+
+
 async def traced_send(func, instance, args, kwargs):
     topic, value, headers, partition, key, bootstrap_servers = parse_send(instance, args, kwargs)
     cluster_id = await _get_cluster_id(instance.client, topic)
+    tracing_headers = {}
 
-    with core.context_with_data(
-        "aiokafka.send",
-        span_name=schematize_messaging_operation(PRODUCE, provider="kafka", direction=SpanDirection.OUTBOUND),
-        span_type=SpanTypes.WORKER,
-        service=trace_utils.ext_service(None, config.aiokafka),
-        tags=common_aiokafka_tags(topic, bootstrap_servers),
+    event = KafkaProducerEvent(
+        operation=schematize_messaging_operation(PRODUCE, provider="kafka", direction=SpanDirection.OUTBOUND),
+        topic=topic,
+        bootstrap_servers=bootstrap_servers,
+        distributed_headers=tracing_headers,
+        component=config.aiokafka.integration_name,
         integration_config=config.aiokafka,
-    ) as ctx:
+        service=trace_utils.ext_service(None, config.aiokafka),
+    )
+
+    with core.context_with_event(event, dispatch_end_event=False) as ctx:
+        span = span_from_context(ctx)
         core.set_item("kafka_cluster_id", cluster_id)
-        if cluster_id and span_from_context(ctx) is not None:
-            span_from_context(ctx)._set_attribute(kafkax.CLUSTER_ID, cluster_id)
+        if cluster_id:
+            span._set_attribute(kafkax.CLUSTER_ID, cluster_id)
+
+        span._set_attribute(TOMBSTONE, str(value is None))
+        span.set_tag(MESSAGE_KEY, key.decode("utf-8") if key else None)
+        if partition is not None:
+            span._set_attribute(PARTITION, partition)
+
+        for header_key, header_value in tracing_headers.items():
+            headers.append((header_key, header_value.encode("utf-8")))
+
         core.dispatch("aiokafka.send.start", (topic, value, key, headers, ctx, partition))
         args, kwargs = set_argument_value(args, kwargs, 5, "headers", headers, override_unset=True)
 
         try:
             result = await func(*args, **kwargs)
-        except BaseException as e:
-            core.dispatch("aiokafka.send.completed", (ctx, (type(e), e, e.__traceback__), None))
-            raise e
+        except BaseException as error:
+            _dispatch_send_error(ctx, error)
+            raise
 
         def sent_callback(future):
             try:
-                result = future.result()
-                core.dispatch("aiokafka.send.completed", (ctx, (None, None, None), result))
-            except Exception as e:
-                core.dispatch("aiokafka.send.completed", (ctx, (type(e), e, e.__traceback__), None))
+                record_metadata = future.result()
+                result_partition = getattr(record_metadata, "partition", None)
+                result_offset = getattr(record_metadata, "offset", None)
+                if isinstance(result_partition, int):
+                    span._set_attribute(PARTITION, result_partition)
+                if isinstance(result_offset, int):
+                    span._set_attribute(MESSAGE_OFFSET, result_offset)
+                core.dispatch("aiokafka.send.completed", (ctx, (None, None, None), record_metadata))
+                ctx.dispatch_ended_event()
+            except Exception as error:
+                _dispatch_send_error(ctx, error)
 
         result.add_done_callback(sent_callback)
         return result
@@ -169,7 +174,7 @@ async def traced_getone(func, instance, args, kwargs):
     start_ns = time_ns()
     err = None
     message = None
-    parent_ctx = None
+    request_headers = None
 
     group_id = instance._group_id
     bootstrap_servers = instance._client._bootstrap_servers
@@ -182,7 +187,7 @@ async def traced_getone(func, instance, args, kwargs):
                 for key, val in message.headers
                 if val is not None
             }
-            parent_ctx = HTTPPropagator.extract(dd_headers)
+            request_headers = dd_headers
     except Exception as e:
         err = e
 
@@ -196,20 +201,38 @@ async def traced_getone(func, instance, args, kwargs):
         client = instance._client
         cluster_id = getattr(client, "_dd_cluster_id", "") if client is not None else ""
 
-    with core.context_with_data(
-        "aiokafka.getone",
-        call_trace=False,
-        span_name=schematize_messaging_operation(CONSUME, provider="kafka", direction=SpanDirection.INBOUND),
-        span_type=SpanTypes.WORKER,
-        service=trace_utils.ext_service(None, config.aiokafka),
-        distributed_context=parent_ctx,
-        tags=common_consume_aiokafka_tags(topic, bootstrap_servers, group_id),
+    event = KafkaProcessEvent(
+        operation=schematize_messaging_operation(CONSUME, provider="kafka", direction=SpanDirection.INBOUND),
+        topic=topic,
+        bootstrap_servers=bootstrap_servers,
+        group_id=group_id,
+        request_headers=request_headers,
+        component=config.aiokafka.integration_name,
         integration_config=config.aiokafka,
-    ) as ctx:
+        service=trace_utils.ext_service(None, config.aiokafka),
+    )
+
+    with core.context_with_event(event) as ctx:
+        span = span_from_context(ctx)
+        span.start_ns = start_ns
         core.set_item("kafka_cluster_id", cluster_id)
-        if cluster_id and span_from_context(ctx) is not None:
-            span_from_context(ctx)._set_attribute(kafkax.CLUSTER_ID, cluster_id)
+        if cluster_id:
+            span._set_attribute(kafkax.CLUSTER_ID, cluster_id)
+
+        span._set_attribute(RECEIVED_MESSAGE, str(message is not None))
+        if message is not None:
+            message_key = message.key.decode("utf-8") if message.key else None
+            span._set_attribute(TOMBSTONE, str(message.value is None))
+            if isinstance(message_key, str):
+                span.set_tag(MESSAGE_KEY, message_key)
+            if message.partition is not None:
+                span._set_attribute(PARTITION, message.partition)
+            if message.offset is not None:
+                span._set_attribute(MESSAGE_OFFSET, message.offset)
+
         core.dispatch("aiokafka.getone.message", (instance, ctx, start_ns, message, err))
+        if err is not None:
+            span.set_exc_info(type(err), err, err.__traceback__)
 
     if err is not None:
         raise err
@@ -220,15 +243,18 @@ async def traced_getmany(func, instance, args, kwargs):
     group_id = instance._group_id
     bootstrap_servers = instance._client._bootstrap_servers
 
-    with core.context_with_data(
-        "aiokafka.getmany",
-        call_trace=False,
-        span_name=schematize_messaging_operation(CONSUME, provider="kafka", direction=SpanDirection.INBOUND),
-        span_type=SpanTypes.WORKER,
-        service=trace_utils.ext_service(None, config.aiokafka),
-        tags=common_consume_aiokafka_tags(None, bootstrap_servers, group_id),
+    event = KafkaProcessEvent(
+        operation=schematize_messaging_operation(CONSUME, provider="kafka", direction=SpanDirection.INBOUND),
+        topic=None,
+        bootstrap_servers=bootstrap_servers,
+        group_id=group_id,
+        component=config.aiokafka.integration_name,
         integration_config=config.aiokafka,
-    ) as ctx:
+        service=trace_utils.ext_service(None, config.aiokafka),
+    )
+
+    with core.context_with_event(event) as ctx:
+        span = span_from_context(ctx)
         messages = await func(*args, **kwargs)
 
         topic = None
@@ -239,8 +265,36 @@ async def traced_getmany(func, instance, args, kwargs):
                     break
         cluster_id = await _get_cluster_id(instance._client, topic)
         core.set_item("kafka_cluster_id", cluster_id)
-        if cluster_id and span_from_context(ctx) is not None:
-            span_from_context(ctx)._set_attribute(kafkax.CLUSTER_ID, cluster_id)
+        if cluster_id:
+            span._set_attribute(kafkax.CLUSTER_ID, cluster_id)
+
+        span._set_attribute(RECEIVED_MESSAGE, str(messages is not None))
+        if messages:
+            first_topic = next(iter(messages)).topic
+            span._set_attribute(MESSAGING_DESTINATION_NAME, first_topic)
+
+            topics_partitions = {}
+            for topic_partition in messages:
+                partitions = topics_partitions.setdefault(topic_partition.topic, [])
+                partitions.append(topic_partition.partition)
+
+            span.set_tag(TOPIC, ",".join(topics_partitions))
+            for message_topic, partitions in topics_partitions.items():
+                span._set_attribute(f"kafka.partitions.{message_topic}", ",".join(map(str, sorted(partitions))))
+
+            for records in messages.values():
+                for record in records:
+                    if config.aiokafka.distributed_tracing_enabled and record.headers:
+                        dd_headers = {
+                            key: (
+                                val.decode("utf-8", errors="ignore")
+                                if isinstance(val, (bytes, bytearray))
+                                else str(val)
+                            )
+                            for key, val in record.headers
+                            if val is not None
+                        }
+                        span.link_span(HTTPPropagator.extract(dd_headers))
 
         core.dispatch("aiokafka.getmany.message", (instance, ctx, messages))
 

--- a/ddtrace/contrib/internal/aiokafka/patch.py
+++ b/ddtrace/contrib/internal/aiokafka/patch.py
@@ -174,7 +174,7 @@ async def traced_getone(func, instance, args, kwargs):
     start_ns = time_ns()
     err = None
     message = None
-    request_headers = None
+    parent_ctx = None
 
     group_id = instance._group_id
     bootstrap_servers = instance._client._bootstrap_servers
@@ -187,7 +187,7 @@ async def traced_getone(func, instance, args, kwargs):
                 for key, val in message.headers
                 if val is not None
             }
-            request_headers = dd_headers
+            parent_ctx = HTTPPropagator.extract(dd_headers)
     except Exception as e:
         err = e
 
@@ -201,12 +201,16 @@ async def traced_getone(func, instance, args, kwargs):
         client = instance._client
         cluster_id = getattr(client, "_dd_cluster_id", "") if client is not None else ""
 
+    # Parent via extracted context without activating it, so a surrounding local
+    # span stays active after getone returns.
     event = KafkaProcessEvent(
         operation=schematize_messaging_operation(CONSUME, provider="kafka", direction=SpanDirection.INBOUND),
         topic=topic,
         bootstrap_servers=bootstrap_servers,
         group_id=group_id,
-        request_headers=request_headers,
+        distributed_context=parent_ctx,
+        use_active_context=False,
+        activate=False,
         component=config.aiokafka.integration_name,
         integration_config=config.aiokafka,
         service=trace_utils.ext_service(None, config.aiokafka),

--- a/ddtrace/contrib/internal/aiokafka/patch.py
+++ b/ddtrace/contrib/internal/aiokafka/patch.py
@@ -252,6 +252,8 @@ async def traced_getmany(func, instance, args, kwargs):
         topic=None,
         bootstrap_servers=bootstrap_servers,
         group_id=group_id,
+        use_active_context=False,
+        activate=False,
         component=config.aiokafka.integration_name,
         integration_config=config.aiokafka,
         service=trace_utils.ext_service(None, config.aiokafka),

--- a/ddtrace/contrib/internal/aiokafka/patch.py
+++ b/ddtrace/contrib/internal/aiokafka/patch.py
@@ -300,7 +300,9 @@ async def traced_getmany(func, instance, args, kwargs):
                             for key, val in record.headers
                             if val is not None
                         }
-                        span.link_span(HTTPPropagator.extract(dd_headers))
+                        link_ctx = HTTPPropagator.extract(dd_headers)
+                        if link_ctx.trace_id and link_ctx.span_id:
+                            event.span_links.append(link_ctx)
 
         core.dispatch("aiokafka.getmany.message", (instance, ctx, messages))
 

--- a/ddtrace/contrib/internal/kafka/patch.py
+++ b/ddtrace/contrib/internal/kafka/patch.py
@@ -198,10 +198,11 @@ def traced_produce(func, instance, args, kwargs):
         distributed_headers=tracing_headers,
         component=config.kafka.integration_name,
         integration_config=config.kafka,
-        service=trace_utils.ext_service(pin, config.kafka),
     )
 
-    with core.context_with_event(event) as ctx:
+    ctx = core.context_with_event(event)
+    ctx.set_item("service", trace_utils.ext_service(pin, config.kafka))
+    with ctx:
         span = span_from_context(ctx)
         cluster_id = _get_cluster_id(instance, topic)
         core.set_item("kafka_cluster_id", cluster_id)
@@ -298,10 +299,11 @@ def _instrument_message(messages, pin, start_ns, instance, err):
         span_links=links,
         component=config.kafka.integration_name,
         integration_config=config.kafka,
-        service=trace_utils.ext_service(pin, config.kafka),
     )
 
-    with core.context_with_event(event) as event_ctx:
+    event_ctx = core.context_with_event(event)
+    event_ctx.set_item("service", trace_utils.ext_service(pin, config.kafka))
+    with event_ctx:
         span = span_from_context(event_ctx)
 
         # reset span start time to before function call

--- a/ddtrace/contrib/internal/kafka/patch.py
+++ b/ddtrace/contrib/internal/kafka/patch.py
@@ -6,29 +6,23 @@ import confluent_kafka
 
 from ddtrace import config
 from ddtrace._trace.pin import Pin
-from ddtrace.constants import _SPAN_MEASURED_KEY
-from ddtrace.constants import SPAN_KIND
 from ddtrace.contrib import trace_utils
-from ddtrace.contrib.internal.trace_utils import set_service_and_source
-from ddtrace.ext import SpanKind
-from ddtrace.ext import SpanTypes
+from ddtrace.contrib._events.kafka import KafkaProcessEvent
+from ddtrace.contrib._events.kafka import KafkaProducerEvent
 from ddtrace.ext import kafka as kafkax
 from ddtrace.internal import core
-from ddtrace.internal.constants import COMPONENT
-from ddtrace.internal.constants import MESSAGING_DESTINATION_NAME
-from ddtrace.internal.constants import MESSAGING_SYSTEM
 from ddtrace.internal.logger import get_logger
 from ddtrace.internal.schema import schematize_messaging_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.internal.settings import env
+from ddtrace.internal.span_bus import span_from_context
 from ddtrace.internal.utils import ArgumentError
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils import set_argument_value
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.version import parse_version
 from ddtrace.propagation.http import HTTPPropagator as Propagator
-from ddtrace.trace import tracer
 
 
 _Producer = confluent_kafka.Producer
@@ -195,25 +189,29 @@ def traced_produce(func, instance, args, kwargs):
     message_key = kwargs.get("key", "") or ""
     partition = kwargs.get("partition", -1)
     headers = get_argument_value(args, kwargs, 6, "headers", optional=True) or {}
-    with tracer.trace(
-        schematize_messaging_operation(kafkax.PRODUCE, provider="kafka", direction=SpanDirection.OUTBOUND),
-        span_type=SpanTypes.WORKER,
-    ) as span:
-        set_service_and_source(span, trace_utils.ext_service(pin, config.kafka), config.kafka)
+    tracing_headers = {}
+
+    event = KafkaProducerEvent(
+        operation=schematize_messaging_operation(kafkax.PRODUCE, provider="kafka", direction=SpanDirection.OUTBOUND),
+        topic=topic,
+        bootstrap_servers=instance._dd_bootstrap_servers,
+        distributed_headers=tracing_headers,
+        component=config.kafka.integration_name,
+        integration_config=config.kafka,
+        service=trace_utils.ext_service(pin, config.kafka),
+    )
+
+    with core.context_with_event(event) as ctx:
+        span = span_from_context(ctx)
         cluster_id = _get_cluster_id(instance, topic)
         core.set_item("kafka_cluster_id", cluster_id)
         if cluster_id:
             span._set_attribute(kafkax.CLUSTER_ID, cluster_id)
 
-        core.dispatch("kafka.produce.start", (instance, args, kwargs, isinstance(instance, _SerializingProducer), span))
-
-        span._set_attribute(MESSAGING_SYSTEM, kafkax.SERVICE)
-        span._set_attribute(COMPONENT, config.kafka.integration_name)
-        span._set_attribute(SPAN_KIND, SpanKind.PRODUCER)
-        span._set_attribute(kafkax.TOPIC, topic)
-        if topic:
-            # Should fall back to broker id if topic is not provided but it is not readily available here
-            span._set_attribute(MESSAGING_DESTINATION_NAME, topic)
+        core.dispatch(
+            "kafka.produce.start",
+            (instance, args, kwargs, isinstance(instance, _SerializingProducer), span),
+        )
 
         if _SerializingProducer is not None and isinstance(instance, _SerializingProducer):
             serialized_key = serialize_key(instance, topic, message_key, headers)
@@ -224,16 +222,14 @@ def traced_produce(func, instance, args, kwargs):
 
         span.set_tag(kafkax.PARTITION, partition)
         span._set_attribute(kafkax.TOMBSTONE, str(value is None))
-        span._set_attribute(_SPAN_MEASURED_KEY, 1)
-        if instance._dd_bootstrap_servers is not None:
-            span._set_attribute(kafkax.HOST_LIST, instance._dd_bootstrap_servers)
 
-        # inject headers with Datadog tags if trace propagation is enabled
-        if config.kafka.distributed_tracing_enabled:
-            # inject headers with Datadog tags:
-            headers = get_argument_value(args, kwargs, 6, "headers", True) or {}
-            Propagator.inject(span.context, headers)
+        if tracing_headers:
+            if isinstance(headers, dict):
+                headers.update(tracing_headers)
+            else:
+                headers.extend(tracing_headers.items())
             args, kwargs = set_argument_value(args, kwargs, 6, "headers", headers, override_unset=True)
+
         return func(*args, **kwargs)
 
 
@@ -266,9 +262,10 @@ def traced_poll_or_consume(func, instance, args, kwargs):
 
 
 def _instrument_message(messages, pin, start_ns, instance, err):
-    ctx = None
-    links = []
     first_message = messages[0] if len(messages) else None
+    topic = str(first_message.topic()) if first_message is not None else None
+    request_headers = None
+    links = []
     if config.kafka.distributed_tracing_enabled:
         if config.kafka.propagation_as_span_links:
             # Relate the consume span to every message's producer via span links rather
@@ -284,16 +281,24 @@ def _instrument_message(messages, pin, start_ns, instance, err):
         elif first_message is not None and first_message.headers():
             # First message is used to extract context and enrich datadog spans
             # This approach aligns with the opentelemetry confluent kafka semantics
-            ctx = Propagator.extract(dict(first_message.headers()))
-    with tracer.start_span(
-        name=schematize_messaging_operation(kafkax.CONSUME, provider="kafka", direction=SpanDirection.PROCESSING),
-        span_type=SpanTypes.WORKER,
-        child_of=ctx if ctx is not None and ctx.trace_id is not None else tracer.context_provider.active(),
-        activate=True,
-    ) as span:
+            request_headers = dict(first_message.headers())
+
+    event = KafkaProcessEvent(
+        operation=schematize_messaging_operation(kafkax.CONSUME, provider="kafka", direction=SpanDirection.PROCESSING),
+        topic=topic,
+        bootstrap_servers=instance._dd_bootstrap_servers,
+        group_id=instance._group_id,
+        request_headers=request_headers,
+        component=config.kafka.integration_name,
+        integration_config=config.kafka,
+        service=trace_utils.ext_service(pin, config.kafka),
+    )
+
+    with core.context_with_event(event) as event_ctx:
+        span = span_from_context(event_ctx)
         if links:
             core.dispatch("kafka.consume.link_spans", (span, links))
-        set_service_and_source(span, trace_utils.ext_service(pin, config.kafka), config.kafka)
+
         # reset span start time to before function call
         span.start_ns = start_ns
         cluster_id = None
@@ -305,19 +310,12 @@ def _instrument_message(messages, pin, start_ns, instance, err):
                 core.set_item("kafka_topic", str(first_message.topic()))
                 core.dispatch("kafka.consume.start", (instance, message, span))
 
-        span._set_attribute(MESSAGING_SYSTEM, kafkax.SERVICE)
-        span._set_attribute(COMPONENT, config.kafka.integration_name)
-        span._set_attribute(SPAN_KIND, SpanKind.CONSUMER)
         if cluster_id:
             span._set_attribute(kafkax.CLUSTER_ID, cluster_id)
         span._set_attribute(kafkax.RECEIVED_MESSAGE, str(first_message is not None))
-        span._set_attribute(kafkax.GROUP_ID, instance._group_id)
         if first_message is not None:
             message_key = first_message.key() or ""
             message_offset = first_message.offset() or -1
-            topic = str(first_message.topic())
-            span._set_attribute(kafkax.TOPIC, topic)
-            span._set_attribute(MESSAGING_DESTINATION_NAME, topic)
 
             # If this is a deserializing consumer, do not set the key as a tag since we
             # do not have the serialization function
@@ -335,7 +333,6 @@ def _instrument_message(messages, pin, start_ns, instance, err):
                 pass
             span._set_attribute(kafkax.TOMBSTONE, str(is_tombstone))
             span.set_tag(kafkax.MESSAGE_OFFSET, message_offset)
-        span._set_attribute(_SPAN_MEASURED_KEY, 1)
 
         if err is not None:
             span.set_exc_info(*sys.exc_info())
@@ -372,7 +369,10 @@ def serialize_key(instance, topic, key, headers):
                 log.debug("Failed to set Kafka Consumer key tag: %s", str(key))
                 return None
         else:
-            log.warning("Failed to set Kafka Consumer key tag, no method available to serialize key: %s", str(key))
+            log.warning(
+                "Failed to set Kafka Consumer key tag, no method available to serialize key: %s",
+                str(key),
+            )
             return None
 
 

--- a/ddtrace/contrib/internal/kafka/patch.py
+++ b/ddtrace/contrib/internal/kafka/patch.py
@@ -224,6 +224,9 @@ def traced_produce(func, instance, args, kwargs):
         span._set_attribute(kafkax.TOMBSTONE, str(value is None))
 
         if tracing_headers:
+            # Re-read after kafka.produce.start: DSM may have replaced kwargs["headers"]
+            # with a pathway-bearing mapping distinct from the empty object captured above.
+            headers = get_argument_value(args, kwargs, 6, "headers", optional=True) or {}
             if isinstance(headers, dict):
                 headers.update(tracing_headers)
             else:
@@ -264,7 +267,7 @@ def traced_poll_or_consume(func, instance, args, kwargs):
 def _instrument_message(messages, pin, start_ns, instance, err):
     first_message = messages[0] if len(messages) else None
     topic = str(first_message.topic()) if first_message is not None else None
-    request_headers = None
+    distributed_context = None
     links = []
     if config.kafka.distributed_tracing_enabled:
         if config.kafka.propagation_as_span_links:
@@ -281,14 +284,17 @@ def _instrument_message(messages, pin, start_ns, instance, err):
         elif first_message is not None and first_message.headers():
             # First message is used to extract context and enrich datadog spans
             # This approach aligns with the opentelemetry confluent kafka semantics
-            request_headers = dict(first_message.headers())
+            extracted = Propagator.extract(dict(first_message.headers()))
+            if extracted is not None and extracted.trace_id is not None:
+                distributed_context = extracted
 
     event = KafkaProcessEvent(
         operation=schematize_messaging_operation(kafkax.CONSUME, provider="kafka", direction=SpanDirection.PROCESSING),
         topic=topic,
         bootstrap_servers=instance._dd_bootstrap_servers,
         group_id=instance._group_id,
-        request_headers=request_headers,
+        distributed_context=distributed_context,
+        use_active_context=distributed_context is None,
         component=config.kafka.integration_name,
         integration_config=config.kafka,
         service=trace_utils.ext_service(pin, config.kafka),

--- a/ddtrace/contrib/internal/kafka/patch.py
+++ b/ddtrace/contrib/internal/kafka/patch.py
@@ -291,10 +291,11 @@ def _instrument_message(messages, pin, start_ns, instance, err):
     event = KafkaProcessEvent(
         operation=schematize_messaging_operation(kafkax.CONSUME, provider="kafka", direction=SpanDirection.PROCESSING),
         topic=topic,
-        bootstrap_servers=instance._dd_bootstrap_servers,
         group_id=instance._group_id,
         distributed_context=distributed_context,
         use_active_context=distributed_context is None,
+        activate=distributed_context is None,
+        span_links=links,
         component=config.kafka.integration_name,
         integration_config=config.kafka,
         service=trace_utils.ext_service(pin, config.kafka),
@@ -302,8 +303,6 @@ def _instrument_message(messages, pin, start_ns, instance, err):
 
     with core.context_with_event(event) as event_ctx:
         span = span_from_context(event_ctx)
-        if links:
-            core.dispatch("kafka.consume.link_spans", (span, links))
 
         # reset span start time to before function call
         span.start_ns = start_ns

--- a/tests/contrib/aiokafka/test_aiokafka.py
+++ b/tests/contrib/aiokafka/test_aiokafka.py
@@ -148,7 +148,7 @@ async def test_getone_preserves_local_span_when_headers_are_from_another_trace(t
         offset=1,
     )
     client = SimpleNamespace(_bootstrap_servers=[BOOTSTRAP_SERVERS], _dd_cluster_id="test-cluster")
-    consumer = SimpleNamespace(_client=client, _group_id="test-group")
+    consumer = SimpleNamespace(_client=client, _group_id="test-group", _enable_auto_commit=False)
 
     async def getone(*args, **kwargs):
         return message

--- a/tests/contrib/aiokafka/test_aiokafka.py
+++ b/tests/contrib/aiokafka/test_aiokafka.py
@@ -176,6 +176,28 @@ async def test_getmany_empty_result():
 
 
 @pytest.mark.asyncio
+async def test_getmany_preserves_local_span(tracer, test_spans):
+    client = SimpleNamespace(_bootstrap_servers=[BOOTSTRAP_SERVERS], _dd_cluster_id="test-cluster")
+    consumer = SimpleNamespace(_client=client, _group_id="test-group")
+    active_span_during_getmany = None
+
+    async def getmany(*args, **kwargs):
+        nonlocal active_span_during_getmany
+        active_span_during_getmany = tracer.current_span()
+        return {}
+
+    with tracer.trace("local") as parent:
+        result = await traced_getmany(getmany, consumer, (), {})
+
+        assert result == {}
+        assert active_span_during_getmany is parent
+        assert tracer.current_span() is parent
+        test_spans.assert_span_count(1)
+        consume_span = test_spans.pop()[0]
+        assert consume_span.parent_id is None
+
+
+@pytest.mark.asyncio
 @pytest.mark.snapshot()
 async def test_send_multiple_servers():
     topic = await create_topic("send_multiple_servers")

--- a/tests/contrib/aiokafka/test_aiokafka.py
+++ b/tests/contrib/aiokafka/test_aiokafka.py
@@ -5,10 +5,13 @@ from aiokafka.errors import MessageSizeTooLargeError
 from aiokafka.structs import TopicPartition
 import pytest
 
+from ddtrace._trace.context import Context
 from ddtrace.contrib.internal.aiokafka.patch import patch
 from ddtrace.contrib.internal.aiokafka.patch import traced_getmany
+from ddtrace.contrib.internal.aiokafka.patch import traced_getone
 from ddtrace.contrib.internal.aiokafka.patch import traced_send
 from ddtrace.contrib.internal.aiokafka.patch import unpatch
+from ddtrace.propagation.http import HTTPPropagator
 from tests.utils import override_config
 from tests.utils import override_global_tracer
 
@@ -130,6 +133,33 @@ async def test_send_span_records_delivery_future_failure(tracer, test_spans):
     assert span.finished
     assert span.error == 1
     test_spans.assert_span_count(1)
+
+
+@pytest.mark.asyncio
+async def test_getone_preserves_local_span_when_headers_are_from_another_trace(tracer, test_spans):
+    carrier = {}
+    HTTPPropagator.inject(Context(trace_id=2**64 - 1, span_id=99), carrier)
+    message = SimpleNamespace(
+        headers=[(key, value.encode("utf-8") if isinstance(value, str) else value) for key, value in carrier.items()],
+        topic="topic",
+        key=None,
+        value=PAYLOAD,
+        partition=0,
+        offset=1,
+    )
+    client = SimpleNamespace(_bootstrap_servers=[BOOTSTRAP_SERVERS], _dd_cluster_id="test-cluster")
+    consumer = SimpleNamespace(_client=client, _group_id="test-group")
+
+    async def getone(*args, **kwargs):
+        return message
+
+    with override_config("aiokafka", dict(distributed_tracing_enabled=True)):
+        with tracer.trace("local") as parent:
+            result = await traced_getone(getone, consumer, (), {})
+            assert result is message
+            assert tracer.current_span() is parent
+            with tracer.trace("after") as after:
+                assert after.parent_id == parent.span_id
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/aiokafka/test_aiokafka.py
+++ b/tests/contrib/aiokafka/test_aiokafka.py
@@ -1,8 +1,12 @@
+import asyncio
+from types import SimpleNamespace
+
 from aiokafka.errors import MessageSizeTooLargeError
 from aiokafka.structs import TopicPartition
 import pytest
 
 from ddtrace.contrib.internal.aiokafka.patch import patch
+from ddtrace.contrib.internal.aiokafka.patch import traced_send
 from ddtrace.contrib.internal.aiokafka.patch import unpatch
 from tests.utils import override_config
 from tests.utils import override_global_tracer
@@ -78,6 +82,30 @@ async def test_send_commit():
         await consumer.commit()
 
         assert not has_header(result.headers, "x-datadog-trace-id")
+
+
+@pytest.mark.asyncio
+async def test_send_span_finishes_when_delivery_future_resolves(tracer, test_spans):
+    delivery_future = asyncio.get_running_loop().create_future()
+    client = SimpleNamespace(_bootstrap_servers=[BOOTSTRAP_SERVERS], _dd_cluster_id="test-cluster")
+    producer = SimpleNamespace(client=client)
+
+    async def send(*args, **kwargs):
+        return delivery_future
+
+    returned_future = await traced_send(send, producer, ("topic", PAYLOAD), {})
+    span = tracer.current_span()
+
+    assert returned_future is delivery_future
+    assert span is not None
+    assert not span.finished
+    test_spans.assert_has_no_spans()
+
+    delivery_future.set_result(SimpleNamespace(topic="topic", partition=0, offset=1))
+    await asyncio.sleep(0)
+
+    assert span.finished
+    test_spans.assert_span_count(1)
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/aiokafka/test_aiokafka.py
+++ b/tests/contrib/aiokafka/test_aiokafka.py
@@ -1,17 +1,9 @@
-import asyncio
-from types import SimpleNamespace
-
 from aiokafka.errors import MessageSizeTooLargeError
 from aiokafka.structs import TopicPartition
 import pytest
 
-from ddtrace._trace.context import Context
 from ddtrace.contrib.internal.aiokafka.patch import patch
-from ddtrace.contrib.internal.aiokafka.patch import traced_getmany
-from ddtrace.contrib.internal.aiokafka.patch import traced_getone
-from ddtrace.contrib.internal.aiokafka.patch import traced_send
 from ddtrace.contrib.internal.aiokafka.patch import unpatch
-from ddtrace.propagation.http import HTTPPropagator
 from tests.utils import override_config
 from tests.utils import override_global_tracer
 
@@ -86,115 +78,6 @@ async def test_send_commit():
         await consumer.commit()
 
         assert not has_header(result.headers, "x-datadog-trace-id")
-
-
-@pytest.mark.asyncio
-async def test_send_span_finishes_when_delivery_future_resolves(tracer, test_spans):
-    delivery_future = asyncio.get_running_loop().create_future()
-    client = SimpleNamespace(_bootstrap_servers=[BOOTSTRAP_SERVERS], _dd_cluster_id="test-cluster")
-    producer = SimpleNamespace(client=client)
-
-    async def send(*args, **kwargs):
-        return delivery_future
-
-    returned_future = await traced_send(send, producer, ("topic", PAYLOAD), {})
-    span = tracer.current_span()
-
-    assert returned_future is delivery_future
-    assert span is not None
-    assert not span.finished
-    test_spans.assert_has_no_spans()
-
-    delivery_future.set_result(SimpleNamespace(topic="topic", partition=0, offset=1))
-    await asyncio.sleep(0)
-
-    assert span.finished
-    test_spans.assert_span_count(1)
-
-
-@pytest.mark.asyncio
-async def test_send_span_records_delivery_future_failure(tracer, test_spans):
-    delivery_future = asyncio.get_running_loop().create_future()
-    client = SimpleNamespace(_bootstrap_servers=[BOOTSTRAP_SERVERS], _dd_cluster_id="test-cluster")
-    producer = SimpleNamespace(client=client)
-
-    async def send(*args, **kwargs):
-        return delivery_future
-
-    await traced_send(send, producer, ("topic", PAYLOAD), {})
-    span = tracer.current_span()
-
-    assert span is not None
-    assert not span.finished
-
-    delivery_future.set_exception(RuntimeError("delivery failed"))
-    await asyncio.sleep(0)
-
-    assert span.finished
-    assert span.error == 1
-    test_spans.assert_span_count(1)
-
-
-@pytest.mark.asyncio
-async def test_getone_preserves_local_span_when_headers_are_from_another_trace(tracer, test_spans):
-    carrier = {}
-    HTTPPropagator.inject(Context(trace_id=2**64 - 1, span_id=99), carrier)
-    message = SimpleNamespace(
-        headers=[(key, value.encode("utf-8") if isinstance(value, str) else value) for key, value in carrier.items()],
-        topic="topic",
-        key=None,
-        value=PAYLOAD,
-        partition=0,
-        offset=1,
-    )
-    client = SimpleNamespace(_bootstrap_servers=[BOOTSTRAP_SERVERS], _dd_cluster_id="test-cluster")
-    consumer = SimpleNamespace(_client=client, _group_id="test-group", _enable_auto_commit=False)
-
-    async def getone(*args, **kwargs):
-        return message
-
-    with override_config("aiokafka", dict(distributed_tracing_enabled=True)):
-        with tracer.trace("local") as parent:
-            result = await traced_getone(getone, consumer, (), {})
-            assert result is message
-            assert tracer.current_span() is parent
-            with tracer.trace("after") as after:
-                assert after.parent_id == parent.span_id
-
-
-@pytest.mark.asyncio
-async def test_getmany_empty_result():
-    client = SimpleNamespace(_bootstrap_servers=[BOOTSTRAP_SERVERS], _dd_cluster_id="test-cluster")
-    consumer = SimpleNamespace(_client=client, _group_id="test-group")
-
-    async def getmany(*args, **kwargs):
-        return {}
-
-    result = await traced_getmany(getmany, consumer, (), {})
-
-    assert result == {}
-
-
-@pytest.mark.asyncio
-async def test_getmany_preserves_local_span(tracer, test_spans):
-    client = SimpleNamespace(_bootstrap_servers=[BOOTSTRAP_SERVERS], _dd_cluster_id="test-cluster")
-    consumer = SimpleNamespace(_client=client, _group_id="test-group")
-    active_span_during_getmany = None
-
-    async def getmany(*args, **kwargs):
-        nonlocal active_span_during_getmany
-        active_span_during_getmany = tracer.current_span()
-        return {}
-
-    with tracer.trace("local") as parent:
-        result = await traced_getmany(getmany, consumer, (), {})
-
-        assert result == {}
-        assert active_span_during_getmany is parent
-        assert tracer.current_span() is parent
-        test_spans.assert_span_count(1)
-        consume_span = test_spans.pop()[0]
-        assert consume_span.parent_id is None
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/aiokafka/test_aiokafka.py
+++ b/tests/contrib/aiokafka/test_aiokafka.py
@@ -1,8 +1,13 @@
+import asyncio
+from types import SimpleNamespace
+
 from aiokafka.errors import MessageSizeTooLargeError
 from aiokafka.structs import TopicPartition
 import pytest
 
 from ddtrace.contrib.internal.aiokafka.patch import patch
+from ddtrace.contrib.internal.aiokafka.patch import traced_getmany
+from ddtrace.contrib.internal.aiokafka.patch import traced_send
 from ddtrace.contrib.internal.aiokafka.patch import unpatch
 from tests.utils import override_config
 from tests.utils import override_global_tracer
@@ -78,6 +83,66 @@ async def test_send_commit():
         await consumer.commit()
 
         assert not has_header(result.headers, "x-datadog-trace-id")
+
+
+@pytest.mark.asyncio
+async def test_send_span_finishes_when_delivery_future_resolves(tracer, test_spans):
+    delivery_future = asyncio.get_running_loop().create_future()
+    client = SimpleNamespace(_bootstrap_servers=[BOOTSTRAP_SERVERS], _dd_cluster_id="test-cluster")
+    producer = SimpleNamespace(client=client)
+
+    async def send(*args, **kwargs):
+        return delivery_future
+
+    returned_future = await traced_send(send, producer, ("topic", PAYLOAD), {})
+    span = tracer.current_span()
+
+    assert returned_future is delivery_future
+    assert span is not None
+    assert not span.finished
+    test_spans.assert_has_no_spans()
+
+    delivery_future.set_result(SimpleNamespace(topic="topic", partition=0, offset=1))
+    await asyncio.sleep(0)
+
+    assert span.finished
+    test_spans.assert_span_count(1)
+
+
+@pytest.mark.asyncio
+async def test_send_span_records_delivery_future_failure(tracer, test_spans):
+    delivery_future = asyncio.get_running_loop().create_future()
+    client = SimpleNamespace(_bootstrap_servers=[BOOTSTRAP_SERVERS], _dd_cluster_id="test-cluster")
+    producer = SimpleNamespace(client=client)
+
+    async def send(*args, **kwargs):
+        return delivery_future
+
+    await traced_send(send, producer, ("topic", PAYLOAD), {})
+    span = tracer.current_span()
+
+    assert span is not None
+    assert not span.finished
+
+    delivery_future.set_exception(RuntimeError("delivery failed"))
+    await asyncio.sleep(0)
+
+    assert span.finished
+    assert span.error == 1
+    test_spans.assert_span_count(1)
+
+
+@pytest.mark.asyncio
+async def test_getmany_empty_result():
+    client = SimpleNamespace(_bootstrap_servers=[BOOTSTRAP_SERVERS], _dd_cluster_id="test-cluster")
+    consumer = SimpleNamespace(_client=client, _group_id="test-group")
+
+    async def getmany(*args, **kwargs):
+        return {}
+
+    result = await traced_getmany(getmany, consumer, (), {})
+
+    assert result == {}
 
 
 @pytest.mark.asyncio

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -3,21 +3,27 @@ import logging
 import os
 import random
 import time
+from types import SimpleNamespace
 
 import confluent_kafka
 from confluent_kafka import TopicPartition
 import pytest
 
+from ddtrace._trace.context import Context
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib._events.kafka import KafkaProcessEvent
 from ddtrace.contrib._events.kafka import KafkaProducerEvent
 from ddtrace.contrib._events.messaging import MessagingProcessEvent
 from ddtrace.contrib._events.messaging import MessagingProducerEvent
 from ddtrace.contrib.internal.kafka.patch import TracedConsumer
 from ddtrace.contrib.internal.kafka.patch import TracedProducer
+from ddtrace.contrib.internal.kafka.patch import _instrument_message
 from ddtrace.contrib.internal.kafka.patch import patch
 from ddtrace.contrib.internal.kafka.patch import traced_produce
 from ddtrace.contrib.internal.kafka.patch import unpatch
+from ddtrace.internal import core
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
+from ddtrace.propagation.http import HTTPPropagator
 from tests.utils import override_config
 
 from .conftest import BOOTSTRAP_SERVERS
@@ -40,7 +46,7 @@ SNAPSHOT_IGNORES = [
 def test_kafka_events_specialize_messaging_events():
     assert issubclass(KafkaProducerEvent, MessagingProducerEvent)
     assert issubclass(KafkaProcessEvent, MessagingProcessEvent)
-    assert KafkaProcessEvent.activate_distributed_headers is True
+    assert KafkaProcessEvent.activate_distributed_headers is False
 
 
 def test_consumer_created_with_logger_does_not_raise(kafka_tracer):
@@ -701,6 +707,66 @@ def test_producer_injects_trace_headers_after_key_serialization(kafka_tracer, ka
     assert "x-datadog-trace-id" not in serialized_headers[0]
     assert produced_headers is not None
     assert "x-datadog-trace-id" in produced_headers
+
+
+def test_produce_preserves_dsm_headers_when_caller_omits_headers():
+    produced_headers = None
+    instance = SimpleNamespace(_dd_bootstrap_servers="localhost:9092", _dd_cluster_id="test-cluster")
+    Pin().onto(instance)
+
+    def produce(*args, **kwargs):
+        nonlocal produced_headers
+        produced_headers = kwargs.get("headers")
+
+    def inject_dsm_headers(inst, args, kwargs, is_serializing, span):
+        headers = kwargs.get("headers", {})
+        headers["dd-pathway-ctx-base64"] = "pathway"
+        kwargs["headers"] = headers
+
+    core.on("kafka.produce.start", inject_dsm_headers)
+    try:
+        with override_config("kafka", dict(distributed_tracing_enabled=True)):
+            traced_produce(produce, instance, ("topic", PAYLOAD), {})
+        assert produced_headers is not None
+        assert produced_headers.get("dd-pathway-ctx-base64") == "pathway"
+        assert "x-datadog-trace-id" in produced_headers
+    finally:
+        core.reset_listeners("kafka.produce.start", inject_dsm_headers)
+
+
+def test_consume_restores_local_span_when_message_has_foreign_trace(kafka_tracer, test_spans):
+    carrier = {}
+    HTTPPropagator.inject(Context(trace_id=2**64 - 1, span_id=99), carrier)
+
+    class Message:
+        def topic(self):
+            return "topic"
+
+        def headers(self):
+            return list(carrier.items())
+
+        def key(self):
+            return b"key"
+
+        def offset(self):
+            return 1
+
+        def partition(self):
+            return 0
+
+        def __len__(self):
+            return 1
+
+    instance = SimpleNamespace(_group_id="group", _dd_bootstrap_servers="localhost:9092", _dd_cluster_id="test-cluster")
+    pin = Pin()
+    pin.onto(instance)
+
+    with override_config("kafka", dict(distributed_tracing_enabled=True, propagation_as_span_links=False)):
+        with kafka_tracer.trace("local") as parent:
+            _instrument_message([Message()], pin, time.time_ns(), instance, None)
+            assert kafka_tracer.current_span() is parent
+            with kafka_tracer.trace("after") as after:
+                assert after.parent_id == parent.span_id
 
 
 def test_consumer_uses_active_context_when_no_valid_distributed_context_exists(

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -8,9 +8,14 @@ import confluent_kafka
 from confluent_kafka import TopicPartition
 import pytest
 
+from ddtrace.contrib._events.kafka import KafkaProcessEvent
+from ddtrace.contrib._events.kafka import KafkaProducerEvent
+from ddtrace.contrib._events.messaging import MessagingProcessEvent
+from ddtrace.contrib._events.messaging import MessagingProducerEvent
 from ddtrace.contrib.internal.kafka.patch import TracedConsumer
 from ddtrace.contrib.internal.kafka.patch import TracedProducer
 from ddtrace.contrib.internal.kafka.patch import patch
+from ddtrace.contrib.internal.kafka.patch import traced_produce
 from ddtrace.contrib.internal.kafka.patch import unpatch
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
 from tests.utils import override_config
@@ -30,6 +35,12 @@ SNAPSHOT_IGNORES = [
     "meta.messaging.kafka.bootstrap.servers",
     "meta.peer.service",
 ]
+
+
+def test_kafka_events_specialize_messaging_events():
+    assert issubclass(KafkaProducerEvent, MessagingProducerEvent)
+    assert issubclass(KafkaProcessEvent, MessagingProcessEvent)
+    assert KafkaProcessEvent.activate_distributed_headers is True
 
 
 def test_consumer_created_with_logger_does_not_raise(kafka_tracer):
@@ -657,6 +668,39 @@ def test_context_header_injection_works_no_client_added_headers(kafka_topic, pro
                 propagation_asserted = True
 
         assert propagation_asserted is True
+
+
+def test_producer_injects_trace_headers_after_key_serialization(kafka_tracer, kafka_topic):
+    serialized_headers = []
+    produced_headers = None
+
+    def key_serializer(key, serialization_context):
+        serialized_headers.append(dict(serialization_context.headers))
+        return key.encode("utf-8")
+
+    producer = confluent_kafka.SerializingProducer(
+        {
+            "bootstrap.servers": BOOTSTRAP_SERVERS,
+            "key.serializer": key_serializer,
+        }
+    )
+
+    def produce(*args, **kwargs):
+        nonlocal produced_headers
+        produced_headers = kwargs["headers"]
+
+    with override_config("kafka", dict(distributed_tracing_enabled=True)):
+        traced_produce(
+            produce,
+            producer,
+            (kafka_topic, PAYLOAD),
+            {"key": KEY, "headers": {"custom": "value"}},
+        )
+
+    assert len(serialized_headers) == 1
+    assert "x-datadog-trace-id" not in serialized_headers[0]
+    assert produced_headers is not None
+    assert "x-datadog-trace-id" in produced_headers
 
 
 def test_consumer_uses_active_context_when_no_valid_distributed_context_exists(

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -3,16 +3,21 @@ import logging
 import os
 import random
 import time
+from types import SimpleNamespace
 
 import confluent_kafka
 from confluent_kafka import TopicPartition
 import pytest
 
+from ddtrace._trace.context import Context
+from ddtrace._trace.pin import Pin
 from ddtrace.contrib.internal.kafka.patch import TracedConsumer
 from ddtrace.contrib.internal.kafka.patch import TracedProducer
+from ddtrace.contrib.internal.kafka.patch import _instrument_message
 from ddtrace.contrib.internal.kafka.patch import patch
 from ddtrace.contrib.internal.kafka.patch import unpatch
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
+from ddtrace.propagation.http import HTTPPropagator
 from tests.utils import override_config
 
 from .conftest import BOOTSTRAP_SERVERS
@@ -657,6 +662,50 @@ def test_context_header_injection_works_no_client_added_headers(kafka_topic, pro
                 propagation_asserted = True
 
         assert propagation_asserted is True
+
+
+def test_consume_restores_active_span_after_foreign_distributed_context(kafka_tracer):
+    carrier = {}
+    HTTPPropagator.inject(Context(trace_id=2**64 - 1, span_id=99), carrier)
+
+    class Message:
+        def topic(self):
+            return "topic"
+
+        def headers(self):
+            return list(carrier.items())
+
+        def key(self):
+            return b"key"
+
+        def value(self):
+            return PAYLOAD
+
+        def error(self):
+            return None
+
+        def offset(self):
+            return 1
+
+        def partition(self):
+            return 0
+
+        def __len__(self):
+            return 1
+
+    instance = SimpleNamespace(
+        _group_id="group",
+        _dd_bootstrap_servers="localhost:9092",
+        _dd_cluster_id="test-cluster",
+        _auto_commit=False,
+    )
+    pin = Pin()
+    pin.onto(instance)
+
+    with override_config("kafka", dict(distributed_tracing_enabled=True, propagation_as_span_links=False)):
+        with kafka_tracer.trace("local") as parent:
+            _instrument_message([Message()], pin, time.time_ns(), instance, None)
+            assert kafka_tracer.current_span() is parent
 
 
 def test_consumer_uses_active_context_when_no_valid_distributed_context_exists(

--- a/tests/contrib/kafka/test_kafka.py
+++ b/tests/contrib/kafka/test_kafka.py
@@ -3,27 +3,16 @@ import logging
 import os
 import random
 import time
-from types import SimpleNamespace
 
 import confluent_kafka
 from confluent_kafka import TopicPartition
 import pytest
 
-from ddtrace._trace.context import Context
-from ddtrace._trace.pin import Pin
-from ddtrace.contrib._events.kafka import KafkaProcessEvent
-from ddtrace.contrib._events.kafka import KafkaProducerEvent
-from ddtrace.contrib._events.messaging import MessagingProcessEvent
-from ddtrace.contrib._events.messaging import MessagingProducerEvent
 from ddtrace.contrib.internal.kafka.patch import TracedConsumer
 from ddtrace.contrib.internal.kafka.patch import TracedProducer
-from ddtrace.contrib.internal.kafka.patch import _instrument_message
 from ddtrace.contrib.internal.kafka.patch import patch
-from ddtrace.contrib.internal.kafka.patch import traced_produce
 from ddtrace.contrib.internal.kafka.patch import unpatch
-from ddtrace.internal import core
 from ddtrace.internal.utils.retry import fibonacci_backoff_with_jitter
-from ddtrace.propagation.http import HTTPPropagator
 from tests.utils import override_config
 
 from .conftest import BOOTSTRAP_SERVERS
@@ -41,12 +30,6 @@ SNAPSHOT_IGNORES = [
     "meta.messaging.kafka.bootstrap.servers",
     "meta.peer.service",
 ]
-
-
-def test_kafka_events_specialize_messaging_events():
-    assert issubclass(KafkaProducerEvent, MessagingProducerEvent)
-    assert issubclass(KafkaProcessEvent, MessagingProcessEvent)
-    assert KafkaProcessEvent.activate_distributed_headers is False
 
 
 def test_consumer_created_with_logger_does_not_raise(kafka_tracer):
@@ -674,99 +657,6 @@ def test_context_header_injection_works_no_client_added_headers(kafka_topic, pro
                 propagation_asserted = True
 
         assert propagation_asserted is True
-
-
-def test_producer_injects_trace_headers_after_key_serialization(kafka_tracer, kafka_topic):
-    serialized_headers = []
-    produced_headers = None
-
-    def key_serializer(key, serialization_context):
-        serialized_headers.append(dict(serialization_context.headers))
-        return key.encode("utf-8")
-
-    producer = confluent_kafka.SerializingProducer(
-        {
-            "bootstrap.servers": BOOTSTRAP_SERVERS,
-            "key.serializer": key_serializer,
-        }
-    )
-
-    def produce(*args, **kwargs):
-        nonlocal produced_headers
-        produced_headers = kwargs["headers"]
-
-    with override_config("kafka", dict(distributed_tracing_enabled=True)):
-        traced_produce(
-            produce,
-            producer,
-            (kafka_topic, PAYLOAD),
-            {"key": KEY, "headers": {"custom": "value"}},
-        )
-
-    assert len(serialized_headers) == 1
-    assert "x-datadog-trace-id" not in serialized_headers[0]
-    assert produced_headers is not None
-    assert "x-datadog-trace-id" in produced_headers
-
-
-def test_produce_preserves_dsm_headers_when_caller_omits_headers():
-    produced_headers = None
-    instance = SimpleNamespace(_dd_bootstrap_servers="localhost:9092", _dd_cluster_id="test-cluster")
-    Pin().onto(instance)
-
-    def produce(*args, **kwargs):
-        nonlocal produced_headers
-        produced_headers = kwargs.get("headers")
-
-    def inject_dsm_headers(inst, args, kwargs, is_serializing, span):
-        headers = kwargs.get("headers", {})
-        headers["dd-pathway-ctx-base64"] = "pathway"
-        kwargs["headers"] = headers
-
-    core.on("kafka.produce.start", inject_dsm_headers)
-    try:
-        with override_config("kafka", dict(distributed_tracing_enabled=True)):
-            traced_produce(produce, instance, ("topic", PAYLOAD), {})
-        assert produced_headers is not None
-        assert produced_headers.get("dd-pathway-ctx-base64") == "pathway"
-        assert "x-datadog-trace-id" in produced_headers
-    finally:
-        core.reset_listeners("kafka.produce.start", inject_dsm_headers)
-
-
-def test_consume_restores_local_span_when_message_has_foreign_trace(kafka_tracer, test_spans):
-    carrier = {}
-    HTTPPropagator.inject(Context(trace_id=2**64 - 1, span_id=99), carrier)
-
-    class Message:
-        def topic(self):
-            return "topic"
-
-        def headers(self):
-            return list(carrier.items())
-
-        def key(self):
-            return b"key"
-
-        def offset(self):
-            return 1
-
-        def partition(self):
-            return 0
-
-        def __len__(self):
-            return 1
-
-    instance = SimpleNamespace(_group_id="group", _dd_bootstrap_servers="localhost:9092", _dd_cluster_id="test-cluster")
-    pin = Pin()
-    pin.onto(instance)
-
-    with override_config("kafka", dict(distributed_tracing_enabled=True, propagation_as_span_links=False)):
-        with kafka_tracer.trace("local") as parent:
-            _instrument_message([Message()], pin, time.time_ns(), instance, None)
-            assert kafka_tracer.current_span() is parent
-            with kafka_tracer.trace("after") as after:
-                assert after.parent_id == parent.span_id
 
 
 def test_consumer_uses_active_context_when_no_valid_distributed_context_exists(


### PR DESCRIPTION
This PR introduces shared messaging events and migrates Kafka, and aiokafka from legacy trace handlers to `core.context_with_event()`.

### Instrumented operations
- **Kafka**
  - `Producer.produce` → `KafkaProducerEvent`
  - `Consumer.poll` → `KafkaProcessEvent`
  - `Consumer.consume` → `KafkaProcessEvent`
- **aiokafka**
  - `Producer.send` → `KafkaProducerEvent`
  - `Consumer.getone` → `KafkaProcessEvent`
  - `Consumer.getmany` → `KafkaProcessEvent`
 - **Kombu**
    - `Producer._publish` → `MessagingProducerEvent`
    - `Consumer.receive` → `MessagingProcessEvent`