### PR TITLE
ci(windows): isolate `cargo build` artifacts

### DIFF
--- a/.gitlab/package.yml
+++ b/.gitlab/package.yml
@@ -353,6 +353,9 @@ variables:
         WINDOWS_ARCH: ["amd64", "x86"]
   variables:
     WINDOWS_BUILD_IMAGE: "registry.ddbuild.io/images/mirror/dd-trace-py/windows-build:d4d18a67d43d400d3ecc6bda777a5e233a24f434@sha256:58c3e28646ddf8a1021a079a380c8840e51f0b88c1489a522beee6ec99413019"
+    # Legacy Windows builds left loaded Rust proc-macro DLLs here, which makes
+    # the runner's pre-job git clean fail before the build script can execute.
+    GIT_CLEAN_FLAGS: "-ffdx -e src/native/target*/"
   script:
     - bash .gitlab/scripts/build-wheel-windows.sh
   artifacts:

--- a/.gitlab/scripts/windows-docker-build.ps1
+++ b/.gitlab/scripts/windows-docker-build.ps1
@@ -34,6 +34,11 @@ foreach ($line in $cmdOut) {
 $env:DISTUTILS_USE_SDK = '1'
 $env:MSSdk = '1'
 
+# Keep Rust proc-macro DLLs in the disposable container filesystem. When these
+# are built in the mounted checkout, Windows can retain a lock after the build
+# and prevent GitLab Runner from cleaning the workspace for the next job.
+$env:_DD_NATIVE_CARGO_TARGET_DIR = 'C:\cargo-target'
+
 # rust-tuf has too long paths
 Write-Host "=== Enabling git long paths ==="
 git config --global core.longpaths true

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,14 @@ IAST_DIR = DDTRACE_DIR / "appsec" / "_iast" / "_taint_tracking"
 DDUP_DIR = DDTRACE_DIR / "internal" / "datadog" / "profiling" / "ddup"
 STACK_DIR = DDTRACE_DIR / "internal" / "datadog" / "profiling" / "stack"
 VENDOR_DIR = DDTRACE_DIR / "vendor"
-CARGO_TARGET_DIR = NATIVE_CRATE.absolute() / f"target{sys.version_info.major}.{sys.version_info.minor}"
+# Windows CI overrides this to keep lock-prone Rust DLLs out of the
+# Git checkout.
+CARGO_TARGET_DIR = Path(
+    os.getenv(
+        "_DD_NATIVE_CARGO_TARGET_DIR",
+        NATIVE_CRATE.absolute() / f"target{sys.version_info.major}.{sys.version_info.minor}",
+    )
+).absolute()
 DD_CARGO_ARGS = shlex.split(os.getenv("DD_CARGO_ARGS", ""))
 
 # TODO(py-315): locked pyo3 is 0.28.3 (ABI3_MAX_MINOR = 14). Native 3.15


### PR DESCRIPTION
## Description

On Windows CI, Rust proc-macro DLLs are built inside the git checkout (under `src/native/target<major>.<minor>/`). After a build job finishes, Windows keeps file locks on those DLLs. When GitLab Runner tries to clean the workspace with `git clean` before the next job, the locked files cause the clean to fail -- so the next job never starts correctly.

This PR makes the following changes:
- Build Windows Rust artifacts under `C:\cargo-target` (inside the disposable build container rather than the mounted Git checkout)
- Allow `setup.py` native build consumers to share a private Cargo target override
- Exclude legacy `src/native/target*` directories from the Windows job's pre-job cleanup so runners that already contain locked DLLs can fetch and execute this fix.

