### PR TITLE
perf(ci_visibility): fast-path undecorated()

### DIFF
--- a/ddtrace/internal/utils/inspection.py
+++ b/ddtrace/internal/utils/inspection.py
@@ -6,6 +6,7 @@ from functools import singledispatch
 from pathlib import Path
 from types import CodeType
 from types import FunctionType
+from types import MethodType
 from types import ModuleType
 from typing import Iterator
 from typing import Optional
@@ -52,6 +53,20 @@ def undecorated(f: FunctionType, name: str, path: Path) -> FunctionType:
 
     def match(g):
         return g.__code__.co_name == name and resolved_code_origin(g.__code__) == path
+
+    # PERF: an undecorated callable is already the function we are looking for, and that
+    # is the common case (every plain test function). Without this shortcut the search
+    # below still probes every wrapper attribute and then, as a last resort, every name in
+    # object.__dir__(f) -- tens of attribute reads -- only to fall through and return f.
+    # Restricted to plain functions and bound methods, the two shapes whose result is
+    # known without searching: a matching function is itself the answer, and a matching
+    # bound method's answer is the underlying function, which is the only matching
+    # FunctionType the search could reach through it.
+    if _isinstance(f, FunctionType) and match(f):
+        return f
+    if _isinstance(f, MethodType) and match(f):
+        # f is annotated FunctionType, but callers pass bound methods for test methods.
+        return cast(FunctionType, cast(MethodType, f).__func__)
 
     seen_functions = {f}
     q = deque([f])  # FIFO: use popleft and append

--- a/releasenotes/notes/ci_visibility-perf-test-source-location-lookup-df5a7084e10d925a.yaml
+++ b/releasenotes/notes/ci_visibility-perf-test-source-location-lookup-df5a7084e10d925a.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    CI Visibility: This reduces the per-test overhead of the ``pytest`` plugin by speeding up the source
+    location lookup performed for every test. The improvement is most noticeable on large suites of fast tests.

--- a/tests/internal/test_utils_inspection.py
+++ b/tests/internal/test_utils_inspection.py
@@ -34,6 +34,41 @@ def test_undecorated():
     assert undecorated(undecorated, name, path) is undecorated
 
 
+def test_undecorated_methods():
+    # Bound methods reach undecorated() from the pytest plugin, for class-based tests.
+    def d(f):
+        def wrapper(*args, **kwargs):
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    class C:
+        def plain(self):
+            pass
+
+        @d
+        def decorated(self):
+            pass
+
+    path = Path(__file__).resolve()
+    instance = C()
+
+    # An undecorated method resolves to the function behind the bound method.
+    assert undecorated(instance.plain, "plain", path) is C.plain
+    assert undecorated(C.plain, "plain", path) is C.plain
+
+    # A name that matches nothing reachable falls back to the object it was given.
+    # Bind once: attribute access builds a new bound method object each time.
+    plain = instance.plain
+    assert undecorated(plain, "nonexistent", path) is plain
+
+    # Decorated *methods* are a long-standing gap, unrelated to the shortcut above: the
+    # closure walk only runs for plain functions, so a bound method wrapping a
+    # closure-based decorator resolves to the wrapper rather than the decorated body.
+    decorated = instance.decorated
+    assert undecorated(decorated, "decorated", path) is decorated
+
+
 def test_class_decoration():
     class Decorator:
         def __init__(self, f):


### PR DESCRIPTION
<!-- dd-meta {"pullId":"35f2ebc1-3aaa-45ae-8f4c-267ab3ab2ff7","source":"chat","resourceId":"b51bea3e-3f29-4e84-9ccb-8a62a41d450e","workflowId":"52aec231-96ef-4830-b9ee-0b811185a65e","codeChangeId":"52aec231-96ef-4830-b9ee-0b811185a65e","sourceType":"code_channel"} -->
## Description

Profiling the `benchmarks/pytest_plugin` workload (1000 trivial tests, hermetic offline mode, exactly as the scenario configures it) showed the ddtrace pytest plugin roughly doubling the session: **+1376 ms CPU (+69%) / +1448 ms wall (+53%)**, about 1.38 ms CPU per test. The single largest ddtrace frame in that profile was `undecorated()`.

`undecorated()` is called once per test — `_get_test_location_info` → `_get_source_lines` → `undecorated()` — to find the function whose source lines describe the test. It never tested the callable it was given. So a plain test function, which is the common case, ran the entire breadth-first search (wrapper attributes, `partial` args, closure cells, `__dict__`/`__slots__`, then a last-resort walk over every name in `object.__dir__(f)`) and fell through to return that same object unchanged. Over 1000 tests that was 39k generator iterations and 40k `_isinstance` calls doing no useful work.

The fix returns early for the two shapes whose result is known without searching: a function that already matches is itself the answer, and a bound method that matches resolves to its underlying function — the only matching `FunctionType` the search could reach through it. Every other shape (decorated functions, `partial`, callable instances, class decorators) still goes through the unchanged search.

Note the comment added about decorated *methods*: a bound method wrapping a closure-based decorator resolves to the wrapper rather than the decorated body. That is a pre-existing gap — the closure walk is gated on `FunctionType`, which a bound method is not — and this change neither fixes nor worsens it. It is documented in the new test so the current behavior is pinned rather than assumed.

## Testing

Behavior equivalence was the main risk, so it was checked directly rather than inferred. A harness ran the new implementation against a verbatim copy of the old one over nine decoration shapes — plain function, `functools.wraps`, double-wrapped, closure-only (no `wraps`), `partial`, bound method, decorated method, callable instance, and a name that matches nothing — and returned the identical object in all nine. It also caught a real difference during development: an earlier version of the fast path returned the bound method itself instead of its underlying function, which the harness flagged and which is why the `MethodType` branch unwraps to `__func__`.

`tests/internal/test_utils_inspection.py::test_undecorated_methods` is new and covers the bound-method paths the fast path handles: an undecorated method resolving to the underlying function, a non-matching name falling back to the object passed in, and the decorated-method gap described above.

Suites run locally (Python 3.12): `wrapping` (333 passed), `internal`, `ci_visibility::testing`, `ci_visibility::pytest` (196 passed). Three failures reproduce identically on a clean tree and are unrelated to this change — `test_periodic.py::test_writer_recreate_fork_child_does_not_deadlock` (SIGSEGV in a fork child; the test's own docstring notes it is libc/timing dependent), `test_patch.py::test_generate_report_with_invalid_path`, and `test_pytest_xdist.py::test_discards_manifest_generated_by_unrelated_process`.

Performance, `benchmarks/pytest_plugin` workload at 5000 tests, interleaved A/B against the same tree with only this change reverted, on a locally built extension:

| | baseline | candidate | delta |
|---|---|---|---|
| child CPU (median) | 12.87 s | 12.54 s | −2.5% |
| wall (median) | 15.79 s | 15.51 s | −1.8% |

Two independent 7-round runs put it at −2.5% to −4.0% CPU and −1.8% to −2.8% wall, roughly 60–90 µs per test. In isolation `undecorated()` goes from 27.4 µs to 1.1 µs for a plain function (24×) and 19.9 µs to 1.3 µs for a bound method (15×).

## Risks

Low, and confined to source-location reporting. If the fast path ever returned the wrong function, the effect would be wrong `test.source.start`/`end` line numbers on test events — not a failed or mis-reported test. The nine-shape equivalence check and the new unit test cover the shapes the fast path can trigger on; anything it does not recognize falls through to the original search untouched.

## Additional Notes

The profile turned up further per-test overhead that this PR does not touch, listed here so it is not lost (exact per-test call counts, 1000-test run):

- **Telemetry, 5 count-metrics per test** through two layers: `PayloadFileTelemetryAPI.add_count_metric` (5/test) → `TelemetryWriter.add_count_metric` (5/test), plus `_make_tags` (6/test), `_convert_metric_tags` (4/test), `MetricRecorder.add` (6/test). Largest remaining `ddtrace/testing` block.
- **Span lifecycle, 2 spans per test** via `tracer_api/context.py` → `tracer.trace()`; `ddtrace/_trace` is 2.0% of the session.
- **Disabled-coverage overhead**: `coverage_collection()` is entered per test even when `settings.coverage_enabled` is false, along with `record_coverage_started`/`record_coverage_finished` (2 of the 5 telemetry metrics).
- **OTel thread context**: `_sync_otel_thread_context` and `_on_context_provider_activate`, 5/test each.
- **Report hooks**: `pytest_runtest_makereport` 6/test, `_get_user_property` 6/test (linear scan of `user_properties`), `pytest_report_teststatus` 3/test.

Two things were investigated and ruled out as targets: `item_to_test_ref` (3 calls/test) already caches on the item, and the session-end writer join is 18.6 µs, not a bottleneck — a 5 s figure for it in an early cProfile run was the profiler inflating the main thread while the writer thread ran unprofiled.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b51bea3e-3f29-4e84-9ccb-8a62a41d450e)

Comment @datadog to request changes