### PR TITLE
ci: only combine coverage when multiple data files exist

### DIFF
--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -369,7 +369,7 @@ include:
       # Keep CI Visibility session names tied to the CI job and test command;
       # ddtest expands these placeholders for each local worker.
       "${riot_cmd[@]}" --command \
-        'export PYTEST_ADDOPTS="$DDTEST_PYTEST_ADDOPTS"; export DD_TEST_SESSION_NAME="${{CI_JOB_NAME}}-pytest ${{DDTEST_SUITE_PATH}} ${{DDTEST_PYTEST_ADDOPTS}} node-{{{{nodeIndex}}}}-worker-{{{{workerIndex}}}}"; case "$NIGHTLY_BUILD" in true) ;; *) case "$PYTEST_ADDOPTS" in *--no-cov*) ;; *) export PYTEST_ADDOPTS="$PYTEST_ADDOPTS --no-cov" ;; esac ;; esac; export COVERAGE_FILE="$COVERAGE_FILE"; ddtest run --platform python --framework pytest --ci-node "$CI_NODE_INDEX" --ci-node-workers 4; coverage_files=(.coverage.*); if [[ -e "${{coverage_files[0]}}" ]]; then coverage combine; fi' \
+        'export PYTEST_ADDOPTS="$DDTEST_PYTEST_ADDOPTS"; export DD_TEST_SESSION_NAME="${{CI_JOB_NAME}}-pytest ${{DDTEST_SUITE_PATH}} ${{DDTEST_PYTEST_ADDOPTS}} node-{{{{nodeIndex}}}}-worker-{{{{workerIndex}}}}"; case "$NIGHTLY_BUILD" in true) ;; *) case "$PYTEST_ADDOPTS" in *--no-cov*) ;; *) export PYTEST_ADDOPTS="$PYTEST_ADDOPTS --no-cov" ;; esac ;; esac; export COVERAGE_FILE="$COVERAGE_FILE"; ddtest run --platform python --framework pytest --ci-node "$CI_NODE_INDEX" --ci-node-workers 4; coverage_files=(.coverage.*); if [[ ${#coverage_files[@]} -gt 1 ]]; then coverage combine; fi' \
         "${TEST_ENVIRONMENT_HASH}"
 
 .ddtest_run_snapshot:
@@ -384,7 +384,7 @@ include:
       # is session-token-keyed, and parallel xdist workers cause cross-session
       # contamination (wrong stats, '400: list index out of range').
       "${riot_cmd[@]}" --command \
-        'export PYTEST_ADDOPTS="$DDTEST_PYTEST_ADDOPTS"; export DD_TEST_SESSION_NAME="${{CI_JOB_NAME}}-pytest ${{DDTEST_SUITE_PATH}} ${{DDTEST_PYTEST_ADDOPTS}} node-{{{{nodeIndex}}}}-worker-{{{{workerIndex}}}}"; case "$NIGHTLY_BUILD" in true) ;; *) case "$PYTEST_ADDOPTS" in *--no-cov*) ;; *) export PYTEST_ADDOPTS="$PYTEST_ADDOPTS --no-cov" ;; esac ;; esac; export COVERAGE_FILE="$COVERAGE_FILE"; export DD_TRACE_AGENT_URL="http://testagent:9126"; ddtest run --platform python --framework pytest --ci-node "$CI_NODE_INDEX" --ci-node-workers 1; coverage_files=(.coverage.*); if [[ -e "${{coverage_files[0]}}" ]]; then coverage combine; fi' \
+        'export PYTEST_ADDOPTS="$DDTEST_PYTEST_ADDOPTS"; export DD_TEST_SESSION_NAME="${{CI_JOB_NAME}}-pytest ${{DDTEST_SUITE_PATH}} ${{DDTEST_PYTEST_ADDOPTS}} node-{{{{nodeIndex}}}}-worker-{{{{workerIndex}}}}"; case "$NIGHTLY_BUILD" in true) ;; *) case "$PYTEST_ADDOPTS" in *--no-cov*) ;; *) export PYTEST_ADDOPTS="$PYTEST_ADDOPTS --no-cov" ;; esac ;; esac; export COVERAGE_FILE="$COVERAGE_FILE"; export DD_TRACE_AGENT_URL="http://testagent:9126"; ddtest run --platform python --framework pytest --ci-node "$CI_NODE_INDEX" --ci-node-workers 1; coverage_files=(.coverage.*); if [[ ${#coverage_files[@]} -gt 1 ]]; then coverage combine; fi' \
         "${TEST_ENVIRONMENT_HASH}"
 
 # Required jobs will appear here

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -369,7 +369,7 @@ include:
       # Keep CI Visibility session names tied to the CI job and test command;
       # ddtest expands these placeholders for each local worker.
       "${riot_cmd[@]}" --command \
-        'export PYTEST_ADDOPTS="$DDTEST_PYTEST_ADDOPTS"; export DD_TEST_SESSION_NAME="${{CI_JOB_NAME}}-pytest ${{DDTEST_SUITE_PATH}} ${{DDTEST_PYTEST_ADDOPTS}} node-{{{{nodeIndex}}}}-worker-{{{{workerIndex}}}}"; case "$NIGHTLY_BUILD" in true) ;; *) case "$PYTEST_ADDOPTS" in *--no-cov*) ;; *) export PYTEST_ADDOPTS="$PYTEST_ADDOPTS --no-cov" ;; esac ;; esac; export COVERAGE_FILE="$COVERAGE_FILE"; ddtest run --platform python --framework pytest --ci-node "$CI_NODE_INDEX" --ci-node-workers 4; coverage_files=(.coverage.*); if [[ ${#coverage_files[@]} -gt 1 ]]; then coverage combine; fi' \
+        'export PYTEST_ADDOPTS="$DDTEST_PYTEST_ADDOPTS"; export DD_TEST_SESSION_NAME="${{CI_JOB_NAME}}-pytest ${{DDTEST_SUITE_PATH}} ${{DDTEST_PYTEST_ADDOPTS}} node-{{{{nodeIndex}}}}-worker-{{{{workerIndex}}}}"; case "$NIGHTLY_BUILD" in true) ;; *) case "$PYTEST_ADDOPTS" in *--no-cov*) ;; *) export PYTEST_ADDOPTS="$PYTEST_ADDOPTS --no-cov" ;; esac ;; esac; export COVERAGE_FILE="$COVERAGE_FILE"; ddtest run --platform python --framework pytest --ci-node "$CI_NODE_INDEX" --ci-node-workers 4; coverage_files=(.coverage.*); if [[ ${{#coverage_files[@]}} -gt 1 ]]; then coverage combine; fi' \
         "${TEST_ENVIRONMENT_HASH}"
 
 .ddtest_run_snapshot:
@@ -384,7 +384,7 @@ include:
       # is session-token-keyed, and parallel xdist workers cause cross-session
       # contamination (wrong stats, '400: list index out of range').
       "${riot_cmd[@]}" --command \
-        'export PYTEST_ADDOPTS="$DDTEST_PYTEST_ADDOPTS"; export DD_TEST_SESSION_NAME="${{CI_JOB_NAME}}-pytest ${{DDTEST_SUITE_PATH}} ${{DDTEST_PYTEST_ADDOPTS}} node-{{{{nodeIndex}}}}-worker-{{{{workerIndex}}}}"; case "$NIGHTLY_BUILD" in true) ;; *) case "$PYTEST_ADDOPTS" in *--no-cov*) ;; *) export PYTEST_ADDOPTS="$PYTEST_ADDOPTS --no-cov" ;; esac ;; esac; export COVERAGE_FILE="$COVERAGE_FILE"; export DD_TRACE_AGENT_URL="http://testagent:9126"; ddtest run --platform python --framework pytest --ci-node "$CI_NODE_INDEX" --ci-node-workers 1; coverage_files=(.coverage.*); if [[ ${#coverage_files[@]} -gt 1 ]]; then coverage combine; fi' \
+        'export PYTEST_ADDOPTS="$DDTEST_PYTEST_ADDOPTS"; export DD_TEST_SESSION_NAME="${{CI_JOB_NAME}}-pytest ${{DDTEST_SUITE_PATH}} ${{DDTEST_PYTEST_ADDOPTS}} node-{{{{nodeIndex}}}}-worker-{{{{workerIndex}}}}"; case "$NIGHTLY_BUILD" in true) ;; *) case "$PYTEST_ADDOPTS" in *--no-cov*) ;; *) export PYTEST_ADDOPTS="$PYTEST_ADDOPTS --no-cov" ;; esac ;; esac; export COVERAGE_FILE="$COVERAGE_FILE"; export DD_TRACE_AGENT_URL="http://testagent:9126"; ddtest run --platform python --framework pytest --ci-node "$CI_NODE_INDEX" --ci-node-workers 1; coverage_files=(.coverage.*); if [[ ${{#coverage_files[@]}} -gt 1 ]]; then coverage combine; fi' \
         "${TEST_ENVIRONMENT_HASH}"
 
 # Required jobs will appear here


### PR DESCRIPTION


## Description

Single-worker ddtest jobs (e.g. snapshot suites with --ci-node-workers 1) write coverage directly to ${COVERAGE_FILE} with no xdist shard suffix. The post-test guard matched any `.coverage.*` file and ran `coverage combine` whenever one existed, but `coverage combine` (no args) globs ${COVERAGE_FILE}.* for shards and raises NoDataError when none are found, exiting 1. That non-zero code propagated through the riot command string and failed the job even though pytest passed.

Only run `coverage combine` when there is more than one coverage data file, i.e. the multi-worker/shard case. This is generic across .ddtest_run, .ddtest_run_snapshot, and any future template regardless of worker count.