### PR TITLE
fix(aiguard): classify AI Guard evaluation failures in error telemetry

### DIFF
--- a/ddtrace/aiguard/_api_client.py
+++ b/ddtrace/aiguard/_api_client.py
@@ -134,6 +134,24 @@ def _classify_transport_error(exc: BaseException) -> str:
     return AI_GUARD.ERROR_CLIENT if isinstance(exc, HttpClientError) else AI_GUARD.ERROR_INTERNAL
 
 
+def _loggable_endpoint(url: str) -> str:
+    """The endpoint with any credentials stripped, for debug logs.
+
+    An endpoint override can carry userinfo or a query credential, and these logs are exactly what
+    customers are asked to share during an investigation, so keep only scheme, host, port and path.
+    """
+    try:
+        parsed = urlparse(url)
+        host = parsed.hostname or ""
+        if parsed.port:
+            host = f"{host}:{parsed.port}"
+        if not host:
+            return "<unparseable>"
+        return f"{parsed.scheme}://{host}{parsed.path}" if parsed.scheme else f"{host}{parsed.path}"
+    except Exception:
+        return "<unparseable>"
+
+
 def _status_tag(status: Optional[int]) -> str:
     """Clamp a response status to the declared allowlist, keeping the tag bounded."""
     return str(status) if status in AI_GUARD.STATUSES else AI_GUARD.STATUS_OTHER
@@ -166,7 +184,8 @@ class AIGuardClient:
 
         # Logged once so a single debug capture answers which host was contacted and with which
         # timeout, without asking for a reproduction.
-        logger.debug("AI Guard client ready: endpoint=%s timeout=%ss", self._endpoint, self._timeout)
+        self._loggable_endpoint = _loggable_endpoint(endpoint)
+        logger.debug("AI Guard client ready: endpoint=%s timeout=%ss", self._loggable_endpoint, self._timeout)
 
     @staticmethod
     def _call_path_tags(source: str, integration: str) -> tuple[tuple[str, str], ...]:
@@ -317,9 +336,11 @@ class AIGuardClient:
 
         from ddtrace.trace import tracer
 
-        # Classifies the error metric when a raise below escapes. Transport failures and
-        # unexpected internal errors keep the default; response-driven raises narrow it.
-        error_type: str = AI_GUARD.ERROR_CLIENT
+        # Classifies the error metric when a raise below escapes. Transport and response paths
+        # each set their own type, so anything still holding the default failed inside our own
+        # code, which is what internal_error means; client_error is reserved for a transport
+        # failure the native client reports but we do not recognise.
+        error_type: str = AI_GUARD.ERROR_INTERNAL
         error_status: Optional[int] = None
         call_path_tags = self._call_path_tags(source, integration)
 
@@ -488,7 +509,7 @@ class AIGuardClient:
                     "AI Guard evaluation failed (%s) for %d messages via %s",
                     error_type,
                     len(messages),
-                    self._endpoint,
+                    self._loggable_endpoint,
                     exc_info=True,
                 )
                 raise

--- a/ddtrace/aiguard/_api_client.py
+++ b/ddtrace/aiguard/_api_client.py
@@ -117,7 +117,7 @@ _TRANSPORT_ERROR_TYPES: tuple[tuple[type[BaseException], str], ...] = (
     (ConnectionFailedError, AI_GUARD.ERROR_CONNECTION),
     (TimedOutError, AI_GUARD.ERROR_TIMEOUT),
     (InvalidConfigError, AI_GUARD.ERROR_INVALID_CONFIG),
-    (HttpIoError, AI_GUARD.ERROR_IO),
+    (HttpIoError, AI_GUARD.ERROR_NETWORK),
 )
 
 
@@ -164,17 +164,9 @@ class AIGuardClient:
 
         self._timeout = aiguard_config._ai_guard_timeout // 1000
 
-        self._endpoint_tag = (
-            AI_GUARD.ENDPOINT_CUSTOM if aiguard_config._ai_guard_endpoint else AI_GUARD.ENDPOINT_DEFAULT
-        )
-        # Logged once so a single debug capture answers which host was contacted, with which
-        # timeout, and whether the endpoint was overridden, without asking for a reproduction.
-        logger.debug(
-            "AI Guard client ready: endpoint=%s (%s) timeout=%ss",
-            self._endpoint,
-            self._endpoint_tag,
-            self._timeout,
-        )
+        # Logged once so a single debug capture answers which host was contacted and with which
+        # timeout, without asking for a reproduction.
+        logger.debug("AI Guard client ready: endpoint=%s timeout=%ss", self._endpoint, self._timeout)
 
     @staticmethod
     def _call_path_tags(source: str, integration: str) -> tuple[tuple[str, str], ...]:
@@ -483,11 +475,11 @@ class AIGuardClient:
 
             except Exception:
                 self._add_request_to_telemetry((("error", "true"),) + call_path_tags)
-                error_tags = call_path_tags + (("endpoint", self._endpoint_tag),)
+                error_tags = call_path_tags
                 # Only bad_status has a status to report, and an absent tag stays distinguishable
                 # from a status we deliberately clamped away.
                 if error_status is not None:
-                    error_tags += (("status", _status_tag(error_status)),)
+                    error_tags += (("http_status", _status_tag(error_status)),)
                 self._add_error_to_telemetry(error_type, error_tags)
                 # Log the classification and target, but only the size of the conversation: the
                 # messages may carry sensitive data that redaction would have removed, and this

--- a/ddtrace/aiguard/_api_client.py
+++ b/ddtrace/aiguard/_api_client.py
@@ -24,6 +24,11 @@ from ddtrace.internal import telemetry
 from ddtrace.internal._exceptions import DDBlockException
 from ddtrace.internal.http import HTTPConnection
 import ddtrace.internal.logger as ddlogger
+from ddtrace.internal.native import ConnectionFailedError
+from ddtrace.internal.native import HttpClientError
+from ddtrace.internal.native import HttpIoError
+from ddtrace.internal.native import InvalidConfigError
+from ddtrace.internal.native import TimedOutError
 from ddtrace.internal.settings.aiguard import aiguard_config
 from ddtrace.internal.telemetry import TELEMETRY_NAMESPACE
 from ddtrace.internal.telemetry.constants import MetricTagType
@@ -106,6 +111,34 @@ class AIGuardAbortError(DDBlockException):
         super().__init__(f"AIGuardAbortError(action='{action}', reason='{reason}', tags='{tags}')")
 
 
+# Transport failures the native HTTP client distinguishes. Ordered most specific first so a
+# subclass is never shadowed by its base.
+_TRANSPORT_ERROR_TYPES: tuple[tuple[type[BaseException], str], ...] = (
+    (ConnectionFailedError, AI_GUARD.ERROR_CONNECTION),
+    (TimedOutError, AI_GUARD.ERROR_TIMEOUT),
+    (InvalidConfigError, AI_GUARD.ERROR_INVALID_CONFIG),
+    (HttpIoError, AI_GUARD.ERROR_IO),
+)
+
+
+def _classify_transport_error(exc: BaseException) -> str:
+    """Map a failure from the evaluate request onto an error metric type.
+
+    Splitting these apart is what separates "never reached the service" from "reached it and was
+    rejected"; client_error remains the catch-all for an unrecognised transport failure, and
+    anything that is not a transport failure at all is reported as an internal error.
+    """
+    for error_cls, error_type in _TRANSPORT_ERROR_TYPES:
+        if isinstance(exc, error_cls):
+            return error_type
+    return AI_GUARD.ERROR_CLIENT if isinstance(exc, HttpClientError) else AI_GUARD.ERROR_INTERNAL
+
+
+def _status_tag(status: Optional[int]) -> str:
+    """Clamp a response status to the declared allowlist, keeping the tag bounded."""
+    return str(status) if status in AI_GUARD.STATUSES else AI_GUARD.STATUS_OTHER
+
+
 class AIGuardClient:
     """HTTP client for communicating with AI Guard security service."""
 
@@ -131,6 +164,18 @@ class AIGuardClient:
 
         self._timeout = aiguard_config._ai_guard_timeout // 1000
 
+        self._endpoint_tag = (
+            AI_GUARD.ENDPOINT_CUSTOM if aiguard_config._ai_guard_endpoint else AI_GUARD.ENDPOINT_DEFAULT
+        )
+        # Logged once so a single debug capture answers which host was contacted, with which
+        # timeout, and whether the endpoint was overridden, without asking for a reproduction.
+        logger.debug(
+            "AI Guard client ready: endpoint=%s (%s) timeout=%ss",
+            self._endpoint,
+            self._endpoint_tag,
+            self._timeout,
+        )
+
     @staticmethod
     def _call_path_tags(source: str, integration: str) -> tuple[tuple[str, str], ...]:
         """Tags identifying the call path that reached the evaluation, required on every metric.
@@ -149,9 +194,9 @@ class AIGuardClient:
         telemetry.telemetry_writer.add_count_metric(TELEMETRY_NAMESPACE.AI_GUARD, AI_GUARD.REQUESTS_METRIC, 1, tags)
 
     @staticmethod
-    def _add_error_to_telemetry(error_type: str, call_path_tags: tuple[tuple[str, str], ...], count: int = 1) -> None:
+    def _add_error_to_telemetry(error_type: str, tags: tuple[tuple[str, str], ...], count: int = 1) -> None:
         telemetry.telemetry_writer.add_count_metric(
-            TELEMETRY_NAMESPACE.AI_GUARD, AI_GUARD.ERROR_METRIC, count, (("type", error_type),) + call_path_tags
+            TELEMETRY_NAMESPACE.AI_GUARD, AI_GUARD.ERROR_METRIC, count, (("type", error_type),) + tags
         )
 
     @staticmethod
@@ -283,6 +328,7 @@ class AIGuardClient:
         # Classifies the error metric when a raise below escapes. Transport failures and
         # unexpected internal errors keep the default; response-driven raises narrow it.
         error_type: str = AI_GUARD.ERROR_CLIENT
+        error_status: Optional[int] = None
         call_path_tags = self._call_path_tags(source, integration)
 
         with tracer.trace(AI_GUARD.RESOURCE_TYPE) as span:
@@ -299,6 +345,7 @@ class AIGuardClient:
                 try:
                     response = self._execute_request(f"{self._endpoint}/evaluate", payload)
                 except Exception as e:
+                    error_type = _classify_transport_error(e)
                     raise AIGuardClientError(message=f"Unexpected error calling AI Guard service: {e}") from e
 
                 try:
@@ -306,7 +353,11 @@ class AIGuardClient:
                 except Exception as e:
                     # A body we cannot decode is a response problem, not a transport one, unless
                     # the status code already explains the failure.
-                    error_type = AI_GUARD.ERROR_BAD_RESPONSE if response.status == 200 else AI_GUARD.ERROR_BAD_STATUS
+                    if response.status == 200:
+                        error_type = AI_GUARD.ERROR_BAD_RESPONSE
+                    else:
+                        error_type = AI_GUARD.ERROR_BAD_STATUS
+                        error_status = response.status
                     raise AIGuardClientError(
                         message=f"AI Guard service returned an undecodable response body: {e}",
                         status=response.status,
@@ -369,6 +420,7 @@ class AIGuardClient:
                         meta_struct.update({"tag_probs": tag_probs})
                 else:
                     error_type = AI_GUARD.ERROR_BAD_STATUS
+                    error_status = response.status
                     raise AIGuardClientError(
                         message=f"AI Guard service call failed, status: {response.status}",
                         status=response.status,
@@ -431,10 +483,22 @@ class AIGuardClient:
 
             except Exception:
                 self._add_request_to_telemetry((("error", "true"),) + call_path_tags)
-                self._add_error_to_telemetry(error_type, call_path_tags)
-                # Log the size only: the messages may carry sensitive data that redaction would have
-                # removed, and this runs before any redaction decision is known.
-                logger.debug("AI Guard evaluation failed for %d messages", len(messages), exc_info=True)
+                error_tags = call_path_tags + (("endpoint", self._endpoint_tag),)
+                # Only bad_status has a status to report, and an absent tag stays distinguishable
+                # from a status we deliberately clamped away.
+                if error_status is not None:
+                    error_tags += (("status", _status_tag(error_status)),)
+                self._add_error_to_telemetry(error_type, error_tags)
+                # Log the classification and target, but only the size of the conversation: the
+                # messages may carry sensitive data that redaction would have removed, and this
+                # runs before any redaction decision is known.
+                logger.debug(
+                    "AI Guard evaluation failed (%s) for %d messages via %s",
+                    error_type,
+                    len(messages),
+                    self._endpoint,
+                    exc_info=True,
+                )
                 raise
 
     def _execute_request(self, url: str, payload: Any) -> Response:

--- a/ddtrace/aiguard/_api_client.py
+++ b/ddtrace/aiguard/_api_client.py
@@ -146,10 +146,10 @@ def _loggable_endpoint(url: str) -> str:
         if parsed.port:
             host = f"{host}:{parsed.port}"
         if not host:
-            return "<unparseable>"
+            return "<unparsable>"
         return f"{parsed.scheme}://{host}{parsed.path}" if parsed.scheme else f"{host}{parsed.path}"
     except Exception:
-        return "<unparseable>"
+        return "<unparsable>"
 
 
 def _status_tag(status: Optional[int]) -> str:

--- a/ddtrace/aiguard/_constants.py
+++ b/ddtrace/aiguard/_constants.py
@@ -54,20 +54,15 @@ class AI_GUARD(metaclass=Constant_Class):
     ERROR_CONNECTION: Literal["connection_failed"] = "connection_failed"
     ERROR_TIMEOUT: Literal["timeout"] = "timeout"
     ERROR_INVALID_CONFIG: Literal["invalid_config"] = "invalid_config"
-    ERROR_IO: Literal["io_error"] = "io_error"
+    ERROR_NETWORK: Literal["network_error"] = "network_error"
     # Anything raised inside our own code rather than by the transport. Kept separate so tracer
     # bugs do not inflate the transport buckets that customer-egress alerting reads.
     ERROR_INTERNAL: Literal["internal_error"] = "internal_error"
 
-    # Values of the "status" tag, set only on bad_status errors. Clamped to this allowlist so the
-    # tag cannot grow a new series per status a service ever returns.
+    # Values of the "http_status" tag, set only on bad_status errors. Clamped to this allowlist so
+    # the tag cannot grow a new series per status a service ever returns.
     STATUSES: tuple[int, ...] = (401, 403, 404, 408, 413, 429, 500, 502, 503, 504)
     STATUS_OTHER: Literal["other"] = "other"
-
-    # Values of the "endpoint" tag: whether DD_AI_GUARD_ENDPOINT overrode the default, so a
-    # misconfigured override shows up next to the failures it causes.
-    ENDPOINT_DEFAULT: Literal["default"] = "default"
-    ENDPOINT_CUSTOM: Literal["custom"] = "custom"
     # A replacement the service asked for could not be applied. Reported per affected path, and
     # never fails the evaluation, see the redaction errors addendum of the AI Guard redaction RFC.
     ERROR_REDACTION: Literal["redaction_error"] = "redaction_error"

--- a/ddtrace/aiguard/_constants.py
+++ b/ddtrace/aiguard/_constants.py
@@ -49,6 +49,25 @@ class AI_GUARD(metaclass=Constant_Class):
     ERROR_CLIENT: Literal["client_error"] = "client_error"
     ERROR_BAD_STATUS: Literal["bad_status"] = "bad_status"
     ERROR_BAD_RESPONSE: Literal["bad_response"] = "bad_response"
+    # Transport failures, split out of client_error so a customer-side network problem is
+    # distinguishable from a request that reached the service and was rejected.
+    ERROR_CONNECTION: Literal["connection_failed"] = "connection_failed"
+    ERROR_TIMEOUT: Literal["timeout"] = "timeout"
+    ERROR_INVALID_CONFIG: Literal["invalid_config"] = "invalid_config"
+    ERROR_IO: Literal["io_error"] = "io_error"
+    # Anything raised inside our own code rather than by the transport. Kept separate so tracer
+    # bugs do not inflate the transport buckets that customer-egress alerting reads.
+    ERROR_INTERNAL: Literal["internal_error"] = "internal_error"
+
+    # Values of the "status" tag, set only on bad_status errors. Clamped to this allowlist so the
+    # tag cannot grow a new series per status a service ever returns.
+    STATUSES: tuple[int, ...] = (401, 403, 404, 408, 413, 429, 500, 502, 503, 504)
+    STATUS_OTHER: Literal["other"] = "other"
+
+    # Values of the "endpoint" tag: whether DD_AI_GUARD_ENDPOINT overrode the default, so a
+    # misconfigured override shows up next to the failures it causes.
+    ENDPOINT_DEFAULT: Literal["default"] = "default"
+    ENDPOINT_CUSTOM: Literal["custom"] = "custom"
     # A replacement the service asked for could not be applied. Reported per affected path, and
     # never fails the evaluation, see the redaction errors addendum of the AI Guard redaction RFC.
     ERROR_REDACTION: Literal["redaction_error"] = "redaction_error"

--- a/releasenotes/notes/fix-aiguard-error-telemetry-classification-d85851552246f817.yaml
+++ b/releasenotes/notes/fix-aiguard-error-telemetry-classification-d85851552246f817.yaml
@@ -4,6 +4,6 @@ fixes:
     AI Guard: Fixes an issue where every failed evaluation reported the same ``client_error``
     telemetry type, making it impossible to tell a request that never reached Datadog from one
     that was rejected. The ``ai_guard.error`` metric now reports ``connection_failed``,
-    ``timeout``, ``invalid_config``, ``io_error`` and ``internal_error`` types, adds the response
-    status to ``bad_status`` errors, and records whether ``DD_AI_GUARD_ENDPOINT`` was overridden.
-    Debug logs now include the resolved endpoint and the failure classification.
+    ``timeout``, ``invalid_config``, ``network_error`` and ``internal_error`` types, and adds an
+    ``http_status`` tag to ``bad_status`` errors. Debug logs now include the resolved endpoint and
+    the failure classification.

--- a/releasenotes/notes/fix-aiguard-error-telemetry-classification-d85851552246f817.yaml
+++ b/releasenotes/notes/fix-aiguard-error-telemetry-classification-d85851552246f817.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    AI Guard: Fixes an issue where every failed evaluation reported the same ``client_error``
+    telemetry type, making it impossible to tell a request that never reached Datadog from one
+    that was rejected. The ``ai_guard.error`` metric now reports ``connection_failed``,
+    ``timeout``, ``invalid_config``, ``io_error`` and ``internal_error`` types, adds the response
+    status to ``bad_status`` errors, and records whether ``DD_AI_GUARD_ENDPOINT`` was overridden.
+    Debug logs now include the resolved endpoint and the failure classification.

--- a/tests/aiguard/api/test_api_client.py
+++ b/tests/aiguard/api/test_api_client.py
@@ -204,10 +204,7 @@ def test_evaluate_http_error(mock_execute_request, telemetry_mock, ai_guard_clie
     assert exc_info.value.errors == errors
     assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
     assert_telemetry(
-        telemetry_mock,
-        "error",
-        (("type", "bad_status"),),
-        extra=(("endpoint", AI_GUARD.ENDPOINT_CUSTOM), ("status", str(mock_response.status))),
+        telemetry_mock, "error", (("type", "bad_status"),), extra=(("http_status", str(mock_response.status)),)
     )
 
 
@@ -228,10 +225,7 @@ def test_evaluate_http_error_empty_json_body(mock_execute_request, telemetry_moc
     assert exc_info.value.errors == []
     assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
     assert_telemetry(
-        telemetry_mock,
-        "error",
-        (("type", "bad_status"),),
-        extra=(("endpoint", AI_GUARD.ENDPOINT_CUSTOM), ("status", str(mock_response.status))),
+        telemetry_mock, "error", (("type", "bad_status"),), extra=(("http_status", str(mock_response.status)),)
     )
 
 
@@ -250,9 +244,7 @@ def test_evaluate_invalid_json(mock_execute_request, telemetry_mock, ai_guard_cl
     assert str(exc_info.value) == "AI Guard service returned an undecodable response body: Invalid JSON"
     assert exc_info.value.status == 200
     assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
-    assert_telemetry(
-        telemetry_mock, "error", (("type", "bad_response"),), extra=(("endpoint", AI_GUARD.ENDPOINT_CUSTOM),)
-    )
+    assert_telemetry(telemetry_mock, "error", (("type", "bad_response"),))
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
@@ -270,10 +262,7 @@ def test_evaluate_invalid_json_error_status(mock_execute_request, telemetry_mock
     assert exc_info.value.status == 502
     assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
     assert_telemetry(
-        telemetry_mock,
-        "error",
-        (("type", "bad_status"),),
-        extra=(("endpoint", AI_GUARD.ENDPOINT_CUSTOM), ("status", str(mock_response.status))),
+        telemetry_mock, "error", (("type", "bad_status"),), extra=(("http_status", str(mock_response.status)),)
     )
 
 
@@ -288,9 +277,7 @@ def test_evaluate_transport_failure(mock_execute_request, telemetry_mock, ai_gua
 
     assert str(exc_info.value) == "Unexpected error calling AI Guard service: Connection refused"
     assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
-    assert_telemetry(
-        telemetry_mock, "error", (("type", AI_GUARD.ERROR_CONNECTION),), extra=(("endpoint", AI_GUARD.ENDPOINT_CUSTOM),)
-    )
+    assert_telemetry(telemetry_mock, "error", (("type", AI_GUARD.ERROR_CONNECTION),))
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
@@ -307,9 +294,7 @@ def test_evaluate_malformed_response(mock_execute_request, telemetry_mock, ai_gu
 
     assert str(exc_info.value).startswith("AI Guard service returned unexpected response format")
     assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
-    assert_telemetry(
-        telemetry_mock, "error", (("type", "bad_response"),), extra=(("endpoint", AI_GUARD.ENDPOINT_CUSTOM),)
-    )
+    assert_telemetry(telemetry_mock, "error", (("type", "bad_response"),))
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
@@ -326,9 +311,7 @@ def test_evaluate_invalid_action(mock_execute_request, telemetry_mock, ai_guard_
         == "AI Guard service returned unrecognized action: 'GO_TO_SLEEP'. Expected ['ALLOW', 'DENY', 'ABORT']"
     )
     assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
-    assert_telemetry(
-        telemetry_mock, "error", (("type", "bad_response"),), extra=(("endpoint", AI_GUARD.ENDPOINT_CUSTOM),)
-    )
+    assert_telemetry(telemetry_mock, "error", (("type", "bad_response"),))
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
@@ -447,12 +430,7 @@ def test_evaluate_error_metrics_report_call_path_tags(mock_execute_request, tele
 
     assert_telemetry(telemetry_mock, "requests", (("error", "true"),), source="auto", integration="anthropic")
     assert_telemetry(
-        telemetry_mock,
-        "error",
-        (("type", AI_GUARD.ERROR_CONNECTION),),
-        source="auto",
-        integration="anthropic",
-        extra=(("endpoint", AI_GUARD.ENDPOINT_CUSTOM),),
+        telemetry_mock, "error", (("type", AI_GUARD.ERROR_CONNECTION),), source="auto", integration="anthropic"
     )
 
 

--- a/tests/aiguard/api/test_api_client.py
+++ b/tests/aiguard/api/test_api_client.py
@@ -14,6 +14,7 @@ from ddtrace.aiguard import Options
 from ddtrace.aiguard import ToolCall
 from ddtrace.aiguard import new_ai_guard_client
 from ddtrace.aiguard._constants import AI_GUARD
+from ddtrace.internal.native import ConnectionFailedError
 from ddtrace.internal.settings.aiguard import aiguard_config
 from tests.aiguard.utils import assert_ai_guard_span
 from tests.aiguard.utils import assert_mock_execute_request_call
@@ -92,12 +93,12 @@ def _build_test_params():
     return params
 
 
-def assert_telemetry(mocked, metric, tags, source=AI_GUARD.SOURCE_SDK, integration=AI_GUARD.INTEGRATION_NONE):
+def assert_telemetry(mocked, metric, tags, source=AI_GUARD.SOURCE_SDK, integration=AI_GUARD.INTEGRATION_NONE, extra=()):
     """Assert one metric was emitted. Every AI Guard metric ends with the call-path tags, which
-    default here to a direct SDK call.
+    default here to a direct SDK call; extra carries the tags the error metric appends after them.
     """
     metrics = [(args[0].value,) + args[1:] for args, kwargs in mocked.call_args_list]
-    expected_tags = tuple(tags) + (("source", source), ("integration", integration))
+    expected_tags = tuple(tags) + (("source", source), ("integration", integration)) + tuple(extra)
     assert ("ai_guard", metric, 1, expected_tags) in metrics
 
 
@@ -202,7 +203,12 @@ def test_evaluate_http_error(mock_execute_request, telemetry_mock, ai_guard_clie
     assert exc_info.value.status == 500
     assert exc_info.value.errors == errors
     assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
-    assert_telemetry(telemetry_mock, "error", (("type", "bad_status"),))
+    assert_telemetry(
+        telemetry_mock,
+        "error",
+        (("type", "bad_status"),),
+        extra=(("endpoint", AI_GUARD.ENDPOINT_CUSTOM), ("status", str(mock_response.status))),
+    )
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
@@ -221,7 +227,12 @@ def test_evaluate_http_error_empty_json_body(mock_execute_request, telemetry_moc
     assert exc_info.value.status == 500
     assert exc_info.value.errors == []
     assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
-    assert_telemetry(telemetry_mock, "error", (("type", "bad_status"),))
+    assert_telemetry(
+        telemetry_mock,
+        "error",
+        (("type", "bad_status"),),
+        extra=(("endpoint", AI_GUARD.ENDPOINT_CUSTOM), ("status", str(mock_response.status))),
+    )
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
@@ -239,7 +250,9 @@ def test_evaluate_invalid_json(mock_execute_request, telemetry_mock, ai_guard_cl
     assert str(exc_info.value) == "AI Guard service returned an undecodable response body: Invalid JSON"
     assert exc_info.value.status == 200
     assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
-    assert_telemetry(telemetry_mock, "error", (("type", "bad_response"),))
+    assert_telemetry(
+        telemetry_mock, "error", (("type", "bad_response"),), extra=(("endpoint", AI_GUARD.ENDPOINT_CUSTOM),)
+    )
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
@@ -256,21 +269,28 @@ def test_evaluate_invalid_json_error_status(mock_execute_request, telemetry_mock
 
     assert exc_info.value.status == 502
     assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
-    assert_telemetry(telemetry_mock, "error", (("type", "bad_status"),))
+    assert_telemetry(
+        telemetry_mock,
+        "error",
+        (("type", "bad_status"),),
+        extra=(("endpoint", AI_GUARD.ENDPOINT_CUSTOM), ("status", str(mock_response.status))),
+    )
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
 @patch("ddtrace.aiguard._api_client.AIGuardClient._execute_request")
 def test_evaluate_transport_failure(mock_execute_request, telemetry_mock, ai_guard_client):
-    """A failure reaching the service is a client_error."""
-    mock_execute_request.side_effect = Exception("Connection refused")
+    """A failure reaching the service reports which kind of transport failure it was."""
+    mock_execute_request.side_effect = ConnectionFailedError("Connection refused")
 
     with pytest.raises(AIGuardClientError) as exc_info:
         ai_guard_client.evaluate(TOOL_CALL)
 
     assert str(exc_info.value) == "Unexpected error calling AI Guard service: Connection refused"
     assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
-    assert_telemetry(telemetry_mock, "error", (("type", "client_error"),))
+    assert_telemetry(
+        telemetry_mock, "error", (("type", AI_GUARD.ERROR_CONNECTION),), extra=(("endpoint", AI_GUARD.ENDPOINT_CUSTOM),)
+    )
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
@@ -287,7 +307,9 @@ def test_evaluate_malformed_response(mock_execute_request, telemetry_mock, ai_gu
 
     assert str(exc_info.value).startswith("AI Guard service returned unexpected response format")
     assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
-    assert_telemetry(telemetry_mock, "error", (("type", "bad_response"),))
+    assert_telemetry(
+        telemetry_mock, "error", (("type", "bad_response"),), extra=(("endpoint", AI_GUARD.ENDPOINT_CUSTOM),)
+    )
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
@@ -304,7 +326,9 @@ def test_evaluate_invalid_action(mock_execute_request, telemetry_mock, ai_guard_
         == "AI Guard service returned unrecognized action: 'GO_TO_SLEEP'. Expected ['ALLOW', 'DENY', 'ABORT']"
     )
     assert_telemetry(telemetry_mock, "requests", (("error", "true"),))
-    assert_telemetry(telemetry_mock, "error", (("type", "bad_response"),))
+    assert_telemetry(
+        telemetry_mock, "error", (("type", "bad_response"),), extra=(("endpoint", AI_GUARD.ENDPOINT_CUSTOM),)
+    )
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
@@ -416,13 +440,20 @@ def test_evaluate_reports_call_path_tags(
 @patch("ddtrace.aiguard._api_client.AIGuardClient._execute_request")
 def test_evaluate_error_metrics_report_call_path_tags(mock_execute_request, telemetry_mock, ai_guard_client):
     """A failed auto-instrumented evaluation still attributes both the requests and error metrics."""
-    mock_execute_request.side_effect = Exception("Connection refused")
+    mock_execute_request.side_effect = ConnectionFailedError("Connection refused")
 
     with pytest.raises(AIGuardClientError):
         ai_guard_client.evaluate(TOOL_CALL, source=AI_GUARD.SOURCE_AUTO, integration=AI_GUARD.INTEGRATION_ANTHROPIC)
 
-    for metric, tags in (("requests", (("error", "true"),)), ("error", (("type", "client_error"),))):
-        assert_telemetry(telemetry_mock, metric, tags, source="auto", integration="anthropic")
+    assert_telemetry(telemetry_mock, "requests", (("error", "true"),), source="auto", integration="anthropic")
+    assert_telemetry(
+        telemetry_mock,
+        "error",
+        (("type", AI_GUARD.ERROR_CONNECTION),),
+        source="auto",
+        integration="anthropic",
+        extra=(("endpoint", AI_GUARD.ENDPOINT_CUSTOM),),
+    )
 
 
 @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")

--- a/tests/aiguard/api/test_error_telemetry.py
+++ b/tests/aiguard/api/test_error_telemetry.py
@@ -1,0 +1,122 @@
+"""Error telemetry has to say *why* an evaluation failed, not just that it did.
+
+A customer investigation stalled because every failure reported type=client_error: there was no
+way to tell a request that never left the pod (proxy, firewall, DNS) from one the service received
+and rejected (bad app key, missing entitlement, rate limit). These tests pin the classification
+and the tag values that distinguish them.
+Spec: https://datadoghq.atlassian.net/wiki/spaces/AIGuard/pages/6600426215
+"""
+
+from typing import Any
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+
+from ddtrace.aiguard import AIGuardClientError
+from ddtrace.aiguard._api_client import _classify_transport_error
+from ddtrace.aiguard._api_client import _status_tag
+from ddtrace.aiguard._constants import AI_GUARD
+from ddtrace.internal.native import ConnectionFailedError
+from ddtrace.internal.native import HttpClientError
+from ddtrace.internal.native import HttpIoError
+from ddtrace.internal.native import InvalidConfigError
+from ddtrace.internal.native import TimedOutError
+from tests.aiguard.utils import mock_evaluate_response
+
+
+MESSAGES = [{"role": "user", "content": "What is the meaning of life?"}]
+
+
+def _error_metrics(add_count_metric: Mock) -> list[dict[str, str]]:
+    """Tags of every ai_guard.error point, as dicts for order-independent assertions."""
+    return [dict(args[3]) for args, _ in add_count_metric.call_args_list if args[1] == AI_GUARD.ERROR_METRIC]
+
+
+def _evaluate_failing_with(ai_guard_client: Any, exc: BaseException, add_count_metric: Mock) -> dict[str, str]:
+    with patch.object(ai_guard_client, "_execute_request", side_effect=exc):
+        with pytest.raises(AIGuardClientError):
+            ai_guard_client.evaluate(MESSAGES)
+    errors = _error_metrics(add_count_metric)
+    assert len(errors) == 1
+    return errors[0]
+
+
+class TestClassification:
+    @pytest.mark.parametrize(
+        "exc,expected",
+        [
+            (ConnectionFailedError("refused"), AI_GUARD.ERROR_CONNECTION),
+            (TimedOutError("too slow"), AI_GUARD.ERROR_TIMEOUT),
+            (InvalidConfigError("bad url"), AI_GUARD.ERROR_INVALID_CONFIG),
+            (HttpIoError("broken pipe"), AI_GUARD.ERROR_IO),
+            # An unrecognised transport failure still reports as a transport problem.
+            (HttpClientError("something else"), AI_GUARD.ERROR_CLIENT),
+            # Our own bug must not inflate the transport buckets that alerting reads.
+            (ValueError("bug in our code"), AI_GUARD.ERROR_INTERNAL),
+            (TypeError("bug in our code"), AI_GUARD.ERROR_INTERNAL),
+        ],
+    )
+    def test_transport_errors_are_classified(self, exc, expected):
+        assert _classify_transport_error(exc) == expected
+
+    @pytest.mark.parametrize("status", AI_GUARD.STATUSES)
+    def test_declared_statuses_are_reported_verbatim(self, status):
+        assert _status_tag(status) == str(status)
+
+    @pytest.mark.parametrize("status", [None, 0, 201, 418, 599])
+    def test_undeclared_statuses_are_clamped(self, status):
+        """Keeps the tag bounded: an unexpected status cannot open a new series."""
+        assert _status_tag(status) == AI_GUARD.STATUS_OTHER
+
+
+class TestErrorTelemetryTags:
+    @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
+    def test_connection_failure_is_distinguishable_from_a_rejection(self, add_count_metric, ai_guard_client):
+        """The case that was undiagnosable: the request never reached the service."""
+        tags = _evaluate_failing_with(ai_guard_client, ConnectionFailedError("refused"), add_count_metric)
+
+        assert tags["type"] == AI_GUARD.ERROR_CONNECTION
+        assert tags["endpoint"] == AI_GUARD.ENDPOINT_CUSTOM
+        # No status: nothing answered, so reporting one would be a lie.
+        assert "status" not in tags
+
+    @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
+    def test_timeout_is_reported_as_its_own_type(self, add_count_metric, ai_guard_client):
+        tags = _evaluate_failing_with(ai_guard_client, TimedOutError("too slow"), add_count_metric)
+
+        assert tags["type"] == AI_GUARD.ERROR_TIMEOUT
+        assert "status" not in tags
+
+    @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
+    def test_internal_error_is_not_reported_as_a_transport_failure(self, add_count_metric, ai_guard_client):
+        tags = _evaluate_failing_with(ai_guard_client, ValueError("bug in our code"), add_count_metric)
+
+        assert tags["type"] == AI_GUARD.ERROR_INTERNAL
+
+    @pytest.mark.parametrize(
+        "status,expected_status",
+        [(401, "401"), (403, "403"), (404, "404"), (429, "429"), (503, "503"), (418, AI_GUARD.STATUS_OTHER)],
+    )
+    @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
+    def test_rejection_carries_the_status(self, add_count_metric, ai_guard_client, status, expected_status):
+        """401 (bad app key), 403/404 (entitlement or wrong endpoint) and 429 all used to look alike."""
+        response = mock_evaluate_response("ALLOW")
+        response.status = status
+
+        with patch.object(ai_guard_client, "_execute_request", return_value=response):
+            with pytest.raises(AIGuardClientError):
+                ai_guard_client.evaluate(MESSAGES)
+
+        errors = _error_metrics(add_count_metric)
+        assert len(errors) == 1
+        assert errors[0]["type"] == AI_GUARD.ERROR_BAD_STATUS
+        assert errors[0]["status"] == expected_status
+
+    @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
+    def test_call_path_tags_are_still_present(self, add_count_metric, ai_guard_client):
+        """The new tags are additive: the existing call-path dimensions must survive."""
+        tags = _evaluate_failing_with(ai_guard_client, ConnectionFailedError("refused"), add_count_metric)
+
+        assert tags["source"] == AI_GUARD.SOURCE_SDK
+        assert tags["integration"] == AI_GUARD.INTEGRATION_NONE

--- a/tests/aiguard/api/test_error_telemetry.py
+++ b/tests/aiguard/api/test_error_telemetry.py
@@ -49,7 +49,7 @@ class TestClassification:
             (ConnectionFailedError("refused"), AI_GUARD.ERROR_CONNECTION),
             (TimedOutError("too slow"), AI_GUARD.ERROR_TIMEOUT),
             (InvalidConfigError("bad url"), AI_GUARD.ERROR_INVALID_CONFIG),
-            (HttpIoError("broken pipe"), AI_GUARD.ERROR_IO),
+            (HttpIoError("broken pipe"), AI_GUARD.ERROR_NETWORK),
             # An unrecognised transport failure still reports as a transport problem.
             (HttpClientError("something else"), AI_GUARD.ERROR_CLIENT),
             # Our own bug must not inflate the transport buckets that alerting reads.
@@ -77,16 +77,15 @@ class TestErrorTelemetryTags:
         tags = _evaluate_failing_with(ai_guard_client, ConnectionFailedError("refused"), add_count_metric)
 
         assert tags["type"] == AI_GUARD.ERROR_CONNECTION
-        assert tags["endpoint"] == AI_GUARD.ENDPOINT_CUSTOM
         # No status: nothing answered, so reporting one would be a lie.
-        assert "status" not in tags
+        assert "http_status" not in tags
 
     @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
     def test_timeout_is_reported_as_its_own_type(self, add_count_metric, ai_guard_client):
         tags = _evaluate_failing_with(ai_guard_client, TimedOutError("too slow"), add_count_metric)
 
         assert tags["type"] == AI_GUARD.ERROR_TIMEOUT
-        assert "status" not in tags
+        assert "http_status" not in tags
 
     @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
     def test_internal_error_is_not_reported_as_a_transport_failure(self, add_count_metric, ai_guard_client):
@@ -111,7 +110,7 @@ class TestErrorTelemetryTags:
         errors = _error_metrics(add_count_metric)
         assert len(errors) == 1
         assert errors[0]["type"] == AI_GUARD.ERROR_BAD_STATUS
-        assert errors[0]["status"] == expected_status
+        assert errors[0]["http_status"] == expected_status
 
     @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
     def test_call_path_tags_are_still_present(self, add_count_metric, ai_guard_client):

--- a/tests/aiguard/api/test_error_telemetry.py
+++ b/tests/aiguard/api/test_error_telemetry.py
@@ -167,8 +167,8 @@ class TestEndpointIsNotLoggedVerbatim:
             ("https://api.example.com/ai-guard?token=s3cret", "https://api.example.com/ai-guard"),
             ("https://user:s3cret@api.example.com/ai-guard?token=t0ken", "https://api.example.com/ai-guard"),
             # nothing usable to log, and never the raw value
-            ("not a url", "<unparseable>"),
-            ("", "<unparseable>"),
+            ("not a url", "<unparsable>"),
+            ("", "<unparsable>"),
         ],
     )
     def test_credentials_are_stripped(self, url, expected):

--- a/tests/aiguard/api/test_error_telemetry.py
+++ b/tests/aiguard/api/test_error_telemetry.py
@@ -15,6 +15,7 @@ import pytest
 
 from ddtrace.aiguard import AIGuardClientError
 from ddtrace.aiguard._api_client import _classify_transport_error
+from ddtrace.aiguard._api_client import _loggable_endpoint
 from ddtrace.aiguard._api_client import _status_tag
 from ddtrace.aiguard._constants import AI_GUARD
 from ddtrace.internal.native import ConnectionFailedError
@@ -119,3 +120,69 @@ class TestErrorTelemetryTags:
 
         assert tags["source"] == AI_GUARD.SOURCE_SDK
         assert tags["integration"] == AI_GUARD.INTEGRATION_NONE
+
+
+class TestInternalErrorsAreNotAttributedToTransport:
+    """Only the transport and response paths set a specific type, so anything raised elsewhere in
+    evaluate() is our own code failing and must not land in the buckets egress alerting reads.
+    """
+
+    @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
+    def test_failure_before_the_request_reports_internal_error(self, add_count_metric, ai_guard_client):
+        """_get_tool_name runs before the HTTP call, so its failure never reaches the classifier."""
+        with patch.object(ai_guard_client, "_get_tool_name", side_effect=RuntimeError("bug")):
+            with pytest.raises(RuntimeError):
+                ai_guard_client.evaluate(MESSAGES)
+
+        errors = _error_metrics(add_count_metric)
+        assert len(errors) == 1
+        assert errors[0]["type"] == AI_GUARD.ERROR_INTERNAL
+
+    @patch("ddtrace.internal.telemetry.telemetry_writer.add_count_metric")
+    def test_failure_after_the_response_reports_internal_error(self, add_count_metric, ai_guard_client):
+        """A raise while building the result is equally ours, and equally not a transport failure."""
+        response = mock_evaluate_response("ALLOW")
+        with patch.object(ai_guard_client, "_execute_request", return_value=response):
+            with patch.object(ai_guard_client, "_messages_for_meta_struct", side_effect=RuntimeError("bug")):
+                with pytest.raises(RuntimeError):
+                    ai_guard_client.evaluate(MESSAGES)
+
+        errors = _error_metrics(add_count_metric)
+        assert len(errors) == 1
+        assert errors[0]["type"] == AI_GUARD.ERROR_INTERNAL
+
+
+class TestEndpointIsNotLoggedVerbatim:
+    """Customers are asked for these debug logs during investigations, so an endpoint override
+    carrying credentials must not end up in them.
+    """
+
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("https://api.example.com/ai-guard", "https://api.example.com/ai-guard"),
+            ("https://api.example.com:8443/ai-guard", "https://api.example.com:8443/ai-guard"),
+            # userinfo and query credentials are dropped
+            ("https://user:s3cret@api.example.com/ai-guard", "https://api.example.com/ai-guard"),
+            ("https://api.example.com/ai-guard?token=s3cret", "https://api.example.com/ai-guard"),
+            ("https://user:s3cret@api.example.com/ai-guard?token=t0ken", "https://api.example.com/ai-guard"),
+            # nothing usable to log, and never the raw value
+            ("not a url", "<unparseable>"),
+            ("", "<unparseable>"),
+        ],
+    )
+    def test_credentials_are_stripped(self, url, expected):
+        assert _loggable_endpoint(url) == expected
+
+    @pytest.mark.parametrize("secret", ["s3cret", "t0ken"])
+    def test_no_secret_reaches_the_startup_log(self, secret, caplog):
+        from ddtrace.aiguard._api_client import AIGuardClient
+
+        with caplog.at_level("DEBUG", logger="ddtrace.aiguard._api_client"):
+            AIGuardClient(
+                endpoint="https://user:s3cret@api.example.com/ai-guard?token=t0ken",
+                api_key="test-api-key",
+                app_key="test-app-key",
+            )
+
+        assert secret not in caplog.text


### PR DESCRIPTION
## Description

Every AI Guard evaluation failure that was not a decodable non-200 response reported
`ai_guard.error{type:client_error}`, and `bad_status` carried no status code. That left the metric
unable to answer the questions that actually matter during an incident:

- Did the request reach the AI Guard service at all?
- Is this a proxy / firewall / DNS problem, a timeout, or a malformed endpoint?
- Is a rejection an auth failure (401), a missing entitlement (403/404), or rate limiting (429)?
- Is the failure a tracer bug rather than a customer network problem?

There was also a genuine misclassification: `error_type` defaulted to `AI_GUARD.ERROR_CLIENT` and
was only narrowed on response-driven paths, so an exception raised inside our own code reported as
a client error — inflating precisely the bucket an operator uses to detect customer-side egress
problems.

This splits the transport failures using the exception hierarchy the native HTTP client already
exposes (`ConnectionFailedError`, `TimedOutError`, `InvalidConfigError`, `HttpIoError`,
`HttpClientError`):

| New `type` value | Meaning |
|---|---|
| `connection_failed` | TCP/socket connection could not be established — proxy, firewall, DNS, unreachable |
| `timeout` | Exceeded `DD_AI_GUARD_TIMEOUT` |
| `invalid_config` | Request could not be built, e.g. malformed `DD_AI_GUARD_ENDPOINT` |
| `network_error` | Network failure mid-request, e.g. connection reset |
| `internal_error` | Raised inside the tracer, **not** the transport |

Also adds an **`http_status`** tag on `bad_status`, clamped to a declared allowlist (`401`, `403`,
`404`, `408`, `413`, `429`, `500`, `502`, `503`, `504`, else `other`) so cardinality stays bounded.
Named `http_status` rather than `status` so it cannot be read as an *evaluation* status.

The one debug log statement the client had reported only a message count; it now reports the
classification too. It stays at `debug` per the convention that instrumentation errors never log
above debug, and it still logs no message content, preserving the existing redaction-safety
property.

## Scope note: the endpoint credential leak was split out

An earlier revision of this PR also sanitized `DD_AI_GUARD_ENDPOINT` out of AI Guard's error
messages, logs and span error tags, and stripped userinfo from the base URL before it reached the
transport. That is a real, pre-existing bug — the endpoint can carry a credential in userinfo, in a
path segment or in a query parameter, and it currently surfaces in the raised exception, the chained
traceback, the span `error.message` / `error.stack` tags, and in `ddtrace.internal.http`'s own log
line — but it is an independent fix with its own risk profile, so it has been rolled back out of
this PR and tracked separately:

**[APPSEC-70144](https://datadoghq.atlassian.net/browse/APPSEC-70144)** — Credentials in
`DD_AI_GUARD_ENDPOINT` leak into AI Guard error messages, logs and span error tags.

This PR is now only about how an already-raised failure is classified in telemetry. It makes the
leak no better and no worse.

## Testing

`tests/aiguard/api/test_error_telemetry.py` covers:

- Every transport exception the native client can raise, mapped to its `type` value, including the
  unrecognised-`HttpClientError` fallback and non-transport exceptions landing on `internal_error`.
- `internal_error` for a raise before the request (`_get_tool_name`) and after the response
  (`_messages_for_meta_struct`), which are the two gaps the old default hid.
- `http_status` present and clamped on `bad_status`, and absent on transport failures.
- The existing `source` / `integration` call-path tags still on every point.
- The failure log line carrying the classification.

Full suite: `scripts/run-tests --venv 125d7e3 -- tests/aiguard/api/` → 344 passed (Python 3.13).

## Risks

Low, and confined to AI Guard.

- **Telemetry**: `client_error` stops being the catch-all. Any dashboard or monitor filtering
  `ai_guard.error{type:client_error}` will see its volume drop and should be widened to the new
  values. `http_status` adds one dimension, bounded to 11 values, on `bad_status` points only.
- **No behavioural change to evaluations**: the decision path, blocking, redaction and the span
  contents are untouched. Only the classification of an already-raised failure and one debug log
  line change.

## Additional Notes

- **Intake registration is a prerequisite for querying the new values.** The new `type` values and
  the `http_status` tag have to be registered with instrumentation telemetry intake before they can
  be queried in the app; the tracer side is this PR.
- **The `backport 4.15` label cannot be honoured automatically.** The bot already reported a
  conflict in `_api_client.py` and `_constants.py` against the 4.15 branch, so this needs a manual
  backport PR. 4.15 is where `ai_guard.error` first ships (`4.15.0rc1`), so shipping the metric
  without this fix would release the `client_error`-for-everything behaviour the PR removes.

Jira: [APPSEC-70124](https://datadoghq.atlassian.net/browse/APPSEC-70124)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[APPSEC-70144]: https://datadoghq.atlassian.net/browse/APPSEC-70144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ