### PR TITLE
test(pymongo): isolate async patch phases

### DIFF
--- a/tests/contrib/pymongo/test_async.py
+++ b/tests/contrib/pymongo/test_async.py
@@ -205,35 +205,3 @@ class TestAsyncPymongo(AsyncioTestCase):
         finally:
             await client.close()
             await asyncio.sleep(0.1)
-
-    @mark_asyncio
-    async def test_async_patch_unpatch(self):
-        patch()
-        patch()
-
-        # Close each async client before switching patch state so late background work cannot leak spans.
-        client = AsyncMongoClient(port=MONGO_CONFIG["port"])
-        try:
-            await client["testdb"].drop_collection("test")
-        finally:
-            await client.close()
-            await asyncio.sleep(0.1)
-        assert len(self.pop_spans()) >= 1
-
-        unpatch()
-        client2 = AsyncMongoClient(port=MONGO_CONFIG["port"])
-        try:
-            await client2["testdb"].drop_collection("test")
-        finally:
-            await client2.close()
-            await asyncio.sleep(0.1)
-        assert len(self.pop_spans()) == 0
-
-        patch()
-        client3 = AsyncMongoClient(port=MONGO_CONFIG["port"])
-        try:
-            await client3["testdb"].drop_collection("test")
-        finally:
-            await client3.close()
-            await asyncio.sleep(0.1)
-        assert len(self.pop_spans()) >= 1

--- a/tests/contrib/pymongo/test_async.py
+++ b/tests/contrib/pymongo/test_async.py
@@ -211,28 +211,29 @@ class TestAsyncPymongo(AsyncioTestCase):
         patch()
         patch()
 
+        # Close each async client before switching patch state so late background work cannot leak spans.
         client = AsyncMongoClient(port=MONGO_CONFIG["port"])
         try:
             await client["testdb"].drop_collection("test")
-            assert len(self.pop_spans()) >= 1
-
-            unpatch()
-            client2 = AsyncMongoClient(port=MONGO_CONFIG["port"])
-            try:
-                await client2["testdb"].drop_collection("test")
-                assert len(self.pop_spans()) == 0
-            finally:
-                await client2.close()
-                await asyncio.sleep(0.1)
-
-            patch()
-            client3 = AsyncMongoClient(port=MONGO_CONFIG["port"])
-            try:
-                await client3["testdb"].drop_collection("test")
-                assert len(self.pop_spans()) >= 1
-            finally:
-                await client3.close()
-                await asyncio.sleep(0.1)
         finally:
             await client.close()
             await asyncio.sleep(0.1)
+        assert len(self.pop_spans()) >= 1
+
+        unpatch()
+        client2 = AsyncMongoClient(port=MONGO_CONFIG["port"])
+        try:
+            await client2["testdb"].drop_collection("test")
+        finally:
+            await client2.close()
+            await asyncio.sleep(0.1)
+        assert len(self.pop_spans()) == 0
+
+        patch()
+        client3 = AsyncMongoClient(port=MONGO_CONFIG["port"])
+        try:
+            await client3["testdb"].drop_collection("test")
+        finally:
+            await client3.close()
+            await asyncio.sleep(0.1)
+        assert len(self.pop_spans()) >= 1


### PR DESCRIPTION
## Description

The async pymongo patch/unpatch test intermittently observes an instrumented command span during its unpatched phase. Async clients can finish background work after an operation returns, and the test kept its first instrumented client alive while changing global patch state, allowing late spans to cross phase boundaries.

