### PR TITLE
chore(profiling): report asyncio discovery diagnostics

### DIFF
--- a/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/include/profiler_stats.hpp
@@ -49,8 +49,14 @@ class ProfilerStats
     // Samples dropped because the cap was reached (cumulative over tracker lifetime)
     std::optional<size_t> heap_tracker_cap_drops;
 
-    // Peak number of asyncio tasks seen across sampled threads in any single sampling
-    // cycle during the current profile period (see set_asyncio_task_count).
+    // Asyncio diagnostics used to distinguish hook, loop tracking, offset discovery, and task traversal failures.
+    std::optional<bool> asyncio_initialized;
+    std::optional<bool> asyncio_runtime_offsets_discovered;
+    std::optional<size_t> asyncio_interpreter_tasks_head_offset;
+    std::optional<size_t> asyncio_thread_tasks_head_offset;
+
+    // Peak numbers seen across sampled threads in any single sampling cycle during the current profile period.
+    std::optional<size_t> asyncio_loop_count;
     std::optional<size_t> asyncio_task_count;
 
     // Number of greenlets currently tracked by the stack profiler
@@ -98,6 +104,21 @@ class ProfilerStats
 
     void set_heap_tracker_cap_drops(size_t count);
     std::optional<size_t> get_heap_tracker_cap_drops() const;
+
+    void set_asyncio_initialized(bool initialized);
+    std::optional<bool> get_asyncio_initialized() const;
+
+    void set_asyncio_runtime_offsets_discovered(bool discovered);
+    std::optional<bool> get_asyncio_runtime_offsets_discovered() const;
+
+    void set_asyncio_interpreter_tasks_head_offset(size_t offset);
+    std::optional<size_t> get_asyncio_interpreter_tasks_head_offset() const;
+
+    void set_asyncio_thread_tasks_head_offset(size_t offset);
+    std::optional<size_t> get_asyncio_thread_tasks_head_offset() const;
+
+    void set_asyncio_loop_count(size_t count);
+    std::optional<size_t> get_asyncio_loop_count() const;
 
     void set_asyncio_task_count(size_t count);
     std::optional<size_t> get_asyncio_task_count() const;

--- a/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
+++ b/ddtrace/internal/datadog/profiling/dd_wrapper/src/profiler_stats.cpp
@@ -61,6 +61,11 @@ Datadog::ProfilerStats::reset_state()
     copy_memory_error_count = 0;
     heap_tracker_size = std::nullopt;
     heap_tracker_cap_drops = std::nullopt;
+    asyncio_initialized = std::nullopt;
+    asyncio_runtime_offsets_discovered = std::nullopt;
+    asyncio_interpreter_tasks_head_offset = std::nullopt;
+    asyncio_thread_tasks_head_offset = std::nullopt;
+    asyncio_loop_count = std::nullopt;
     asyncio_task_count = std::nullopt;
     greenlet_count = std::nullopt;
     sample_capture_cpu_time_us = 0;
@@ -193,10 +198,70 @@ Datadog::ProfilerStats::get_heap_tracker_cap_drops() const
 }
 
 void
+Datadog::ProfilerStats::set_asyncio_initialized(bool initialized)
+{
+    asyncio_initialized = initialized;
+}
+
+std::optional<bool>
+Datadog::ProfilerStats::get_asyncio_initialized() const
+{
+    return asyncio_initialized;
+}
+
+void
+Datadog::ProfilerStats::set_asyncio_runtime_offsets_discovered(bool discovered)
+{
+    asyncio_runtime_offsets_discovered = discovered;
+}
+
+std::optional<bool>
+Datadog::ProfilerStats::get_asyncio_runtime_offsets_discovered() const
+{
+    return asyncio_runtime_offsets_discovered;
+}
+
+void
+Datadog::ProfilerStats::set_asyncio_interpreter_tasks_head_offset(size_t offset)
+{
+    asyncio_interpreter_tasks_head_offset = offset;
+}
+
+std::optional<size_t>
+Datadog::ProfilerStats::get_asyncio_interpreter_tasks_head_offset() const
+{
+    return asyncio_interpreter_tasks_head_offset;
+}
+
+void
+Datadog::ProfilerStats::set_asyncio_thread_tasks_head_offset(size_t offset)
+{
+    asyncio_thread_tasks_head_offset = offset;
+}
+
+std::optional<size_t>
+Datadog::ProfilerStats::get_asyncio_thread_tasks_head_offset() const
+{
+    return asyncio_thread_tasks_head_offset;
+}
+
+void
+Datadog::ProfilerStats::set_asyncio_loop_count(size_t count)
+{
+    if (!asyncio_loop_count.has_value() || count > *asyncio_loop_count) {
+        asyncio_loop_count = count;
+    }
+}
+
+std::optional<size_t>
+Datadog::ProfilerStats::get_asyncio_loop_count() const
+{
+    return asyncio_loop_count;
+}
+
+void
 Datadog::ProfilerStats::set_asyncio_task_count(size_t count)
 {
-    // Track the peak (max) asyncio task count observed across sampling cycles
-    // within a profile period
     if (!asyncio_task_count.has_value() || count > *asyncio_task_count) {
         asyncio_task_count = count;
     }
@@ -285,6 +350,31 @@ Datadog::ProfilerStats::get_internal_metadata_json()
     if (maybe_heap_cap_drops) {
         internal_metadata_json += R"("heap_tracker_cap_drops": )";
         append_to_string(internal_metadata_json, *maybe_heap_cap_drops);
+        internal_metadata_json += ",";
+    }
+
+    append_optional_bool(internal_metadata_json, "asyncio_initialized", asyncio_initialized);
+    append_optional_bool(
+      internal_metadata_json, "asyncio_runtime_offsets_discovered", asyncio_runtime_offsets_discovered);
+
+    auto maybe_asyncio_interpreter_offset = get_asyncio_interpreter_tasks_head_offset();
+    if (maybe_asyncio_interpreter_offset) {
+        internal_metadata_json += R"("asyncio_interpreter_tasks_head_offset": )";
+        append_to_string(internal_metadata_json, *maybe_asyncio_interpreter_offset);
+        internal_metadata_json += ",";
+    }
+
+    auto maybe_asyncio_thread_offset = get_asyncio_thread_tasks_head_offset();
+    if (maybe_asyncio_thread_offset) {
+        internal_metadata_json += R"("asyncio_thread_tasks_head_offset": )";
+        append_to_string(internal_metadata_json, *maybe_asyncio_thread_offset);
+        internal_metadata_json += ",";
+    }
+
+    auto maybe_asyncio_loop_count = get_asyncio_loop_count();
+    if (maybe_asyncio_loop_count) {
+        internal_metadata_json += R"("asyncio_loop_count": )";
+        append_to_string(internal_metadata_json, *maybe_asyncio_loop_count);
         internal_metadata_json += ",";
     }
 

--- a/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
+++ b/ddtrace/internal/datadog/profiling/stack/echion/echion/echion_sampler.h
@@ -54,6 +54,7 @@ class EchionSampler
     PyObject* asyncio_scheduled_tasks_ = nullptr;
     PyObject* asyncio_eager_tasks_ = nullptr;
     // Asyncio may be initialized while the sampling thread is running.
+    std::atomic<bool> asyncio_initialized_{ false };
     std::atomic<size_t> asyncio_interpreter_tasks_head_offset_{ 0 };
     std::atomic<size_t> asyncio_thread_tasks_head_offset_{ 0 };
 
@@ -73,10 +74,10 @@ class EchionSampler
     // The pointer is borrowed and used as an address only by the sampling thread.
     PyObject* current_gc_frame_ = nullptr;
 
-    // Accumulated asyncio task count across sampled threads in the current sampling cycle.
-    // When thread subsampling is enabled (_DD_PROFILING_STACK_MAX_THREADS), this only
-    // reflects tasks from the sampled subset, not all threads in the process.
-    // Only accessed from the sampling thread, so no lock/atomic is needed.
+    // Accumulated asyncio loop and task counts across sampled threads in the current sampling cycle.
+    // When thread subsampling is enabled (_DD_PROFILING_STACK_MAX_THREADS), these only reflect the sampled subset,
+    // not all threads in the process. Only accessed from the sampling thread, so no lock/atomic is needed.
+    size_t asyncio_loop_count_ = 0;
     size_t asyncio_task_count_ = 0;
 
     // Maximum number of leaf tasks / greenlets to unwind and emit per cycle.
@@ -135,6 +136,7 @@ class EchionSampler
 
     PyObject* asyncio_scheduled_tasks() const { return asyncio_scheduled_tasks_; }
     PyObject* asyncio_eager_tasks() const { return asyncio_eager_tasks_; }
+    bool asyncio_initialized() const { return asyncio_initialized_.load(std::memory_order_relaxed); }
 
     void set_asyncio_offsets(const AsyncioOffsets& offsets)
     {
@@ -156,6 +158,7 @@ class EchionSampler
     {
         asyncio_scheduled_tasks_ = scheduled_tasks;
         asyncio_eager_tasks_ = (eager_tasks != Py_None) ? eager_tasks : nullptr;
+        asyncio_initialized_.store(true, std::memory_order_relaxed);
     }
 
     std::optional<BoundaryFrame>& asyncio_boundary_frame() { return asyncio_boundary_frame_; }
@@ -167,7 +170,13 @@ class EchionSampler
     PyObject* current_gc_frame() const { return current_gc_frame_; }
     [[nodiscard]] GCFrameScope use_gc_frame(PyObject* frame) { return GCFrameScope(*this, frame); }
 
-    void reset_asyncio_task_count() { asyncio_task_count_ = 0; }
+    void reset_asyncio_counts()
+    {
+        asyncio_loop_count_ = 0;
+        asyncio_task_count_ = 0;
+    }
+    void increment_asyncio_loop_count() { asyncio_loop_count_++; }
+    size_t asyncio_loop_count() const { return asyncio_loop_count_; }
     void add_asyncio_task_count(size_t count) { asyncio_task_count_ += count; }
     size_t asyncio_task_count() const { return asyncio_task_count_; }
 
@@ -213,6 +222,7 @@ class EchionSampler
 
         asyncio_boundary_frame_.reset();
         uvloop_boundary_frame_.reset();
+        asyncio_loop_count_ = 0;
         asyncio_task_count_ = 0;
         rng_ = std::minstd_rand{ std::random_device{}() };
 

--- a/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
+++ b/ddtrace/internal/datadog/profiling/stack/src/echion/threads.cc
@@ -28,6 +28,7 @@ ThreadInfo::unwind(EchionSampler& echion, PyThreadState* tstate, microsecond_t w
     unwind_python_stack(echion, tstate, python_stack);
 
     if (asyncio_loop) {
+        echion.increment_asyncio_loop_count();
         // unwind_tasks returns a [[nodiscard]] Result<void>.
         // We cast it to void to ignore failures.
         (void)unwind_tasks(echion, tstate, wall_time_us);

--- a/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
+++ b/ddtrace/internal/datadog/profiling/stack/src/sampler.cpp
@@ -487,14 +487,13 @@ Sampler::sampling_thread(const uint64_t seq_num)
             }
         }
 
-        // Reset per-cycle asyncio task accumulator before iterating sampled threads
-        echion->reset_asyncio_task_count();
+        // Reset per-cycle asyncio accumulators before iterating sampled threads.
+        echion->reset_asyncio_counts();
 
         try {
             capture_samples(wall_time_us);
 
-            // Collect greenlet count before acquiring the profile lock to avoid
-            // holding two locks simultaneously (greenlet lock then profile lock).
+            // Collect greenlet count before acquiring the profile lock to avoid holding two locks simultaneously.
             size_t greenlet_count;
             {
                 const std::lock_guard<std::mutex> guard(echion->greenlet_info_map_lock());
@@ -526,7 +525,17 @@ Sampler::sampling_thread(const uint64_t seq_num)
                 borrow.stats().increment_sampling_event_count();
                 borrow.stats().set_string_table_count(echion->string_table().size());
                 update_fast_copy_stats(borrow.stats());
+                borrow.stats().set_asyncio_initialized(echion->asyncio_initialized());
+                borrow.stats().set_asyncio_loop_count(echion->asyncio_loop_count());
                 borrow.stats().set_asyncio_task_count(echion->asyncio_task_count());
+#if PY_VERSION_HEX >= 0x030e0000
+                const size_t asyncio_interpreter_offset = echion->asyncio_interpreter_tasks_head_offset();
+                const size_t asyncio_thread_offset = echion->asyncio_thread_tasks_head_offset();
+                borrow.stats().set_asyncio_runtime_offsets_discovered(asyncio_interpreter_offset != 0 &&
+                                                                      asyncio_thread_offset != 0);
+                borrow.stats().set_asyncio_interpreter_tasks_head_offset(asyncio_interpreter_offset);
+                borrow.stats().set_asyncio_thread_tasks_head_offset(asyncio_thread_offset);
+#endif
                 borrow.stats().set_greenlet_count(greenlet_count);
 
                 if (copy_errors > 0) {

--- a/tests/profiling/collector/test_asyncio_task_count.py
+++ b/tests/profiling/collector/test_asyncio_task_count.py
@@ -13,6 +13,7 @@ def test_asyncio_task_count_present():
     import asyncio
     import json
     import os
+    import sys
     import time
 
     from ddtrace.profiling import profiler
@@ -41,17 +42,32 @@ def test_asyncio_task_count_present():
     files = pprof_utils.get_internal_metadata_files(output_filename)
     assert files, "Expected at least one internal_metadata.json file"
 
+    found_initialized = False
+    found_loop = False
     found_positive = False
+    found_runtime_offsets = False
     for f in files:
         with open(f) as fp:
             metadata = json.load(fp)
+        if metadata.get("asyncio_initialized"):
+            found_initialized = True
+        if metadata.get("asyncio_loop_count", 0) > 0:
+            found_loop = True
         if "asyncio_task_count" in metadata:
             assert isinstance(metadata["asyncio_task_count"], int)
             assert metadata["asyncio_task_count"] >= 0
             if metadata["asyncio_task_count"] > 0:
                 found_positive = True
+        if metadata.get("asyncio_runtime_offsets_discovered"):
+            assert metadata["asyncio_interpreter_tasks_head_offset"] > 0
+            assert metadata["asyncio_thread_tasks_head_offset"] > 0
+            found_runtime_offsets = True
 
+    assert found_initialized, "Expected asyncio initialization to be reported"
+    assert found_loop, "Expected at least one tracked asyncio loop"
     assert found_positive, "Expected at least one metadata file with asyncio_task_count > 0"
+    if sys.version_info >= (3, 14):
+        assert found_runtime_offsets, "Expected Python 3.14 asyncio runtime offsets to be discovered"
 
 
 @pytest.mark.subprocess(


### PR DESCRIPTION
## Description

Adds internal asyncio discovery diagnostics to profiler metadata so rollout and runtime failures can be distinguished without conflating initialization, loop tracking, offset discovery, and task traversal.

The metadata reports:

- Whether the native asyncio hook initialized
- Whether Python 3.14 runtime offsets were discovered
- The discovered interpreter and thread task-list offsets
- The peak number of sampled threads with a tracked asyncio loop
- The existing peak asyncio task count

This is a stacked follow-up to #19802. It keeps the diagnostic plumbing separate from the runtime offset discovery and ELF parsing implementation.

## Testing

- Python 3.14 profiling tests: both `test_asyncio_task_count` tests passed
- The metadata test asserts successful initialization, a tracked loop, positive task count, and discovered offsets on Python 3.14
- `scripts/lint checks` passed
- clang-format and `git diff --check` passed

## Risks

Low. This adds internal metadata fields and one relaxed atomic initialization flag. Loop and task counts are accumulated on the sampling thread without additional synchronization. It adds no filesystem access, retries, locks, or work to the signal handler.

## Additional Notes

This PR targets `taegyun/prof-echion-asyncio-debug-offsets` and should be reviewed and merged after #19802.

No release note is needed because this only adds internal diagnostic metadata.
