### PR TITLE
ci: isolate windows rust build outputs

### DIFF
--- a/.gitlab/scripts/build-wheel-windows.sh
+++ b/.gitlab/scripts/build-wheel-windows.sh
@@ -35,8 +35,12 @@ section_end "docker_pull"
 section_start "build_wheel" "Building wheel (${UV_PYTHON}, ${WINDOWS_ARCH})"
 rm -rf "${PROJECT_DIR}/dist"
 
+# AIDEV-NOTE: Keep Rust build outputs off the bind-mounted checkout. Windows can
+# retain handles to proc-macro DLLs after the container exits, causing the next
+# GitLab checkout's git clean to fail before the job script starts.
 docker run --rm \
   -v "${PROJECT_DIR_WIN}:C:\\workspace" \
+  -v "C:\\workspace\\src\\native\\target${PYTHON_VERSION}" \
   -e "UV_PYTHON=${UV_PYTHON}" \
   -e "UV_PYTHON_INSTALL_DIR=C:\\tools\\uv-python" \
   -w 'C:\workspace' \


### PR DESCRIPTION
<!-- dd-meta {"pullId":"f9e34f6d-ec30-43b3-9920-d16b7fec9b2e","source":"chat","resourceId":"2e7b9c85-b754-4d58-a0cc-072f4d7a1de6","workflowId":"edab37ad-86fc-4b3a-83c1-ee491a1c2852","codeChangeId":"edab37ad-86fc-4b3a-83c1-ee491a1c2852","sourceType":"scheduled_task"} -->
## Description

Windows wheel jobs persist Rust target directories in the runner checkout. Windows can retain handles to proc-macro DLLs after the build container exits, causing a later GitLab checkout to fail during `git clean` before its job script starts. CI Visibility recorded at least 12 supported-version main-branch failures with this explicit DLL cleanup signature over the last 90 days, including three variants in the latest affected pipeline.

## Changes

- Mount the Python-version-specific Rust target path as an anonymous Docker volume during Windows wheel builds.
- Keep generated Rust DLLs outside the bind-mounted repository checkout while preserving the existing source and wheel output mounts.

## Testing

- `scripts/run-tests --venv d7f4942` passed the Python 3.14 smoke suite, including native, IAST, WAF, OpenTelemetry context, and profiling load checks.
- `scripts/lint checks` passed all repository checks.
- The Windows container mount behavior requires GitLab's Windows runner and will be exercised by the PR pipeline.

## Risks

Low. The anonymous volume is scoped to each build container and removed with `docker run --rm`. Wheel artifacts continue to be written to the bind-mounted `dist` directory. A Windows-only path or mount interaction would fail the existing build matrix without affecting released library behavior.

## Additional Notes

No release note is needed because this change only affects CI infrastructure. Apply the `changelog/no-changelog` label.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/2e7b9c85-b754-4d58-a0cc-072f4d7a1de6)

Comment @datadog to request changes