### PR TITLE
chore(falcon): migrate falcon to events API

### DIFF
--- a/ddtrace/_trace/subscribers/web_framework.py
+++ b/ddtrace/_trace/subscribers/web_framework.py
@@ -23,9 +23,29 @@ class WebFrameworkRequestSubscriber(TracingSubscriber):
     @classmethod
     def on_started(cls, ctx: core.ExecutionContext) -> None:
         event: WebFrameworkRequestEvent = ctx.event
+        span: Span = span_from_context(ctx)
 
         if event.allow_default_resource:
             event.set_resource = True
+
+        try:
+            trace_utils.set_http_meta(
+                span=span,
+                integration_config=event.integration_config,
+                method=event.request_method,
+                url=event.request_url,
+                # set_http_meta checks only integration_config when deciding
+                # whether to trace the query string. aiohttp supports a
+                # per-application override instead.
+                query=event.query if event.trace_query_string is None else None,
+                request_headers=event.request_headers,
+                headers_are_case_sensitive=event.headers_case_sensitive,
+            )
+        except Exception:
+            log.debug("%s: error adding request tags", event.integration_config.integration_name, exc_info=True)
+
+        if event.trace_query_string and event.query is not None:
+            span._set_attribute(http.QUERY_STRING, event.query)
 
     @classmethod
     def on_ended(
@@ -50,24 +70,14 @@ class WebFrameworkRequestSubscriber(TracingSubscriber):
             trace_utils.set_http_meta(
                 span=span,
                 integration_config=event.integration_config,
-                method=method,
-                url=event.request_url,
-                # set_http_meta will check only integration_config to set or not query
-                # however, aiohttp support per-app trace_query_string config overrides
-                query=event.query if event.trace_query_string is None else None,
                 status_code=status_code,
-                request_headers=event.request_headers,
                 response_headers=dict(res_headers) if res_headers is not None else None,
+                headers_are_case_sensitive=event.headers_case_sensitive,
                 route=event.request_route,
             )
         except Exception:
-            log.debug("%s: error adding tags", event.integration_config.integration_name, exc_info=True)
-
-        # aiohttp supports per-app trace_query_string overrides that may differ from
-        # integration_config.trace_query_string.
-        if event.trace_query_string and event.query is not None:
-            span._set_attribute(http.QUERY_STRING, event.query)
+            log.debug("%s: error adding response tags", event.integration_config.integration_name, exc_info=True)
 
         _set_inferred_proxy_tags(span, status_code)
-        for tk, tv in core.get_item("additional_tags", default=dict()).items():
+        for tk, tv in ctx.get_item("additional_tags", default=dict()).items():
             span._set_attribute(tk, tv)

--- a/ddtrace/_trace/trace_handlers.py
+++ b/ddtrace/_trace/trace_handlers.py
@@ -2026,7 +2026,6 @@ def listen():
     for context_name in (
         # web frameworks
         "cherrypy.request",
-        "falcon.request",
         "molten.request",
         "molten.trace_func",
         "pyramid.request",

--- a/ddtrace/contrib/internal/falcon/middleware.py
+++ b/ddtrace/contrib/internal/falcon/middleware.py
@@ -88,6 +88,7 @@ class TraceMiddleware(object):
 
     def process_response(self, req, resp, resource, req_succeeded=None):
         # req_succeeded is unavailable in Falcon 1.0.
+        # TODO[manu]: drop the support at some point
         ctx = req.env.pop(self._request_context_key, None)
         if ctx is None:
             return
@@ -110,10 +111,7 @@ class TraceMiddleware(object):
                 err_type = sys.exc_info()[0]
                 if err_type is not None:
                     if req_succeeded is None or req_succeeded is False:
-                        status = _detect_and_set_status_error(
-                            err_type,
-                            span,
-                        )
+                        status = _detect_and_set_status_error(err_type, span)
 
                 event.request_route = (req.root_path or "") + (req.uri_template or "")
                 event.response_headers = resp._headers

--- a/ddtrace/contrib/internal/falcon/middleware.py
+++ b/ddtrace/contrib/internal/falcon/middleware.py
@@ -32,9 +32,6 @@ class TraceMiddleware(object):
             config.falcon["distributed_tracing"] = distributed_tracing
 
     def process_request(self, req, resp):
-        # Falcon uppercases all header names.
-        headers = {key.lower(): value for key, value in req.headers.items()}
-
         event = WebFrameworkRequestEvent(
             http_operation="falcon.request",
             component=config.falcon.integration_name,
@@ -42,12 +39,15 @@ class TraceMiddleware(object):
             service=self.service,
             request_method=req.method,
             request_url=req.url,
-            request_headers=headers,
+            # Preserve the header mapping passed to set_http_meta before this
+            # migration. Distributed propagation normalizes header names
+            # independently.
+            request_headers=req.headers,
             query=req.query_string,
             request_route=None,
             allow_default_resource=True,
             activate_distributed_headers=True,
-            headers_case_sensitive=True,
+            headers_case_sensitive=False,
         )
 
         with core.context_with_event(

--- a/ddtrace/contrib/internal/falcon/middleware.py
+++ b/ddtrace/contrib/internal/falcon/middleware.py
@@ -1,15 +1,13 @@
 import sys
 
 from ddtrace import config
-from ddtrace.ext import SpanTypes
+from ddtrace.contrib import trace_utils
+from ddtrace.contrib._events.web_framework import WebFrameworkRequestEvent
 from ddtrace.internal import core
-from ddtrace.internal.schema import SpanDirection
 from ddtrace.internal.schema import schematize_service_name
-from ddtrace.internal.schema import schematize_url_operation
 from ddtrace.internal.span_bus import span_from_context
 from ddtrace.internal.utils.deprecations import DDTraceDeprecationWarning
 from ddtrace.internal.utils.deprecations import deprecate
-from ddtrace.trace import tracer
 
 
 class TraceMiddleware(object):
@@ -24,75 +22,105 @@ class TraceMiddleware(object):
                 category=DDTraceDeprecationWarning,
                 removal_version="5.0.0",
             )
+
         self.service = service
+
+        # A Falcon application may contain multiple TraceMiddleware instances,
+        # so each instance must store its own execution context.
+        self._request_context_key = "ddtrace.falcon.request_context.{}".format(id(self))
+
         if distributed_tracing is not None:
             config.falcon["distributed_tracing"] = distributed_tracing
 
     def process_request(self, req, resp):
         # Falcon uppercases all header names.
-        headers = dict((k.lower(), v) for k, v in req.headers.items())
+        headers = {key.lower(): value for key, value in req.headers.items()}
 
-        with core.context_with_data(
-            "falcon.request",
-            span_name=schematize_url_operation("falcon.request", protocol="http", direction=SpanDirection.INBOUND),
-            span_type=SpanTypes.WEB,
-            service=self.service,
-            tags={},
-            distributed_headers=headers,
+        event = WebFrameworkRequestEvent(
+            http_operation="falcon.request",
+            component=config.falcon.integration_name,
             integration_config=config.falcon,
+            service=self.service,
+            request_method=req.method,
+            request_url=req.url,
+            request_headers=headers,
+            query=req.query_string,
+            request_route=None,
+            allow_default_resource=True,
             activate_distributed_headers=True,
             headers_case_sensitive=True,
-        ) as ctx:
-            req_span = span_from_context(ctx)
-            ctx.set_item("req_span", req_span)
-            core.dispatch("web.request.start", (ctx, config.falcon))
+        )
 
-            core.dispatch(
-                "web.request.finish",
-                (req_span, config.falcon, req.method, req.url, None, req.query_string, req.headers, None, None, False),
+        with core.context_with_event(
+            event,
+            dispatch_end_event=False,
+        ) as ctx:
+            request_span = span_from_context(ctx)
+            req.env[self._request_context_key] = ctx
+
+            # Preserve the previous behavior: request metadata is available
+            # before Falcon executes resource handlers.
+            trace_utils.set_http_meta(
+                span=request_span,
+                integration_config=event.integration_config,
+                method=event.request_method,
+                url=event.request_url,
+                query=event.query,
+                request_headers=event.request_headers,
             )
 
     def process_resource(self, req, resp, resource, params):
-        span = tracer.current_span()
-        if not span:
-            return  # unexpected
-        span.resource = "%s %s" % (req.method, _name(resource))
-
-    def process_response(self, req, resp, resource, req_succeeded=None):
-        # req_succeded is not a kwarg in the API, but we need that to support
-        # Falcon 1.0 that doesn't provide this argument
-        span = tracer.current_span()
-        if not span:
-            return  # unexpected
-
-        status = resp.status.partition(" ")[0]
-
-        # falcon does not map errors or unmatched routes
-        # to proper status codes, so we have to try to infer them
-        # here.
-        if resource is None:
-            status = "404"
-            span.resource = "%s 404" % req.method
-            core.dispatch("web.request.finish", (span, config.falcon, None, None, status, None, None, None, None, True))
+        ctx = req.env.get(self._request_context_key)
+        if ctx is None:
             return
 
-        err_type = sys.exc_info()[0]
-        if err_type is not None:
-            if req_succeeded is None:
-                # backward-compatibility with Falcon 1.0; any version
-                # greater than 1.0 has req_succeded in [True, False]
-                # TODO[manu]: drop the support at some point
-                status = _detect_and_set_status_error(err_type, span)
-            elif req_succeeded is False:
-                # Falcon 1.1+ provides that argument that is set to False
-                # if get an Exception (404 is still an exception)
-                status = _detect_and_set_status_error(err_type, span)
+        span = span_from_context(ctx)
+        if span is None:
+            return
 
-        route = (req.root_path or "") + (req.uri_template or "")
+        # Set the resource on the live span before handler execution.
+        span.resource = "%s %s" % (req.method, _name(resource))
 
-        core.dispatch(
-            "web.request.finish", (span, config.falcon, None, None, status, None, None, resp._headers, route, True)
-        )
+        # Prevent the subscriber from replacing a resource customized by the
+        # resource handler.
+        event: WebFrameworkRequestEvent = ctx.event
+        event.set_resource = False
+
+    def process_response(self, req, resp, resource, req_succeeded=None):
+        # req_succeeded is unavailable in Falcon 1.0.
+        ctx = req.env.pop(self._request_context_key, None)
+        if ctx is None:
+            return
+
+        span = span_from_context(ctx)
+        if span is None:
+            return
+
+        event: WebFrameworkRequestEvent = ctx.event
+
+        try:
+            status = resp.status.partition(" ")[0]
+
+            # Falcon does not always map errors or unmatched routes to the
+            # proper status code, so retain the existing inference.
+            if resource is None:
+                status = "404"
+                span.resource = "%s 404" % req.method
+            else:
+                err_type = sys.exc_info()[0]
+                if err_type is not None:
+                    if req_succeeded is None or req_succeeded is False:
+                        status = _detect_and_set_status_error(
+                            err_type,
+                            span,
+                        )
+
+                event.request_route = (req.root_path or "") + (req.uri_template or "")
+                event.response_headers = resp._headers
+
+            event.response_status_code = int(status)
+        finally:
+            ctx.dispatch_ended_event()
 
 
 def _is_404(err_type):
@@ -100,14 +128,12 @@ def _is_404(err_type):
 
 
 def _detect_and_set_status_error(err_type, span):
-    """Detect the HTTP status code from the current stacktrace and
-    set the traceback to the given Span
-    """
+    """Detect the HTTP status code and set the traceback on the span."""
     if not _is_404(err_type):
         span.set_traceback()
         return "500"
-    elif _is_404(err_type):
-        return "404"
+
+    return "404"
 
 
 def _name(r):

--- a/ddtrace/contrib/internal/falcon/middleware.py
+++ b/ddtrace/contrib/internal/falcon/middleware.py
@@ -80,13 +80,12 @@ class TraceMiddleware(object):
         if ctx is None:
             return
 
-        span = span_from_context(ctx)
-        if span is None:
-            return
-
-        event: WebFrameworkRequestEvent = ctx.event
-
         try:
+            span = span_from_context(ctx)
+            if span is None:
+                return
+
+            event: WebFrameworkRequestEvent = ctx.event
             status = resp.status.partition(" ")[0]
 
             # Falcon does not always map errors or unmatched routes to the

--- a/ddtrace/contrib/internal/falcon/middleware.py
+++ b/ddtrace/contrib/internal/falcon/middleware.py
@@ -1,7 +1,6 @@
 import sys
 
 from ddtrace import config
-from ddtrace.contrib import trace_utils
 from ddtrace.contrib._events.web_framework import WebFrameworkRequestEvent
 from ddtrace.internal import core
 from ddtrace.internal.schema import schematize_service_name
@@ -55,19 +54,7 @@ class TraceMiddleware(object):
             event,
             dispatch_end_event=False,
         ) as ctx:
-            request_span = span_from_context(ctx)
             req.env[self._request_context_key] = ctx
-
-            # Preserve the previous behavior: request metadata is available
-            # before Falcon executes resource handlers.
-            trace_utils.set_http_meta(
-                span=request_span,
-                integration_config=event.integration_config,
-                method=event.request_method,
-                url=event.request_url,
-                query=event.query,
-                request_headers=event.request_headers,
-            )
 
     def process_resource(self, req, resp, resource, params):
         ctx = req.env.get(self._request_context_key)

--- a/tests/contrib/falcon/test_middleware.py
+++ b/tests/contrib/falcon/test_middleware.py
@@ -48,25 +48,27 @@ class MiddlewareTestCase(TracerTestCase, testing.TestCase, FalconTestCase):
     ],
 )
 def test_process_response_route_includes_root_path(root_path, uri_template, want_route):
+    middleware = TraceMiddleware()
     span = mock.MagicMock()
+    ctx = mock.MagicMock()
+    ctx.event = mock.MagicMock()
+
     req = mock.MagicMock()
     req.root_path = root_path
     req.uri_template = uri_template
     req.method = "GET"
+    req.env = {
+        middleware._request_context_key: ctx,
+    }
+
     resp = mock.MagicMock()
     resp.status = "200 OK"
     resp._headers = {}
 
-    middleware = TraceMiddleware()
-    with (
-        mock.patch("ddtrace.contrib.internal.falcon.middleware.tracer.current_span", return_value=span),
-        mock.patch("ddtrace.contrib.internal.falcon.middleware.core.dispatch") as mocked_dispatch,
-    ):
+    with mock.patch("ddtrace.contrib.internal.falcon.middleware.span_from_context", return_value=span):
         middleware.process_response(req, resp, mock.MagicMock(), req_succeeded=True)
 
-    web_finish_calls = [c for c in mocked_dispatch.call_args_list if c.args and c.args[0] == "web.request.finish"]
-    assert web_finish_calls, "expected a web.request.finish dispatch"
-    # ``route`` is the second-to-last positional in the args tuple.
-    args_tuple = web_finish_calls[-1].args[1]
-    route_arg = args_tuple[-2]
-    assert route_arg == want_route
+    assert ctx.event.request_route == want_route
+    assert ctx.event.response_status_code == 200
+    assert ctx.event.response_headers == {}
+    ctx.dispatch_ended_event.assert_called_once_with()

--- a/tests/contrib/falcon/test_suite.py
+++ b/tests/contrib/falcon/test_suite.py
@@ -236,6 +236,46 @@ class FalconTestCase(FalconTestMixin):
         assert span.get_tag("http.request.headers.my-header") == "my_value"
         assert span.get_tag("http.response.headers.my-response-header") == "my_response_value"
 
+    def test_request_metadata_available_during_resource_execution(self):
+        observed = {}
+        test_tracer = self.tracer
+
+        class Resource(object):
+            def on_get(self, req, resp):
+                span = test_tracer.current_root_span()
+                assert span is not None
+
+                observed["resource"] = span.resource
+                observed["method"] = span.get_tag(httpx.METHOD)
+                observed["url"] = span.get_tag(httpx.URL)
+
+                # Ensure event finalization does not overwrite application
+                # customization.
+                span.resource = "custom"
+
+        self.api.add_route("/inspect", Resource())
+        response = self.make_test_call(
+            "/inspect",
+            expected_status_code=200,
+        )
+
+        expected_resource = "GET {}.{}".format(
+            Resource.__module__,
+            Resource.__name__,
+        )
+
+        assert response.status_code == 200
+        assert observed == {
+            "resource": expected_resource,
+            "method": "GET",
+            "url": "http://falconframework.org/inspect",
+        }
+
+        traces = self.pop_traces()
+        assert len(traces) == 1
+        assert len(traces[0]) == 1
+        assert traces[0][0].resource == "custom"
+
     def test_inferred_spans_api_gateway_default(self):
         headers = {
             "x-dd-proxy": "aws-apigateway",


### PR DESCRIPTION
Migrates the falcon web framework integration to the typed Events API using WebFrameworkRequestEvent.