### PR TITLE
chore(ci): bump llm-validation-platform to v0.1.3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,7 +59,7 @@ workflow:
 
 include:
   - project: 'DataDog/llm-validation-platform'
-    ref: 0f48ca35f0b3dfd19d5c0dc9f92aa977c99bebbf
+    ref: c331696647a78672101002ba48ccebbd41b0fae8  # v0.1.3
     file: '/ci/llm-validation.gitlab-ci.yml'
   - local: ".gitlab/ci-templates.yml" # Reusable templates (setup_ci_deps, etc.)
   - local: ".gitlab/retry-policies.yml"
@@ -778,4 +778,4 @@ publishing-gate:
 "llm validation":
   variables:
     LLMVAL_BASE_REF: "main"
-    LLMVAL_PLATFORM_REF: "0f48ca35f0b3dfd19d5c0dc9f92aa977c99bebbf"  # keep identical to the include ref above
+    LLMVAL_PLATFORM_REF: "c331696647a78672101002ba48ccebbd41b0fae8"  # v0.1.3 (keep identical to the include ref above)


### PR DESCRIPTION
## Description

Bump the pinned `llm-validation-platform` ref from `0f48ca3` (v0.1.1) to `c331696` (v0.1.3), in both the `include: ref:` and the matching `LLMVAL_PLATFORM_REF` (kept identical, as the pinning policy requires).

v0.1.3 pins the CI runner image by digest instead of the moving `:newest` tag. That tag drifted on 2025-09-09 and broke the gate's runtime node install for every consumer still on the moving tag; dd-trace-py was latent-exposed (it hadn't failed only because it hadn't had an `AGENTS.md`-touching PR since the drift). This bump picks up the fix before the next such PR would trip it.

## Testing

CI-config-only change; no product code affected. The gate self-skips unless the monitored instruction file changes, so it stays green on this PR; the fix is exercised on the next instruction-file PR.

## Risks

Low. Scope is limited to the LLM-validation CI gate job. Note this jumps v0.1.1 → v0.1.3 (skips v0.1.2); the deltas are the image pin (v0.1.3) and the base-ref-validation / generic-config changes (v0.1.2), both schema-compatible with the existing `.llm-validation/` config.

## Additional Notes

Companion bumps landed for the other tracers: dd-trace-js (#10291) and dd-trace-dotnet (#9230).
