### PR TITLE
test(tracing): control jitter rate limiter test clock

### DIFF
--- a/tests/tracer/test_rate_limiter.py
+++ b/tests/tracer/test_rate_limiter.py
@@ -213,11 +213,12 @@ def test_rate_limiter_with_jitter_expected_calls(rate_limit):
     acc = []
 
     exceeded = 0
-    for i in range(rate_limit * 10):
-        try:
-            limiter.limit(lambda n: acc.append(n), i)
-        except RateLimitExceeded:
-            exceeded += 1
+    with mock.patch("ddtrace.internal.rate_limiter.time.monotonic", return_value=limiter.last_time):
+        for i in range(rate_limit * 10):
+            try:
+                limiter.limit(lambda n: acc.append(n), i)
+            except RateLimitExceeded:
+                exceeded += 1
 
     assert not set(range(rate_limit)) < set(acc)
     assert len(acc) == rate_limit
@@ -230,31 +231,32 @@ def test_rate_limiter_with_jitter_expected_calls_tau(rate_limit):
     acc = []
 
     exceeded = 0
-    for i in range(rate_limit * 10):
-        try:
-            limiter.limit(lambda n: acc.append(n), i)
-        except RateLimitExceeded:
-            exceeded += 1
+    with mock.patch("ddtrace.internal.rate_limiter.time.monotonic", return_value=limiter.last_time):
+        for i in range(rate_limit * 10):
+            try:
+                limiter.limit(lambda n: acc.append(n), i)
+            except RateLimitExceeded:
+                exceeded += 1
 
-    # With tau = 1 / rate_limit we have an initial budget of 1 and therefore we
-    # expect a single call in a tight loop.
     assert acc == [0]
 
 
 @pytest.mark.parametrize("rate_limit", list(range(10)))
 def test_rate_limiter_with_jitter_expected_calls_decorator(rate_limit):
     acc = []
+    limiter = BudgetRateLimiterWithJitter(limit_rate=rate_limit)
 
-    @BudgetRateLimiterWithJitter(limit_rate=rate_limit)
+    @limiter
     def appender(n):
         acc.append(n)
 
     exceeded = 0
-    for i in range(rate_limit * 10):
-        try:
-            appender(i)
-        except RateLimitExceeded:
-            exceeded += 1
+    with mock.patch("ddtrace.internal.rate_limiter.time.monotonic", return_value=limiter.last_time):
+        for i in range(rate_limit * 10):
+            try:
+                appender(i)
+            except RateLimitExceeded:
+                exceeded += 1
 
     assert not set(range(rate_limit)) < set(acc)
     assert len(acc) == rate_limit


### PR DESCRIPTION
## Description

[Timing report](https://chonk.us1.prod.dog/v2/get/chonk-uploads-prod/brian.marks/36dadb5e-3608-4fa4-9381-5a53a4d72be1) (AppGate required)

The initial-budget assertions for `BudgetRateLimiterWithJitter` used live monotonic time. A scheduler pause could replenish the budget while their call loops were still running, so the tests could admit an extra call even though the limiter behaved correctly.

Freeze monotonic reads at each limiter's initial timestamp while testing the initial budget. The decorator test now keeps a reference to its limiter so it uses the same clock control. Production code is unchanged.

## Testing

- `scripts/run-tests -s --venv 1abb88b -- -q tests/tracer/test_rate_limiter.py` (Python 3.14.5; 71 passed)
- `scripts/run-tests --venv 169be99 -- -q tests/tracer/test_rate_limiter.py` (Python 3.9.25; 71 passed)
- Forced a 200 ms pause after initial-budget exhaustion against both direct and decorator paths: 10/10 runs failed before the clock freeze and 10/10 passed after it.
- `scripts/lint checks`

## Risks

Low. The change only controls time in tests. It does not change production rate-limiter behavior.

## Additional Notes

No release note is needed for this test-only change. The timing assumption originated in [#3642](https://github.com/DataDog/dd-trace-py/pull/3642).
