### PR TITLE
chore(kombu): migrate kombu to events API

### DIFF
--- a/.claude/skills/apm-integrations/references/reference-integrations.md
+++ b/.claude/skills/apm-integrations/references/reference-integrations.md
@@ -18,7 +18,7 @@ All patch modules live in `ddtrace/contrib/internal/{name}/`.
 | http-client | `httpx/patch.py` | `requests/connection.py` | Outbound HTTP, `http.*` span tags. httpx and requests use `context_with_event` |
 | http-server | `flask/patch.py` | `django/patch.py` | Web frameworks, request/response spans, Pin + `context_with_data` |
 | logging | `logging/patch.py` | `loguru/patch.py` | Log correlation injection (trace ID, span ID) -- no spans created |
-| messaging | `kafka/patch.py`, `aiokafka/patch.py` | `kombu/patch.py` | Kafka and aiokafka use shared messaging events; Kombu and RQ still use Pin |
+| messaging | `kafka/patch.py`, `aiokafka/patch.py`, `kombu/patch.py` | `rq/patch.py` | Kafka, aiokafka, and Kombu use shared messaging events; RQ still uses Pin |
 | object-store | `botocore/patch.py` (S3) | -- | S3 via botocore service-specific handlers |
 | orchestration | `celery/patch.py` | -- | Task orchestration, distributed tracing, Pin + `tracer.trace` via signals |
 | rpc | `grpc/patch.py` | -- | RPC frameworks, client + server spans, Pin + `tracer.trace` |

--- a/ddtrace/contrib/internal/kombu/patch.py
+++ b/ddtrace/contrib/internal/kombu/patch.py
@@ -4,26 +4,20 @@ import wrapt
 
 from ddtrace import config
 from ddtrace._trace.pin import Pin
-from ddtrace.constants import _SPAN_MEASURED_KEY
-from ddtrace.constants import SPAN_KIND
 
 # project
-from ddtrace.contrib import trace_utils
-from ddtrace.contrib.internal.trace_utils import set_service_and_source
-from ddtrace.ext import SpanKind
-from ddtrace.ext import SpanTypes
+from ddtrace.contrib._events.messaging import MessagingProcessEvent
+from ddtrace.contrib._events.messaging import MessagingProducerEvent
 from ddtrace.ext import kombu as kombux
 from ddtrace.internal import core
-from ddtrace.internal.constants import COMPONENT
 from ddtrace.internal.schema import schematize_messaging_operation
 from ddtrace.internal.schema import schematize_service_name
 from ddtrace.internal.schema.span_attribute_schema import SpanDirection
 from ddtrace.internal.settings import env
+from ddtrace.internal.span_bus import span_from_context
 from ddtrace.internal.utils import get_argument_value
 from ddtrace.internal.utils.formats import asbool
 from ddtrace.internal.utils.wrappers import unwrap
-from ddtrace.propagation.http import HTTPPropagator
-from ddtrace.trace import tracer
 
 from .constants import DEFAULT_SERVICE
 from .utils import HEADER_POS
@@ -46,8 +40,6 @@ config._add(
         "service_name": config.service or env.get("DD_KOMBU_SERVICE", default=DEFAULT_SERVICE),
     },
 )
-
-propagator = HTTPPropagator
 
 
 def _supported_versions() -> dict[str, str]:
@@ -109,29 +101,26 @@ def traced_receive(func, instance, args, kwargs):
 
     # Signature only takes 2 args: (body, message)
     message = get_argument_value(args, kwargs, 1, "message")
+    exchange = message.delivery_info["exchange"]
 
-    trace_utils.activate_distributed_headers(tracer, request_headers=message.headers, int_config=config.kombu)
+    event = MessagingProcessEvent(
+        operation=schematize_messaging_operation(
+            kombux.RECEIVE_NAME, provider="kombu", direction=SpanDirection.PROCESSING
+        ),
+        request_headers=message.headers,
+        component=config.kombu.integration_name,
+        integration_config=config.kombu,
+        service=pin.service,
+        resource=exchange,
+    )
 
-    with tracer.trace(
-        schematize_messaging_operation(kombux.RECEIVE_NAME, provider="kombu", direction=SpanDirection.PROCESSING),
-        span_type=SpanTypes.WORKER,
-    ) as s:
-        set_service_and_source(s, pin.service, config.kombu)
-        s._set_attribute(COMPONENT, config.kombu.integration_name)
-
-        # set span.kind to the type of operation being performed
-        s._set_attribute(SPAN_KIND, SpanKind.CONSUMER)
-
-        s._set_attribute(_SPAN_MEASURED_KEY, 1)
-        # run the command
-        exchange = message.delivery_info["exchange"]
-        s.resource = exchange
-        s._set_attribute(kombux.EXCHANGE, exchange)
-
-        s.set_tags(extract_conn_tags(message.channel.connection))
-        s._set_attribute(kombux.ROUTING_KEY, message.delivery_info["routing_key"])
+    with core.context_with_event(event) as ctx:
+        span = span_from_context(ctx)
+        span._set_attribute(kombux.EXCHANGE, exchange)
+        span.set_tags(extract_conn_tags(message.channel.connection))
+        span._set_attribute(kombux.ROUTING_KEY, message.delivery_info["routing_key"])
         result = func(*args, **kwargs)
-        core.dispatch("kombu.amqp.receive.post", (instance, message, s))
+        core.dispatch("kombu.amqp.receive.post", (instance, message, span))
         return result
 
 
@@ -140,29 +129,28 @@ def traced_publish(func, instance, args, kwargs):
     if not pin or not pin.enabled():
         return func(*args, **kwargs)
 
-    with tracer.trace(
-        schematize_messaging_operation(kombux.PUBLISH_NAME, provider="kombu", direction=SpanDirection.OUTBOUND),
-        span_type=SpanTypes.WORKER,
-    ) as s:
-        set_service_and_source(s, pin.service, config.kombu)
-        s._set_attribute(COMPONENT, config.kombu.integration_name)
+    exchange_name = get_exchange_from_args(args)
+    event = MessagingProducerEvent(
+        operation=schematize_messaging_operation(
+            kombux.PUBLISH_NAME, provider="kombu", direction=SpanDirection.OUTBOUND
+        ),
+        distributed_headers=args[HEADER_POS],
+        component=config.kombu.integration_name,
+        integration_config=config.kombu,
+        service=pin.service,
+        resource=exchange_name,
+    )
 
-        # set span.kind to the type of operation being performed
-        s._set_attribute(SPAN_KIND, SpanKind.PRODUCER)
-
-        s._set_attribute(_SPAN_MEASURED_KEY, 1)
-        exchange_name = get_exchange_from_args(args)
-        s.resource = exchange_name
-        s._set_attribute(kombux.EXCHANGE, exchange_name)
+    with core.context_with_event(event) as ctx:
+        span = span_from_context(ctx)
+        span._set_attribute(kombux.EXCHANGE, exchange_name)
         if pin.tags:
-            s.set_tags(pin.tags)
-        s._set_attribute(kombux.ROUTING_KEY, get_routing_key_from_args(args))
-        s.set_tags(extract_conn_tags(instance.channel.connection))
-        s._set_attribute(kombux.BODY_LEN, get_body_length_from_args(args))
-        # run the command
-        if config.kombu.distributed_tracing_enabled:
-            propagator.inject(s.context, args[HEADER_POS])
+            span.set_tags(pin.tags)
+        span._set_attribute(kombux.ROUTING_KEY, get_routing_key_from_args(args))
+        span.set_tags(extract_conn_tags(instance.channel.connection))
+        span._set_attribute(kombux.BODY_LEN, get_body_length_from_args(args))
+
         core.dispatch(
-            "kombu.amqp.publish.pre", (args, kwargs, s)
+            "kombu.amqp.publish.pre", (args, kwargs, span)
         )  # Has to happen after trace injection for actual payload size
         return func(*args, **kwargs)

--- a/ddtrace/contrib/internal/kombu/patch.py
+++ b/ddtrace/contrib/internal/kombu/patch.py
@@ -108,6 +108,7 @@ def traced_receive(func, instance, args, kwargs):
             kombux.RECEIVE_NAME, provider="kombu", direction=SpanDirection.PROCESSING
         ),
         request_headers=message.headers,
+        activate_distributed_headers=True,
         component=config.kombu.integration_name,
         integration_config=config.kombu,
         service=pin.service,

--- a/tests/contrib/kombu/test.py
+++ b/tests/contrib/kombu/test.py
@@ -4,10 +4,14 @@ import mock
 import pytest
 
 from ddtrace import config
+from ddtrace._trace.subscribers.messaging import HTTPPropagator
+from ddtrace.contrib._events.messaging import MessagingProcessEvent
+from ddtrace.contrib._events.messaging import MessagingProducerEvent
 from ddtrace.contrib.internal.kombu import utils
 from ddtrace.contrib.internal.kombu.patch import patch
 from ddtrace.contrib.internal.kombu.patch import unpatch
 from ddtrace.ext import kombu as kombux
+from ddtrace.internal import core
 from ddtrace.internal.datastreams.processor import PROPAGATION_KEY_BASE_64
 from ddtrace.internal.native import DDSketch
 from ddtrace.internal.schema.default import DEFAULT_SPAN_SERVICE_NAME
@@ -78,6 +82,7 @@ class TestKombuPatch(TracerTestCase):
         self.assertEqual(producer_span.error, 0)
         self.assertEqual(producer_span.get_tag("out.vhost"), "/")
         self.assertEqual(producer_span.get_tag("out.host"), "127.0.0.1")
+        self.assertEqual(producer_span.get_metric("network.destination.port"), self.TEST_PORT)
         self.assertEqual(producer_span.get_tag("kombu.exchange"), "tasks")
         self.assertEqual(producer_span.get_metric("kombu.body_length"), 18)
         self.assertEqual(producer_span.get_tag("kombu.routing_key"), "tasks")
@@ -92,8 +97,50 @@ class TestKombuPatch(TracerTestCase):
         self.assertEqual(consumer_span.error, 0)
         self.assertEqual(consumer_span.get_tag("kombu.exchange"), "tasks")
         self.assertEqual(consumer_span.get_tag("kombu.routing_key"), "tasks")
+        self.assertEqual(consumer_span.get_metric("network.destination.port"), self.TEST_PORT)
         self.assertEqual(consumer_span.get_tag("component"), "kombu")
         self.assertEqual(consumer_span.get_tag("span.kind"), "consumer")
+
+    def test_uses_messaging_events(self):
+        context_with_event = core.context_with_event
+        with mock.patch.object(core, "context_with_event", wraps=context_with_event) as context_mock:
+            self._publish_consume()
+
+        events = [call.args[0] for call in context_mock.call_args_list]
+        producer_events = [event for event in events if isinstance(event, MessagingProducerEvent)]
+        process_events = [event for event in events if isinstance(event, MessagingProcessEvent)]
+
+        self.assertEqual(len(producer_events), 1)
+        self.assertEqual(len(process_events), 1)
+
+    def test_publish_injects_trace_headers_before_dsm_dispatch(self):
+        order = []
+        dispatch = core.dispatch
+        inject = HTTPPropagator.inject
+
+        def record_dispatch(event_name, args):
+            if event_name == "kombu.amqp.publish.pre":
+                order.append("dsm")
+            return dispatch(event_name, args)
+
+        def record_inject(context, headers):
+            order.append("inject")
+            return inject(context, headers)
+
+        exchange = kombu.Exchange("trace_header_ordering")
+        queue = kombu.Queue("trace_header_ordering", exchange, routing_key="trace_header_ordering")
+        with (
+            mock.patch.object(core, "dispatch", side_effect=record_dispatch),
+            mock.patch.object(HTTPPropagator, "inject", side_effect=record_inject),
+        ):
+            self.producer.publish(
+                {"hello": "world"},
+                exchange=exchange,
+                routing_key=queue.routing_key,
+                declare=[queue],
+            )
+
+        self.assertEqual(order, ["inject", "dsm"])
 
     def _gen_distributed_spans(self):
         self._publish_consume()

--- a/tests/contrib/kombu/test_kombu_patch.py
+++ b/tests/contrib/kombu/test_kombu_patch.py
@@ -22,10 +22,13 @@ class TestKombuPatch(PatchTestCase.Base):
     __get_version__ = get_version
 
     def assert_module_patched(self, kombu):
-        pass
+        self.assert_wrapped(kombu.Producer._publish)
+        self.assert_wrapped(kombu.Consumer.receive)
 
     def assert_not_module_patched(self, kombu):
-        pass
+        self.assert_not_wrapped(kombu.Producer._publish)
+        self.assert_not_wrapped(kombu.Consumer.receive)
 
     def assert_not_module_double_patched(self, kombu):
-        pass
+        self.assert_not_double_wrapped(kombu.Producer._publish)
+        self.assert_not_double_wrapped(kombu.Consumer.receive)


### PR DESCRIPTION
This PR migrates Kombu from legacy trace handlers to `core.context_with_event()`.
### Instrumented operations
- **Kombu**
  - `Producer._publish` → `MessagingProducerEvent`
  - `Consumer.receive` → `MessagingProcessEvent`
Stacked on #20229.