### PR TITLE
fix(config): treat empty OpenTelemetry variables as unset

### DIFF
--- a/ddtrace/internal/settings/env.py
+++ b/ddtrace/internal/settings/env.py
@@ -1,7 +1,8 @@
 """Centralized environment variable access for dd-trace-py.
 
-This module provides a drop-in replacement for os.environ, enabling centralized
-control and validation of all environment variable access in ddtrace.
+This module provides a configuration-aware view of os.environ, enabling
+centralized control and validation of all environment variable access in
+ddtrace.
 
 All DD_*/_DD_*/OTEL_*/DATADOG_* environment variable accesses are validated
 against the registry in supported-configurations.json. Unregistered variables
@@ -17,6 +18,7 @@ from collections.abc import MutableMapping
 import logging
 import os
 from typing import Iterator
+from typing import Optional
 
 from ddtrace.internal.settings._supported_configurations import CONFIGURATION_ALIASES
 from ddtrace.internal.settings._supported_configurations import DEPRECATED_CONFIGURATIONS
@@ -30,6 +32,15 @@ logger = logging.getLogger(__name__)
 
 _ALIAS_TARGETS: frozenset[str] = frozenset(alias for aliases in CONFIGURATION_ALIASES.values() for alias in aliases)
 _warned_keys: set[str] = set()
+
+
+def _get_env_value(key: str) -> Optional[str]:
+    """Return the environment value, masking empty values for OTel config variables (OTel specification requirement)"""
+    value = os.environ.get(key)
+
+    if key.startswith("OTEL_") and value == "":
+        return None
+    return value
 
 
 def _validate_key(key: str) -> None:
@@ -56,8 +67,8 @@ class EnvConfig(MutableMapping):
     """A MutableMapping wrapper around os.environ.
 
     Serves as the centralized entry point for all environment variable access
-    in dd-trace-py. Drop-in replacement for os.environ — supports reads, writes,
-    deletes, containment checks, iteration, and all standard dict-like operations.
+    in dd-trace-py. Empty OTEL_* values are excluded from reads and iteration.
+    Writes and deletes operate directly on os.environ.
 
     Validates that DD_*/_DD_*/OTEL_*/DATADOG_* accesses use registered
     configuration variables from supported-configurations.json.
@@ -65,10 +76,10 @@ class EnvConfig(MutableMapping):
 
     def __getitem__(self, key: str) -> str:
         _validate_key(key)
-        if (value := os.environ.get(key)) is not None:
+        if (value := _get_env_value(key)) is not None:
             return value
         for alias in CONFIGURATION_ALIASES.get(key, ()):
-            if (value := os.environ.get(alias)) is not None:
+            if (value := _get_env_value(alias)) is not None:
                 return value
         raise KeyError(key)
 
@@ -82,16 +93,16 @@ class EnvConfig(MutableMapping):
     def __contains__(self, key: object) -> bool:
         if isinstance(key, str):
             _validate_key(key)
-            if key in os.environ:
+            if _get_env_value(key) is not None:
                 return True
-            return any(alias in os.environ for alias in CONFIGURATION_ALIASES.get(key, ()))
+            return any(_get_env_value(alias) is not None for alias in CONFIGURATION_ALIASES.get(key, ()))
         return key in os.environ
 
     def __iter__(self) -> Iterator[str]:
-        return iter(os.environ)
+        return (key for key in os.environ if _get_env_value(key) is not None)
 
     def __len__(self) -> int:
-        return len(os.environ)
+        return sum(1 for _ in self)
 
     def copy(self) -> dict:
         return dict(self)

--- a/releasenotes/notes/fix-empty-otel-environment-values-432fa61f1d58cf71.yaml
+++ b/releasenotes/notes/fix-empty-otel-environment-values-432fa61f1d58cf71.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    opentelemetry: Fixes an issue where empty ``OTEL_*`` environment
+    variables override ddtrace defaults instead of being treated as unset.

--- a/tests/internal/test_env.py
+++ b/tests/internal/test_env.py
@@ -14,6 +14,10 @@ env_module = sys.modules["ddtrace.internal.settings.env"]
 ENV_LOGGER = env_module.__name__
 
 
+def _visible_environ() -> dict[str, str]:
+    return {key: value for key, value in os.environ.items() if not (key.startswith("OTEL_") and value == "")}
+
+
 @pytest.fixture(autouse=True)
 def reset_warned_keys():
     env_module._warned_keys.clear()
@@ -114,6 +118,38 @@ def test_contains_false_for_unset_key(monkeypatch):
     assert "DD_AGENT_HOST" not in dd_environ
 
 
+def test_empty_otel_value_is_treated_as_unset(monkeypatch):
+    key = "OTEL_SERVICE_NAME"
+    monkeypatch.setenv(key, "")
+
+    assert os.environ[key] == ""
+    assert key not in dd_environ
+    assert dd_environ.get(key) is None
+    assert dd_environ.get(key, "default") == "default"
+    with pytest.raises(KeyError):
+        dd_environ[key]
+
+    visible_environ = _visible_environ()
+    assert len(dd_environ) == len(visible_environ)
+    assert set(dd_environ) == set(visible_environ)
+    assert dd_environ.copy() == visible_environ
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("DD_SERVICE", ""),
+        ("OTEL_SERVICE_NAME", " "),
+    ],
+)
+def test_nonempty_otel_and_empty_non_otel_values_remain_set(monkeypatch, key, value):
+    monkeypatch.setenv(key, value)
+
+    assert key in dd_environ
+    assert dd_environ[key] == value
+    assert key in dd_environ.copy()
+
+
 def test_contains_warns_on_unregistered_key(caplog, monkeypatch):
     monkeypatch.delenv("DD_UNREGISTERED_CONTAINS_TEST", raising=False)
     with caplog.at_level(logging.DEBUG, logger=ENV_LOGGER):
@@ -122,15 +158,16 @@ def test_contains_warns_on_unregistered_key(caplog, monkeypatch):
     assert "DD_UNREGISTERED_CONTAINS_TEST" in caplog.text
 
 
-def test_len_and_iter_match_os_environ():
-    assert len(dd_environ) == len(os.environ)
-    assert set(dd_environ) == set(os.environ)
+def test_len_and_iter_match_visible_environ():
+    visible_environ = _visible_environ()
+    assert len(dd_environ) == len(visible_environ)
+    assert set(dd_environ) == set(visible_environ)
 
 
 def test_copy_returns_plain_dict():
     snapshot = dd_environ.copy()
     assert isinstance(snapshot, dict)
-    assert snapshot == dict(os.environ)
+    assert snapshot == _visible_environ()
 
 
 def _pick_alias_pair() -> tuple[str, str]:

--- a/tests/opentelemetry/test_config.py
+++ b/tests/opentelemetry/test_config.py
@@ -103,6 +103,28 @@ def test_otel_service_configuration():
     assert config.service == "Test", config.service
 
 
+@pytest.mark.subprocess(
+    env={
+        "OTEL_SERVICE_NAME": "",
+        "OTEL_RESOURCE_ATTRIBUTES": "service.name=resource-service",
+        "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+        "OTEL_EXPORTER_OTLP_TIMEOUT": "",
+        "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "",
+        "OTEL_METRIC_EXPORT_TIMEOUT": "",
+        "OTEL_TRACES_SPAN_METRICS_ENABLED": "",
+    }
+)
+def test_empty_otel_configuration_is_unset():
+    from ddtrace import config
+    from ddtrace.internal.settings._opentelemetry import otel_config
+
+    assert config.service == "resource-service"
+    assert config._otel_stats_computation_enabled is None
+    assert otel_config.exporter.TIMEOUT == 10000
+    assert otel_config.exporter.TRACES_PROTOCOL == "http/protobuf"
+    assert otel_config.exporter.METRICS_METRIC_READER_EXPORT_TIMEOUT == 7500
+
+
 @pytest.mark.subprocess(env={"OTEL_LOG_LEVEL": "debug"})
 def test_otel_log_level_configuration_debug():
     from ddtrace import config


### PR DESCRIPTION
## Description

Treat empty `OTEL_*` environment variables as unset through ddtrace's configuration mapping, matching OpenTelemetry environment-variable semantics.

https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#parsing-empty-value

This preserves the raw values in `os.environ`. Empty non-OTel variables and whitespace-only OTel values also remain explicitly set.

## Testing

- `tests/internal/test_env.py`: 28 passed.
- Focused OTel subprocess configuration test: 1 passed.
- Focused formatting, style, spelling, and Reno validation passed.
- `scripts/lint checks`

## Risks

Low. The behavior change is limited to ddtrace's internal environment mapping.
Components that read `os.environ` directly are unchanged.

## Additional Notes

None.
