### PR TITLE
test(appsec): shard appsec_integrations_stripe to stop nightly job timeouts

### DIFF
--- a/tests/appsec/suitespec.yml
+++ b/tests/appsec/suitespec.yml
@@ -231,6 +231,7 @@ suites:
         - name: appsec_integrations_packages
           dependencies: [gevent, pytest-xdist, pytest-asyncio, requests, SQLAlchemy, 'psycopg2-binary~=2.9.9', psycopg, pymysql, 'mysqlclient==2.1.1', mysql-connector-python, 'MarkupSafe~=2.1.1', 'Werkzeug~=3.0.6', babel]
   appsec_integrations_stripe:
+    venvs_per_job: 1
     paths:
       - '@bootstrap'
       - '@core'


### PR DESCRIPTION
## Description

Jira: [APPSEC-70116](https://datadoghq.atlassian.net/browse/APPSEC-70116)

The `appsec/appsec_integrations_stripe` job has failed with a 20-minute platform timeout on **every** nightly scheduled pipeline on `main` since 2026-09-08, including both `retry: 2` attempts. It reads as a flaky Stripe test, but it is neither flaky nor Stripe's fault — the job lost its parallelism and now runs all 24 test environments sequentially inside a single 20-minute job.

**The failures are deterministic, not random.** Every timeout falls inside one ~40-minute window each morning, which is the nightly pipeline plus its two retries 20 minutes apart. Every other run of the same suite on the same day passes in ~650–790s.

| Date | Timeout times (UTC) | Duration | Other runs that day |
| --- | --- | --- | --- |
| 09-08 | 05:39, 05:59, 06:19 | 1201–1202s | ~650–790s ✅ |
| 09-09 | 05:39, 05:59, 06:19 | 1202s | ~650–790s ✅ |
| 09-10 | 05:39, 06:00, 06:20 | 1202s | ~650–790s ✅ |
| 09-11 | 05:41, 06:01, 06:22 | 1212s | ~650–790s ✅ |

One nightly run passed at 1178s, 34 seconds under the cap — hence the flaky appearance. All three attempts do identical over-budget work, so retries cannot help.

### Root cause

1. The suite has **24 test environments**: 4 stripe variants (`latest`, `~=11.0`, `~=12.0`, `~=13.0`) × Python 3.9–3.14.
2. In `tests/appsec/suitespec.yml` it declared neither `venvs_per_job` nor `parallelism` — the only appsec suite out of 28 in that state.
3. So `scripts/gen_gitlab_config.py:683` leaves `jobspec.parallelism = None`, with the comment *"leave as None (GitLab default: single job)"*.
4. **That comment used to be wrong in a helpful way.** The job extended `.test_base_riot`, which sets `parallel: 4` (`.gitlab/tests.yml:21`), so emitting no `parallel:` key meant *inheriting* 4, and `ci-split-input.sh` split the 24 riot hashes four ways. Those are the historical `appsec_integrations_stripe 1/4 … 4/4` jobs at ~330–412s each.
5. #20063 ("chore(tests): run security suites with uv") added a `matrix:` block to this suite. That block auto-enrolls a suite into uv, because `tests/suitespec.py:82` defines `UV_TEST_SUITES` as every suite whose config contains a `matrix` key.
6. The job now extends `.test_base_uv`, which has **no `parallel:`**. With `shard_count = self.parallelism or 1` (`gen_gitlab_config.py:172`), all 24 environment hashes are packed into `TEST_ENVIRONMENTS_1` and run in one sequential loop.
7. One job doing 24 environments takes ~11–13 min, which fits inside `.testrunner`'s default `timeout: 20m`. On nightly, `NIGHTLY_BUILD=true` adds `DD_CIVISIBILITY_CODE_COVERAGE_REPORT_UPLOAD_ENABLED=1` (`riotfile.py:123`) — confirmed by diffing the generated environments, it is the *only* nightly delta for this suite. Per-test coverage collection and upload roughly doubles runtime, pushing the job to ~20 min.

The first timeout was the first nightly pipeline after #20063 landed.

### Fix

Declare `venvs_per_job: 1`, which is what all 27 sibling appsec suites already do. This makes the suite scalable in the generator and yields a baseline `parallel: 24`, so each job runs a single environment in ~3–4 min including setup — large headroom even under nightly coverage — and the suite cannot silently regress to one job again.

## Testing

- `scripts/lint suitespec-check` passes (all files covered, all patterns matching).
- Verified the resulting parallelism from the generator's own logic: `venvs=24 venvs_per_job=1 -> baseline parallelism = 24`.
- Confirmed via `get_test_environments(nightly=True/False)` that the only nightly env delta for this suite is `DD_CIVISIBILITY_CODE_COVERAGE_REPORT_UPLOAD_ENABLED=1`.
- No dependency or command changes, so the `test_suitespec_matches_riot` parity gate is unaffected.
- The real verification is CI itself: this job should appear as `appsec_integrations_stripe 1/24 … 24/24`.

## Risks

Low. Test-orchestration config only — no library or test code changes. It increases the job count for this suite from 1 to 24 short jobs; the generator's `TARGET_JOBS` scaler handles packing, and this matches every sibling appsec suite.

## Additional Notes

No release note: test/CI-infrastructure change only, so `changelog/no-changelog` applies.

Two follow-ups deliberately **not** in this PR, both documented in APPSEC-70116:

1. **The latent trap remains.** `gen_gitlab_config.py:683` is only correct for uv jobs; for riot jobs `parallelism = None` silently means 4. Any suite that gains a `matrix:` block without `venvs_per_job` will quietly drop from 4 shards to 1. Suites currently exposed:

   | Environments | Suite |
   | --- | --- |
   | 24 | `appsec::appsec_integrations_stripe` (fixed here) |
   | 11 | `contrib::mysqlpython` |
   | 7 | `smoke_test` |
   | 6 | `runtime` |
   | 1 | `wait` |

   `contrib::mysqlpython` is the next most exposed. Giving `.test_base_uv` a `parallel:` default, or having the generator emit an explicit `parallel: 1`, would close the whole class of bug.

2. **Unrelated pre-existing bug** in `tests/appsec/integrations/stripe_tests/test_stripe.py:24`: versions are compared as strings, `(major, minor) >= ("12", "5")`, so a single-digit stripe major such as 9.x evaluates `"9" >= "12"` as true and selects the wrong client path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[APPSEC-70116]: https://datadoghq.atlassian.net/browse/APPSEC-70116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ